### PR TITLE
Fix OpenGL header compatibility for macOS builds

### DIFF
--- a/render/gl/backend.cpp
+++ b/render/gl/backend.cpp
@@ -17,11 +17,11 @@
 #include "ground/plant_gpu.h"
 #include "ground/stone_gpu.h"
 #include "mesh.h"
+#include "opengl_headers.h"
 #include "render_constants.h"
 #include "shader.h"
 #include "state_scopes.h"
 #include "texture.h"
-#include <GL/gl.h>
 #include <QDebug>
 #include <cmath>
 #include <cstddef>

--- a/render/gl/backend/cylinder_pipeline.cpp
+++ b/render/gl/backend/cylinder_pipeline.cpp
@@ -4,7 +4,7 @@
 #include "../primitives.h"
 #include "../render_constants.h"
 #include "gl/shader_cache.h"
-#include <GL/gl.h>
+#include "../opengl_headers.h"
 #include <algorithm>
 #include <cstddef>
 #include <qopenglext.h>

--- a/render/gl/backend/terrain_pipeline.cpp
+++ b/render/gl/backend/terrain_pipeline.cpp
@@ -2,7 +2,7 @@
 #include "../backend.h"
 #include "../render_constants.h"
 #include "../shader_cache.h"
-#include <GL/gl.h>
+#include "../opengl_headers.h"
 #include <QDebug>
 #include <QOpenGLExtraFunctions>
 #include <cstddef>

--- a/render/gl/backend/vegetation_pipeline.cpp
+++ b/render/gl/backend/vegetation_pipeline.cpp
@@ -1,7 +1,7 @@
 #include "vegetation_pipeline.h"
 #include "../render_constants.h"
 #include "gl/shader_cache.h"
-#include <GL/gl.h>
+#include "../opengl_headers.h"
 #include <QDebug>
 #include <cmath>
 #include <cstddef>

--- a/render/gl/buffer.cpp
+++ b/render/gl/buffer.cpp
@@ -1,5 +1,5 @@
 #include "buffer.h"
-#include <GL/gl.h>
+#include "opengl_headers.h"
 #include <cstddef>
 #include <qopenglext.h>
 #include <vector>

--- a/render/gl/mesh.cpp
+++ b/render/gl/mesh.cpp
@@ -1,7 +1,7 @@
 #include "mesh.h"
 #include "gl/buffer.h"
 #include "render_constants.h"
-#include <GL/gl.h>
+#include "opengl_headers.h"
 #include <QOpenGLFunctions_3_3_Core>
 #include <memory>
 #include <vector>

--- a/render/gl/opengl_headers.h
+++ b/render/gl/opengl_headers.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Platform-specific OpenGL header inclusion
+#ifdef __APPLE__
+    #include <OpenGL/gl.h>
+    #include <OpenGL/glu.h>
+#else
+    #include <GL/gl.h>
+    #include <GL/glu.h>
+#endif

--- a/render/gl/resources.cpp
+++ b/render/gl/resources.cpp
@@ -2,7 +2,7 @@
 #include "gl/mesh.h"
 #include "gl/texture.h"
 #include "render_constants.h"
-#include <GL/gl.h>
+#include "opengl_headers.h"
 #include <QVector3D>
 #include <cmath>
 #include <memory>

--- a/render/gl/shader.cpp
+++ b/render/gl/shader.cpp
@@ -1,7 +1,7 @@
 #include "shader.h"
 #include "render_constants.h"
 #include "utils/resource_utils.h"
-#include <GL/gl.h>
+#include "opengl_headers.h"
 #include <QByteArray>
 #include <QDebug>
 #include <QFile>

--- a/render/gl/texture.cpp
+++ b/render/gl/texture.cpp
@@ -1,5 +1,5 @@
 #include "texture.h"
-#include <GL/gl.h>
+#include "opengl_headers.h"
 #include <QDebug>
 #include <QImage>
 #include <qglobal.h>


### PR DESCRIPTION
## Summary
Fixed critical OpenGL header compatibility issues that prevented the project from building on macOS. The code was using Linux/Windows OpenGL header paths which don't exist on macOS.

## Bug Fixes

### Fix OpenGL header includes for cross-platform compatibility
The project was failing to build on macOS because it was using `<GL/gl.h>` includes which are the Linux/Windows OpenGL header paths. On macOS, OpenGL headers are located in the system framework at `<OpenGL/gl.h>`. I created a platform-specific header wrapper that automatically includes the correct OpenGL headers based on the target platform, ensuring the project builds successfully on macOS, Linux, and Windows without any platform-specific code in individual source files.

### Update include paths for subdirectory files
Files in the `render/gl/backend/` subdirectory couldn't find the new OpenGL header wrapper because they were looking in the wrong directory. I updated the include paths to use `#include "../opengl_headers.h"` so all files can properly locate the platform-specific OpenGL headers regardless of their directory location.

## Console error:

<img width="1470" height="937" alt="image" src="https://github.com/user-attachments/assets/b40bac38-58b4-4017-813f-c5085f496c7e" />
