### PR TITLE
Complete Linux desktop launcher metadata

### DIFF
--- a/dist/linux/standard_of_iron.desktop
+++ b/dist/linux/standard_of_iron.desktop
@@ -1,6 +1,10 @@
 [Desktop Entry]
 Type=Application
 Name=Standard of Iron
+GenericName=Real-Time Strategy Game
+Comment=Historical real-time strategy game set during the Punic Wars
 Exec=standard_of_iron
 Icon=standard_of_iron
-Categories=Game;
+Terminal=false
+Categories=Game;StrategyGame;
+Keywords=RTS;Strategy;Rome;Carthage;Punic Wars;


### PR DESCRIPTION
Add Comment, GenericName, Terminal, expanded Categories, and Keywords to the Linux .desktop launcher so the game integrates better with desktop environment menus and search. StartupWMClass is intentionally omitted: the app never calls QGuiApplication::setDesktopFileName() or setApplicationName(), so no explicit WM_CLASS value can be verified from the source.

Closes #1086