### PR TITLE
Improve ground and riverbank realism

### DIFF
--- a/assets/shaders/riverbank.frag
+++ b/assets/shaders/riverbank.frag
@@ -27,6 +27,7 @@ uniform vec3 u_snow_color;
 uniform float u_moisture_level;
 uniform float u_rock_exposure;
 uniform float u_snow_coverage;
+uniform float u_ambient_boost;
 uniform vec3 u_camera_pos;
 uniform vec3 u_light_dir;
 
@@ -78,6 +79,31 @@ float fbm(vec2 point) {
   }
 
   return result;
+}
+
+float band_limit(float texels_per_pixel, float frequency) {
+  return 1.0 - smoothstep(0.30, 0.85, texels_per_pixel * frequency);
+}
+
+vec2 cellular_distances(vec2 point) {
+  vec2 cell = floor(point);
+  vec2 local = fract(point);
+  float nearest = 8.0;
+  float second = 8.0;
+  for (int y = -1; y <= 1; ++y) {
+    for (int x = -1; x <= 1; ++x) {
+      vec2 offset = vec2(float(x), float(y));
+      vec2 site = offset + vec2(hash21(cell + offset), hash21(cell + offset + 19.7));
+      float distance_to_site = length(site - local);
+      if (distance_to_site < nearest) {
+        second = nearest;
+        nearest = distance_to_site;
+      } else if (distance_to_site < second) {
+        second = distance_to_site;
+      }
+    }
+  }
+  return vec2(nearest, second);
 }
 
 vec3 safe_normalize(vec3 value, vec3 fallback) {
@@ -194,12 +220,12 @@ void main() {
   float bank_snow = smoothstep(0.54, 0.78, macro + detail * 0.12) * snow_coverage;
   map_ground = mix(map_ground, max(u_snow_color, vec3(0.025)), bank_snow * 0.82);
 
-  vec3 wet_silt = soil * mix(vec3(0.60, 0.62, 0.57), vec3(0.50, 0.55, 0.50), moisture);
+  vec3 wet_silt = soil * mix(vec3(0.86, 0.88, 0.82), vec3(0.74, 0.79, 0.74), moisture);
 
-  vec3 damp_earth =
-      soil * mix(vec3(0.78, 0.80, 0.72), vec3(0.68, 0.73, 0.66), moisture);
+  vec3 damp_earth = mix(soil, grass_dry, 0.26) *
+                    mix(vec3(1.12, 1.12, 1.05), vec3(0.98, 1.02, 0.95), moisture);
 
-  vec3 dry_earth = mix(soil, grass_dry, 0.20) * mix(0.92, 0.84, moisture);
+  vec3 dry_earth = mix(soil, grass_dry, 0.46) * mix(1.24, 1.10, moisture);
 
   vec3 bank_grass = terrain_grass;
 
@@ -228,19 +254,34 @@ void main() {
 
   earth = mix(earth, map_ground * mix(0.90, 0.98, detail), land_merge);
 
-  float pebble_cells = value_noise(world_uv * 4.6 + vec2(41.0, -13.0));
+  float footprint = max(length(fwidth(world_uv)), 1e-5);
 
-  float pebble_breakup = value_noise(world_uv * 12.0 + vec2(-19.0, 8.0));
+  vec2 cobble_cells = cellular_distances(world_uv * 5.2 + vec2(41.0, -13.0));
+  float cobble =
+      (1.0 - smoothstep(0.10, 0.46, cobble_cells.x)) * band_limit(footprint, 5.2);
+  vec2 shingle_cells = cellular_distances(world_uv * 13.5 + vec2(-19.0, 8.0));
+  float shingle =
+      (1.0 - smoothstep(0.14, 0.50, shingle_cells.x)) * band_limit(footprint, 13.5);
 
+  float bar_field = smoothstep(0.38, 0.72, macro * 0.55 + detail * 0.45);
   float pebble_region =
-      smoothstep(0.11, 0.42, shore_t) * (1.0 - smoothstep(0.58, 0.76, shore_t));
+      smoothstep(0.06, 0.34, shore_t) * (1.0 - smoothstep(0.52, 0.80, shore_t));
 
-  float pebbles = smoothstep(0.79, 0.94, pebble_cells) *
-                  smoothstep(0.54, 0.82, pebble_breakup) * pebble_region;
+  float pebbles = clamp(cobble * 0.62 + shingle * 0.38, 0.0, 1.0) * pebble_region *
+                  mix(0.35, 1.0, bar_field);
 
   vec3 stone_color = biome_stone * mix(0.78, 0.94, grain);
 
-  earth = mix(earth, stone_color, pebbles * mix(0.24, 0.52, rock_exposure));
+  stone_color *= mix(0.68, 1.0, smoothstep(0.04, 0.44, shore_t));
+
+  earth = mix(earth, stone_color, pebbles * mix(0.38, 0.66, rock_exposure));
+
+  float waterline = (1.0 - smoothstep(0.0, 0.085, shore_t)) *
+                    (0.55 + 0.45 * smoothstep(0.35, 0.70, detail));
+  earth *= 1.0 - waterline * 0.16;
+  float stain =
+      smoothstep(0.055, 0.10, shore_t) * (1.0 - smoothstep(0.10, 0.20, shore_t));
+  earth = mix(earth, earth * vec3(0.84, 0.87, 0.81), stain * 0.35);
 
   float deposited_silt_noise =
       fbm(vec2(tex_coord.y * 7.0 + macro, world_uv.y * 0.35 - slow_wash.x));
@@ -251,8 +292,10 @@ void main() {
 
   vec3 base_normal = safe_normalize(v_normal, vec3(0.0, 1.0, 0.0));
 
-  vec3 normal =
-      procedural_detail_normal(base_normal, world_uv * 2.8, 0.42 * (0.35 + grain));
+  float relief_fade = band_limit(footprint, 2.8);
+  float relief_strength =
+      (0.42 * (0.35 + grain) + pebbles * 0.55 + cobble * 0.25) * relief_fade;
+  vec3 normal = procedural_detail_normal(base_normal, world_uv * 2.8, relief_strength);
 
   vec3 light_dir = safe_normalize(u_light_dir, vec3(0.0, 1.0, 0.0));
 
@@ -260,11 +303,18 @@ void main() {
 
   float ndl = max(dot(normal, light_dir), 0.0);
 
-  float ambient_occlusion = mix(0.78, 0.94, shore_t);
+  float ambient_occlusion = mix(0.74, 1.0, smoothstep(0.0, 0.55, shore_t));
+  ambient_occlusion *= 1.0 - (1.0 - relief_fade) * pebbles * 0.30;
 
-  float diffuse_light = 0.56 * ambient_occlusion + ndl * 0.38;
+  vec3 sky_light = vec3(0.88, 0.94, 1.06);
+  vec3 bounce_light = vec3(1.14, 0.98, 0.76);
+  vec3 sun_light = vec3(1.10, 1.00, 0.86);
+  float sky_access = 0.5 + 0.5 * normal.y;
+  vec3 ambient_term =
+      0.40 * ambient_occlusion * mix(bounce_light, sky_light, sky_access);
 
-  vec3 color = earth * diffuse_light;
+  float exposure = u_ambient_boost > 0.001 ? u_ambient_boost : 1.0;
+  vec3 color = earth * (ambient_term + sun_light * ndl * 0.70) * exposure;
 
   vec3 half_dir = safe_normalize(light_dir + view_dir, normal);
 
@@ -294,5 +344,9 @@ void main() {
 
   color = mix(color, u_fog_color, fog_amount);
 
-  frag_color = vec4(saturate(color), segment_visibility);
+  float dissolve_noise = (macro - 0.5) * 0.34 + (detail - 0.5) * 0.20;
+  float edge_fade =
+      1.0 - smoothstep(0.62 + dissolve_noise, 1.0 + dissolve_noise, shore_t);
+
+  frag_color = vec4(saturate(color), segment_visibility * edge_fade);
 }

--- a/assets/shaders/terrain_chunk.frag
+++ b/assets/shaders/terrain_chunk.frag
@@ -114,6 +114,18 @@ vec2 cellular_distances(vec2 p) {
   return vec2(nearest, second);
 }
 
+float curvature_from_normal_field(vec3 shading_normal) {
+  vec3 dpdx = dFdx(v_world_pos);
+  vec3 dpdy = dFdy(v_world_pos);
+  float span_x = max(length(dpdx), 1e-4);
+  float span_y = max(length(dpdy), 1e-4);
+  vec3 dndx = dFdx(shading_normal);
+  vec3 dndy = dFdy(shading_normal);
+  float curve_x = dot(dndx, dpdx / span_x) / span_x;
+  float curve_y = dot(dndy, dpdy / span_y) / span_y;
+  return -0.5 * (curve_x + curve_y);
+}
+
 float compute_curvature() {
   if (u_has_height_tex != 1) {
     return 0.0;
@@ -138,6 +150,21 @@ vec3 geom_normal() {
   vec3 dy = dFdy(v_world_pos);
   vec3 n = normalize(cross(dx, dy));
   return (dot(n, v_normal) < 0.0) ? -n : n;
+}
+
+float band_limit(float texels_per_pixel, float frequency) {
+  return 1.0 - smoothstep(0.30, 0.85, texels_per_pixel * frequency);
+}
+
+vec3 relief_octave(vec2 coord, float footprint, float frequency, float step_size) {
+  float fade = band_limit(footprint, frequency);
+  if (fade <= 0.001) {
+    return vec3(0.0);
+  }
+  float h0 = gradient_noise(coord * frequency);
+  float hx = gradient_noise((coord + vec2(step_size, 0.0)) * frequency);
+  float hz = gradient_noise((coord + vec2(0.0, step_size)) * frequency);
+  return vec3(vec2(hx - h0, hz - h0) / step_size, fade);
 }
 
 float sample_height(vec2 uv) {
@@ -208,10 +235,12 @@ float min_cliff_distance_radial(vec2 uv, int r, float rise_delta) {
 void main() {
   float entry_mask = clamp(v_entry_mask, 0.0, 1.0);
   float feature_foot = clamp(v_feature_foot, 0.0, 1.0);
-  vec3 normal = geom_normal();
 
-  normal = normalize(
-      mix(normal, normalize(v_normal), max(entry_mask * 0.5, feature_foot * 0.22)));
+  vec3 smooth_normal = normalize(v_normal);
+  vec3 facet_normal = geom_normal();
+  float facet_break = 1.0 - clamp(dot(facet_normal, smooth_normal), 0.0, 1.0);
+  float facet_weight = 0.20 * smoothstep(0.30, 0.80, facet_break);
+  vec3 normal = normalize(mix(smooth_normal, facet_normal, facet_weight));
 
   if (u_has_height_tex == 1) {
     vec2 huv = v_world_pos.xz * u_height_uv_scale + u_height_uv_offset;
@@ -236,7 +265,9 @@ void main() {
   float entry_face = entry_core * smoothstep(0.045, 0.16, slope) *
                      (1.0 - smoothstep(0.58, 0.82, slope));
   float entry_signal = entry_core * (0.30 + 0.70 * smoothstep(0.025, 0.14, slope));
-  float curvature = compute_curvature();
+  float curvature = (u_has_height_tex == 1)
+                        ? compute_curvature()
+                        : curvature_from_normal_field(smooth_normal);
   float curvature_response = clamp(u_curvature_response, 0.0, 1.0);
   float ridge_response = clamp(u_ridge_response, 0.0, 1.0);
   float gully_response = clamp(u_gully_response, 0.0, 1.0);
@@ -250,6 +281,13 @@ void main() {
 
   float tile_scale = max(u_tile_size, 0.0001);
   vec2 world_coord = (v_world_pos.xz / tile_scale) + u_noise_offset;
+
+  float coord_footprint = max(length(fwidth(world_coord)), 1e-5);
+
+  float wall_axis = step(abs(normal.x), abs(normal.z));
+  vec2 wall_coord = vec2(mix(v_world_pos.z, v_world_pos.x, wall_axis) / tile_scale,
+                         v_world_pos.y / tile_scale);
+  wall_coord += u_noise_offset.yx;
 
   float macro_scale = max(u_macro_noise_scale, 0.010);
   vec2 domain_warp = vec2(gradient_fbm(world_coord * macro_scale * 0.43 + 13.7),
@@ -281,8 +319,13 @@ void main() {
             0.0,
             1.0);
   float surface_detail = gradient_fbm(world_coord * 0.44 + vec2(5.7, -2.1));
-  float surface_grain = gradient_noise(world_coord * 1.75 + vec2(-17.0, 8.0));
-  float granular = gradient_noise(world_coord * 5.2 + vec2(42.0, 19.0));
+  float grain_fade = band_limit(coord_footprint, 1.75);
+  float granular_fade = band_limit(coord_footprint, 5.2);
+  float speck_fade = band_limit(coord_footprint, 17.0);
+  float surface_grain =
+      gradient_noise(world_coord * 1.75 + vec2(-17.0, 8.0)) * grain_fade;
+  float granular = gradient_noise(world_coord * 5.2 + vec2(42.0, 19.0)) * granular_fade;
+  float speckle = gradient_fbm(world_coord * 17.0 + vec2(-63.0, 24.0)) * speck_fade;
 
   float grass_mix = 0.16 + regional_field * 0.68;
   vec3 grass_color = mix(u_grass_primary, u_grass_secondary, grass_mix);
@@ -307,8 +350,29 @@ void main() {
   grass_color = mix(grass_color, u_grass_secondary * 0.92, lush_patch * 0.24);
   float grass_weave = gradient_fbm(world_coord * 0.16 + domain_warp * 0.12 + 18.0);
   float grass_clumps = smoothstep(0.34, 0.76, thatch_field);
+
+  float sward_drift = gradient_fbm(world_coord * macro_scale * 8.5 +
+                                   domain_warp * 0.55 + vec2(63.0, -14.0));
+  float graze_drift = gradient_fbm(world_coord * macro_scale * 22.0 -
+                                   domain_warp * 0.40 + vec2(-28.0, 51.0));
+  float tussock =
+      gradient_fbm(world_coord * 0.90 + domain_warp * 0.20 + vec2(-8.0, 33.0)) *
+      band_limit(coord_footprint, 0.90);
+
   grass_color *= 0.94 + grass_clumps * 0.09 + surface_detail * 0.040 +
-                 grass_weave * 0.035 + surface_grain * 0.008;
+                 grass_weave * 0.035 + surface_grain * 0.012 + tussock * 0.055 +
+                 speckle * 0.014;
+
+  vec3 cropped_sward = mix(u_grass_dry, u_grass_primary, 0.45);
+  vec3 deep_sward = mix(u_grass_secondary, u_grass_primary, 0.30) * 0.88;
+  grass_color = mix(
+      grass_color, cropped_sward, clamp(sward_drift * 0.85 + 0.42, 0.0, 1.0) * 0.30);
+  grass_color =
+      mix(grass_color, deep_sward, clamp(-graze_drift * 0.95 + 0.34, 0.0, 1.0) * 0.24);
+  grass_color *= 1.0 + sward_drift * 0.10 + graze_drift * 0.065;
+
+  vec3 blade_shade = mix(u_grass_secondary, u_grass_dry, 0.35);
+  grass_color = mix(grass_color, blade_shade, clamp(tussock, 0.0, 1.0) * 0.10);
 
   float low_ground = 1.0 - smoothstep(0.45, 2.6, v_world_pos.y);
   float damp_patch = smoothstep(0.75,
@@ -335,8 +399,9 @@ void main() {
                      entry_toe * 0.015);
   soil_mix = clamp(soil_mix, 0.0, 0.72);
   vec3 ground_soil = mix(u_soil_color, u_grass_dry, level_ground * 0.24);
-  vec3 varied_soil = ground_soil * (1.0 + surface_detail * 0.075 +
-                                    surface_grain * 0.045 + granular * 0.022);
+  vec3 varied_soil =
+      ground_soil * (1.0 + surface_detail * 0.075 + surface_grain * 0.045 +
+                     granular * 0.040 + speckle * 0.030);
   vec3 compacted_entry_earth = mix(u_soil_color, u_grass_dry, 0.18);
   varied_soil =
       mix(varied_soil, compacted_entry_earth, entry_signal * 0.38 + entry_face * 0.10);
@@ -359,25 +424,48 @@ void main() {
   rock_mask *= smoothstep(0.010, 0.050, slope);
   rock_mask *= 1.0 - soil_mix * 0.55;
 
-  vec2 rock_cells = cellular_distances(world_coord * 0.34 + vec2(8.0, -5.0));
+  float wall_blend = smoothstep(0.28, 0.72, slope);
+  vec2 rock_coord = mix(world_coord, wall_coord, wall_blend);
+  float rock_footprint = max(length(fwidth(rock_coord)), 1e-5);
+
+  vec2 rock_cells = cellular_distances(rock_coord * 0.34 + vec2(8.0, -5.0));
   float fracture = 1.0 - smoothstep(0.025, 0.12, rock_cells.y - rock_cells.x);
-  float rock_value =
-      clamp(0.48 + surface_detail * 0.31 + surface_grain * 0.12, 0.0, 1.0);
+  vec2 rock_chips = cellular_distances(rock_coord * 1.9 + vec2(-27.0, 14.0));
+  float chipping = (1.0 - smoothstep(0.03, 0.16, rock_chips.y - rock_chips.x)) *
+                   band_limit(rock_footprint, 1.9);
+  float rock_detail = gradient_fbm(rock_coord * 0.62 + vec2(3.3, -11.0));
+  float rock_grain = gradient_noise(rock_coord * 2.4 + vec2(-17.0, 8.0)) *
+                     band_limit(rock_footprint, 2.4);
+  float rock_value = clamp(0.44 + rock_detail * 0.44 + rock_grain * 0.20, 0.0, 1.0);
   vec3 rock_color = mix(u_rock_low, u_rock_high, rock_value);
-  float rock_strata = gradient_noise(
-      vec2(world_coord.x * 0.11 + v_world_pos.y * 0.32, world_coord.y * 0.035));
-  rock_color *= 1.0 + rock_strata * 0.085;
-  rock_color *= 1.0 - fracture * (0.055 + 0.075 * u_rock_detail_strength);
-  rock_color *= 1.0 + granular * 0.028;
+  float rock_strata =
+      gradient_noise(vec2(rock_coord.x * 0.11 + v_world_pos.y * 0.32,
+                          mix(world_coord.y, wall_coord.y, wall_blend) * 0.035));
+  float bedding = gradient_noise(vec2(rock_coord.x * 0.06, v_world_pos.y * 0.85));
+  rock_color *= 1.0 + rock_strata * 0.145 + bedding * 0.120 * wall_blend;
+  rock_color *= 1.0 - fracture * (0.115 + 0.150 * u_rock_detail_strength);
+  rock_color *= 1.0 - chipping * (0.070 + 0.090 * u_rock_detail_strength);
+  rock_color *= 1.0 + rock_grain * 0.075;
+
+  float ledge = 1.0 - smoothstep(0.30, 0.68, slope);
+  float scrub_field = gradient_fbm(rock_coord * 1.15 + vec2(-52.0, 17.0)) * 0.5 + 0.5;
+  float scrub = smoothstep(0.52,
+                           0.86,
+                           scrub_field * 0.62 + fracture * 0.26 + ledge * 0.28 -
+                               high_ground * 0.18);
+  vec3 lichen = mix(u_grass_dry, u_grass_secondary, 0.55) * 0.62;
+  rock_color = mix(rock_color, lichen, scrub * 0.34 * (1.0 - u_snow_coverage * 0.6));
 
   vec3 terrain_color = mix(soil_blend, rock_color, rock_mask);
 
   if (u_crack_intensity > 0.01) {
-    float crack_noise1 = noise21(world_coord * 4.0);
-    float crack_noise2 = noise21(world_coord * 8.0 + vec2(42.0, 17.0));
-    float crack_pattern =
-        smoothstep(0.45, 0.50, crack_noise1) * smoothstep(0.40, 0.55, crack_noise2);
-    crack_pattern *= (1.0 - slope * 0.8);
+    vec2 crack_warp = vec2(gradient_noise(world_coord * 0.9 + vec2(4.0, -13.0)),
+                           gradient_noise(world_coord * 0.9 + vec2(-21.0, 6.0)));
+    vec2 crack_cells = cellular_distances(world_coord * 2.6 + crack_warp * 0.55);
+    float vein = 1.0 - smoothstep(0.010, 0.075, crack_cells.y - crack_cells.x);
+    float crack_pattern = vein * band_limit(coord_footprint, 2.6);
+    crack_pattern *= (1.0 - slope * 0.8) * (0.35 + 0.65 * dry_patch);
+    crack_pattern *= 1.0 - damp_patch * 0.75;
     float crack_darkening = 1.0 - crack_pattern * u_crack_intensity * 0.35;
     terrain_color *= crack_darkening;
   }
@@ -404,30 +492,60 @@ void main() {
   terrain_color *= u_tint;
 
   vec3 L = normalize(u_light_dir);
-  float micro_h0 = gradient_noise(world_coord * 1.75 + vec2(-17.0, 8.0));
-  float hx = gradient_noise((world_coord + vec2(0.10, 0.0)) * 1.75 + vec2(-17.0, 8.0));
-  float hz = gradient_noise((world_coord + vec2(0.0, 0.10)) * 1.75 + vec2(-17.0, 8.0));
-  vec3 detail_normal =
-      normalize(normal + vec3(hx - micro_h0, 0.0, hz - micro_h0) *
-                             (0.018 + 0.055 * soil_mix + 0.14 * rock_mask +
-                              0.012 * exposed_ground));
+
+  vec2 relief_coord = mix(world_coord, wall_coord, wall_blend);
+  float relief_footprint = max(length(fwidth(relief_coord)), 1e-5);
+
+  vec3 coarse_relief =
+      relief_octave(relief_coord + vec2(-17.0, 8.0), relief_footprint, 1.40, 0.10);
+  vec3 mid_relief =
+      relief_octave(relief_coord + vec2(31.0, -19.0), relief_footprint, 4.30, 0.033);
+  vec3 fine_relief =
+      relief_octave(relief_coord + vec2(-9.0, 44.0), relief_footprint, 12.50, 0.011);
+
+  vec2 relief_gradient = coarse_relief.xy * (0.30 * coarse_relief.z) +
+                         mid_relief.xy * (0.20 * mid_relief.z) +
+                         fine_relief.xy * (0.11 * fine_relief.z);
+  float relief_resolved =
+      0.30 * coarse_relief.z + 0.20 * mid_relief.z + 0.11 * fine_relief.z;
+  float relief_lost = clamp(1.0 - relief_resolved / 0.61, 0.0, 1.0);
+
+  float relief_amp = 0.020 + 0.090 * soil_mix + 0.30 * rock_mask +
+                     0.030 * exposed_ground + 0.055 * bare_patch;
+  vec3 relief_offset =
+      mix(vec3(relief_gradient.x, 0.0, relief_gradient.y),
+          vec3(relief_gradient.x, relief_gradient.y, 0.0) * wall_axis +
+              vec3(0.0, relief_gradient.y, relief_gradient.x) * (1.0 - wall_axis),
+          wall_blend);
+  vec3 detail_normal = normalize(normal - relief_offset * relief_amp);
+
   float ndl = max(dot(detail_normal, L), 0.0);
   float concavity =
       max(gully_mask * gully_response, smoothstep(-0.025, 0.01, -curvature) * 0.35);
-  float ambient_occlusion = mix(1.0, 0.78, concavity * (1.0 - 0.55 * entry_mask));
-  float ambient = 0.48 * ambient_occlusion;
-  float wet_glint = wet_surface * pow(max(dot(detail_normal, L), 0.0), 10.0) * 0.07;
-  float shade = ambient + ndl * 0.64 + wet_glint;
-  vec3 lit_color = terrain_color * shade * u_ambient_boost;
+  float ambient_occlusion = mix(1.0, 0.74, concavity * (1.0 - 0.55 * entry_mask));
 
-  vec3 sun_tint = vec3(1.055, 0.965, 0.86);
-  vec3 shadow_tint = vec3(0.88, 0.91, 0.96);
-  float grade_t = clamp(ndl * 1.4, 0.0, 1.0);
-  lit_color *= mix(shadow_tint, sun_tint, grade_t);
+  ambient_occlusion *= 1.0 - relief_lost * relief_amp * 0.30;
+  ambient_occlusion *= 1.0 - 0.10 * smoothstep(0.20, 0.75, slope);
+
+  vec3 sky_light = vec3(0.88, 0.94, 1.06);
+  vec3 bounce_light = vec3(1.14, 0.98, 0.76);
+  vec3 sun_light = vec3(1.10, 1.00, 0.86);
+  float sky_access = 0.5 + 0.5 * detail_normal.y;
+  vec3 ambient_term =
+      0.40 * ambient_occlusion * mix(bounce_light, sky_light, sky_access);
+
+  float wet_glint = wet_surface * pow(max(dot(detail_normal, L), 0.0), 10.0) * 0.07;
 
   vec3 to_camera = u_camera_pos - v_world_pos;
   float view_distance = max(length(to_camera), 1e-4);
-  vec3 fog_view_dir = to_camera / view_distance;
+  vec3 view_dir = to_camera / view_distance;
+
+  float grazing = pow(1.0 - clamp(dot(detail_normal, view_dir), 0.0, 1.0), 5.0);
+  float sheen = grazing * (0.035 + 0.075 * u_moisture_level) * (1.0 - rock_mask * 0.70);
+
+  vec3 lit_color = terrain_color *
+                   (ambient_term + sun_light * (ndl * 0.70 + wet_glint) + sheen) *
+                   u_ambient_boost;
   float visibility_factor = 1.0;
   if (u_has_visibility == 1 && u_visibility_size.x > 0.0 && u_visibility_size.y > 0.0) {
     float tile_size = max(u_visibility_tile_size, 0.0001);
@@ -444,7 +562,7 @@ void main() {
   lit_color *= visibility_factor;
   float distance_fog =
       smoothstep(u_fog_start, max(u_fog_start + 1e-4, u_fog_end), view_distance);
-  float horizon_fog = smoothstep(0.20, 0.88, 1.0 - abs(fog_view_dir.y));
+  float horizon_fog = smoothstep(0.20, 0.88, 1.0 - abs(view_dir.y));
   float fog_amount = clamp(distance_fog * (0.72 + 0.60 * horizon_fog), 0.0, 1.0);
   lit_color = mix(lit_color, u_fog_color, fog_amount);
 

--- a/render/draw_queue.h
+++ b/render/draw_queue.h
@@ -158,6 +158,8 @@ struct TerrainFeatureCmd {
   float biome_moisture = 0.5F;
   float biome_rock_exposure = 0.3F;
   float biome_snow_coverage = 0.0F;
+
+  float ambient_boost = TerrainChunkParams::k_default_ambient_boost;
   float alpha = 1.0F;
   LinearFeatureKind kind = LinearFeatureKind::Water;
   WaterSurfaceKind water_kind = WaterSurfaceKind::River;

--- a/render/gl/backend/water_linear_command_executor.cpp
+++ b/render/gl/backend/water_linear_command_executor.cpp
@@ -180,6 +180,12 @@ void Backend::execute_water_linear_commands(const PreparedBatch& prepared,
       if (riverbank_shader == nullptr) {
         break;
       }
+
+      std::optional<BlendScope> shore_blend_scope;
+      if (!is_transparent) {
+        shore_blend_scope.emplace(true);
+      }
+      glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
       const auto& visibility = feature.visibility;
       if (m_last_bound_shader != riverbank_shader) {
         riverbank_shader->use();
@@ -293,6 +299,12 @@ void Backend::execute_water_linear_commands(const PreparedBatch& prepared,
             riverbank_shader->set_uniform(
                 m_water_pipeline->m_riverbank_uniforms.snow_coverage,
                 single.biome_snow_coverage);
+          }
+          if (m_water_pipeline->m_riverbank_uniforms.ambient_boost !=
+              Shader::InvalidUniform) {
+            riverbank_shader->set_uniform(
+                m_water_pipeline->m_riverbank_uniforms.ambient_boost,
+                single.ambient_boost);
           }
           riverbank_shader->set_uniform(m_water_pipeline->m_riverbank_uniforms.model,
                                         single.model);

--- a/render/gl/backend/water_pipeline.cpp
+++ b/render/gl/backend/water_pipeline.cpp
@@ -131,6 +131,8 @@ void WaterPipeline::cache_riverbank_uniforms() {
       m_riverbank_shader->optional_uniform_handle("u_rock_exposure");
   m_riverbank_uniforms.snow_coverage =
       m_riverbank_shader->optional_uniform_handle("u_snow_coverage");
+  m_riverbank_uniforms.ambient_boost =
+      m_riverbank_shader->optional_uniform_handle("u_ambient_boost");
   m_riverbank_uniforms.camera_position =
       m_riverbank_shader->optional_uniform_handle("u_camera_pos");
   m_riverbank_uniforms.light_direction =

--- a/render/gl/backend/water_pipeline.h
+++ b/render/gl/backend/water_pipeline.h
@@ -62,6 +62,7 @@ public:
     GL::Shader::UniformHandle moisture{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle rock_exposure{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle snow_coverage{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle ambient_boost{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle camera_position{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle light_direction{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle fog_color{GL::Shader::InvalidUniform};

--- a/render/ground/linear_feature_geometry.cpp
+++ b/render/ground/linear_feature_geometry.cpp
@@ -158,7 +158,7 @@ auto make_river_ribbon_settings() -> LinearFeatureRibbonSettings {
   settings.edge_noise_weights = {0.52F, 0.32F, 0.16F};
 
   settings.width_scale = 1.08F;
-  settings.width_variation_scale = 0.035F;
+  settings.width_variation_scale = 0.105F;
   settings.meander_frequency = 2.8F;
 
   settings.meander_amplitude = 0.11F;
@@ -753,7 +753,7 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
   const LinearFeatureRibbonSegment ribbon_segment{
       segment.start, segment.end, segment.width};
 
-  constexpr int k_rings_per_side = 5;
+  constexpr int k_rings_per_side = 7;
   constexpr int k_total_rings = k_rings_per_side * 2;
 
   int length_steps = static_cast<int>(std::ceil(length / (tile_size * 0.22F))) + 1;
@@ -819,6 +819,25 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
   std::vector<unsigned int> indices;
   const float rendered_water_width_scale = make_river_ribbon_settings().width_scale;
 
+  auto is_same_watercourse_continuation = [&](const Game::Map::RiverSegment& other) {
+    const float join_distance = std::max(tile_size * 0.60F, 0.10F);
+    const float join_distance_sq = join_distance * join_distance;
+    const bool shares_endpoint =
+        (other.start - segment.start).lengthSquared() <= join_distance_sq ||
+        (other.start - segment.end).lengthSquared() <= join_distance_sq ||
+        (other.end - segment.start).lengthSquared() <= join_distance_sq ||
+        (other.end - segment.end).lengthSquared() <= join_distance_sq;
+    if (!shares_endpoint) {
+      return false;
+    }
+    QVector3D neighbor_direction = other.end - other.start;
+    if (neighbor_direction.lengthSquared() < 0.000001F) {
+      return false;
+    }
+    neighbor_direction.normalize();
+    return std::abs(QVector3D::dotProduct(neighbor_direction, dir)) >= 0.50F;
+  };
+
   auto bank_point_inside_other_channel = [&](const QVector3D& center) {
     for (std::size_t other_index = 0; other_index < river_network.size();
          ++other_index) {
@@ -826,6 +845,9 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
         continue;
       }
       const auto& other = river_network[other_index];
+      if (is_same_watercourse_continuation(other)) {
+        continue;
+      }
       const float river_dx = other.end.x() - other.start.x();
       const float river_dz = other.end.z() - other.start.z();
       const float length_squared = river_dx * river_dx + river_dz * river_dz;
@@ -854,41 +876,58 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
     const auto cross_section =
         sample_linear_feature_cross_section(ribbon_segment, t, ribbon_settings);
     QVector3D const center_pos = cross_section.center;
-    const float bank_half_width = cross_section.half_width;
+
+    const float bank_half_width =
+        cross_section.half_width - std::min(0.22F, cross_section.half_width * 0.075F);
     const QVector3D bank_direction = local_bank_direction(t);
     const QVector3D bank_perpendicular(-bank_direction.z(), 0.0F, bank_direction.x());
     float const center_height =
         sample_height_clamped(height_map, center_pos.x(), center_pos.z());
 
     struct RingProfile {
+
       float distance_from_water;
+
       float height_offset;
+
+      float terrain_follow;
     };
 
     constexpr RingProfile k_bank_rings[k_rings_per_side] = {
-        {0.0F, 0.02F},
-        {0.125F, 0.175F},
-        {0.25F, 0.30F},
-        {0.375F, 0.125F},
-        {0.50F, -0.15F},
+        {0.00F, -0.055F, 0.00F},
+        {0.09F, -0.010F, 0.06F},
+        {0.24F, 0.060F, 0.24F},
+        {0.44F, 0.130F, 0.52F},
+        {0.66F, 0.160F, 0.80F},
+        {0.85F, 0.070F, 0.94F},
+        {1.00F, 0.025F, 1.00F},
     };
 
     float const ring_noise =
-        value_noise(center_pos.x() * 3.0F, center_pos.z() * 3.0F) * 0.075F;
-    float const base_bank_width = 0.50F + ring_noise;
+        value_noise(center_pos.x() * 0.055F, center_pos.z() * 0.055F) * 0.34F - 0.17F;
+    float const base_bank_width =
+        std::clamp(segment.width * 0.17F, 0.45F, 1.80F) * (1.0F + ring_noise);
+
+    float const side_bias =
+        value_noise(center_pos.x() * 0.028F + 21.7F, center_pos.z() * 0.028F - 8.3F) -
+        0.5F;
+    float const left_bank_width = base_bank_width * (1.0F + side_bias * 0.70F);
+    float const right_bank_width = base_bank_width * (1.0F - side_bias * 0.70F);
 
     auto bank_surface_height = [&](const QVector3D& position, int ring) {
       float const terrain_height =
           sample_height_clamped(height_map, position.x(), position.z());
 
-      const float clamped_height = std::min(terrain_height, center_height + 0.05F);
-      return clamped_height + k_bank_rings[ring].height_offset;
+      const float channel_height = std::min(terrain_height, center_height + 0.05F);
+      const float follow = k_bank_rings[ring].terrain_follow;
+      return channel_height + (terrain_height - channel_height) * follow +
+             k_bank_rings[ring].height_offset;
     };
 
     auto const ring_start_idx = static_cast<unsigned int>(vertices.size());
 
     for (int ring = 0; ring < k_rings_per_side; ++ring) {
-      float const ring_dist = k_bank_rings[ring].distance_from_water * base_bank_width;
+      float const ring_dist = k_bank_rings[ring].distance_from_water * left_bank_width;
 
       QVector3D const ring_pos =
           center_pos - bank_perpendicular * (bank_half_width + ring_dist);
@@ -908,7 +947,7 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
         QVector3D const next_ring_pos =
             center_pos - bank_perpendicular *
                              (bank_half_width +
-                              k_bank_rings[1].distance_from_water * base_bank_width);
+                              k_bank_rings[1].distance_from_water * left_bank_width);
         float const next_height = bank_surface_height(next_ring_pos, ring + 1);
         QVector3D const slope_vec(next_ring_pos.x() - ring_pos.x(),
                                   next_height - ring_height_y,
@@ -932,7 +971,7 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
             center_pos -
             bank_perpendicular *
                 (bank_half_width +
-                 k_bank_rings[ring + 1].distance_from_water * base_bank_width);
+                 k_bank_rings[ring + 1].distance_from_water * left_bank_width);
         float const next_height = bank_surface_height(next_ring_pos, ring + 1);
 
         QVector3D const slope_from_prev(ring_pos.x() - prev_pos.x(),
@@ -952,13 +991,13 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
       vtx.normal[0] = normal.x();
       vtx.normal[1] = normal.y();
       vtx.normal[2] = normal.z();
-      vtx.tex_coord[0] = static_cast<float>(ring) / (k_rings_per_side - 1);
+      vtx.tex_coord[0] = k_bank_rings[ring].distance_from_water;
       vtx.tex_coord[1] = t;
       vertices.push_back(vtx);
     }
 
     for (int ring = 0; ring < k_rings_per_side; ++ring) {
-      float const ring_dist = k_bank_rings[ring].distance_from_water * base_bank_width;
+      float const ring_dist = k_bank_rings[ring].distance_from_water * right_bank_width;
 
       QVector3D const ring_pos =
           center_pos + bank_perpendicular * (bank_half_width + ring_dist);
@@ -978,7 +1017,7 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
         QVector3D const next_ring_pos =
             center_pos + bank_perpendicular *
                              (bank_half_width +
-                              k_bank_rings[1].distance_from_water * base_bank_width);
+                              k_bank_rings[1].distance_from_water * right_bank_width);
         float const next_height = bank_surface_height(next_ring_pos, ring + 1);
         QVector3D const slope_vec(next_ring_pos.x() - ring_pos.x(),
                                   next_height - ring_height_y,
@@ -1002,7 +1041,7 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
             center_pos +
             bank_perpendicular *
                 (bank_half_width +
-                 k_bank_rings[ring + 1].distance_from_water * base_bank_width);
+                 k_bank_rings[ring + 1].distance_from_water * right_bank_width);
         float const next_height = bank_surface_height(next_ring_pos, ring + 1);
 
         QVector3D const slope_from_prev(ring_pos.x() - prev_pos.x(),
@@ -1022,7 +1061,7 @@ auto build_riverbank_mesh(const std::vector<Game::Map::RiverSegment>& river_netw
       vtx.normal[0] = normal.x();
       vtx.normal[1] = normal.y();
       vtx.normal[2] = normal.z();
-      vtx.tex_coord[0] = static_cast<float>(ring) / (k_rings_per_side - 1);
+      vtx.tex_coord[0] = k_bank_rings[ring].distance_from_water;
       vtx.tex_coord[1] = t;
       vertices.push_back(vtx);
     }
@@ -1318,12 +1357,25 @@ auto build_lake_shore_mesh(const Game::Map::Lake& lake,
       const float angle =
           two_pi * static_cast<float>(segment) / static_cast<float>(angular_segments);
       const float boundary = Game::Map::lake_boundary_scale(lake, angle);
+
+      const float edge_local_x =
+          std::cos(angle) * (half_width * boundary + water_render_margin);
+      const float edge_local_z =
+          std::sin(angle) * (half_depth * boundary + water_render_margin);
+      const float edge_world_x =
+          lake.center.x() + edge_local_x * cos_rotation - edge_local_z * sin_rotation;
+      const float edge_world_z =
+          lake.center.z() + edge_local_x * sin_rotation + edge_local_z * cos_rotation;
+      const float local_shore_width =
+          shore_width *
+          (0.55F + 0.95F * value_noise(edge_world_x * 0.18F, edge_world_z * 0.18F));
+
       const float local_x =
           std::cos(angle) *
-          (half_width * boundary + water_render_margin + shore_width * shore_t);
+          (half_width * boundary + water_render_margin + local_shore_width * shore_t);
       const float local_z =
           std::sin(angle) *
-          (half_depth * boundary + water_render_margin + shore_width * shore_t);
+          (half_depth * boundary + water_render_margin + local_shore_width * shore_t);
       const float rotated_x = local_x * cos_rotation - local_z * sin_rotation;
       const float rotated_z = local_x * sin_rotation + local_z * cos_rotation;
       const float world_x = lake.center.x() + rotated_x;
@@ -1339,10 +1391,10 @@ auto build_lake_shore_mesh(const Game::Map::Lake& lake,
       vertex.position = {world_x, shore_height, world_z};
       QVector3D outward(rotated_x, 0.0F, rotated_z);
       outward.normalize();
-      const float radial_slope =
-          std::clamp((terrain_y + 0.060F - water_edge_y) / std::max(shore_width, 0.01F),
-                     -0.65F,
-                     0.65F);
+      const float radial_slope = std::clamp((terrain_y + 0.060F - water_edge_y) /
+                                                std::max(local_shore_width, 0.01F),
+                                            -0.65F,
+                                            0.65F);
       const QVector3D bank_normal =
           QVector3D(-outward.x() * radial_slope, 1.0F, -outward.z() * radial_slope)
               .normalized();

--- a/render/ground/riverbank_renderer.cpp
+++ b/render/ground/riverbank_renderer.cpp
@@ -229,6 +229,7 @@ void ShorelineRenderer::submit(Renderer& renderer, ResourceManager* resources) {
     cmd.biome_moisture = climate.moisture_level;
     cmd.biome_rock_exposure = climate.rock_exposure;
     cmd.biome_snow_coverage = climate.snow_coverage;
+    cmd.ambient_boost = surface.terrain_ambient_boost * 0.95F;
     cmd.alpha = segment_visibility;
     cmd.visibility = visibility_resources;
     renderer.terrain_feature(cmd);

--- a/tests/render/linear_feature_geometry_test.cpp
+++ b/tests/render/linear_feature_geometry_test.cpp
@@ -310,11 +310,13 @@ TEST(LinearFeatureGeometryTest, BuildsRiverbankMeshWithVisibilitySamples) {
                        });
   ASSERT_NE(widest_vertex, result.mesh->get_vertices().end());
 
-  EXPECT_LT(std::abs(widest_vertex->position[2]), 2.25F);
-  ASSERT_GE(result.mesh->get_vertices().size(), 10U);
+  EXPECT_LT(std::abs(widest_vertex->position[2]), 2.75F);
+  ASSERT_GE(result.mesh->get_vertices().size(), 14U);
 
-  EXPECT_LT(result.mesh->get_vertices()[4].position[1], 0.0F);
-  EXPECT_LT(result.mesh->get_vertices()[9].position[1], 0.0F);
+  EXPECT_LT(result.mesh->get_vertices()[0].position[1], 0.0F);
+  EXPECT_LT(result.mesh->get_vertices()[7].position[1], 0.0F);
+  EXPECT_NEAR(result.mesh->get_vertices()[6].position[1], 0.025F, 0.001F);
+  EXPECT_NEAR(result.mesh->get_vertices()[13].position[1], 0.025F, 0.001F);
   EXPECT_TRUE(std::all_of(result.mesh->get_vertices().begin(),
                           result.mesh->get_vertices().end(),
                           [](const auto& vertex) { return vertex.normal[1] > 0.0F; }));
@@ -349,10 +351,12 @@ TEST(LinearFeatureGeometryTest, JoinsRiverbankStripsAtWaypointBends) {
 
   ASSERT_NE(first.mesh, nullptr);
   ASSERT_NE(second.mesh, nullptr);
-  ASSERT_GE(first.mesh->get_vertices().size(), 10U);
-  ASSERT_GE(second.mesh->get_vertices().size(), 10U);
-  const std::size_t first_last_row = first.mesh->get_vertices().size() - 10U;
-  for (std::size_t ring = 0; ring < 10U; ++ring) {
+  constexpr std::size_t k_bank_row_vertices = 14U;
+  ASSERT_GE(first.mesh->get_vertices().size(), k_bank_row_vertices);
+  ASSERT_GE(second.mesh->get_vertices().size(), k_bank_row_vertices);
+  const std::size_t first_last_row =
+      first.mesh->get_vertices().size() - k_bank_row_vertices;
+  for (std::size_t ring = 0; ring < k_bank_row_vertices; ++ring) {
     const auto& before = first.mesh->get_vertices()[first_last_row + ring];
     const auto& after = second.mesh->get_vertices()[ring];
     EXPECT_NEAR(before.position[0], after.position[0], 0.001F);

--- a/tests/render/shader_source_test.cpp
+++ b/tests/render/shader_source_test.cpp
@@ -169,5 +169,21 @@ TEST(ShaderSource, TerrainGroundUsesCoherentBiomeMaterialPatches) {
   EXPECT_NE(flat.find("float thatch_field = clamp("), std::string::npos);
   EXPECT_NE(flat.find("float lush_patch = smoothstep("), std::string::npos);
   EXPECT_NE(flat.find("float soil_mix = bare_patch * 0.52;"), std::string::npos);
-  EXPECT_NE(flat.find("0.055 * soil_mix"), std::string::npos);
+  EXPECT_NE(flat.find("0.090 * soil_mix"), std::string::npos);
+}
+
+TEST(ShaderSource, TerrainGroundShadesFromInterpolatedNormals) {
+  const auto root = find_repo_root();
+  const auto frag = read_text(root / "assets" / "shaders" / "terrain_chunk.frag");
+  ASSERT_FALSE(frag.empty());
+  const auto flat = collapse_whitespace(frag);
+
+  EXPECT_NE(flat.find("vec3 smooth_normal = normalize(v_normal);"), std::string::npos);
+  EXPECT_NE(flat.find("mix(smooth_normal, facet_normal, facet_weight)"),
+            std::string::npos);
+
+  EXPECT_NE(flat.find("curvature_from_normal_field(smooth_normal)"), std::string::npos);
+
+  EXPECT_NE(flat.find("float band_limit("), std::string::npos);
+  EXPECT_NE(flat.find("relief_octave("), std::string::npos);
 }


### PR DESCRIPTION
Terrain surface (terrain_chunk.frag):

- Shade from the interpolated vertex normals. The mesh builder already computes edge-preserving filtered normals from the heightfield, but the fragment shader threw them away for a per-triangle dFdx/dFdy normal, so every hill and mountain rendered flat-shaded. The derivative normal now only survives as a small correction where it genuinely disagrees.

- Give compute_curvature a normal-field path. No height texture is ever bound for chunk rendering, so curvature was always 0 and the ridge, gully, and ambient-occlusion response were dead code regardless of the per-biome weights feeding them.

- Band limit the high-frequency layers against their own screen footprint, and build the relief normal from three independently faded octaves so distance costs detail gradually instead of collapsing the surface flat. Relief that has shrunk below a pixel folds back in as occlusion.

- Project rock detail triplanar-style on steep slopes. The XZ projection smeared cliff faces into vertical streaks.

- Replace the crack pattern with warped cellular veins. Thresholded value noise on a world-aligned grid produced a visible checkerboard.

- Split lighting into a hemispheric sky/bounce ambient plus a tinted sun term, and add lichen and scrub in fractures and on rock shelves.

Riverbanks:

- Widen the bank profile from a fixed 0.5 m apron to one that scales with the channel, and reshape it into seven rings: submerged toe, silt shelf, damp beach, dry bar, levee crest, back slope, and a ring that lands on the terrain. Against an 11 m river the old apron read as a painted edge, and its outermost ring sat below the terrain, so most of the strip was buried and the shader's whole shore gradient was invisible.

- Stop clipping a bank against its own watercourse. Rivers arrive split into one segment per authored waypoint, so every segment overlapped its neighbour's channel and lost its bank around each waypoint, leaving the shore dashed.

- Pass ambient_boost through to the riverbank pass. Banks were lit at full exposure while the terrain they merge into was scaled, which rimmed every shore in bright grass.

- Dissolve the outer rings over the terrain rather than ending on a hard line, since the bank pass cannot colour-match the terrain pass exactly.

- Vary lake shore depth around the perimeter instead of tracing a constant-width stroke, and sort the bank sediment lighter.

- Halve the river bank width. Scaling the apron to the channel overshot: against the wider campaign rivers it read as a broad beach rather than a shore. Lake shore width is unchanged.

- Reduce relief strength and add broad hue drifts (cropped ground yellowing, sheltered growth deepening) so the field varies at pasture scale instead of pixel scale.

Verified against the arena campaign terrain review across all eight mission maps and the water_showcase scenario.