### PR TITLE
feat: async save system with binary format, autosave, and export/import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,7 @@ if(QT_VERSION_MAJOR EQUAL 6)
             ui/qml/ProductionPanel.qml
             ui/qml/SaveGamePanel.qml
             ui/qml/LoadGamePanel.qml
+            ui/qml/SaveProgressOverlay.qml
             ui/qml/ObjectivesPanel.qml
             ui/qml/SettingsPanel.qml
             ui/qml/HUDVictory.qml

--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -8,6 +8,7 @@
 #include <QElapsedTimer>
 #include <QEventLoop>
 #include <QFile>
+#include <QFileInfo>
 #include <QImage>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -165,6 +166,7 @@
 #include "save_load_coordinator.h"
 #include "selection_query_service.h"
 #include "skirmish_runtime_coordinator.h"
+#include "user_settings.h"
 #include "utils/resource_utils.h"
 #include "visibility_coordinator.h"
 
@@ -263,6 +265,7 @@ auto build_player_state_map(int owner_id, int population_cap) -> QVariantMap {
 
 GameEngine::GameEngine(QObject* parent)
     : QObject(parent)
+    , m_save_load_service(Game::Systems::SaveLoadService::instance())
     , m_commander_input(this, this)
     , m_selected_units_model(new SelectedUnitsModel(this, this)) {
 
@@ -291,7 +294,8 @@ GameEngine::GameEngine(QObject* parent)
 
   m_picking_service = std::make_unique<Game::Systems::PickingService>();
   m_victory_service = std::make_unique<Game::Systems::VictoryService>();
-  m_save_load_service = std::make_unique<Game::Systems::SaveLoadService>();
+
+  connect_save_service_signals();
   m_camera_service = std::make_unique<Game::Systems::CameraService>();
   m_rain_manager = std::make_unique<Game::Systems::RainManager>();
 
@@ -582,6 +586,14 @@ GameEngine::GameEngine(QObject* parent)
 }
 
 GameEngine::~GameEngine() {
+
+  m_autosave_timer.stop();
+  if (m_save_load_service != nullptr) {
+
+    m_save_load_service->wait_for_pending_saves();
+    m_save_load_service->disconnect(this);
+    m_save_load_service->shutdown();
+  }
 
   if (m_audio_event_handler) {
     m_audio_event_handler->shutdown();
@@ -2713,7 +2725,7 @@ auto GameEngine::available_campaigns() const -> QVariantList {
 }
 
 void GameEngine::load_campaigns() {
-  if (!m_save_load_service) {
+  if (m_save_load_service == nullptr) {
     return;
   }
 
@@ -2762,7 +2774,7 @@ void GameEngine::mark_current_mission_completed() {
     return;
   }
 
-  if (!m_save_load_service) {
+  if (m_save_load_service == nullptr) {
     qWarning() << "Save/Load service not initialized";
     return;
   }
@@ -3125,22 +3137,79 @@ void GameEngine::apply_skirmish_commander_setup(const QVariantList& player_confi
 }
 
 void GameEngine::open_settings() {
-  if (m_save_load_service) {
-    m_save_load_service->open_settings();
+  if (m_save_load_service != nullptr) {
+    Game::Systems::SaveLoadService::open_settings();
   }
 }
 
-void GameEngine::load_save() {
-  load_game_from_slot("savegame");
+void GameEngine::connect_save_service_signals() {
+  if (m_save_load_service == nullptr) {
+    return;
+  }
+
+  connect(
+      m_save_load_service,
+      &Game::Systems::SaveLoadService::save_progress,
+      this,
+      [this](
+          quint64 job_id, const QString& slot_name, int percent, const QString& stage) {
+        if (job_id != m_active_save_job) {
+          return;
+        }
+        m_save_progress_slot = slot_name;
+        m_save_progress_percent = percent;
+        m_save_progress_stage = stage;
+        emit save_progress_changed();
+      });
+
+  connect(m_save_load_service,
+          &Game::Systems::SaveLoadService::save_finished,
+          this,
+          [this](quint64 job_id,
+                 const QString& slot_name,
+                 bool success,
+                 const QString& error) {
+            if (job_id == m_active_save_job) {
+              m_active_save_job = 0;
+              m_save_progress_percent = success ? 100 : 0;
+              m_save_progress_stage.clear();
+              emit save_progress_changed();
+            }
+            if (!success) {
+              set_error(error);
+            }
+            emit save_completed(slot_name, success, error);
+          });
+
+  connect(m_save_load_service,
+          &Game::Systems::SaveLoadService::save_slots_changed,
+          this,
+          &GameEngine::save_slots_changed);
+
+  connect(&m_autosave_timer, &QTimer::timeout, this, &GameEngine::autosave);
+  restart_autosave_timer();
 }
 
-void GameEngine::save_game(const QString& filename) {
-  save_game_to_slot(filename);
+void GameEngine::restart_autosave_timer() {
+  const int minutes = autosave_interval_minutes();
+  if (minutes <= 0) {
+    m_autosave_timer.stop();
+    return;
+  }
+  m_autosave_timer.setInterval(minutes * 60 * 1000);
+  m_autosave_timer.start();
 }
 
-void GameEngine::save_game_to_slot(const QString& slot_name) {
-  if (!m_save_load_service || !m_world) {
-    set_error("Save: not initialized");
+void GameEngine::begin_save(const QString& slot_name,
+                            Game::Systems::Save::SlotKind kind,
+                            int autosave_retention) {
+  if ((m_save_load_service == nullptr) || !m_world) {
+    set_error(tr("Save: not initialized"));
+    return;
+  }
+
+  if (m_active_save_job != 0) {
+    set_error(tr("A save is already in progress"));
     return;
   }
 
@@ -3148,34 +3217,101 @@ void GameEngine::save_game_to_slot(const QString& slot_name) {
     request_exit_commander_control_mode();
   }
   const Game::Systems::RuntimeSnapshot runtime_snapshot = to_runtime_snapshot();
-  const QByteArray screenshot = capture_screenshot();
   std::optional<Game::Mission::MissionContext> mission_context;
   if (m_campaign_manager) {
     mission_context = m_campaign_manager->current_mission_context();
   }
 
-  const App::Core::SaveToSlotEffects effects = m_save_load_coordinator->save_to_slot(
-      {.world = *m_world,
-       .save_load_service = *m_save_load_service,
-       .camera = m_camera,
-       .level = m_level,
-       .runtime_snapshot = runtime_snapshot,
-       .slot = slot_name,
-       .title = slot_name,
-       .map_name = m_level.map_name,
-       .screenshot = screenshot,
-       .mission_context = std::move(mission_context)});
-  if (!effects.success) {
+  const App::Core::SaveToSlotEffects effects =
+      m_save_load_coordinator->begin_save_to_slot(
+          {.world = *m_world,
+           .save_load_service = *m_save_load_service,
+           .camera = m_camera,
+           .level = m_level,
+           .runtime_snapshot = runtime_snapshot,
+           .slot = slot_name,
+           .title = slot_name,
+           .map_name = m_level.map_name,
+           .mission_context = std::move(mission_context),
+           .kind = kind,
+           .play_time_seconds = m_campaign_mission_elapsed,
+           .autosave_retention = autosave_retention});
+  if (!effects.queued) {
     set_error(effects.error);
     return;
   }
-  if (effects.emit_save_slots_changed) {
-    emit save_slots_changed();
+
+  m_active_save_job = effects.job_id;
+  m_save_progress_slot = slot_name;
+  m_save_progress_percent = 0;
+  m_save_progress_stage = tr("Queued");
+  emit save_progress_changed();
+
+  m_screenshot_target_slot = slot_name;
+  m_screenshot_requested.store(true, std::memory_order_release);
+}
+
+void GameEngine::save_game_to_slot(const QString& slot_name) {
+  begin_save(slot_name, Game::Systems::Save::SlotKind::Manual, 0);
+}
+
+void GameEngine::quicksave() {
+  begin_save(QStringLiteral("quicksave"), Game::Systems::Save::SlotKind::Quicksave, 0);
+}
+
+void GameEngine::autosave() {
+
+  if ((m_save_load_service == nullptr) || !m_world || !m_runtime.initialized ||
+      m_runtime.loading || m_level.map_path.isEmpty() ||
+      !m_runtime.victory_state.isEmpty() || m_active_save_job != 0) {
+    return;
   }
+
+  const int retention = autosave_slot_count();
+  begin_save(m_save_load_service->next_autosave_slot(retention),
+             Game::Systems::Save::SlotKind::Autosave,
+             retention);
+}
+
+void GameEngine::cancel_active_save() {
+  if (m_active_save_job == 0 || (m_save_load_service == nullptr)) {
+    return;
+  }
+  m_save_load_service->cancel_save(m_active_save_job);
+  m_save_progress_stage = tr("Cancelling...");
+  emit save_progress_changed();
+}
+
+auto GameEngine::autosave_slot_count() const -> int {
+  return App::Core::UserSettings::load_autosave_slot_count();
+}
+
+void GameEngine::set_autosave_slot_count(int count) {
+  if (count == autosave_slot_count()) {
+    return;
+  }
+  App::Core::UserSettings::save_autosave_slot_count(count);
+  if (m_save_load_service != nullptr) {
+    m_save_load_service->prune_autosaves(autosave_slot_count());
+  }
+  emit autosave_settings_changed();
+}
+
+auto GameEngine::autosave_interval_minutes() const -> int {
+  return App::Core::UserSettings::load_autosave_interval_minutes();
+}
+
+void GameEngine::set_autosave_interval_minutes(int minutes) {
+  if (minutes == autosave_interval_minutes()) {
+    return;
+  }
+  App::Core::UserSettings::save_autosave_interval_minutes(minutes);
+  restart_autosave_timer();
+  emit autosave_settings_changed();
 }
 
 void GameEngine::load_game_from_slot(const QString& slot_name) {
-  if (!m_save_load_service || !m_world) {
+  if ((m_save_load_service == nullptr) || !m_world) {
     set_error("Load: not initialized");
     return;
   }
@@ -3246,7 +3382,7 @@ void GameEngine::load_game_from_slot(const QString& slot_name) {
 }
 
 auto GameEngine::get_save_slots() const -> QVariantList {
-  if (!m_save_load_service) {
+  if (m_save_load_service == nullptr) {
     qWarning() << "Cannot get save slots: service not initialized";
     return {};
   }
@@ -3259,7 +3395,7 @@ void GameEngine::refresh_save_slots() {
 }
 
 auto GameEngine::delete_save_slot(const QString& slot_name) -> bool {
-  if (!m_save_load_service) {
+  if (m_save_load_service == nullptr) {
     qWarning() << "Cannot delete save slot: service not initialized";
     return false;
   }
@@ -3270,11 +3406,80 @@ auto GameEngine::delete_save_slot(const QString& slot_name) -> bool {
     QString const error = m_save_load_service->get_last_error();
     qWarning() << "Failed to delete save slot:" << error;
     set_error(error);
-  } else {
-    emit save_slots_changed();
   }
 
   return success;
+}
+
+auto GameEngine::has_save_slot(const QString& slot_name) const -> bool {
+  return m_save_load_service != nullptr && m_save_load_service->slot_exists(slot_name);
+}
+
+auto GameEngine::verify_save_slot(const QString& slot_name) -> bool {
+  if (m_save_load_service == nullptr) {
+    return false;
+  }
+
+  QString error;
+  if (!m_save_load_service->verify_save_slot(slot_name, &error)) {
+    set_error(error);
+    return false;
+  }
+  return true;
+}
+
+auto GameEngine::export_save_slot(const QString& slot_name) -> QString {
+  if (m_save_load_service == nullptr) {
+    return {};
+  }
+
+  const QString file_stem = Game::Systems::Save::sanitize_file_stem(slot_name);
+  if (file_stem.isEmpty()) {
+    set_error(tr("Cannot export a save with an empty name"));
+    return {};
+  }
+
+  const QString file_path =
+      QStringLiteral("%1/%2.%3")
+          .arg(Game::Systems::SaveLoadService::exports_directory(),
+               file_stem,
+               Game::Systems::Save::package_file_suffix());
+
+  QString error;
+  if (!m_save_load_service->export_slot(slot_name, file_path, &error)) {
+    set_error(error);
+    return {};
+  }
+  return file_path;
+}
+
+auto GameEngine::list_exported_saves() const -> QVariantList {
+  QVariantList result;
+  if (m_save_load_service == nullptr) {
+    return result;
+  }
+
+  for (const QString& path : m_save_load_service->list_exported_packages()) {
+    QVariantMap entry;
+    entry.insert(QStringLiteral("path"), path);
+    entry.insert(QStringLiteral("name"), QFileInfo(path).completeBaseName());
+    result.append(entry);
+  }
+  return result;
+}
+
+auto GameEngine::import_save_file(const QString& file_path) -> QString {
+  if (m_save_load_service == nullptr) {
+    return {};
+  }
+
+  QString slot_name;
+  QString error;
+  if (!m_save_load_service->import_package(file_path, slot_name, &error)) {
+    set_error(error);
+    return {};
+  }
+  return slot_name;
 }
 
 auto GameEngine::to_runtime_snapshot() const -> Game::Systems::RuntimeSnapshot {
@@ -3334,13 +3539,38 @@ void GameEngine::sync_scatter_world_props() {
   m_last_world_props_revision = revision;
 }
 
-auto GameEngine::capture_screenshot() const -> QByteArray {
-  return {};
+auto GameEngine::consume_screenshot_request() -> bool {
+  return m_screenshot_requested.exchange(false, std::memory_order_acq_rel);
+}
+
+void GameEngine::submit_frame_image(const QImage& image) {
+  if (image.isNull()) {
+    return;
+  }
+
+  QMetaObject::invokeMethod(
+      this, [this, image]() { on_frame_image_captured(image); }, Qt::QueuedConnection);
+}
+
+void GameEngine::on_frame_image_captured(const QImage& image) {
+  const QString slot_name = m_screenshot_target_slot;
+  m_screenshot_target_slot.clear();
+  if (slot_name.isEmpty() || (m_save_load_service == nullptr) || image.isNull()) {
+    return;
+  }
+
+  const QByteArray png = Game::Systems::Save::encode_preview(image);
+  if (png.isEmpty()) {
+    qWarning() << "GameEngine: failed to encode save preview for" << slot_name;
+    return;
+  }
+
+  m_save_load_service->attach_screenshot(slot_name, png);
 }
 
 void GameEngine::exit_game() {
-  if (m_save_load_service) {
-    m_save_load_service->exit_game();
+  if (m_save_load_service != nullptr) {
+    Game::Systems::SaveLoadService::exit_game();
   }
 }
 

--- a/app/core/game_engine.h
+++ b/app/core/game_engine.h
@@ -8,6 +8,7 @@
 #include <QPoint>
 #include <QPointF>
 #include <QStringList>
+#include <QTimer>
 #include <QVariant>
 #include <QVector3D>
 
@@ -35,6 +36,7 @@
 #include "game/core/event_manager.h"
 #include "game/map/mission_definition.h"
 #include "game/systems/game_state_serializer.h"
+#include "game/systems/save_format.h"
 #include "input_command_handler.h"
 #include "minimap_manager.h"
 #include "mission_setup_coordinator.h"
@@ -181,6 +183,17 @@ public:
   Q_PROPERTY(bool commander_control_available READ commander_control_available NOTIFY
                  commander_control_available_changed)
   Q_PROPERTY(QObject* commander_input READ commander_input CONSTANT)
+  Q_PROPERTY(bool save_in_progress READ save_in_progress NOTIFY save_progress_changed)
+  Q_PROPERTY(
+      int save_progress_percent READ save_progress_percent NOTIFY save_progress_changed)
+  Q_PROPERTY(
+      QString save_progress_stage READ save_progress_stage NOTIFY save_progress_changed)
+  Q_PROPERTY(
+      QString save_progress_slot READ save_progress_slot NOTIFY save_progress_changed)
+  Q_PROPERTY(int autosave_slot_count READ autosave_slot_count WRITE
+                 set_autosave_slot_count NOTIFY autosave_settings_changed)
+  Q_PROPERTY(int autosave_interval_minutes READ autosave_interval_minutes WRITE
+                 set_autosave_interval_minutes NOTIFY autosave_settings_changed)
 
   Q_INVOKABLE void on_map_clicked(qreal sx, qreal sy);
   Q_INVOKABLE void on_right_click(qreal sx, qreal sy);
@@ -351,13 +364,28 @@ public:
   Q_INVOKABLE [[nodiscard]] QVariantMap
   get_mission_definition(const QString& mission_id) const;
   Q_INVOKABLE void open_settings();
-  Q_INVOKABLE void load_save();
-  Q_INVOKABLE void save_game(const QString& filename = "savegame.json");
   Q_INVOKABLE void save_game_to_slot(const QString& slot_name);
+  Q_INVOKABLE void quicksave();
+  Q_INVOKABLE void autosave();
+  Q_INVOKABLE void cancel_active_save();
   Q_INVOKABLE void load_game_from_slot(const QString& slot_name);
   Q_INVOKABLE [[nodiscard]] QVariantList get_save_slots() const;
   Q_INVOKABLE void refresh_save_slots();
   Q_INVOKABLE bool delete_save_slot(const QString& slot_name);
+  Q_INVOKABLE [[nodiscard]] bool has_save_slot(const QString& slot_name) const;
+  Q_INVOKABLE [[nodiscard]] bool verify_save_slot(const QString& slot_name);
+  Q_INVOKABLE [[nodiscard]] QString export_save_slot(const QString& slot_name);
+  Q_INVOKABLE [[nodiscard]] QVariantList list_exported_saves() const;
+  Q_INVOKABLE [[nodiscard]] QString import_save_file(const QString& file_path);
+
+  [[nodiscard]] bool save_in_progress() const { return m_active_save_job != 0; }
+  [[nodiscard]] int save_progress_percent() const { return m_save_progress_percent; }
+  [[nodiscard]] QString save_progress_stage() const { return m_save_progress_stage; }
+  [[nodiscard]] QString save_progress_slot() const { return m_save_progress_slot; }
+  [[nodiscard]] int autosave_slot_count() const;
+  void set_autosave_slot_count(int count);
+  [[nodiscard]] int autosave_interval_minutes() const;
+  void set_autosave_interval_minutes(int minutes);
   Q_INVOKABLE void exit_game();
   Q_INVOKABLE [[nodiscard]] QVariantList get_owner_info() const;
   Q_INVOKABLE [[nodiscard]] QImage
@@ -387,6 +415,9 @@ public:
   QObject* audio_system();
 
   void setWindow(QQuickWindow* w) { m_window = w; }
+
+  [[nodiscard]] bool consume_screenshot_request();
+  void submit_frame_image(const QImage& image);
 
   void ensure_initialized();
   [[nodiscard]] bool renderer_initialized() const { return m_runtime.initialized; }
@@ -504,7 +535,6 @@ private:
   void set_error(const QString& error_message);
   [[nodiscard]] Game::Systems::RuntimeSnapshot to_runtime_snapshot() const;
   void apply_runtime_snapshot(const Game::Systems::RuntimeSnapshot& snapshot);
-  [[nodiscard]] QByteArray capture_screenshot() const;
   [[nodiscard]] AppSceneContext scene_context() const;
   void start_skirmish_internal(const QString& map_path,
                                const QVariantList& player_configs,
@@ -520,6 +550,12 @@ private:
   void update_loading_overlay();
   void update_cursor_position();
   void restore_controlled_commander_direct_control_if_ready();
+  void on_frame_image_captured(const QImage& image);
+  void begin_save(const QString& slot_name,
+                  Game::Systems::Save::SlotKind kind,
+                  int autosave_retention);
+  void connect_save_service_signals();
+  void restart_autosave_timer();
   void seed_commander_rally_preview_from_view_center();
   void seed_barracks_rally_preview_from_selection();
 
@@ -540,7 +576,7 @@ private:
   std::unique_ptr<Game::Systems::RainManager> m_rain_manager;
   std::unique_ptr<Game::Systems::PickingService> m_picking_service;
   std::unique_ptr<Game::Systems::VictoryService> m_victory_service;
-  std::unique_ptr<Game::Systems::SaveLoadService> m_save_load_service;
+  Game::Systems::SaveLoadService* m_save_load_service = nullptr;
   std::unique_ptr<CursorManager> m_cursor_manager;
   std::unique_ptr<HoverTracker> m_hover_tracker;
   bool m_civilian_delivery_available = false;
@@ -593,6 +629,13 @@ private:
   QElapsedTimer m_loading_overlay_timer;
   bool m_finalize_progress_after_overlay = false;
   bool m_show_objectives_after_loading = false;
+  quint64 m_active_save_job = 0;
+  std::atomic_bool m_screenshot_requested{false};
+  QString m_screenshot_target_slot;
+  int m_save_progress_percent = 0;
+  QString m_save_progress_stage;
+  QString m_save_progress_slot;
+  QTimer m_autosave_timer;
   float m_campaign_mission_elapsed = 0.0F;
   std::vector<PendingMissionWave> m_pending_mission_waves;
   Engine::Core::ScopedEventSubscription<Engine::Core::UnitDiedEvent>
@@ -656,4 +699,7 @@ signals:
   void game_mode_changed();
   void commander_control_available_changed();
   void mission_announcement(QString text);
+  void save_progress_changed();
+  void save_completed(QString slot_name, bool success, QString error);
+  void autosave_settings_changed();
 };

--- a/app/core/save_load_coordinator.cpp
+++ b/app/core/save_load_coordinator.cpp
@@ -8,6 +8,7 @@
 #include "audio_coordinator.h"
 #include "audio_resource_loader.h"
 #include "campaign_manager.h"
+#include "game/core/serialization.h"
 #include "game/core/world.h"
 #include "game/map/map_loader.h"
 #include "game/map/map_transformer.h"
@@ -24,30 +25,17 @@ namespace App::Core {
 
 namespace {
 
-void append_mission_metadata(
-    QJsonObject& metadata,
-    const std::optional<Game::Mission::MissionContext>& mission_context) {
-  if (!mission_context.has_value()) {
-    return;
-  }
-
-  metadata["mission_mode"] = mission_context->mode;
-  metadata["mission_campaign_id"] = mission_context->campaign_id;
-  metadata["mission_id"] = mission_context->mission_id;
-  metadata["mission_difficulty"] = mission_context->difficulty;
-}
-
-void restore_mission_context(const QJsonObject& metadata,
+void restore_mission_context(const Game::Systems::Save::Record& record,
                              CampaignManager* campaign_manager) {
-  if (campaign_manager == nullptr || !metadata.contains("mission_mode")) {
+  if (campaign_manager == nullptr || record.mode.isEmpty()) {
     return;
   }
 
   Game::Mission::MissionContext mission_context;
-  mission_context.mode = metadata["mission_mode"].toString();
-  mission_context.campaign_id = metadata["mission_campaign_id"].toString();
-  mission_context.mission_id = metadata["mission_id"].toString();
-  mission_context.difficulty = metadata["mission_difficulty"].toString();
+  mission_context.mode = record.mode;
+  mission_context.campaign_id = record.campaign_id;
+  mission_context.mission_id = record.mission_id;
+  mission_context.difficulty = record.difficulty;
   campaign_manager->set_mission_context(mission_context);
 }
 
@@ -81,7 +69,7 @@ void SaveLoadCoordinator::apply_runtime_snapshot(
   context.cursor_mode = static_cast<CursorMode>(snapshot.cursor_mode);
 }
 
-auto SaveLoadCoordinator::save_to_slot(const SaveToSlotContext& context) const
+auto SaveLoadCoordinator::begin_save_to_slot(const SaveToSlotContext& context) const
     -> SaveToSlotEffects {
   QJsonObject metadata = Game::Systems::GameStateSerializer::build_metadata(
       context.world, context.camera, context.level, context.runtime_snapshot);
@@ -91,18 +79,34 @@ auto SaveLoadCoordinator::save_to_slot(const SaveToSlotContext& context) const
     metadata["undead_zones"] = undead_system->serialize_state();
   }
 
-  append_mission_metadata(metadata, context.mission_context);
+  Game::Systems::SaveRequest request;
+  request.slot_name = context.slot;
+  request.title = context.title;
+  request.map_name =
+      context.map_name.isEmpty() ? QStringLiteral("Unknown Map") : context.map_name;
+  request.map_path = context.level.map_path;
+  if (context.mission_context.has_value()) {
+    request.mode = context.mission_context->mode;
+    request.campaign_id = context.mission_context->campaign_id;
+    request.mission_id = context.mission_context->mission_id;
+    request.difficulty = context.mission_context->difficulty;
+  }
+  if (request.mode.isEmpty()) {
+    request.mode = QStringLiteral("skirmish");
+  }
+  request.kind = context.kind;
+  request.play_time_seconds = context.play_time_seconds;
+  request.metadata = metadata;
+  request.autosave_retention = context.autosave_retention;
 
-  if (!context.save_load_service.save_game_to_slot(context.world,
-                                                   context.slot,
-                                                   context.title,
-                                                   context.map_name,
-                                                   metadata,
-                                                   context.screenshot)) {
+  request.world = Engine::Core::Serialization::serialize_world(&context.world);
+
+  const quint64 job_id = context.save_load_service.begin_save(request);
+  if (job_id == 0) {
     return {.error = context.save_load_service.get_last_error()};
   }
 
-  return {.success = true, .emit_save_slots_changed = true};
+  return {.queued = true, .job_id = job_id};
 }
 
 auto SaveLoadCoordinator::load_from_slot(const LoadFromSlotContext& context) const
@@ -111,9 +115,12 @@ auto SaveLoadCoordinator::load_from_slot(const LoadFromSlotContext& context) con
     return {.error = context.save_load_service.get_last_error()};
   }
 
-  const QJsonObject metadata = context.save_load_service.get_last_metadata();
-  restore_mission_context(metadata, context.campaign_manager);
+  const Game::Systems::Save::Record& record =
+      context.save_load_service.get_last_record();
+  const QJsonObject metadata = record.metadata;
+  restore_mission_context(record, context.campaign_manager);
 
+  Game::Systems::GameStateSerializer::restore_player_nations_from_metadata(metadata);
   Game::Systems::GameStateSerializer::restore_level_from_metadata(metadata,
                                                                   context.level);
   Game::Systems::GameStateSerializer::restore_camera_from_metadata(

--- a/app/core/save_load_coordinator.h
+++ b/app/core/save_load_coordinator.h
@@ -11,6 +11,7 @@
 #include "entity_cache.h"
 #include "game/map/mission_context.h"
 #include "game/systems/game_state_serializer.h"
+#include "game/systems/save_format.h"
 
 class AudioCoordinator;
 class CampaignManager;
@@ -59,13 +60,15 @@ struct SaveToSlotContext {
   QString slot;
   QString title;
   QString map_name;
-  const QByteArray& screenshot;
   std::optional<Game::Mission::MissionContext> mission_context;
+  Game::Systems::Save::SlotKind kind = Game::Systems::Save::SlotKind::Manual;
+  double play_time_seconds = 0.0;
+  int autosave_retention = 0;
 };
 
 struct SaveToSlotEffects {
-  bool success = false;
-  bool emit_save_slots_changed = false;
+  bool queued = false;
+  quint64 job_id = 0;
   QString error;
 };
 
@@ -103,7 +106,7 @@ public:
                               ApplyRuntimeContext context) const;
 
   [[nodiscard]] auto
-  save_to_slot(const SaveToSlotContext& context) const -> SaveToSlotEffects;
+  begin_save_to_slot(const SaveToSlotContext& context) const -> SaveToSlotEffects;
   [[nodiscard]] auto
   load_from_slot(const LoadFromSlotContext& context) const -> LoadFromSlotEffects;
 };

--- a/app/core/user_settings.h
+++ b/app/core/user_settings.h
@@ -22,6 +22,14 @@ inline constexpr char kSoundVolumeKey[] = "audio/sound_volume";
 inline constexpr char kMusicVolumeKey[] = "audio/music_volume";
 inline constexpr char kVoiceVolumeKey[] = "audio/voice_volume";
 inline constexpr char kAmbienceVolumeKey[] = "audio/ambience_volume";
+inline constexpr char kAutosaveSlotCountKey[] = "saves/autosave_slot_count";
+inline constexpr char kAutosaveIntervalKey[] = "saves/autosave_interval_minutes";
+
+inline constexpr int kDefaultAutosaveSlotCount = 3;
+inline constexpr int kMinAutosaveSlotCount = 1;
+inline constexpr int kMaxAutosaveSlotCount = 10;
+inline constexpr int kDefaultAutosaveIntervalMinutes = 5;
+inline constexpr int kMaxAutosaveIntervalMinutes = 60;
 
 struct AudioVolumes {
   float master{AudioConstants::DEFAULT_VOLUME};
@@ -175,6 +183,38 @@ inline void save_voice_volume(float volume) {
 
 inline void save_ambience_volume(float volume) {
   save_audio_volume(kAmbienceVolumeKey, volume, "ambience");
+}
+
+inline auto load_autosave_slot_count() -> int {
+  auto settings = open();
+  const int stored =
+      settings
+          .value(QString::fromLatin1(kAutosaveSlotCountKey), kDefaultAutosaveSlotCount)
+          .toInt();
+  return std::clamp(stored, kMinAutosaveSlotCount, kMaxAutosaveSlotCount);
+}
+
+inline void save_autosave_slot_count(int count) {
+  auto settings = open();
+  settings.setValue(QString::fromLatin1(kAutosaveSlotCountKey),
+                    std::clamp(count, kMinAutosaveSlotCount, kMaxAutosaveSlotCount));
+  settings.sync();
+}
+
+inline auto load_autosave_interval_minutes() -> int {
+  auto settings = open();
+  const int stored = settings
+                         .value(QString::fromLatin1(kAutosaveIntervalKey),
+                                kDefaultAutosaveIntervalMinutes)
+                         .toInt();
+  return std::clamp(stored, 0, kMaxAutosaveIntervalMinutes);
+}
+
+inline void save_autosave_interval_minutes(int minutes) {
+  auto settings = open();
+  settings.setValue(QString::fromLatin1(kAutosaveIntervalKey),
+                    std::clamp(minutes, 0, kMaxAutosaveIntervalMinutes));
+  settings.sync();
 }
 
 } // namespace App::Core::UserSettings

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(game_systems STATIC
     systems/global_stats_registry.cpp
     systems/victory_service.cpp
     systems/undead_awakening_system.cpp
+    systems/save_format.cpp
     systems/save_load_service.cpp
     systems/save_storage.cpp
     systems/game_state_serializer.cpp

--- a/game/systems/game_state_serializer.cpp
+++ b/game/systems/game_state_serializer.cpp
@@ -6,29 +6,17 @@
 #include <qvectornd.h>
 
 #include <algorithm>
+#include <utility>
+#include <vector>
 
 #include "app/utils/json_vec_utils.h"
 #include "game/game_config.h"
 #include "game/map/terrain_service.h"
+#include "game/systems/nation_id.h"
+#include "game/systems/nation_registry.h"
 #include "render/gl/camera.h"
 
 namespace Game::Systems {
-
-namespace {
-
-auto value_for_key(const QJsonObject& object,
-                   const char* key,
-                   const char* legacy_key = nullptr) -> QJsonValue {
-  if (object.contains(key)) {
-    return object.value(key);
-  }
-  if ((legacy_key != nullptr) && object.contains(legacy_key)) {
-    return object.value(legacy_key);
-  }
-  return {};
-}
-
-} // namespace
 
 auto GameStateSerializer::build_metadata(const Engine::Core::World&,
                                          const Render::GL::Camera* camera,
@@ -86,6 +74,16 @@ auto GameStateSerializer::build_metadata(const Engine::Core::World&,
   runtime_obj["resources_by_owner"] = resources_array;
   metadata["runtime"] = runtime_obj;
 
+  QJsonArray nations_array;
+  for (const auto& [player_id, nation_id] :
+       NationRegistry::instance().player_nation_assignments()) {
+    QJsonObject nation_obj;
+    nation_obj["owner_id"] = player_id;
+    nation_obj["nation"] = nation_id_to_qstring(nation_id);
+    nations_array.append(nation_obj);
+  }
+  metadata["player_nations"] = nations_array;
+
   return metadata;
 }
 
@@ -135,17 +133,13 @@ void GameStateSerializer::restore_runtime_from_metadata(const QJsonObject& metad
         runtime_obj.value("time_scale").toDouble(runtime.time_scale));
   }
 
-  if (const auto victory_state =
-          value_for_key(runtime_obj, "victory_state", "victoryState");
-      !victory_state.isUndefined()) {
-    runtime.victory_state = victory_state.toString(runtime.victory_state);
+  if (runtime_obj.contains("victory_state")) {
+    runtime.victory_state =
+        runtime_obj.value("victory_state").toString(runtime.victory_state);
   }
 
-  if (const auto cursor_value = value_for_key(runtime_obj, "cursor_mode", "cursorMode");
-      !cursor_value.isUndefined()) {
-    if (cursor_value.isDouble()) {
-      runtime.cursor_mode = cursor_value.toInt(0);
-    }
+  if (runtime_obj.contains("cursor_mode")) {
+    runtime.cursor_mode = runtime_obj.value("cursor_mode").toInt(runtime.cursor_mode);
   }
 
   if (metadata.contains("local_owner_id")) {
@@ -153,16 +147,14 @@ void GameStateSerializer::restore_runtime_from_metadata(const QJsonObject& metad
         metadata.value("local_owner_id").toInt(runtime.local_owner_id);
   }
 
-  if (const auto selected_player_id =
-          value_for_key(runtime_obj, "selected_player_id", "selectedPlayerId");
-      !selected_player_id.isUndefined()) {
-    runtime.selected_player_id = selected_player_id.toInt(runtime.selected_player_id);
+  if (runtime_obj.contains("selected_player_id")) {
+    runtime.selected_player_id =
+        runtime_obj.value("selected_player_id").toInt(runtime.selected_player_id);
   }
 
-  if (const auto follow_selection =
-          value_for_key(runtime_obj, "follow_selection", "followSelection");
-      !follow_selection.isUndefined()) {
-    runtime.follow_selection = follow_selection.toBool(runtime.follow_selection);
+  if (runtime_obj.contains("follow_selection")) {
+    runtime.follow_selection =
+        runtime_obj.value("follow_selection").toBool(runtime.follow_selection);
   }
 
   if (runtime_obj.contains("resources_by_owner")) {
@@ -183,18 +175,30 @@ void GameStateSerializer::restore_runtime_from_metadata(const QJsonObject& metad
       }
       runtime.resources_by_owner.push_back(row);
     }
-  } else if (runtime_obj.contains("wood_by_owner")) {
-    runtime.resources_by_owner.clear();
-    const auto wood_array = runtime_obj.value("wood_by_owner").toArray();
-    runtime.resources_by_owner.reserve(wood_array.size());
-    for (const auto& value : wood_array) {
-      const auto wood_obj = value.toObject();
-      OwnerResourceState row;
-      row.owner_id = wood_obj.value("owner_id").toInt(0);
-      row.amounts.set(ResourceType::Wood, wood_obj.value("wood").toInt(0));
-      runtime.resources_by_owner.push_back(row);
-    }
   }
+}
+
+void GameStateSerializer::restore_player_nations_from_metadata(
+    const QJsonObject& metadata) {
+  if (!metadata.contains("player_nations")) {
+    return;
+  }
+
+  std::vector<std::pair<int, NationID>> assignments;
+  const auto nations_array = metadata.value("player_nations").toArray();
+  assignments.reserve(nations_array.size());
+  for (const auto& value : nations_array) {
+    const auto nation_obj = value.toObject();
+    NationID nation_id{};
+    if (!try_parse_nation_id(nation_obj.value("nation").toString(), nation_id)) {
+      qWarning() << "Ignoring unknown nation in save:"
+                 << nation_obj.value("nation").toString();
+      continue;
+    }
+    assignments.emplace_back(nation_obj.value("owner_id").toInt(0), nation_id);
+  }
+
+  NationRegistry::instance().restore_player_nations(assignments);
 }
 
 void GameStateSerializer::restore_level_from_metadata(const QJsonObject& metadata,
@@ -213,14 +217,9 @@ void GameStateSerializer::restore_level_from_metadata(const QJsonObject& metadat
         metadata.value("player_unit_id").toVariant().toULongLong());
   }
 
-  auto max_troops_value = value_for_key(metadata, "max_troops_per_player");
-  if (max_troops_value.isUndefined()) {
-    max_troops_value =
-        value_for_key(metadata, "game_max_troops_per_player", "gameMaxTroopsPerPlayer");
-  }
-  int max_troops = max_troops_value.isUndefined()
-                       ? level.max_troops_per_player
-                       : max_troops_value.toInt(level.max_troops_per_player);
+  int max_troops = metadata.value("max_troops_per_player")
+                       .toInt(metadata.value("game_max_troops_per_player")
+                                  .toInt(level.max_troops_per_player));
   if (max_troops <= 0) {
     max_troops = Game::GameConfig::instance().get_max_troops_per_player();
   }

--- a/game/systems/game_state_serializer.h
+++ b/game/systems/game_state_serializer.h
@@ -68,6 +68,8 @@ public:
 
   static void restore_level_from_metadata(const QJsonObject& metadata,
                                           LevelSnapshot& level);
+
+  static void restore_player_nations_from_metadata(const QJsonObject& metadata);
 };
 
 } // namespace Game::Systems

--- a/game/systems/nation_registry.cpp
+++ b/game/systems/nation_registry.cpp
@@ -152,6 +152,25 @@ void NationRegistry::set_player_nation(int player_id, NationID nation_id) {
   m_player_nations[player_id] = nation_id;
 }
 
+auto NationRegistry::player_nation_assignments() const
+    -> std::vector<std::pair<int, NationID>> {
+  std::vector<std::pair<int, NationID>> assignments;
+  assignments.reserve(m_player_nations.size());
+  for (const auto& [player_id, nation_id] : m_player_nations) {
+    assignments.emplace_back(player_id, nation_id);
+  }
+  std::sort(assignments.begin(), assignments.end());
+  return assignments;
+}
+
+void NationRegistry::restore_player_nations(
+    const std::vector<std::pair<int, NationID>>& assignments) {
+  m_player_nations.clear();
+  for (const auto& [player_id, nation_id] : assignments) {
+    m_player_nations[player_id] = nation_id;
+  }
+}
+
 void NationRegistry::initialize_defaults() {
   if (m_initialized) {
     return;

--- a/game/systems/nation_registry.h
+++ b/game/systems/nation_registry.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "../units/building_type.h"
@@ -90,6 +91,10 @@ public:
   auto get_nation_for_player(int player_id) const -> const Nation*;
 
   void set_player_nation(int player_id, NationID nation_id);
+
+  [[nodiscard]] auto
+  player_nation_assignments() const -> std::vector<std::pair<int, NationID>>;
+  void restore_player_nations(const std::vector<std::pair<int, NationID>>& assignments);
 
   auto get_all_nations() const -> const std::vector<Nation>& { return m_nations; }
 

--- a/game/systems/save_format.cpp
+++ b/game/systems/save_format.cpp
@@ -1,0 +1,335 @@
+#include "save_format.h"
+
+#include <QBuffer>
+#include <QCryptographicHash>
+#include <QDataStream>
+#include <QIODevice>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QLatin1String>
+#include <QStringLiteral>
+
+#include <cstring>
+
+namespace Game::Systems::Save {
+
+namespace {
+
+constexpr const char* k_magic = "SOISAVE\x01";
+constexpr int k_magic_size = 8;
+constexpr int k_compression_level = 6;
+constexpr qint64 k_max_package_blob = 512LL * 1024LL * 1024LL;
+
+auto make_error(QString* out_error, const QString& message) -> bool {
+  if (out_error != nullptr) {
+    *out_error = message;
+  }
+  return false;
+}
+
+} // namespace
+
+auto compression_to_string(Compression compression) -> QString {
+  switch (compression) {
+  case Compression::None:
+    return QStringLiteral("none");
+  case Compression::Zlib:
+    return QStringLiteral("zlib");
+  }
+  return QStringLiteral("none");
+}
+
+auto compression_from_string(const QString& value, Compression& out) -> bool {
+  if (value == QStringLiteral("none")) {
+    out = Compression::None;
+    return true;
+  }
+  if (value == QStringLiteral("zlib")) {
+    out = Compression::Zlib;
+    return true;
+  }
+  return false;
+}
+
+auto slot_kind_to_string(SlotKind kind) -> QString {
+  switch (kind) {
+  case SlotKind::Manual:
+    return QStringLiteral("manual");
+  case SlotKind::Quicksave:
+    return QStringLiteral("quicksave");
+  case SlotKind::Autosave:
+    return QStringLiteral("autosave");
+  }
+  return QStringLiteral("manual");
+}
+
+auto slot_kind_from_string(const QString& value, SlotKind& out) -> bool {
+  if (value == QStringLiteral("manual")) {
+    out = SlotKind::Manual;
+    return true;
+  }
+  if (value == QStringLiteral("quicksave")) {
+    out = SlotKind::Quicksave;
+    return true;
+  }
+  if (value == QStringLiteral("autosave")) {
+    out = SlotKind::Autosave;
+    return true;
+  }
+  return false;
+}
+
+auto checksum_of(const QByteArray& bytes) -> QString {
+  return QString::fromLatin1(
+      QCryptographicHash::hash(bytes, QCryptographicHash::Sha256).toHex());
+}
+
+auto pack(const QByteArray& raw, Compression compression) -> Payload {
+  Payload payload;
+  payload.compression = compression;
+  payload.raw_size = raw.size();
+  payload.raw_checksum = checksum_of(raw);
+  payload.blob =
+      compression == Compression::Zlib ? qCompress(raw, k_compression_level) : raw;
+  payload.blob_checksum = checksum_of(payload.blob);
+  return payload;
+}
+
+auto verify_blob(const Payload& payload, QString* out_error) -> bool {
+  if (payload.blob_checksum.isEmpty()) {
+    return make_error(out_error, QStringLiteral("Save payload has no checksum"));
+  }
+  if (checksum_of(payload.blob) != payload.blob_checksum) {
+    return make_error(out_error,
+                      QStringLiteral("Save payload is corrupted (stored checksum "
+                                     "mismatch)"));
+  }
+  return true;
+}
+
+auto unpack(const Payload& payload, QByteArray& out_raw, QString* out_error) -> bool {
+  if (!verify_blob(payload, out_error)) {
+    return false;
+  }
+
+  QByteArray raw;
+  if (payload.compression == Compression::Zlib) {
+    raw = qUncompress(payload.blob);
+    if (raw.isEmpty() && payload.raw_size != 0) {
+      return make_error(out_error,
+                        QStringLiteral("Save payload is corrupted (decompression "
+                                       "failed)"));
+    }
+  } else {
+    raw = payload.blob;
+  }
+
+  if (raw.size() != payload.raw_size) {
+    return make_error(out_error,
+                      QStringLiteral("Save payload is corrupted (expected %1 bytes, "
+                                     "got %2)")
+                          .arg(payload.raw_size)
+                          .arg(raw.size()));
+  }
+
+  if (checksum_of(raw) != payload.raw_checksum) {
+    return make_error(out_error,
+                      QStringLiteral("Save payload is corrupted (content checksum "
+                                     "mismatch)"));
+  }
+
+  out_raw = raw;
+  return true;
+}
+
+auto package_file_suffix() -> QString {
+  return QStringLiteral("soisave");
+}
+
+auto encode_preview(const QImage& frame, int width) -> QByteArray {
+  if (frame.isNull() || width <= 0) {
+    return {};
+  }
+
+  const QImage thumbnail = frame.width() > width
+                               ? frame.scaledToWidth(width, Qt::SmoothTransformation)
+                               : frame;
+
+  QByteArray png;
+  QBuffer buffer(&png);
+  if (!buffer.open(QIODevice::WriteOnly) || !thumbnail.save(&buffer, "PNG")) {
+    return {};
+  }
+  buffer.close();
+  return png;
+}
+
+auto sanitize_file_stem(const QString& name) -> QString {
+  QString sanitized;
+  sanitized.reserve(name.size());
+  for (const QChar character : name) {
+    if (character.isLetterOrNumber() || character == QLatin1Char('_') ||
+        character == QLatin1Char('-')) {
+      sanitized.append(character);
+    } else {
+      sanitized.append(QLatin1Char('_'));
+    }
+  }
+  return sanitized;
+}
+
+auto encode_package(const Record& record) -> QByteArray {
+  QJsonObject header;
+  header[QStringLiteral("format_version")] = k_format_version;
+  header[QStringLiteral("slot_name")] = record.slot_name;
+  header[QStringLiteral("title")] = record.title;
+  header[QStringLiteral("map_name")] = record.map_name;
+  header[QStringLiteral("map_path")] = record.map_path;
+  header[QStringLiteral("mode")] = record.mode;
+  header[QStringLiteral("campaign_id")] = record.campaign_id;
+  header[QStringLiteral("mission_id")] = record.mission_id;
+  header[QStringLiteral("difficulty")] = record.difficulty;
+  header[QStringLiteral("kind")] = slot_kind_to_string(record.kind);
+  header[QStringLiteral("play_time_seconds")] = record.play_time_seconds;
+  header[QStringLiteral("created_at")] = record.created_at;
+  header[QStringLiteral("updated_at")] = record.updated_at;
+  header[QStringLiteral("metadata")] = record.metadata;
+  header[QStringLiteral("compression")] =
+      compression_to_string(record.world.compression);
+  header[QStringLiteral("world_raw_size")] = static_cast<double>(record.world.raw_size);
+  header[QStringLiteral("world_raw_checksum")] = record.world.raw_checksum;
+  header[QStringLiteral("world_blob_checksum")] = record.world.blob_checksum;
+  header[QStringLiteral("world_blob_size")] =
+      static_cast<double>(record.world.blob.size());
+  header[QStringLiteral("screenshot_size")] =
+      static_cast<double>(record.screenshot.size());
+  header[QStringLiteral("screenshot_checksum")] = checksum_of(record.screenshot);
+
+  const QByteArray header_bytes = QJsonDocument(header).toJson(QJsonDocument::Compact);
+
+  QByteArray package;
+  QDataStream stream(&package, QIODevice::WriteOnly);
+  stream.setByteOrder(QDataStream::BigEndian);
+  stream.writeRawData(k_magic, k_magic_size);
+  stream << static_cast<quint32>(k_format_version);
+  stream << static_cast<quint32>(header_bytes.size());
+  stream.writeRawData(header_bytes.constData(), static_cast<int>(header_bytes.size()));
+  stream.writeRawData(record.world.blob.constData(),
+                      static_cast<int>(record.world.blob.size()));
+  stream.writeRawData(record.screenshot.constData(),
+                      static_cast<int>(record.screenshot.size()));
+  return package;
+}
+
+auto decode_package(const QByteArray& bytes, Record& out, QString* out_error) -> bool {
+  if (bytes.size() < k_magic_size + 8) {
+    return make_error(out_error, QStringLiteral("Not a Standard of Iron save file"));
+  }
+  if (std::memcmp(bytes.constData(), k_magic, k_magic_size) != 0) {
+    return make_error(out_error, QStringLiteral("Not a Standard of Iron save file"));
+  }
+
+  QDataStream stream(bytes);
+  stream.setByteOrder(QDataStream::BigEndian);
+  stream.skipRawData(k_magic_size);
+
+  quint32 format_version = 0;
+  quint32 header_size = 0;
+  stream >> format_version;
+  stream >> header_size;
+
+  if (format_version != static_cast<quint32>(k_format_version)) {
+    return make_error(out_error,
+                      QStringLiteral("Unsupported save file version %1 (expected %2)")
+                          .arg(format_version)
+                          .arg(k_format_version));
+  }
+
+  if (header_size == 0 || header_size > k_max_package_blob ||
+      static_cast<qint64>(header_size) > bytes.size() - k_magic_size - 8) {
+    return make_error(out_error, QStringLiteral("Save file header is truncated"));
+  }
+
+  QByteArray header_bytes(static_cast<int>(header_size), Qt::Uninitialized);
+  if (stream.readRawData(header_bytes.data(), static_cast<int>(header_size)) !=
+      static_cast<int>(header_size)) {
+    return make_error(out_error, QStringLiteral("Save file header is truncated"));
+  }
+
+  QJsonParseError parse_error{};
+  const QJsonDocument header_doc = QJsonDocument::fromJson(header_bytes, &parse_error);
+  if (parse_error.error != QJsonParseError::NoError || !header_doc.isObject()) {
+    return make_error(out_error,
+                      QStringLiteral("Save file header is corrupted: %1")
+                          .arg(parse_error.errorString()));
+  }
+  const QJsonObject header = header_doc.object();
+
+  Record record;
+  record.slot_name = header.value(QStringLiteral("slot_name")).toString();
+  record.title = header.value(QStringLiteral("title")).toString();
+  record.map_name = header.value(QStringLiteral("map_name")).toString();
+  record.map_path = header.value(QStringLiteral("map_path")).toString();
+  record.mode = header.value(QStringLiteral("mode")).toString();
+  record.campaign_id = header.value(QStringLiteral("campaign_id")).toString();
+  record.mission_id = header.value(QStringLiteral("mission_id")).toString();
+  record.difficulty = header.value(QStringLiteral("difficulty")).toString();
+  if (!slot_kind_from_string(header.value(QStringLiteral("kind")).toString(),
+                             record.kind)) {
+    record.kind = SlotKind::Manual;
+  }
+  record.play_time_seconds =
+      header.value(QStringLiteral("play_time_seconds")).toDouble(0.0);
+  record.created_at = header.value(QStringLiteral("created_at")).toString();
+  record.updated_at = header.value(QStringLiteral("updated_at")).toString();
+  record.metadata = header.value(QStringLiteral("metadata")).toObject();
+
+  if (!compression_from_string(header.value(QStringLiteral("compression")).toString(),
+                               record.world.compression)) {
+    return make_error(out_error,
+                      QStringLiteral("Save file uses an unknown compression format"));
+  }
+  record.world.raw_size =
+      static_cast<qint64>(header.value(QStringLiteral("world_raw_size")).toDouble(0.0));
+  record.world.raw_checksum =
+      header.value(QStringLiteral("world_raw_checksum")).toString();
+  record.world.blob_checksum =
+      header.value(QStringLiteral("world_blob_checksum")).toString();
+
+  const auto blob_size = static_cast<qint64>(
+      header.value(QStringLiteral("world_blob_size")).toDouble(0.0));
+  const auto screenshot_size = static_cast<qint64>(
+      header.value(QStringLiteral("screenshot_size")).toDouble(0.0));
+  if (blob_size < 0 || screenshot_size < 0 || blob_size > k_max_package_blob ||
+      screenshot_size > k_max_package_blob) {
+    return make_error(out_error,
+                      QStringLiteral("Save file declares implausible sizes"));
+  }
+
+  const qint64 body_offset = k_magic_size + 8 + static_cast<qint64>(header_size);
+  if (bytes.size() - body_offset != blob_size + screenshot_size) {
+    return make_error(out_error, QStringLiteral("Save file body is truncated"));
+  }
+
+  record.world.blob =
+      bytes.mid(static_cast<int>(body_offset), static_cast<int>(blob_size));
+  record.screenshot = bytes.mid(static_cast<int>(body_offset + blob_size),
+                                static_cast<int>(screenshot_size));
+
+  if (!verify_blob(record.world, out_error)) {
+    return false;
+  }
+
+  const QString screenshot_checksum =
+      header.value(QStringLiteral("screenshot_checksum")).toString();
+  if (!screenshot_checksum.isEmpty() &&
+      checksum_of(record.screenshot) != screenshot_checksum) {
+    return make_error(out_error,
+                      QStringLiteral("Save file preview image is corrupted"));
+  }
+
+  out = record;
+  return true;
+}
+
+} // namespace Game::Systems::Save

--- a/game/systems/save_format.h
+++ b/game/systems/save_format.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <QByteArray>
+#include <QImage>
+#include <QJsonObject>
+#include <QString>
+
+namespace Game::Systems::Save {
+
+inline constexpr int k_format_version = 1;
+inline constexpr int k_schema_version = 1;
+
+enum class Compression {
+  None,
+  Zlib
+};
+
+enum class SlotKind {
+  Manual,
+  Quicksave,
+  Autosave
+};
+
+auto compression_to_string(Compression compression) -> QString;
+auto compression_from_string(const QString& value, Compression& out) -> bool;
+
+auto slot_kind_to_string(SlotKind kind) -> QString;
+auto slot_kind_from_string(const QString& value, SlotKind& out) -> bool;
+
+auto checksum_of(const QByteArray& bytes) -> QString;
+
+struct Payload {
+  QByteArray blob;
+  Compression compression = Compression::Zlib;
+  qint64 raw_size = 0;
+  QString raw_checksum;
+  QString blob_checksum;
+
+  [[nodiscard]] auto is_empty() const -> bool { return blob.isEmpty(); }
+};
+
+auto pack(const QByteArray& raw,
+          Compression compression = Compression::Zlib) -> Payload;
+
+auto unpack(const Payload& payload, QByteArray& out_raw, QString* out_error) -> bool;
+
+auto verify_blob(const Payload& payload, QString* out_error) -> bool;
+
+struct Record {
+  QString slot_name;
+  QString title;
+  QString map_name;
+  QString map_path;
+  QString mode;
+  QString campaign_id;
+  QString mission_id;
+  QString difficulty;
+  SlotKind kind = SlotKind::Manual;
+  double play_time_seconds = 0.0;
+  QString created_at;
+  QString updated_at;
+  QJsonObject metadata;
+  Payload world;
+  QByteArray screenshot;
+};
+
+auto encode_package(const Record& record) -> QByteArray;
+auto decode_package(const QByteArray& bytes, Record& out, QString* out_error) -> bool;
+
+auto package_file_suffix() -> QString;
+
+inline constexpr int k_preview_width = 320;
+
+auto encode_preview(const QImage& frame, int width = k_preview_width) -> QByteArray;
+
+auto sanitize_file_stem(const QString& name) -> QString;
+
+} // namespace Game::Systems::Save

--- a/game/systems/save_load_service.cpp
+++ b/game/systems/save_load_service.cpp
@@ -4,22 +4,15 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>
-#include <QJsonDocument>
-#include <QJsonObject>
+#include <QFile>
+#include <QFileInfo>
 #include <QJsonParseError>
+#include <QSaveFile>
 #include <QStandardPaths>
-#include <qcoreapplication.h>
-#include <qdir.h>
-#include <qglobal.h>
-#include <qjsonarray.h>
-#include <qjsondocument.h>
-#include <qjsonobject.h>
-#include <qnamespace.h>
-#include <qstandardpaths.h>
-#include <qstringliteral.h>
 
+#include <algorithm>
+#include <chrono>
 #include <exception>
-#include <memory>
 
 #include "game/core/serialization.h"
 #include "game/core/world.h"
@@ -27,88 +20,283 @@
 
 namespace Game::Systems {
 
+namespace {
+
+constexpr const char* k_autosave_prefix = "autosave_";
+constexpr int k_min_autosave_retention = 1;
+constexpr int k_max_autosave_retention = 20;
+
+auto clamp_retention(int retention) -> int {
+  return std::clamp(retention, k_min_autosave_retention, k_max_autosave_retention);
+}
+
+auto now_iso() -> QString {
+  return QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs);
+}
+
+} // namespace
+
 SaveLoadService::SaveLoadService() {
-  ensure_saves_directory_exists();
-  m_storage = std::make_unique<SaveStorage>(get_database_path());
+  ensure_directories();
+  m_storage = std::make_unique<SaveStorage>(database_path());
   QString init_error;
   if (!m_storage->initialize(&init_error)) {
-    m_last_error = init_error;
+    set_last_error(init_error);
     qWarning() << "SaveLoadService: failed to initialize storage" << init_error;
   }
 }
 
-SaveLoadService::~SaveLoadService() = default;
-
-auto SaveLoadService::get_saves_directory() -> QString {
-  QString const saves_path =
-      QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-  return saves_path + "/saves";
+SaveLoadService::~SaveLoadService() {
+  shutdown();
 }
 
-auto SaveLoadService::get_database_path() -> QString {
-  return get_saves_directory() + QStringLiteral("/saves.sqlite");
+auto SaveLoadService::instance() -> SaveLoadService* {
+  static SaveLoadService service;
+  return &service;
 }
 
-void SaveLoadService::ensure_saves_directory_exists() {
-  QString const saves_dir = get_saves_directory();
+auto SaveLoadService::saves_directory() -> QString {
+  return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/saves";
+}
+
+auto SaveLoadService::exports_directory() -> QString {
+  return saves_directory() + QStringLiteral("/exports");
+}
+
+auto SaveLoadService::database_path() -> QString {
+  return saves_directory() + QStringLiteral("/saves.sqlite");
+}
+
+void SaveLoadService::ensure_directories() {
   QDir const dir;
-  if (!dir.exists(saves_dir)) {
-    dir.mkpath(saves_dir);
+  dir.mkpath(saves_directory());
+  dir.mkpath(exports_directory());
+}
+
+auto SaveLoadService::get_last_error() const -> QString {
+  const std::lock_guard<std::mutex> lock(m_mutex);
+  return m_last_error;
+}
+
+void SaveLoadService::clear_error() {
+  set_last_error({});
+}
+
+void SaveLoadService::set_last_error(const QString& error) const {
+  const std::lock_guard<std::mutex> lock(m_mutex);
+  m_last_error = error;
+}
+
+void SaveLoadService::ensure_worker_started() {
+  if (m_worker_started) {
+    return;
+  }
+  m_worker_started = true;
+  m_worker = std::thread([this]() { worker_loop(); });
+}
+
+auto SaveLoadService::begin_save(const SaveRequest& request) -> quint64 {
+  if (request.slot_name.isEmpty()) {
+    set_last_error(QStringLiteral("Cannot save: empty slot name"));
+    return 0;
+  }
+
+  quint64 job_id = 0;
+  {
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_stopping) {
+      m_last_error = QStringLiteral("Save service is shutting down");
+      return 0;
+    }
+    job_id = m_next_job_id++;
+    m_queue.push_back(Job{job_id, JobKind::Write, request, QByteArray()});
+    ensure_worker_started();
+  }
+
+  m_queue_cv.notify_one();
+  emit save_progress(job_id, request.slot_name, 0, tr("Queued"));
+  return job_id;
+}
+
+void SaveLoadService::attach_screenshot(const QString& slot_name,
+                                        const QByteArray& screenshot) {
+  if (slot_name.isEmpty() || screenshot.isEmpty()) {
+    return;
+  }
+
+  {
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_stopping) {
+      return;
+    }
+    Job job;
+    job.id = m_next_job_id++;
+    job.kind = JobKind::Screenshot;
+    job.request.slot_name = slot_name;
+    job.screenshot = screenshot;
+    m_queue.push_back(std::move(job));
+    ensure_worker_started();
+  }
+
+  m_queue_cv.notify_one();
+}
+
+void SaveLoadService::cancel_save(quint64 job_id) {
+  if (job_id == 0) {
+    return;
+  }
+  const std::lock_guard<std::mutex> lock(m_mutex);
+  m_cancelled.insert(job_id);
+}
+
+auto SaveLoadService::is_cancelled(quint64 job_id) const -> bool {
+  const std::lock_guard<std::mutex> lock(m_mutex);
+  return m_cancelled.contains(job_id);
+}
+
+auto SaveLoadService::pending_save_count() const -> int {
+  const std::lock_guard<std::mutex> lock(m_mutex);
+  return static_cast<int>(m_queue.size()) + (m_active_job != 0 ? 1 : 0);
+}
+
+auto SaveLoadService::wait_for_pending_saves(int timeout_ms) -> bool {
+  std::unique_lock<std::mutex> lock(m_mutex);
+  return m_idle_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this]() {
+    return m_queue.empty() && m_active_job == 0;
+  });
+}
+
+void SaveLoadService::shutdown() {
+  {
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_stopping) {
+      return;
+    }
+    m_stopping = true;
+  }
+  m_queue_cv.notify_all();
+  if (m_worker.joinable()) {
+    m_worker.join();
   }
 }
 
-auto SaveLoadService::save_game_to_slot(Engine::Core::World& world,
-                                        const QString& slot_name,
-                                        const QString& title,
-                                        const QString& map_name,
-                                        const QJsonObject& metadata,
-                                        const QByteArray& screenshot) -> bool {
-  qInfo() << "Saving game to slot:" << slot_name;
+void SaveLoadService::worker_loop() {
+
+  SaveStorage storage(database_path());
+
+  while (true) {
+    Job job;
+    {
+      std::unique_lock<std::mutex> lock(m_mutex);
+      m_queue_cv.wait(lock, [this]() { return m_stopping || !m_queue.empty(); });
+      if (m_stopping && m_queue.empty()) {
+        return;
+      }
+      job = m_queue.front();
+      m_queue.pop_front();
+      m_active_job = job.id;
+    }
+
+    if (job.kind == JobKind::Screenshot) {
+      run_screenshot_job(storage, job);
+    } else {
+      run_write_job(storage, job);
+    }
+
+    {
+      const std::lock_guard<std::mutex> lock(m_mutex);
+      m_active_job = 0;
+      m_cancelled.erase(job.id);
+    }
+    m_idle_cv.notify_all();
+  }
+}
+
+void SaveLoadService::run_screenshot_job(SaveStorage& storage, const Job& job) {
+  QString error;
+  if (storage.update_screenshot(job.request.slot_name, job.screenshot, &error)) {
+    emit save_slots_changed();
+    return;
+  }
+
+  qWarning() << "SaveLoadService: could not attach preview to" << job.request.slot_name
+             << ":" << error;
+}
+
+void SaveLoadService::run_write_job(SaveStorage& storage, const Job& job) {
+  QString error;
+  bool success = false;
+  bool cancelled = false;
+
+  const auto report = [&](int percent, const QString& stage) {
+    emit save_progress(job.id, job.request.slot_name, percent, stage);
+  };
 
   try {
-    if (!m_storage) {
-      m_last_error = QStringLiteral("Save storage unavailable");
-      qWarning() << m_last_error;
-      return false;
+    if (is_cancelled(job.id)) {
+      cancelled = true;
+    } else {
+      report(15, tr("Serializing world"));
+      const QByteArray world_bytes = job.request.world.toJson(QJsonDocument::Compact);
+
+      if (is_cancelled(job.id)) {
+        cancelled = true;
+      } else {
+        report(45, tr("Compressing"));
+        Save::Record record;
+        record.slot_name = job.request.slot_name;
+        record.title = job.request.title;
+        record.map_name = job.request.map_name;
+        record.map_path = job.request.map_path;
+        record.mode = job.request.mode;
+        record.campaign_id = job.request.campaign_id;
+        record.mission_id = job.request.mission_id;
+        record.difficulty = job.request.difficulty;
+        record.kind = job.request.kind;
+        record.play_time_seconds = job.request.play_time_seconds;
+        record.created_at = now_iso();
+        record.updated_at = record.created_at;
+        record.metadata = job.request.metadata;
+        record.screenshot = job.request.screenshot;
+        record.world = Save::pack(world_bytes);
+
+        if (is_cancelled(job.id)) {
+          cancelled = true;
+        } else {
+          report(75, tr("Writing"));
+          success = storage.write_slot(record, &error);
+          if (success && job.request.autosave_retention > 0) {
+            const int retention = clamp_retention(job.request.autosave_retention);
+            QString prune_error;
+            const QStringList autosaves =
+                storage.slot_names_by_kind(Save::SlotKind::Autosave, &prune_error);
+            for (int i = 0; i < autosaves.size() - retention; ++i) {
+              storage.delete_slot(autosaves.at(i), &prune_error);
+            }
+          }
+        }
+      }
     }
+  } catch (const std::exception& exception) {
+    error = QStringLiteral("Exception while saving: %1")
+                .arg(QString::fromUtf8(exception.what()));
+    success = false;
+  }
 
-    QJsonDocument const world_doc =
-        Engine::Core::Serialization::serialize_world(&world);
-    const QByteArray world_bytes = world_doc.toJson(QJsonDocument::Compact);
+  if (cancelled) {
+    error = tr("Save cancelled");
+    success = false;
+  }
 
-    QJsonObject combined_metadata = metadata;
-    combined_metadata.remove("slotName");
-    combined_metadata["slot_name"] = slot_name;
-    combined_metadata["title"] = title;
-    combined_metadata["timestamp"] =
-        QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs);
-    if (!combined_metadata.contains("map_name")) {
-      combined_metadata["map_name"] =
-          map_name.isEmpty() ? QStringLiteral("Unknown Map") : map_name;
-    }
-    combined_metadata["version"] = QStringLiteral("1.0");
-
-    QString storage_error;
-    if (!m_storage->save_slot(slot_name,
-                              title,
-                              combined_metadata,
-                              world_bytes,
-                              screenshot,
-                              &storage_error)) {
-      m_last_error = storage_error;
-      qWarning() << "SaveLoadService: failed to persist slot" << storage_error;
-      return false;
-    }
-
-    m_last_metadata = combined_metadata;
-    m_last_title = title;
-    m_last_screenshot = screenshot;
-    m_last_error.clear();
-    return true;
-  } catch (const std::exception& e) {
-    m_last_error = QString("Exception while saving game to slot: %1").arg(e.what());
-    qWarning() << m_last_error;
-    return false;
+  if (success) {
+    report(100, tr("Done"));
+    emit save_finished(job.id, job.request.slot_name, true, QString());
+    emit save_slots_changed();
+  } else {
+    qWarning() << "SaveLoadService: save to" << job.request.slot_name
+               << "failed:" << error;
+    emit save_finished(job.id, job.request.slot_name, false, error);
+    set_last_error(error);
   }
 }
 
@@ -116,48 +304,64 @@ auto SaveLoadService::load_game_from_slot(Engine::Core::World& world,
                                           const QString& slot_name) -> bool {
   qInfo() << "Loading game from slot:" << slot_name;
 
+  if (!m_storage) {
+    set_last_error(QStringLiteral("Save storage unavailable"));
+    qWarning() << "SaveLoadService: save storage unavailable";
+    return false;
+  }
+
   try {
-    if (!m_storage) {
-      m_last_error = QStringLiteral("Save storage unavailable");
-      qWarning() << m_last_error;
+    Save::Record record;
+    QString error;
+    if (!m_storage->read_slot(slot_name, record, &error)) {
+      set_last_error(error);
+      qWarning() << "SaveLoadService: failed to read slot" << error;
       return false;
     }
 
     QByteArray world_bytes;
-    QJsonObject metadata;
-    QByteArray screenshot;
-    QString title;
-
-    QString load_error;
-    if (!m_storage->load_slot(
-            slot_name, world_bytes, metadata, screenshot, title, &load_error)) {
-      m_last_error = load_error;
-      qWarning() << "SaveLoadService: failed to load slot" << load_error;
+    if (!Save::unpack(record.world, world_bytes, &error)) {
+      const QString message =
+          QStringLiteral("Save slot '%1' is corrupted: %2").arg(slot_name, error);
+      set_last_error(message);
+      qWarning() << message;
       return false;
     }
 
     QJsonParseError parse_error{};
-    QJsonDocument const doc = QJsonDocument::fromJson(world_bytes, &parse_error);
-    if (parse_error.error != QJsonParseError::NoError || doc.isNull()) {
-      m_last_error = QStringLiteral("Corrupted save data for slot '%1': %2")
-                         .arg(slot_name, parse_error.errorString());
-      qWarning() << m_last_error;
+    const QJsonDocument doc = QJsonDocument::fromJson(world_bytes, &parse_error);
+    if (parse_error.error != QJsonParseError::NoError || !doc.isObject()) {
+      const QString message = QStringLiteral("Save slot '%1' is corrupted: %2")
+                                  .arg(slot_name, parse_error.errorString());
+      set_last_error(message);
+      qWarning() << message;
       return false;
     }
 
     world.clear();
     Engine::Core::Serialization::deserialize_world(&world, doc);
 
-    m_last_metadata = metadata;
-    m_last_title = title;
-    m_last_screenshot = screenshot;
-    m_last_error.clear();
+    m_last_record = record;
+    set_last_error({});
     return true;
-  } catch (const std::exception& e) {
-    m_last_error = QString("Exception while loading game from slot: %1").arg(e.what());
-    qWarning() << m_last_error;
+  } catch (const std::exception& exception) {
+    const QString message = QStringLiteral("Exception while loading save '%1': %2")
+                                .arg(slot_name, QString::fromUtf8(exception.what()));
+    set_last_error(message);
+    qWarning() << message;
     return false;
   }
+}
+
+auto SaveLoadService::verify_save_slot(const QString& slot_name,
+                                       QString* out_error) const -> bool {
+  if (!m_storage) {
+    if (out_error != nullptr) {
+      *out_error = QStringLiteral("Save storage unavailable");
+    }
+    return false;
+  }
+  return m_storage->verify_slot(slot_name, out_error);
 }
 
 auto SaveLoadService::get_save_slots() const -> QVariantList {
@@ -168,38 +372,194 @@ auto SaveLoadService::get_save_slots() const -> QVariantList {
   QString list_error;
   QVariantList slot_list = m_storage->list_slots(&list_error);
   if (!list_error.isEmpty()) {
-    m_last_error = list_error;
+    set_last_error(list_error);
     qWarning() << "SaveLoadService: failed to enumerate slots" << list_error;
-  } else {
-    m_last_error.clear();
   }
   return slot_list;
 }
 
+auto SaveLoadService::slot_exists(const QString& slot_name) const -> bool {
+  return m_storage && m_storage->slot_exists(slot_name);
+}
+
 auto SaveLoadService::delete_save_slot(const QString& slot_name) -> bool {
-  qInfo() << "Deleting save slot:" << slot_name;
-
   if (!m_storage) {
-    m_last_error = QStringLiteral("Save storage unavailable");
-    qWarning() << m_last_error;
+    set_last_error(QStringLiteral("Save storage unavailable"));
     return false;
   }
 
-  QString delete_error;
-  if (!m_storage->delete_slot(slot_name, &delete_error)) {
-    m_last_error = delete_error;
-    qWarning() << "SaveLoadService: failed to delete slot" << delete_error;
+  QString error;
+  if (!m_storage->delete_slot(slot_name, &error)) {
+    set_last_error(error);
+    qWarning() << "SaveLoadService: failed to delete slot" << error;
     return false;
   }
 
-  m_last_error.clear();
+  set_last_error({});
+  emit save_slots_changed();
   return true;
+}
+
+auto SaveLoadService::next_autosave_slot(int retention) const -> QString {
+  const int slot_count = clamp_retention(retention);
+  if (!m_storage) {
+    return QStringLiteral("%1%2").arg(QString::fromLatin1(k_autosave_prefix)).arg(1);
+  }
+
+  const QStringList existing = m_storage->slot_names_by_kind(Save::SlotKind::Autosave);
+  for (int index = 1; index <= slot_count; ++index) {
+    const QString candidate =
+        QStringLiteral("%1%2").arg(QString::fromLatin1(k_autosave_prefix)).arg(index);
+    if (!existing.contains(candidate)) {
+      return candidate;
+    }
+  }
+
+  for (const QString& candidate : existing) {
+    if (candidate.startsWith(QString::fromLatin1(k_autosave_prefix))) {
+      return candidate;
+    }
+  }
+
+  return QStringLiteral("%1%2").arg(QString::fromLatin1(k_autosave_prefix)).arg(1);
+}
+
+auto SaveLoadService::prune_autosaves(int retention) -> int {
+  if (!m_storage) {
+    return 0;
+  }
+
+  const int slot_count = clamp_retention(retention);
+  const QStringList existing = m_storage->slot_names_by_kind(Save::SlotKind::Autosave);
+  int removed = 0;
+  for (int i = 0; i < existing.size() - slot_count; ++i) {
+    QString error;
+    if (m_storage->delete_slot(existing.at(i), &error)) {
+      ++removed;
+    } else {
+      qWarning() << "SaveLoadService: failed to prune autosave" << existing.at(i) << ":"
+                 << error;
+    }
+  }
+
+  if (removed > 0) {
+    emit save_slots_changed();
+  }
+  return removed;
+}
+
+auto SaveLoadService::export_slot(const QString& slot_name,
+                                  const QString& file_path,
+                                  QString* out_error) -> bool {
+  if (!m_storage) {
+    if (out_error != nullptr) {
+      *out_error = QStringLiteral("Save storage unavailable");
+    }
+    return false;
+  }
+
+  Save::Record record;
+  if (!m_storage->read_slot(slot_name, record, out_error)) {
+    return false;
+  }
+
+  if (!Save::verify_blob(record.world, out_error)) {
+    return false;
+  }
+
+  ensure_directories();
+  QDir().mkpath(QFileInfo(file_path).absolutePath());
+
+  QSaveFile file(file_path);
+  if (!file.open(QIODevice::WriteOnly)) {
+    if (out_error != nullptr) {
+      *out_error =
+          QStringLiteral("Cannot write '%1': %2").arg(file_path, file.errorString());
+    }
+    return false;
+  }
+
+  const QByteArray package = Save::encode_package(record);
+  if (file.write(package) != package.size() || !file.commit()) {
+    if (out_error != nullptr) {
+      *out_error =
+          QStringLiteral("Failed to write '%1': %2").arg(file_path, file.errorString());
+    }
+    return false;
+  }
+
+  return true;
+}
+
+auto SaveLoadService::import_package(const QString& file_path,
+                                     QString& out_slot_name,
+                                     QString* out_error) -> bool {
+  if (!m_storage) {
+    if (out_error != nullptr) {
+      *out_error = QStringLiteral("Save storage unavailable");
+    }
+    return false;
+  }
+
+  QFile file(file_path);
+  if (!file.open(QIODevice::ReadOnly)) {
+    if (out_error != nullptr) {
+      *out_error =
+          QStringLiteral("Cannot read '%1': %2").arg(file_path, file.errorString());
+    }
+    return false;
+  }
+
+  Save::Record record;
+  if (!Save::decode_package(file.readAll(), record, out_error)) {
+    return false;
+  }
+
+  QString base = Save::sanitize_file_stem(record.slot_name);
+  if (base.isEmpty()) {
+    base = Save::sanitize_file_stem(QFileInfo(file_path).completeBaseName());
+  }
+  if (base.isEmpty()) {
+    base = QStringLiteral("imported_save");
+  }
+
+  QString slot_name = base;
+  int suffix = 2;
+  while (m_storage->slot_exists(slot_name)) {
+    slot_name = QStringLiteral("%1_%2").arg(base).arg(suffix++);
+  }
+
+  record.slot_name = slot_name;
+  record.kind = Save::SlotKind::Manual;
+  record.updated_at = now_iso();
+  if (record.created_at.isEmpty()) {
+    record.created_at = record.updated_at;
+  }
+
+  if (!m_storage->write_slot(record, out_error)) {
+    return false;
+  }
+
+  out_slot_name = slot_name;
+  emit save_slots_changed();
+  return true;
+}
+
+auto SaveLoadService::list_exported_packages() const -> QStringList {
+  QDir const dir(exports_directory());
+  const QStringList filter = {QStringLiteral("*.%1").arg(Save::package_file_suffix())};
+  QStringList result;
+  for (const QString& name :
+       dir.entryList(filter, QDir::Files, QDir::Time | QDir::Reversed)) {
+    result.append(dir.filePath(name));
+  }
+  return result;
 }
 
 auto SaveLoadService::list_campaigns(QString* out_error) -> QVariantList {
   if (!m_storage) {
     if (out_error != nullptr) {
-      *out_error = "Storage not initialized";
+      *out_error = QStringLiteral("Save storage unavailable");
     }
     return {};
   }
@@ -210,7 +570,7 @@ auto SaveLoadService::get_campaign_progress(const QString& campaign_id,
                                             QString* out_error) const -> QVariantMap {
   if (!m_storage) {
     if (out_error != nullptr) {
-      *out_error = "Storage not initialized";
+      *out_error = QStringLiteral("Save storage unavailable");
     }
     return {};
   }
@@ -221,7 +581,7 @@ auto SaveLoadService::mark_campaign_completed(const QString& campaign_id,
                                               QString* out_error) -> bool {
   if (!m_storage) {
     if (out_error != nullptr) {
-      *out_error = "Storage not initialized";
+      *out_error = QStringLiteral("Save storage unavailable");
     }
     return false;
   }
@@ -238,7 +598,7 @@ auto SaveLoadService::save_mission_result(const QString& mission_id,
                                           QString* out_error) -> bool {
   if (!m_storage) {
     if (out_error != nullptr) {
-      *out_error = "Storage not initialized";
+      *out_error = QStringLiteral("Save storage unavailable");
     }
     return false;
   }
@@ -256,7 +616,7 @@ auto SaveLoadService::get_mission_progress(const QString& mission_id,
                                            QString* out_error) const -> QVariantMap {
   if (!m_storage) {
     if (out_error != nullptr) {
-      *out_error = "Storage not initialized";
+      *out_error = QStringLiteral("Save storage unavailable");
     }
     return {};
   }
@@ -267,7 +627,7 @@ auto SaveLoadService::get_campaign_mission_progress(
     const QString& campaign_id, QString* out_error) const -> QVariantList {
   if (!m_storage) {
     if (out_error != nullptr) {
-      *out_error = "Storage not initialized";
+      *out_error = QStringLiteral("Save storage unavailable");
     }
     return {};
   }
@@ -279,16 +639,11 @@ auto SaveLoadService::unlock_next_campaign_mission(const QString& campaign_id,
                                                    QString* out_error) -> bool {
   if (!m_storage) {
     if (out_error != nullptr) {
-      *out_error = "Storage not initialized";
+      *out_error = QStringLiteral("Save storage unavailable");
     }
     return false;
   }
   return m_storage->unlock_next_mission(campaign_id, completed_mission_id, out_error);
-}
-
-SaveLoadService* SaveLoadService::instance() {
-  static SaveLoadService instance;
-  return &instance;
 }
 
 void SaveLoadService::open_settings() {
@@ -297,7 +652,6 @@ void SaveLoadService::open_settings() {
 
 void SaveLoadService::exit_game() {
   qInfo() << "Exit game requested";
-
   QCoreApplication::quit();
 }
 

--- a/game/systems/save_load_service.h
+++ b/game/systems/save_load_service.h
@@ -1,11 +1,23 @@
 #pragma once
 
 #include <QByteArray>
+#include <QJsonDocument>
 #include <QJsonObject>
+#include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QVariantList>
+#include <QVariantMap>
 
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
 #include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+
+#include "save_format.h"
 
 namespace Engine::Core {
 class World;
@@ -15,32 +27,79 @@ namespace Game::Systems {
 
 class SaveStorage;
 
-class SaveLoadService {
+struct SaveRequest {
+  QString slot_name;
+  QString title;
+  QString map_name;
+  QString map_path;
+  QString mode;
+  QString campaign_id;
+  QString mission_id;
+  QString difficulty;
+  Save::SlotKind kind = Save::SlotKind::Manual;
+  double play_time_seconds = 0.0;
+  QJsonObject metadata;
+  QByteArray screenshot;
+  QJsonDocument world;
+  int autosave_retention = 0;
+};
+
+class SaveLoadService : public QObject {
+  Q_OBJECT
+
 public:
   SaveLoadService();
-  ~SaveLoadService();
+  ~SaveLoadService() override;
 
-  auto save_game_to_slot(Engine::Core::World& world,
-                         const QString& slot_name,
-                         const QString& title,
-                         const QString& map_name,
-                         const QJsonObject& metadata = {},
-                         const QByteArray& screenshot = QByteArray()) -> bool;
+  static auto instance() -> SaveLoadService*;
+
+  auto begin_save(const SaveRequest& request) -> quint64;
+
+  void attach_screenshot(const QString& slot_name, const QByteArray& screenshot);
+
+  void cancel_save(quint64 job_id);
+  [[nodiscard]] auto pending_save_count() const -> int;
+  auto wait_for_pending_saves(int timeout_ms = 30000) -> bool;
+  void shutdown();
 
   auto load_game_from_slot(Engine::Core::World& world,
                            const QString& slot_name) -> bool;
 
-  auto get_save_slots() const -> QVariantList;
+  [[nodiscard]] auto verify_save_slot(const QString& slot_name,
+                                      QString* out_error = nullptr) const -> bool;
 
+  [[nodiscard]] auto get_save_slots() const -> QVariantList;
+  [[nodiscard]] auto slot_exists(const QString& slot_name) const -> bool;
   auto delete_save_slot(const QString& slot_name) -> bool;
 
-  auto get_last_error() const -> QString { return m_last_error; }
+  [[nodiscard]] auto next_autosave_slot(int retention) const -> QString;
+  auto prune_autosaves(int retention) -> int;
 
-  void clear_error() { m_last_error.clear(); }
+  auto export_slot(const QString& slot_name,
+                   const QString& file_path,
+                   QString* out_error = nullptr) -> bool;
+  auto import_package(const QString& file_path,
+                      QString& out_slot_name,
+                      QString* out_error = nullptr) -> bool;
+  [[nodiscard]] auto list_exported_packages() const -> QStringList;
 
-  auto get_last_metadata() const -> QJsonObject { return m_last_metadata; }
-  auto get_last_title() const -> QString { return m_last_title; }
-  auto get_last_screenshot() const -> QByteArray { return m_last_screenshot; }
+  static auto saves_directory() -> QString;
+  static auto exports_directory() -> QString;
+  static auto database_path() -> QString;
+
+  [[nodiscard]] auto get_last_error() const -> QString;
+  void clear_error();
+
+  [[nodiscard]] auto get_last_record() const -> const Save::Record& {
+    return m_last_record;
+  }
+  [[nodiscard]] auto get_last_metadata() const -> QJsonObject {
+    return m_last_record.metadata;
+  }
+  [[nodiscard]] auto get_last_title() const -> QString { return m_last_record.title; }
+  [[nodiscard]] auto get_last_screenshot() const -> QByteArray {
+    return m_last_record.screenshot;
+  }
 
   auto list_campaigns(QString* out_error = nullptr) -> QVariantList;
   auto get_campaign_progress(const QString& campaign_id,
@@ -68,22 +127,55 @@ public:
                                     const QString& completed_mission_id,
                                     QString* out_error = nullptr) -> bool;
 
-  static SaveLoadService* instance();
-
   static void open_settings();
-
   static void exit_game();
 
+signals:
+  void save_progress(quint64 job_id,
+                     const QString& slot_name,
+                     int percent,
+                     const QString& stage);
+  void save_finished(quint64 job_id,
+                     const QString& slot_name,
+                     bool success,
+                     const QString& error);
+  void save_slots_changed();
+
 private:
-  static auto get_saves_directory() -> QString;
-  static auto get_database_path() -> QString;
-  static void ensure_saves_directory_exists();
+  enum class JobKind {
+    Write,
+    Screenshot
+  };
+
+  struct Job {
+    quint64 id = 0;
+    JobKind kind = JobKind::Write;
+    SaveRequest request;
+    QByteArray screenshot;
+  };
+
+  void set_last_error(const QString& error) const;
+  void ensure_worker_started();
+  void worker_loop();
+  void run_write_job(SaveStorage& storage, const Job& job);
+  void run_screenshot_job(SaveStorage& storage, const Job& job);
+  [[nodiscard]] auto is_cancelled(quint64 job_id) const -> bool;
+  static void ensure_directories();
 
   mutable QString m_last_error;
-  QJsonObject m_last_metadata;
-  QString m_last_title;
-  QByteArray m_last_screenshot;
+  Save::Record m_last_record;
   std::unique_ptr<SaveStorage> m_storage;
+
+  mutable std::mutex m_mutex;
+  std::condition_variable m_queue_cv;
+  std::condition_variable m_idle_cv;
+  std::deque<Job> m_queue;
+  std::unordered_set<quint64> m_cancelled;
+  std::thread m_worker;
+  quint64 m_next_job_id = 1;
+  quint64 m_active_job = 0;
+  bool m_stopping = false;
+  bool m_worker_started = false;
 };
 
 } // namespace Game::Systems

--- a/game/systems/save_storage.cpp
+++ b/game/systems/save_storage.cpp
@@ -2,36 +2,24 @@
 
 #include <QCoreApplication>
 #include <QDateTime>
+#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QJsonDocument>
-#include <QMetaType>
-#include <QSqlDatabase>
+#include <QJsonObject>
 #include <QSqlError>
 #include <QSqlQuery>
 #include <QVariant>
-#include <qglobal.h>
-#include <qjsonarray.h>
-#include <qjsonobject.h>
-#include <qnamespace.h>
-#include <qsqldatabase.h>
-#include <qsqlerror.h>
-#include <qsqlquery.h>
-#include <qstringliteral.h>
-#include <qvariant.h>
 
 #include <utility>
 
 #include "../map/campaign_definition.h"
 #include "../map/campaign_loader.h"
-#include "../map/mission_loader.h"
-#include "utils/resource_utils.h"
 
 namespace Game::Systems {
 
 namespace {
 constexpr const char* k_driver_name = "QSQLITE";
-constexpr int k_current_schema_version = 3;
 
 auto build_connection_name(const SaveStorage* instance) -> QString {
   return QStringLiteral("SaveStorage_%1")
@@ -45,18 +33,34 @@ auto last_error_string(const QSqlError& error) -> QString {
   return error.text();
 }
 
+auto fail(QString* out_error, const QString& context, const QSqlError& error) -> bool {
+  if (out_error != nullptr) {
+    *out_error = QStringLiteral("%1: %2").arg(context, last_error_string(error));
+  }
+  return false;
+}
+
+auto now_iso() -> QString {
+  return QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs);
+}
+
+auto text(const QString& value) -> QString {
+  return value.isNull() ? QString::fromLatin1("") : value;
+}
+
 class TransactionGuard {
 public:
   explicit TransactionGuard(QSqlDatabase& database)
       : m_database(database) {}
 
+  TransactionGuard(const TransactionGuard&) = delete;
+  auto operator=(const TransactionGuard&) -> TransactionGuard& = delete;
+
   auto begin(QString* out_error) -> bool {
     if (!m_database.transaction()) {
-      if (out_error != nullptr) {
-        *out_error = QStringLiteral("Failed to begin transaction: %1")
-                         .arg(last_error_string(m_database.lastError()));
-      }
-      return false;
+      return fail(out_error,
+                  QStringLiteral("Failed to begin transaction"),
+                  m_database.lastError());
     }
     m_active = true;
     return true;
@@ -68,12 +72,11 @@ public:
     }
 
     if (!m_database.commit()) {
-      if (out_error != nullptr) {
-        *out_error = QStringLiteral("Failed to commit transaction: %1")
-                         .arg(last_error_string(m_database.lastError()));
-      }
+      const bool result = fail(out_error,
+                               QStringLiteral("Failed to commit transaction"),
+                               m_database.lastError());
       rollback();
-      return false;
+      return result;
     }
 
     m_active = false;
@@ -93,6 +96,120 @@ private:
   QSqlDatabase& m_database;
   bool m_active = false;
 };
+
+auto load_campaign_definitions() -> std::vector<Game::Campaign::CampaignDefinition> {
+  std::vector<Game::Campaign::CampaignDefinition> campaigns;
+
+  const QStringList search_paths = {
+      QStringLiteral("assets/campaigns"),
+      QStringLiteral("../assets/campaigns"),
+      QStringLiteral("../../assets/campaigns"),
+      QCoreApplication::applicationDirPath() + QStringLiteral("/assets/campaigns"),
+      QCoreApplication::applicationDirPath() + QStringLiteral("/../assets/campaigns")};
+
+  for (const QString& campaigns_path : search_paths) {
+    QDir const campaigns_dir(campaigns_path);
+    if (!campaigns_dir.exists()) {
+      continue;
+    }
+
+    const QStringList campaign_files =
+        campaigns_dir.entryList(QStringList() << QStringLiteral("*.json"), QDir::Files);
+    if (campaign_files.isEmpty()) {
+      continue;
+    }
+
+    qInfo() << "Loading campaigns from filesystem:" << campaigns_dir.absolutePath();
+    for (const auto& campaign_file : campaign_files) {
+      Game::Campaign::CampaignDefinition campaign;
+      QString error;
+      if (!Game::Campaign::CampaignLoader::load_from_json_file(
+              campaigns_dir.filePath(campaign_file), campaign, &error)) {
+        qWarning() << "Failed to load campaign" << campaign_file << ":" << error;
+        continue;
+      }
+      campaigns.push_back(std::move(campaign));
+    }
+
+    if (!campaigns.empty()) {
+      return campaigns;
+    }
+  }
+
+  qInfo() << "Loading campaigns from Qt resources";
+  const QStringList known_campaigns = {QStringLiteral("second_punic_war")};
+  for (const auto& campaign_name : known_campaigns) {
+    const QString campaign_path =
+        QStringLiteral(":/assets/campaigns/%1.json").arg(campaign_name);
+    if (!QFile::exists(campaign_path)) {
+      qWarning() << "Campaign resource does not exist:" << campaign_path;
+      continue;
+    }
+
+    Game::Campaign::CampaignDefinition campaign;
+    QString error;
+    if (!Game::Campaign::CampaignLoader::load_from_json_file(
+            campaign_path, campaign, &error)) {
+      qWarning() << "Failed to load campaign from resources" << campaign_name << ":"
+                 << error;
+      continue;
+    }
+    campaigns.push_back(std::move(campaign));
+  }
+
+  return campaigns;
+}
+
+auto build_campaign_entry(const Game::Campaign::CampaignDefinition& campaign,
+                          const QVariantList& missions_progress) -> QVariantMap {
+  QVariantMap campaign_map;
+  campaign_map.insert(QStringLiteral("id"), campaign.id);
+  campaign_map.insert(QStringLiteral("title"), campaign.title);
+  campaign_map.insert(QStringLiteral("description"), campaign.description);
+  campaign_map.insert(QStringLiteral("unlocked"), true);
+
+  bool all_completed = true;
+  QVariantList missions_list;
+  for (const auto& mission : campaign.missions) {
+    QVariantMap mission_map;
+    mission_map.insert(QStringLiteral("mission_id"), mission.mission_id);
+    mission_map.insert(QStringLiteral("order_index"), mission.order_index);
+    if (mission.intro_text.has_value()) {
+      mission_map.insert(QStringLiteral("intro_text"), *mission.intro_text);
+    }
+    if (mission.outro_text.has_value()) {
+      mission_map.insert(QStringLiteral("outro_text"), *mission.outro_text);
+    }
+    if (mission.difficulty_modifier.has_value()) {
+      mission_map.insert(QStringLiteral("difficulty_modifier"),
+                         *mission.difficulty_modifier);
+    }
+
+    bool unlocked = mission.order_index == 0;
+    bool completed = false;
+    for (const QVariant& progress_var : missions_progress) {
+      const QVariantMap progress = progress_var.toMap();
+      if (progress[QStringLiteral("mission_id")].toString() == mission.mission_id) {
+        unlocked = progress[QStringLiteral("unlocked")].toBool();
+        completed = progress[QStringLiteral("completed")].toBool();
+        break;
+      }
+    }
+
+    mission_map.insert(QStringLiteral("unlocked"), unlocked);
+    mission_map.insert(QStringLiteral("completed"), completed);
+    missions_list.append(mission_map);
+
+    if (!completed) {
+      all_completed = false;
+    }
+  }
+
+  campaign_map.insert(QStringLiteral("completed"), all_completed);
+  campaign_map.insert(QStringLiteral("missions"), missions_list);
+  return campaign_map;
+}
+
 } // namespace
 
 SaveStorage::SaveStorage(QString database_path)
@@ -125,13 +242,167 @@ auto SaveStorage::initialize(QString* out_error) const -> bool {
   return true;
 }
 
-auto SaveStorage::save_slot(const QString& slot_name,
-                            const QString& title,
-                            const QJsonObject& metadata,
-                            const QByteArray& world_state,
-                            const QByteArray& screenshot,
-                            QString* out_error) -> bool {
+auto SaveStorage::open(QString* out_error) const -> bool {
+  if (m_database.isValid() && m_database.isOpen()) {
+    return true;
+  }
+
+  if (!m_database.isValid()) {
+    m_database = QSqlDatabase::addDatabase(k_driver_name, m_connection_name);
+    m_database.setDatabaseName(m_database_path);
+    m_database.setConnectOptions(QStringLiteral("QSQLITE_BUSY_TIMEOUT=15000"));
+  }
+
+  if (!m_database.open()) {
+    return fail(out_error,
+                QStringLiteral("Failed to open save database"),
+                m_database.lastError());
+  }
+
+  QSqlQuery pragma(m_database);
+  pragma.exec(QStringLiteral("PRAGMA journal_mode=WAL"));
+  pragma.exec(QStringLiteral("PRAGMA synchronous=FULL"));
+  return true;
+}
+
+auto SaveStorage::ensure_schema(QString* out_error) const -> bool {
+  int version = 0;
+  {
+    QSqlQuery version_query(m_database);
+    if (!version_query.exec(QStringLiteral("PRAGMA user_version")) ||
+        !version_query.next()) {
+      return fail(out_error,
+                  QStringLiteral("Failed to read schema version"),
+                  version_query.lastError());
+    }
+    version = version_query.value(0).toInt();
+
+    version_query.finish();
+  }
+
+  if (version == Save::k_schema_version) {
+    return true;
+  }
+
+  if (version != 0) {
+    qWarning() << "Save database schema version" << version
+               << "is not supported; rebuilding a clean database (previous saves are "
+                  "discarded)";
+  }
+
+  TransactionGuard transaction(m_database);
+  if (!transaction.begin(out_error)) {
+    return false;
+  }
+
+  if (!drop_schema(out_error) || !create_schema(out_error)) {
+    transaction.rollback();
+    return false;
+  }
+
+  QSqlQuery set_version(m_database);
+  if (!set_version.exec(
+          QStringLiteral("PRAGMA user_version = %1").arg(Save::k_schema_version))) {
+    fail(out_error,
+         QStringLiteral("Failed to record schema version"),
+         set_version.lastError());
+    transaction.rollback();
+    return false;
+  }
+
+  return transaction.commit(out_error);
+}
+
+auto SaveStorage::drop_schema(QString* out_error) const -> bool {
+  const QStringList tables = {QStringLiteral("saves"),
+                              QStringLiteral("campaigns"),
+                              QStringLiteral("campaign_progress"),
+                              QStringLiteral("campaign_missions"),
+                              QStringLiteral("mission_progress"),
+                              QStringLiteral("mission_results")};
+
+  for (const QString& table : tables) {
+    QSqlQuery query(m_database);
+    if (!query.exec(QStringLiteral("DROP TABLE IF EXISTS %1").arg(table))) {
+      return fail(out_error,
+                  QStringLiteral("Failed to drop table %1").arg(table),
+                  query.lastError());
+    }
+  }
+  return true;
+}
+
+auto SaveStorage::create_schema(QString* out_error) const -> bool {
+  const QStringList statements = {
+      QStringLiteral("CREATE TABLE saves ("
+                     "slot_name TEXT PRIMARY KEY NOT NULL, "
+                     "title TEXT NOT NULL, "
+                     "map_name TEXT NOT NULL, "
+                     "map_path TEXT NOT NULL, "
+                     "mode TEXT NOT NULL, "
+                     "campaign_id TEXT NOT NULL, "
+                     "mission_id TEXT NOT NULL, "
+                     "difficulty TEXT NOT NULL, "
+                     "kind TEXT NOT NULL, "
+                     "play_time_seconds REAL NOT NULL, "
+                     "created_at TEXT NOT NULL, "
+                     "updated_at TEXT NOT NULL, "
+                     "format_version INTEGER NOT NULL, "
+                     "compression TEXT NOT NULL, "
+                     "world_raw_size INTEGER NOT NULL, "
+                     "world_raw_checksum TEXT NOT NULL, "
+                     "world_blob_checksum TEXT NOT NULL, "
+                     "metadata BLOB NOT NULL, "
+                     "world_state BLOB NOT NULL, "
+                     "screenshot BLOB)"),
+      QStringLiteral("CREATE INDEX idx_saves_updated_at ON saves (updated_at DESC)"),
+      QStringLiteral("CREATE INDEX idx_saves_kind ON saves (kind, updated_at)"),
+      QStringLiteral("CREATE TABLE campaign_progress ("
+                     "campaign_id TEXT PRIMARY KEY NOT NULL, "
+                     "completed INTEGER NOT NULL DEFAULT 0, "
+                     "unlocked INTEGER NOT NULL DEFAULT 0, "
+                     "completed_at TEXT)"),
+      QStringLiteral("CREATE TABLE campaign_missions ("
+                     "campaign_id TEXT NOT NULL, "
+                     "mission_id TEXT NOT NULL, "
+                     "order_index INTEGER NOT NULL, "
+                     "unlocked INTEGER NOT NULL DEFAULT 0, "
+                     "completed INTEGER NOT NULL DEFAULT 0, "
+                     "completed_at TEXT, "
+                     "PRIMARY KEY (campaign_id, mission_id))"),
+      QStringLiteral("CREATE TABLE mission_results ("
+                     "mission_id TEXT NOT NULL, "
+                     "mode TEXT NOT NULL, "
+                     "campaign_id TEXT NOT NULL, "
+                     "completed INTEGER NOT NULL DEFAULT 0, "
+                     "completion_time REAL, "
+                     "difficulty TEXT, "
+                     "result TEXT, "
+                     "completed_at TEXT, "
+                     "created_at TEXT NOT NULL, "
+                     "updated_at TEXT NOT NULL, "
+                     "PRIMARY KEY (mission_id, mode, campaign_id))")};
+
+  for (const QString& statement : statements) {
+    QSqlQuery query(m_database);
+    if (!query.exec(statement)) {
+      return fail(
+          out_error, QStringLiteral("Failed to create save schema"), query.lastError());
+    }
+  }
+
+  return true;
+}
+
+auto SaveStorage::write_slot(const Save::Record& record, QString* out_error) -> bool {
   if (!initialize(out_error)) {
+    return false;
+  }
+
+  if (record.slot_name.isEmpty()) {
+    if (out_error != nullptr) {
+      *out_error = QStringLiteral("Refusing to write a save with an empty slot name");
+    }
     return false;
   }
 
@@ -141,88 +412,97 @@ auto SaveStorage::save_slot(const QString& slot_name,
   }
 
   QSqlQuery query(m_database);
-  const QString insert_sql =
-      QStringLiteral("INSERT INTO saves (slot_name, title, map_name, timestamp, "
-                     "metadata, world_state, screenshot, created_at, updated_at) "
-                     "VALUES (:slot_name, :title, :map_name, :timestamp, :metadata, "
-                     ":world_state, :screenshot, :created_at, :updated_at) "
-                     "ON CONFLICT(slot_name) DO UPDATE SET "
-                     "title = excluded.title, "
-                     "map_name = excluded.map_name, "
-                     "timestamp = excluded.timestamp, "
-                     "metadata = excluded.metadata, "
-                     "world_state = excluded.world_state, "
-                     "screenshot = excluded.screenshot, "
-                     "updated_at = excluded.updated_at");
-
-  if (!query.prepare(insert_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to prepare save query: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
-    return false;
+  if (!query.prepare(QStringLiteral(
+          "INSERT INTO saves (slot_name, title, map_name, map_path, mode, "
+          "campaign_id, mission_id, difficulty, kind, play_time_seconds, "
+          "created_at, updated_at, format_version, compression, world_raw_size, "
+          "world_raw_checksum, world_blob_checksum, metadata, world_state, "
+          "screenshot) "
+          "VALUES (:slot_name, :title, :map_name, :map_path, :mode, :campaign_id, "
+          ":mission_id, :difficulty, :kind, :play_time_seconds, :created_at, "
+          ":updated_at, :format_version, :compression, :world_raw_size, "
+          ":world_raw_checksum, :world_blob_checksum, :metadata, :world_state, "
+          ":screenshot) "
+          "ON CONFLICT(slot_name) DO UPDATE SET "
+          "title = excluded.title, "
+          "map_name = excluded.map_name, "
+          "map_path = excluded.map_path, "
+          "mode = excluded.mode, "
+          "campaign_id = excluded.campaign_id, "
+          "mission_id = excluded.mission_id, "
+          "difficulty = excluded.difficulty, "
+          "kind = excluded.kind, "
+          "play_time_seconds = excluded.play_time_seconds, "
+          "updated_at = excluded.updated_at, "
+          "format_version = excluded.format_version, "
+          "compression = excluded.compression, "
+          "world_raw_size = excluded.world_raw_size, "
+          "world_raw_checksum = excluded.world_raw_checksum, "
+          "world_blob_checksum = excluded.world_blob_checksum, "
+          "metadata = excluded.metadata, "
+          "world_state = excluded.world_state, "
+          "screenshot = excluded.screenshot"))) {
+    return fail(
+        out_error, QStringLiteral("Failed to prepare save query"), query.lastError());
   }
 
-  const QString now_iso = QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs);
-  QString map_name = metadata.value("map_name").toString();
-  if (map_name.isEmpty()) {
-    map_name = QStringLiteral("Unknown Map");
-  }
-  const QByteArray metadata_bytes =
-      QJsonDocument(metadata).toJson(QJsonDocument::Compact);
+  const QString timestamp = record.updated_at.isEmpty() ? now_iso() : record.updated_at;
+  const QString created = record.created_at.isEmpty() ? timestamp : record.created_at;
 
-  query.bindValue(QStringLiteral(":slot_name"), slot_name);
-  query.bindValue(QStringLiteral(":title"), title);
-  query.bindValue(QStringLiteral(":map_name"), map_name);
-  query.bindValue(QStringLiteral(":timestamp"), now_iso);
-  query.bindValue(QStringLiteral(":metadata"), metadata_bytes);
-  query.bindValue(QStringLiteral(":world_state"), world_state);
-  if (screenshot.isEmpty()) {
-    query.bindValue(QStringLiteral(":screenshot"), QVariant(QByteArray()));
-  } else {
-    query.bindValue(QStringLiteral(":screenshot"), screenshot);
-  }
-  query.bindValue(QStringLiteral(":created_at"), now_iso);
-  query.bindValue(QStringLiteral(":updated_at"), now_iso);
+  query.bindValue(QStringLiteral(":slot_name"), record.slot_name);
+  query.bindValue(QStringLiteral(":title"), text(record.title));
+  query.bindValue(QStringLiteral(":map_name"), text(record.map_name));
+  query.bindValue(QStringLiteral(":map_path"), text(record.map_path));
+  query.bindValue(QStringLiteral(":mode"), text(record.mode));
+  query.bindValue(QStringLiteral(":campaign_id"), text(record.campaign_id));
+  query.bindValue(QStringLiteral(":mission_id"), text(record.mission_id));
+  query.bindValue(QStringLiteral(":difficulty"), text(record.difficulty));
+  query.bindValue(QStringLiteral(":kind"), Save::slot_kind_to_string(record.kind));
+  query.bindValue(QStringLiteral(":play_time_seconds"), record.play_time_seconds);
+  query.bindValue(QStringLiteral(":created_at"), created);
+  query.bindValue(QStringLiteral(":updated_at"), timestamp);
+  query.bindValue(QStringLiteral(":format_version"), Save::k_format_version);
+  query.bindValue(QStringLiteral(":compression"),
+                  Save::compression_to_string(record.world.compression));
+  query.bindValue(QStringLiteral(":world_raw_size"),
+                  static_cast<qint64>(record.world.raw_size));
+  query.bindValue(QStringLiteral(":world_raw_checksum"),
+                  text(record.world.raw_checksum));
+  query.bindValue(QStringLiteral(":world_blob_checksum"),
+                  text(record.world.blob_checksum));
+  query.bindValue(QStringLiteral(":metadata"),
+                  QJsonDocument(record.metadata).toJson(QJsonDocument::Compact));
+  query.bindValue(QStringLiteral(":world_state"), record.world.blob);
+  query.bindValue(QStringLiteral(":screenshot"), record.screenshot);
 
   if (!query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to persist save slot: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
+    fail(out_error, QStringLiteral("Failed to persist save slot"), query.lastError());
     transaction.rollback();
     return false;
   }
 
-  if (!transaction.commit(out_error)) {
-    return false;
-  }
-
-  return true;
+  return transaction.commit(out_error);
 }
 
-auto SaveStorage::load_slot(const QString& slot_name,
-                            QByteArray& world_state,
-                            QJsonObject& metadata,
-                            QByteArray& screenshot,
-                            QString& title,
-                            QString* out_error) -> bool {
+auto SaveStorage::read_slot(const QString& slot_name,
+                            Save::Record& out_record,
+                            QString* out_error) const -> bool {
   if (!initialize(out_error)) {
     return false;
   }
 
   QSqlQuery query(m_database);
-  query.prepare(
-      QStringLiteral("SELECT title, metadata, world_state, screenshot FROM saves "
-                     "WHERE slot_name = :slot_name"));
+  query.prepare(QStringLiteral(
+      "SELECT title, map_name, map_path, mode, campaign_id, mission_id, "
+      "difficulty, kind, play_time_seconds, created_at, updated_at, "
+      "compression, world_raw_size, world_raw_checksum, world_blob_checksum, "
+      "metadata, world_state, screenshot, format_version "
+      "FROM saves WHERE slot_name = :slot_name"));
   query.bindValue(QStringLiteral(":slot_name"), slot_name);
 
   if (!query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to read save slot: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
-    return false;
+    return fail(
+        out_error, QStringLiteral("Failed to read save slot"), query.lastError());
   }
 
   if (!query.next()) {
@@ -232,12 +512,59 @@ auto SaveStorage::load_slot(const QString& slot_name,
     return false;
   }
 
-  title = query.value(0).toString();
-  const QByteArray metadata_bytes = query.value(1).toByteArray();
-  metadata = QJsonDocument::fromJson(metadata_bytes).object();
-  world_state = query.value(2).toByteArray();
-  screenshot = query.value(3).toByteArray();
+  const int format_version = query.value(18).toInt();
+  if (format_version != Save::k_format_version) {
+    if (out_error != nullptr) {
+      *out_error = QStringLiteral("Save slot '%1' uses unsupported format version %2")
+                       .arg(slot_name)
+                       .arg(format_version);
+    }
+    return false;
+  }
+
+  Save::Record record;
+  record.slot_name = slot_name;
+  record.title = query.value(0).toString();
+  record.map_name = query.value(1).toString();
+  record.map_path = query.value(2).toString();
+  record.mode = query.value(3).toString();
+  record.campaign_id = query.value(4).toString();
+  record.mission_id = query.value(5).toString();
+  record.difficulty = query.value(6).toString();
+  if (!Save::slot_kind_from_string(query.value(7).toString(), record.kind)) {
+    record.kind = Save::SlotKind::Manual;
+  }
+  record.play_time_seconds = query.value(8).toDouble();
+  record.created_at = query.value(9).toString();
+  record.updated_at = query.value(10).toString();
+
+  if (!Save::compression_from_string(query.value(11).toString(),
+                                     record.world.compression)) {
+    if (out_error != nullptr) {
+      *out_error = QStringLiteral("Save slot '%1' uses an unknown compression format")
+                       .arg(slot_name);
+    }
+    return false;
+  }
+
+  record.world.raw_size = query.value(12).toLongLong();
+  record.world.raw_checksum = query.value(13).toString();
+  record.world.blob_checksum = query.value(14).toString();
+  record.metadata = QJsonDocument::fromJson(query.value(15).toByteArray()).object();
+  record.world.blob = query.value(16).toByteArray();
+  record.screenshot = query.value(17).toByteArray();
+
+  out_record = record;
   return true;
+}
+
+auto SaveStorage::verify_slot(const QString& slot_name,
+                              QString* out_error) const -> bool {
+  Save::Record record;
+  if (!read_slot(slot_name, record, out_error)) {
+    return false;
+  }
+  return Save::verify_blob(record.world, out_error);
 }
 
 auto SaveStorage::list_slots(QString* out_error) const -> QVariantList {
@@ -248,38 +575,37 @@ auto SaveStorage::list_slots(QString* out_error) const -> QVariantList {
 
   QSqlQuery query(m_database);
   if (!query.exec(QStringLiteral(
-          "SELECT slot_name, title, map_name, timestamp, metadata, screenshot "
-          "FROM saves ORDER BY datetime(timestamp) DESC"))) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to enumerate save slots: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
+          "SELECT slot_name, title, map_name, mode, campaign_id, mission_id, "
+          "difficulty, kind, play_time_seconds, updated_at, world_raw_size, "
+          "length(world_state), metadata, screenshot "
+          "FROM saves ORDER BY datetime(updated_at) DESC"))) {
+    fail(
+        out_error, QStringLiteral("Failed to enumerate save slots"), query.lastError());
     return result;
   }
 
   while (query.next()) {
     QVariantMap slot;
-    slot.insert(QStringLiteral("slotName"), query.value(0).toString());
+    slot.insert(QStringLiteral("slot_name"), query.value(0).toString());
     slot.insert(QStringLiteral("title"), query.value(1).toString());
     slot.insert(QStringLiteral("map_name"), query.value(2).toString());
-    slot.insert(QStringLiteral("timestamp"), query.value(3).toString());
+    slot.insert(QStringLiteral("mode"), query.value(3).toString());
+    slot.insert(QStringLiteral("campaign_id"), query.value(4).toString());
+    slot.insert(QStringLiteral("mission_id"), query.value(5).toString());
+    slot.insert(QStringLiteral("difficulty"), query.value(6).toString());
+    slot.insert(QStringLiteral("kind"), query.value(7).toString());
+    slot.insert(QStringLiteral("play_time_seconds"), query.value(8).toDouble());
+    slot.insert(QStringLiteral("timestamp"), query.value(9).toString());
+    slot.insert(QStringLiteral("uncompressed_size"), query.value(10).toLongLong());
+    slot.insert(QStringLiteral("stored_size"), query.value(11).toLongLong());
+    slot.insert(
+        QStringLiteral("metadata"),
+        QJsonDocument::fromJson(query.value(12).toByteArray()).object().toVariantMap());
 
-    const QByteArray metadata_bytes = query.value(4).toByteArray();
-    const QJsonObject metadata_obj = QJsonDocument::fromJson(metadata_bytes).object();
-    slot.insert(QStringLiteral("metadata"), metadata_obj.toVariantMap());
-
-    const QByteArray screenshot_bytes = query.value(5).toByteArray();
-    if (!screenshot_bytes.isEmpty()) {
-      slot.insert(QStringLiteral("thumbnail"),
-                  QString::fromLatin1(screenshot_bytes.toBase64()));
-    } else {
-      slot.insert(QStringLiteral("thumbnail"), QString());
-    }
-
-    if (metadata_obj.contains("playTime")) {
-      slot.insert(QStringLiteral("playTime"),
-                  metadata_obj.value("playTime").toString());
-    }
+    const QByteArray screenshot = query.value(13).toByteArray();
+    slot.insert(QStringLiteral("thumbnail"),
+                screenshot.isEmpty() ? QString()
+                                     : QString::fromLatin1(screenshot.toBase64()));
 
     result.append(slot);
   }
@@ -287,199 +613,130 @@ auto SaveStorage::list_slots(QString* out_error) const -> QVariantList {
   return result;
 }
 
-auto SaveStorage::list_campaigns(QString* out_error) -> QVariantList {
-  QVariantList result;
-
+auto SaveStorage::slot_names_by_kind(Save::SlotKind kind,
+                                     QString* out_error) const -> QStringList {
+  QStringList result;
   if (!initialize(out_error)) {
     return result;
   }
 
-  QStringList campaign_files;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("SELECT slot_name FROM saves WHERE kind = :kind "
+                               "ORDER BY datetime(updated_at) ASC"));
+  query.bindValue(QStringLiteral(":kind"), Save::slot_kind_to_string(kind));
 
-  QStringList search_paths = {
-      QStringLiteral("assets/campaigns"),
-      QStringLiteral("../assets/campaigns"),
-      QStringLiteral("../../assets/campaigns"),
-      QCoreApplication::applicationDirPath() + QStringLiteral("/assets/campaigns"),
-      QCoreApplication::applicationDirPath() + QStringLiteral("/../assets/campaigns")};
-
-  bool found_filesystem = false;
-  for (const QString& campaigns_path : search_paths) {
-    QDir campaigns_dir(campaigns_path);
-    if (campaigns_dir.exists()) {
-      campaign_files = campaigns_dir.entryList(
-          QStringList() << QStringLiteral("*.json"), QDir::Files);
-
-      if (!campaign_files.isEmpty()) {
-        qInfo() << "Loading campaigns from filesystem:" << campaigns_dir.absolutePath();
-
-        for (const auto& campaign_file : campaign_files) {
-          const QString campaign_path = campaigns_dir.filePath(campaign_file);
-
-          Game::Campaign::CampaignDefinition campaign;
-          QString error;
-          if (!Game::Campaign::CampaignLoader::load_from_json_file(
-                  campaign_path, campaign, &error)) {
-            qWarning() << "Failed to load campaign" << campaign_file << ":" << error;
-            continue;
-          }
-
-          QString db_error;
-          if (!ensure_campaign_in_db(campaign, &db_error)) {
-            qWarning() << "Failed to initialize campaign in DB for" << campaign.id
-                       << ":" << db_error;
-            continue;
-          }
-          if (!ensure_campaign_missions_in_db(campaign, &db_error)) {
-            qWarning() << "Failed to initialize campaign missions in DB for"
-                       << campaign.id << ":" << db_error;
-
-            continue;
-          }
-
-          QVariantList missions_progress = get_campaign_mission_progress(campaign.id);
-
-          QVariantMap campaign_map;
-          campaign_map.insert(QStringLiteral("id"), campaign.id);
-          campaign_map.insert(QStringLiteral("title"), campaign.title);
-          campaign_map.insert(QStringLiteral("description"), campaign.description);
-          campaign_map.insert(QStringLiteral("unlocked"), true);
-
-          bool all_completed = true;
-          QVariantList missions_list;
-          for (const auto& mission : campaign.missions) {
-            QVariantMap mission_map;
-            mission_map.insert(QStringLiteral("mission_id"), mission.mission_id);
-            mission_map.insert(QStringLiteral("order_index"), mission.order_index);
-            if (mission.intro_text.has_value()) {
-              mission_map.insert(QStringLiteral("intro_text"), *mission.intro_text);
-            }
-            if (mission.outro_text.has_value()) {
-              mission_map.insert(QStringLiteral("outro_text"), *mission.outro_text);
-            }
-            if (mission.difficulty_modifier.has_value()) {
-              mission_map.insert(QStringLiteral("difficulty_modifier"),
-                                 *mission.difficulty_modifier);
-            }
-
-            bool unlocked = mission.order_index == 0;
-            bool completed = false;
-            for (const QVariant& progress_var : missions_progress) {
-              QVariantMap progress = progress_var.toMap();
-              if (progress["mission_id"].toString() == mission.mission_id) {
-                unlocked = progress["unlocked"].toBool();
-                completed = progress["completed"].toBool();
-                break;
-              }
-            }
-
-            mission_map.insert(QStringLiteral("unlocked"), unlocked);
-            mission_map.insert(QStringLiteral("completed"), completed);
-            missions_list.append(mission_map);
-
-            if (!completed) {
-              all_completed = false;
-            }
-          }
-          campaign_map.insert(QStringLiteral("completed"), all_completed);
-          campaign_map.insert(QStringLiteral("missions"), missions_list);
-
-          result.append(campaign_map);
-        }
-
-        found_filesystem = true;
-        break;
-      }
-    }
+  if (!query.exec()) {
+    fail(
+        out_error, QStringLiteral("Failed to enumerate save slots"), query.lastError());
+    return result;
   }
 
-  if (!found_filesystem) {
+  while (query.next()) {
+    result.append(query.value(0).toString());
+  }
+  return result;
+}
 
-    qInfo() << "Loading campaigns from Qt resources";
+auto SaveStorage::slot_exists(const QString& slot_name,
+                              QString* out_error) const -> bool {
+  if (!initialize(out_error)) {
+    return false;
+  }
 
-    QStringList known_campaigns = {QStringLiteral("second_punic_war")};
+  QSqlQuery query(m_database);
+  query.prepare(
+      QStringLiteral("SELECT 1 FROM saves WHERE slot_name = :slot_name LIMIT 1"));
+  query.bindValue(QStringLiteral(":slot_name"), slot_name);
 
-    for (const auto& campaign_name : known_campaigns) {
-      const QString campaign_path =
-          QString(":/assets/campaigns/%1.json").arg(campaign_name);
+  if (!query.exec()) {
+    return fail(
+        out_error, QStringLiteral("Failed to look up save slot"), query.lastError());
+  }
+  return query.next();
+}
 
-      QFile test_file(campaign_path);
-      if (!test_file.exists()) {
-        qWarning() << "Campaign resource does not exist:" << campaign_path;
-        continue;
-      }
+auto SaveStorage::update_screenshot(const QString& slot_name,
+                                    const QByteArray& screenshot,
+                                    QString* out_error) -> bool {
+  if (!initialize(out_error)) {
+    return false;
+  }
 
-      Game::Campaign::CampaignDefinition campaign;
-      QString error;
-      if (!Game::Campaign::CampaignLoader::load_from_json_file(
-              campaign_path, campaign, &error)) {
-        qWarning() << "Failed to load campaign from resources" << campaign_name << ":"
-                   << error;
-        continue;
-      }
+  TransactionGuard transaction(m_database);
+  if (!transaction.begin(out_error)) {
+    return false;
+  }
 
-      QString db_error;
-      if (!ensure_campaign_in_db(campaign, &db_error)) {
-        qWarning() << "Failed to initialize campaign in DB for" << campaign.id << ":"
-                   << db_error;
-        continue;
-      }
-      if (!ensure_campaign_missions_in_db(campaign, &db_error)) {
-        qWarning() << "Failed to initialize campaign missions in DB for" << campaign.id
-                   << ":" << db_error;
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral(
+      "UPDATE saves SET screenshot = :screenshot WHERE slot_name = :slot_name"));
+  query.bindValue(QStringLiteral(":screenshot"), screenshot);
+  query.bindValue(QStringLiteral(":slot_name"), slot_name);
 
-        continue;
-      }
+  if (!query.exec()) {
+    fail(out_error, QStringLiteral("Failed to store save preview"), query.lastError());
+    transaction.rollback();
+    return false;
+  }
 
-      QVariantList missions_progress = get_campaign_mission_progress(campaign.id);
-
-      QVariantMap campaign_map;
-      campaign_map.insert(QStringLiteral("id"), campaign.id);
-      campaign_map.insert(QStringLiteral("title"), campaign.title);
-      campaign_map.insert(QStringLiteral("description"), campaign.description);
-      campaign_map.insert(QStringLiteral("unlocked"), true);
-
-      bool all_completed = true;
-      QVariantList missions_list;
-      for (const auto& mission : campaign.missions) {
-        QVariantMap mission_map;
-        mission_map.insert(QStringLiteral("mission_id"), mission.mission_id);
-        mission_map.insert(QStringLiteral("order_index"), mission.order_index);
-        if (mission.intro_text.has_value()) {
-          mission_map.insert(QStringLiteral("intro_text"), *mission.intro_text);
-        }
-        if (mission.outro_text.has_value()) {
-          mission_map.insert(QStringLiteral("outro_text"), *mission.outro_text);
-        }
-        if (mission.difficulty_modifier.has_value()) {
-          mission_map.insert(QStringLiteral("difficulty_modifier"),
-                             *mission.difficulty_modifier);
-        }
-
-        bool unlocked = mission.order_index == 0;
-        bool completed = false;
-        for (const QVariant& progress_var : missions_progress) {
-          QVariantMap progress = progress_var.toMap();
-          if (progress["mission_id"].toString() == mission.mission_id) {
-            unlocked = progress["unlocked"].toBool();
-            completed = progress["completed"].toBool();
-            break;
-          }
-        }
-
-        mission_map.insert(QStringLiteral("unlocked"), unlocked);
-        mission_map.insert(QStringLiteral("completed"), completed);
-        missions_list.append(mission_map);
-
-        if (!completed) {
-          all_completed = false;
-        }
-      }
-      campaign_map.insert(QStringLiteral("completed"), all_completed);
-      campaign_map.insert(QStringLiteral("missions"), missions_list);
-
-      result.append(campaign_map);
+  if (query.numRowsAffected() == 0) {
+    if (out_error != nullptr) {
+      *out_error = QStringLiteral("Save slot '%1' not found").arg(slot_name);
     }
+    transaction.rollback();
+    return false;
+  }
+
+  return transaction.commit(out_error);
+}
+
+auto SaveStorage::delete_slot(const QString& slot_name, QString* out_error) -> bool {
+  if (!initialize(out_error)) {
+    return false;
+  }
+
+  TransactionGuard transaction(m_database);
+  if (!transaction.begin(out_error)) {
+    return false;
+  }
+
+  QSqlQuery query(m_database);
+  query.prepare(QStringLiteral("DELETE FROM saves WHERE slot_name = :slot_name"));
+  query.bindValue(QStringLiteral(":slot_name"), slot_name);
+
+  if (!query.exec()) {
+    fail(out_error, QStringLiteral("Failed to delete save slot"), query.lastError());
+    transaction.rollback();
+    return false;
+  }
+
+  if (query.numRowsAffected() == 0) {
+    if (out_error != nullptr) {
+      *out_error = QStringLiteral("Save slot '%1' not found").arg(slot_name);
+    }
+    transaction.rollback();
+    return false;
+  }
+
+  return transaction.commit(out_error);
+}
+
+auto SaveStorage::list_campaigns(QString* out_error) -> QVariantList {
+  QVariantList result;
+  if (!initialize(out_error)) {
+    return result;
+  }
+
+  const auto campaigns = load_campaign_definitions();
+  for (const auto& campaign : campaigns) {
+    QString db_error;
+    if (!ensure_campaign_missions_in_db(campaign, &db_error)) {
+      qWarning() << "Failed to initialize campaign missions in DB for" << campaign.id
+                 << ":" << db_error;
+      continue;
+    }
+    result.append(
+        build_campaign_entry(campaign, get_campaign_mission_progress(campaign.id)));
   }
 
   if (result.isEmpty()) {
@@ -497,7 +754,7 @@ auto SaveStorage::list_campaigns(QString* out_error) -> QVariantList {
 auto SaveStorage::get_campaign_progress(const QString& campaign_id,
                                         QString* out_error) const -> QVariantMap {
   QVariantMap result;
-  if (!const_cast<SaveStorage*>(this)->initialize(out_error)) {
+  if (!initialize(out_error)) {
     return result;
   }
 
@@ -508,10 +765,9 @@ auto SaveStorage::get_campaign_progress(const QString& campaign_id,
   query.bindValue(QStringLiteral(":campaign_id"), campaign_id);
 
   if (!query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to get campaign progress: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
+    fail(out_error,
+         QStringLiteral("Failed to get campaign progress"),
+         query.lastError());
     return result;
   }
 
@@ -535,382 +791,25 @@ auto SaveStorage::mark_campaign_completed(const QString& campaign_id,
     return false;
   }
 
-  const QString now_iso = QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs);
-
   QSqlQuery query(m_database);
   query.prepare(QStringLiteral("INSERT INTO campaign_progress (campaign_id, completed, "
                                "unlocked, completed_at) "
                                "VALUES (:campaign_id, 1, 1, :completed_at) "
                                "ON CONFLICT(campaign_id) DO UPDATE SET "
-                               "completed = 1, completed_at = excluded.completed_at"));
+                               "completed = 1, unlocked = 1, "
+                               "completed_at = excluded.completed_at"));
   query.bindValue(QStringLiteral(":campaign_id"), campaign_id);
-  query.bindValue(QStringLiteral(":completed_at"), now_iso);
+  query.bindValue(QStringLiteral(":completed_at"), now_iso());
 
   if (!query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to mark campaign as completed: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
+    fail(out_error,
+         QStringLiteral("Failed to mark campaign as completed"),
+         query.lastError());
     transaction.rollback();
     return false;
   }
 
-  if (!transaction.commit(out_error)) {
-    return false;
-  }
-
-  return true;
-}
-
-auto SaveStorage::delete_slot(const QString& slot_name, QString* out_error) -> bool {
-  if (!initialize(out_error)) {
-    return false;
-  }
-
-  TransactionGuard transaction(m_database);
-  if (!transaction.begin(out_error)) {
-    return false;
-  }
-
-  QSqlQuery query(m_database);
-  query.prepare(QStringLiteral("DELETE FROM saves WHERE slot_name = :slot_name"));
-  query.bindValue(QStringLiteral(":slot_name"), slot_name);
-
-  if (!query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to delete save slot: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
-    transaction.rollback();
-    return false;
-  }
-
-  if (query.numRowsAffected() == 0) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Save slot '%1' not found").arg(slot_name);
-    }
-    transaction.rollback();
-    return false;
-  }
-
-  if (!transaction.commit(out_error)) {
-    return false;
-  }
-
-  return true;
-}
-
-auto SaveStorage::open(QString* out_error) const -> bool {
-  if (m_database.isValid() && m_database.isOpen()) {
-    return true;
-  }
-
-  if (!m_database.isValid()) {
-    m_database = QSqlDatabase::addDatabase(k_driver_name, m_connection_name);
-    m_database.setDatabaseName(m_database_path);
-    m_database.setConnectOptions(QStringLiteral("QSQLITE_BUSY_TIMEOUT=5000"));
-  }
-
-  if (!m_database.open()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to open save database: %1")
-                       .arg(last_error_string(m_database.lastError()));
-    }
-    return false;
-  }
-
-  QSqlQuery foreign_keys_query(m_database);
-  foreign_keys_query.exec(QStringLiteral("PRAGMA foreign_keys = ON"));
-
-  QSqlQuery journal_mode_query(m_database);
-  journal_mode_query.exec(QStringLiteral("PRAGMA journal_mode=WAL"));
-
-  return true;
-}
-
-auto SaveStorage::ensure_schema(QString* out_error) const -> bool {
-  const int current_version = schema_version(out_error);
-  if (current_version < 0) {
-    return false;
-  }
-
-  if (current_version > k_current_schema_version) {
-    if (out_error != nullptr) {
-      *out_error =
-          QStringLiteral("Save database schema version %1 is newer than supported %2")
-              .arg(current_version)
-              .arg(k_current_schema_version);
-    }
-    return false;
-  }
-
-  if (current_version == k_current_schema_version) {
-    return true;
-  }
-
-  TransactionGuard transaction(m_database);
-  if (!transaction.begin(out_error)) {
-    return false;
-  }
-
-  if (!migrate_schema(current_version, out_error)) {
-    transaction.rollback();
-    return false;
-  }
-
-  if (!set_schema_version(k_current_schema_version, out_error)) {
-    transaction.rollback();
-    return false;
-  }
-
-  if (!transaction.commit(out_error)) {
-    return false;
-  }
-
-  return true;
-}
-
-auto SaveStorage::schema_version(QString* out_error) const -> int {
-  QSqlQuery pragma_query(m_database);
-  if (!pragma_query.exec(QStringLiteral("PRAGMA user_version"))) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to read schema version: %1")
-                       .arg(last_error_string(pragma_query.lastError()));
-    }
-    return -1;
-  }
-
-  if (pragma_query.next()) {
-    return pragma_query.value(0).toInt();
-  }
-
-  return 0;
-}
-
-auto SaveStorage::set_schema_version(int version, QString* out_error) const -> bool {
-  QSqlQuery pragma_query(m_database);
-  if (!pragma_query.exec(QStringLiteral("PRAGMA user_version = %1").arg(version))) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to update schema version: %1")
-                       .arg(last_error_string(pragma_query.lastError()));
-    }
-    return false;
-  }
-  return true;
-}
-
-auto SaveStorage::create_base_schema(QString* out_error) const -> bool {
-  QSqlQuery query(m_database);
-  const QString create_sql = QStringLiteral("CREATE TABLE IF NOT EXISTS saves ("
-                                            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                                            "slot_name TEXT UNIQUE NOT NULL, "
-                                            "title TEXT NOT NULL, "
-                                            "map_name TEXT, "
-                                            "timestamp TEXT NOT NULL, "
-                                            "metadata BLOB NOT NULL, "
-                                            "world_state BLOB NOT NULL, "
-                                            "screenshot BLOB, "
-                                            "created_at TEXT NOT NULL, "
-                                            "updated_at TEXT NOT NULL"
-                                            ")");
-
-  if (!query.exec(create_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to create save schema: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
-    return false;
-  }
-
-  QSqlQuery index_query(m_database);
-  if (!index_query.exec(
-          QStringLiteral("CREATE INDEX IF NOT EXISTS idx_saves_updated_at ON saves "
-                         "(updated_at DESC)"))) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to build save index: %1")
-                       .arg(last_error_string(index_query.lastError()));
-    }
-    return false;
-  }
-
-  return true;
-}
-
-auto SaveStorage::migrate_schema(int from_version, QString* out_error) const -> bool {
-  int version = from_version;
-
-  while (version < k_current_schema_version) {
-    switch (version) {
-    case 0:
-      if (!create_base_schema(out_error)) {
-        return false;
-      }
-      version = 1;
-      break;
-    case 1:
-      if (!migrate_to_2(out_error)) {
-        return false;
-      }
-      version = 2;
-      break;
-    case 2:
-      if (!migrate_to_3(out_error)) {
-        return false;
-      }
-      version = 3;
-      break;
-    default:
-      if (out_error != nullptr) {
-        *out_error = QStringLiteral("Unsupported migration path from %1").arg(version);
-      }
-      return false;
-    }
-  }
-
-  return true;
-}
-
-auto SaveStorage::migrate_to_2(QString* out_error) const -> bool {
-
-  QSqlQuery query(m_database);
-  const QString create_campaigns_sql =
-      QStringLiteral("CREATE TABLE IF NOT EXISTS campaigns ("
-                     "id TEXT PRIMARY KEY NOT NULL, "
-                     "title TEXT NOT NULL, "
-                     "description TEXT NOT NULL, "
-                     "map_path TEXT NOT NULL, "
-                     "order_index INTEGER NOT NULL DEFAULT 0"
-                     ")");
-
-  if (!query.exec(create_campaigns_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to create campaigns table: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
-    return false;
-  }
-
-  QSqlQuery progress_query(m_database);
-  const QString create_progress_sql = QStringLiteral(
-      "CREATE TABLE IF NOT EXISTS campaign_progress ("
-      "campaign_id TEXT PRIMARY KEY NOT NULL, "
-      "completed INTEGER NOT NULL DEFAULT 0, "
-      "unlocked INTEGER NOT NULL DEFAULT 0, "
-      "completed_at TEXT, "
-      "FOREIGN KEY(campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE"
-      ")");
-
-  if (!progress_query.exec(create_progress_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to create campaign_progress table: %1")
-                       .arg(last_error_string(progress_query.lastError()));
-    }
-    return false;
-  }
-
-  QSqlQuery insert_query(m_database);
-  const QString insert_campaign_sql = QStringLiteral(
-      "INSERT INTO campaigns (id, title, description, map_path, order_index) "
-      "VALUES ('carthage_vs_rome', 'Carthage vs Rome', "
-      "'Historic battle between Carthage and the Roman Republic. "
-      "Command Carthaginian forces to defeat the Roman barracks.', "
-      "':/assets/maps/map_rivers.json', 0)");
-
-  if (!insert_query.exec(insert_campaign_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to insert initial campaign: %1")
-                       .arg(last_error_string(insert_query.lastError()));
-    }
-    return false;
-  }
-
-  QSqlQuery progress_insert_query(m_database);
-  const QString insert_progress_sql =
-      QStringLiteral("INSERT INTO campaign_progress (campaign_id, completed, unlocked) "
-                     "VALUES ('carthage_vs_rome', 0, 1)");
-
-  if (!progress_insert_query.exec(insert_progress_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to initialize campaign progress: %1")
-                       .arg(last_error_string(progress_insert_query.lastError()));
-    }
-    return false;
-  }
-
-  return true;
-}
-
-auto SaveStorage::migrate_to_3(QString* out_error) const -> bool {
-
-  QSqlQuery query(m_database);
-  const QString create_mission_progress_sql =
-      QStringLiteral("CREATE TABLE IF NOT EXISTS mission_progress ("
-                     "id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                     "mission_id TEXT NOT NULL, "
-                     "mode TEXT NOT NULL, "
-                     "campaign_id TEXT, "
-                     "completed INTEGER NOT NULL DEFAULT 0, "
-                     "completion_time REAL, "
-                     "difficulty TEXT, "
-                     "result TEXT, "
-                     "completed_at TEXT, "
-                     "created_at TEXT NOT NULL, "
-                     "updated_at TEXT NOT NULL, "
-                     "UNIQUE(mission_id, mode, campaign_id)"
-                     ")");
-
-  if (!query.exec(create_mission_progress_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to create mission_progress table: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
-    return false;
-  }
-
-  QSqlQuery missions_query(m_database);
-  const QString create_campaign_missions_sql =
-      QStringLiteral("CREATE TABLE IF NOT EXISTS campaign_missions ("
-                     "id INTEGER PRIMARY KEY AUTOINCREMENT, "
-                     "campaign_id TEXT NOT NULL, "
-                     "mission_id TEXT NOT NULL, "
-                     "order_index INTEGER NOT NULL, "
-                     "unlocked INTEGER NOT NULL DEFAULT 0, "
-                     "completed INTEGER NOT NULL DEFAULT 0, "
-                     "completed_at TEXT, "
-                     "UNIQUE(campaign_id, mission_id)"
-                     ")");
-
-  if (!missions_query.exec(create_campaign_missions_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to create campaign_missions table: %1")
-                       .arg(last_error_string(missions_query.lastError()));
-    }
-    return false;
-  }
-
-  QSqlQuery index_query(m_database);
-  if (!index_query.exec(QStringLiteral(
-          "CREATE INDEX IF NOT EXISTS idx_mission_progress_mission_id ON "
-          "mission_progress (mission_id)"))) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to create mission_progress index: %1")
-                       .arg(last_error_string(index_query.lastError()));
-    }
-    return false;
-  }
-
-  QSqlQuery campaign_index_query(m_database);
-  if (!campaign_index_query.exec(QStringLiteral(
-          "CREATE INDEX IF NOT EXISTS idx_campaign_missions_campaign_id ON "
-          "campaign_missions (campaign_id)"))) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to create campaign_missions index: %1")
-                       .arg(last_error_string(campaign_index_query.lastError()));
-    }
-    return false;
-  }
-
-  return true;
+  return transaction.commit(out_error);
 }
 
 auto SaveStorage::save_mission_result(const QString& mission_id,
@@ -930,60 +829,45 @@ auto SaveStorage::save_mission_result(const QString& mission_id,
     return false;
   }
 
-  const QString now_iso = QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs);
+  const QString timestamp = now_iso();
 
   QSqlQuery query(m_database);
-  const QString insert_sql = QStringLiteral(
-      "INSERT INTO mission_progress (mission_id, mode, campaign_id, completed, "
-      "completion_time, difficulty, result, completed_at, created_at, "
-      "updated_at) "
-      "VALUES (:mission_id, :mode, :campaign_id, :completed, :completion_time, "
-      ":difficulty, :result, :completed_at, :created_at, :updated_at) "
-      "ON CONFLICT(mission_id, mode, campaign_id) DO UPDATE SET "
-      "completed = excluded.completed, "
-      "completion_time = excluded.completion_time, "
-      "difficulty = excluded.difficulty, "
-      "result = excluded.result, "
-      "completed_at = excluded.completed_at, "
-      "updated_at = excluded.updated_at");
-
-  if (!query.prepare(insert_sql)) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to prepare mission_progress insert: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
-    return false;
+  if (!query.prepare(QStringLiteral(
+          "INSERT INTO mission_results (mission_id, mode, campaign_id, completed, "
+          "completion_time, difficulty, result, completed_at, created_at, "
+          "updated_at) "
+          "VALUES (:mission_id, :mode, :campaign_id, :completed, :completion_time, "
+          ":difficulty, :result, :completed_at, :created_at, :updated_at) "
+          "ON CONFLICT(mission_id, mode, campaign_id) DO UPDATE SET "
+          "completed = excluded.completed, "
+          "completion_time = excluded.completion_time, "
+          "difficulty = excluded.difficulty, "
+          "result = excluded.result, "
+          "completed_at = excluded.completed_at, "
+          "updated_at = excluded.updated_at"))) {
+    return fail(out_error,
+                QStringLiteral("Failed to prepare mission result insert"),
+                query.lastError());
   }
 
-  query.bindValue(QStringLiteral(":mission_id"), mission_id);
-  query.bindValue(QStringLiteral(":mode"), mode);
-  if (campaign_id.isEmpty()) {
-    query.bindValue(QStringLiteral(":campaign_id"), QVariant());
-  } else {
-    query.bindValue(QStringLiteral(":campaign_id"), campaign_id);
-  }
+  query.bindValue(QStringLiteral(":mission_id"), text(mission_id));
+  query.bindValue(QStringLiteral(":mode"), text(mode));
+  query.bindValue(QStringLiteral(":campaign_id"), text(campaign_id));
   query.bindValue(QStringLiteral(":completed"), completed ? 1 : 0);
   query.bindValue(QStringLiteral(":completion_time"), completion_time);
   query.bindValue(QStringLiteral(":difficulty"), difficulty);
   query.bindValue(QStringLiteral(":result"), result);
-  query.bindValue(QStringLiteral(":completed_at"), completed ? now_iso : QVariant());
-  query.bindValue(QStringLiteral(":created_at"), now_iso);
-  query.bindValue(QStringLiteral(":updated_at"), now_iso);
+  query.bindValue(QStringLiteral(":completed_at"), completed ? timestamp : QString());
+  query.bindValue(QStringLiteral(":created_at"), timestamp);
+  query.bindValue(QStringLiteral(":updated_at"), timestamp);
 
   if (!query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to save mission result: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
+    fail(out_error, QStringLiteral("Failed to save mission result"), query.lastError());
     transaction.rollback();
     return false;
   }
 
-  if (!transaction.commit(out_error)) {
-    return false;
-  }
-
-  return true;
+  return transaction.commit(out_error);
 }
 
 auto SaveStorage::get_mission_progress(const QString& mission_id,
@@ -996,15 +880,13 @@ auto SaveStorage::get_mission_progress(const QString& mission_id,
   QSqlQuery query(m_database);
   query.prepare(QStringLiteral(
       "SELECT mode, campaign_id, completed, completion_time, difficulty, "
-      "result, completed_at FROM mission_progress "
+      "result, completed_at FROM mission_results "
       "WHERE mission_id = :mission_id ORDER BY updated_at DESC LIMIT 1"));
   query.bindValue(QStringLiteral(":mission_id"), mission_id);
 
   if (!query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to get mission progress: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
+    fail(
+        out_error, QStringLiteral("Failed to get mission progress"), query.lastError());
     return result;
   }
 
@@ -1036,10 +918,9 @@ auto SaveStorage::get_campaign_mission_progress(
   query.bindValue(QStringLiteral(":campaign_id"), campaign_id);
 
   if (!query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to get campaign mission progress: %1")
-                       .arg(last_error_string(query.lastError()));
-    }
+    fail(out_error,
+         QStringLiteral("Failed to get campaign mission progress"),
+         query.lastError());
     return result;
   }
 
@@ -1068,94 +949,28 @@ auto SaveStorage::ensure_campaign_missions_in_db(
   }
 
   for (const auto& mission : campaign.missions) {
-    QSqlQuery check_query(m_database);
-    check_query.prepare(QStringLiteral(
-        "SELECT COUNT(*) FROM campaign_missions "
-        "WHERE campaign_id = :campaign_id AND mission_id = :mission_id"));
-    check_query.bindValue(QStringLiteral(":campaign_id"), campaign.id);
-    check_query.bindValue(QStringLiteral(":mission_id"), mission.mission_id);
+    QSqlQuery query(m_database);
+    query.prepare(QStringLiteral(
+        "INSERT INTO campaign_missions (campaign_id, mission_id, order_index, "
+        "unlocked, completed) VALUES (:campaign_id, :mission_id, :order_index, "
+        ":unlocked, 0) "
+        "ON CONFLICT(campaign_id, mission_id) DO UPDATE SET "
+        "order_index = excluded.order_index"));
+    query.bindValue(QStringLiteral(":campaign_id"), campaign.id);
+    query.bindValue(QStringLiteral(":mission_id"), mission.mission_id);
+    query.bindValue(QStringLiteral(":order_index"), mission.order_index);
+    query.bindValue(QStringLiteral(":unlocked"), mission.order_index == 0 ? 1 : 0);
 
-    if (!check_query.exec() || !check_query.next()) {
-      if (out_error != nullptr) {
-        *out_error = QStringLiteral("Failed to check campaign mission existence: %1")
-                         .arg(last_error_string(check_query.lastError()));
-      }
+    if (!query.exec()) {
+      fail(out_error,
+           QStringLiteral("Failed to register campaign mission"),
+           query.lastError());
       transaction.rollback();
       return false;
     }
-
-    int count = check_query.value(0).toInt();
-    if (count == 0) {
-
-      QSqlQuery insert_query(m_database);
-      insert_query.prepare(QStringLiteral(
-          "INSERT INTO campaign_missions (campaign_id, mission_id, "
-          "order_index, unlocked, completed) "
-          "VALUES (:campaign_id, :mission_id, :order_index, :unlocked, 0)"));
-      insert_query.bindValue(QStringLiteral(":campaign_id"), campaign.id);
-      insert_query.bindValue(QStringLiteral(":mission_id"), mission.mission_id);
-      insert_query.bindValue(QStringLiteral(":order_index"), mission.order_index);
-
-      insert_query.bindValue(QStringLiteral(":unlocked"),
-                             mission.order_index == 0 ? 1 : 0);
-
-      if (!insert_query.exec()) {
-        if (out_error != nullptr) {
-          *out_error = QStringLiteral("Failed to insert campaign mission: %1")
-                           .arg(last_error_string(insert_query.lastError()));
-        }
-        transaction.rollback();
-        return false;
-      }
-    }
   }
 
-  if (!transaction.commit(out_error)) {
-    return false;
-  }
-
-  return true;
-}
-
-auto SaveStorage::ensure_campaign_in_db(
-    const Game::Campaign::CampaignDefinition& campaign, QString* out_error) -> bool {
-  if (!initialize(out_error)) {
-    return false;
-  }
-
-  TransactionGuard transaction(m_database);
-  if (!transaction.begin(out_error)) {
-    return false;
-  }
-
-  QSqlQuery insert_query(m_database);
-  insert_query.prepare(QStringLiteral(
-      "INSERT INTO campaigns (id, title, description, map_path, order_index) "
-      "VALUES (:id, :title, :description, :map_path, :order_index) "
-      "ON CONFLICT(id) DO UPDATE SET "
-      "title = excluded.title, "
-      "description = excluded.description"));
-  insert_query.bindValue(QStringLiteral(":id"), campaign.id);
-  insert_query.bindValue(QStringLiteral(":title"), campaign.title);
-  insert_query.bindValue(QStringLiteral(":description"), campaign.description);
-  insert_query.bindValue(QStringLiteral(":map_path"),
-                         QStringLiteral(":/assets/maps/map_rivers.json"));
-  insert_query.bindValue(QStringLiteral(":order_index"), 0);
-
-  if (!insert_query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to insert campaign: %1")
-                       .arg(last_error_string(insert_query.lastError()));
-    }
-    transaction.rollback();
-    return false;
-  }
-
-  if (!transaction.commit(out_error)) {
-    return false;
-  }
-
-  return true;
+  return transaction.commit(out_error);
 }
 
 auto SaveStorage::unlock_next_mission(const QString& campaign_id,
@@ -1170,22 +985,19 @@ auto SaveStorage::unlock_next_mission(const QString& campaign_id,
     return false;
   }
 
-  const QString now_iso = QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs);
-
   QSqlQuery update_query(m_database);
   update_query.prepare(
-      QStringLiteral("UPDATE campaign_missions SET completed = 1, completed_at = "
-                     ":completed_at "
+      QStringLiteral("UPDATE campaign_missions SET completed = 1, unlocked = 1, "
+                     "completed_at = :completed_at "
                      "WHERE campaign_id = :campaign_id AND mission_id = :mission_id"));
-  update_query.bindValue(QStringLiteral(":completed_at"), now_iso);
+  update_query.bindValue(QStringLiteral(":completed_at"), now_iso());
   update_query.bindValue(QStringLiteral(":campaign_id"), campaign_id);
   update_query.bindValue(QStringLiteral(":mission_id"), completed_mission_id);
 
   if (!update_query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to mark mission as completed: %1")
-                       .arg(last_error_string(update_query.lastError()));
-    }
+    fail(out_error,
+         QStringLiteral("Failed to mark mission as completed"),
+         update_query.lastError());
     transaction.rollback();
     return false;
   }
@@ -1198,48 +1010,41 @@ auto SaveStorage::unlock_next_mission(const QString& campaign_id,
   order_query.bindValue(QStringLiteral(":mission_id"), completed_mission_id);
 
   if (!order_query.exec() || !order_query.next()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to find completed mission order: %1")
-                       .arg(last_error_string(order_query.lastError()));
-    }
+    fail(out_error,
+         QStringLiteral("Failed to find completed mission order"),
+         order_query.lastError());
     transaction.rollback();
     return false;
   }
 
-  int completed_order = order_query.value(0).toInt();
+  const int completed_order = order_query.value(0).toInt();
 
   QSqlQuery unlock_query(m_database);
   unlock_query.prepare(
       QStringLiteral("UPDATE campaign_missions SET unlocked = 1 "
-                     "WHERE campaign_id = :campaign_id AND order_index = "
-                     ":next_order_index"));
+                     "WHERE campaign_id = :campaign_id AND order_index = :next_order"));
   unlock_query.bindValue(QStringLiteral(":campaign_id"), campaign_id);
-  unlock_query.bindValue(QStringLiteral(":next_order_index"), completed_order + 1);
+  unlock_query.bindValue(QStringLiteral(":next_order"), completed_order + 1);
 
   if (!unlock_query.exec()) {
-    if (out_error != nullptr) {
-      *out_error = QStringLiteral("Failed to unlock next mission: %1")
-                       .arg(last_error_string(unlock_query.lastError()));
-    }
+    fail(out_error,
+         QStringLiteral("Failed to unlock next mission"),
+         unlock_query.lastError());
     transaction.rollback();
     return false;
   }
 
   if (unlock_query.numRowsAffected() == 0) {
     if (out_error != nullptr) {
-      *out_error = QStringLiteral("No next mission found to unlock (completed mission "
-                                  "order: %1)")
+      *out_error = QStringLiteral(
+                       "No next mission found to unlock (completed mission order: %1)")
                        .arg(completed_order);
     }
     transaction.rollback();
     return false;
   }
 
-  if (!transaction.commit(out_error)) {
-    return false;
-  }
-
-  return true;
+  return transaction.commit(out_error);
 }
 
 } // namespace Game::Systems

--- a/game/systems/save_storage.h
+++ b/game/systems/save_storage.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <QByteArray>
-#include <QJsonObject>
 #include <QSqlDatabase>
 #include <QString>
+#include <QStringList>
 #include <QVariantList>
+#include <QVariantMap>
 
-#include <memory>
+#include "save_format.h"
 
 namespace Game::Campaign {
 struct CampaignDefinition;
@@ -19,23 +20,31 @@ public:
   explicit SaveStorage(QString database_path);
   ~SaveStorage();
 
+  SaveStorage(const SaveStorage&) = delete;
+  auto operator=(const SaveStorage&) -> SaveStorage& = delete;
+
   auto initialize(QString* out_error = nullptr) const -> bool;
 
-  auto save_slot(const QString& slot_name,
-                 const QString& title,
-                 const QJsonObject& metadata,
-                 const QByteArray& world_state,
-                 const QByteArray& screenshot,
-                 QString* out_error = nullptr) -> bool;
+  auto write_slot(const Save::Record& record, QString* out_error = nullptr) -> bool;
 
-  auto load_slot(const QString& slot_name,
-                 QByteArray& world_state,
-                 QJsonObject& metadata,
-                 QByteArray& screenshot,
-                 QString& title,
-                 QString* out_error = nullptr) -> bool;
+  auto read_slot(const QString& slot_name,
+                 Save::Record& out_record,
+                 QString* out_error = nullptr) const -> bool;
+
+  auto verify_slot(const QString& slot_name,
+                   QString* out_error = nullptr) const -> bool;
 
   auto list_slots(QString* out_error = nullptr) const -> QVariantList;
+
+  auto slot_names_by_kind(Save::SlotKind kind,
+                          QString* out_error = nullptr) const -> QStringList;
+
+  auto slot_exists(const QString& slot_name,
+                   QString* out_error = nullptr) const -> bool;
+
+  auto update_screenshot(const QString& slot_name,
+                         const QByteArray& screenshot,
+                         QString* out_error = nullptr) -> bool;
 
   auto delete_slot(const QString& slot_name, QString* out_error = nullptr) -> bool;
 
@@ -70,16 +79,10 @@ public:
                                  QString* out_error = nullptr) -> bool;
 
 private:
-  auto open(QString* out_error = nullptr) const -> bool;
-  auto ensure_schema(QString* out_error = nullptr) const -> bool;
-  auto create_base_schema(QString* out_error = nullptr) const -> bool;
-  auto migrate_schema(int from_version, QString* out_error = nullptr) const -> bool;
-  auto schema_version(QString* out_error = nullptr) const -> int;
-  auto set_schema_version(int version, QString* out_error = nullptr) const -> bool;
-  auto migrate_to_2(QString* out_error = nullptr) const -> bool;
-  auto migrate_to_3(QString* out_error = nullptr) const -> bool;
-  auto ensure_campaign_in_db(const Game::Campaign::CampaignDefinition& campaign,
-                             QString* out_error = nullptr) -> bool;
+  auto open(QString* out_error) const -> bool;
+  auto ensure_schema(QString* out_error) const -> bool;
+  auto create_schema(QString* out_error) const -> bool;
+  auto drop_schema(QString* out_error) const -> bool;
 
   QString m_database_path;
   QString m_connection_name;

--- a/qml_resources.qrc
+++ b/qml_resources.qrc
@@ -10,6 +10,7 @@
         <file>ui/qml/PlayerConfigPanel.qml</file>
         <file>ui/qml/SaveGamePanel.qml</file>
         <file>ui/qml/LoadGamePanel.qml</file>
+        <file>ui/qml/SaveProgressOverlay.qml</file>
         <file>ui/qml/ObjectivesPanel.qml</file>
         <file>ui/qml/Constants.qml</file>
         <file>ui/qml/StyleGuide.qml</file>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,9 @@ add_executable(standard_of_iron_tests
     controllers/command_controller_test.cpp
     core/runtime_frame_orchestrator_test.cpp
     db/save_storage_test.cpp
+    db/save_format_test.cpp
+    db/save_load_service_test.cpp
+    db/save_preview_test.cpp
     db/mission_progress_test.cpp
     map/terrain_profiles_test.cpp
     map/terrain_service_test.cpp

--- a/tests/db/save_format_test.cpp
+++ b/tests/db/save_format_test.cpp
@@ -1,0 +1,180 @@
+#include <QByteArray>
+#include <QJsonObject>
+#include <QString>
+
+#include <gtest/gtest.h>
+
+#include "systems/save_format.h"
+
+using namespace Game::Systems::Save;
+
+namespace {
+
+auto sample_world() -> QByteArray {
+  QByteArray world;
+  for (int i = 0; i < 2000; ++i) {
+    world.append("{\"id\":");
+    world.append(QByteArray::number(i));
+    world.append(R"(,"type":"archer"},)");
+  }
+  return world;
+}
+
+auto sample_record() -> Record {
+  Record record;
+  record.slot_name = QStringLiteral("shared_save");
+  record.title = QStringLiteral("Shared Save");
+  record.map_name = QStringLiteral("River Crossing");
+  record.map_path = QStringLiteral("assets/maps/river.json");
+  record.mode = QStringLiteral("campaign");
+  record.campaign_id = QStringLiteral("second_punic_war");
+  record.mission_id = QStringLiteral("trebia");
+  record.difficulty = QStringLiteral("hard");
+  record.kind = SlotKind::Manual;
+  record.play_time_seconds = 1234.5;
+  record.created_at = QStringLiteral("2026-07-25T10:00:00.000");
+  record.updated_at = QStringLiteral("2026-07-25T10:30:00.000");
+  record.metadata = QJsonObject{{"map_name", "River Crossing"}, {"local_owner_id", 1}};
+  record.screenshot = QByteArray("preview-bytes");
+  record.world = pack(sample_world());
+  return record;
+}
+
+} // namespace
+
+TEST(SaveFormatTest, PackShrinksRepetitiveDataAndRoundTrips) {
+  const QByteArray world = sample_world();
+  const Payload payload = pack(world);
+
+  EXPECT_EQ(payload.compression, Compression::Zlib);
+  EXPECT_EQ(payload.raw_size, world.size());
+  EXPECT_LT(payload.blob.size(), world.size());
+
+  QString error;
+  QByteArray restored;
+  ASSERT_TRUE(unpack(payload, restored, &error)) << error.toStdString();
+  EXPECT_EQ(restored, world);
+}
+
+TEST(SaveFormatTest, UncompressedPayloadRoundTrips) {
+  const QByteArray world("raw world state");
+  const Payload payload = pack(world, Compression::None);
+
+  EXPECT_EQ(payload.blob, world);
+
+  QString error;
+  QByteArray restored;
+  ASSERT_TRUE(unpack(payload, restored, &error)) << error.toStdString();
+  EXPECT_EQ(restored, world);
+}
+
+TEST(SaveFormatTest, TruncatedBlobIsRejectedBeforeDecompression) {
+  Payload payload = pack(sample_world());
+  payload.blob.truncate(payload.blob.size() / 2);
+
+  QString error;
+  EXPECT_FALSE(verify_blob(payload, &error));
+  EXPECT_TRUE(error.contains("corrupted")) << error.toStdString();
+
+  QByteArray restored;
+  EXPECT_FALSE(unpack(payload, restored, &error));
+  EXPECT_TRUE(restored.isEmpty());
+}
+
+TEST(SaveFormatTest, FlippedByteIsRejected) {
+  Payload payload = pack(sample_world());
+  payload.blob[payload.blob.size() / 2] =
+      static_cast<char>(payload.blob.at(payload.blob.size() / 2) ^ 0xFF);
+
+  QString error;
+  QByteArray restored;
+  EXPECT_FALSE(unpack(payload, restored, &error));
+  EXPECT_TRUE(restored.isEmpty());
+}
+
+TEST(SaveFormatTest, ContentChecksumMismatchIsRejected) {
+  Payload payload = pack(QByteArray("world"));
+  payload.raw_checksum = checksum_of(QByteArray("a different world"));
+
+  QString error;
+  QByteArray restored;
+  EXPECT_FALSE(unpack(payload, restored, &error));
+  EXPECT_TRUE(error.contains("checksum")) << error.toStdString();
+}
+
+TEST(SaveFormatTest, PackageRoundTripsEveryField) {
+  const Record record = sample_record();
+  const QByteArray package = encode_package(record);
+
+  Record decoded;
+  QString error;
+  ASSERT_TRUE(decode_package(package, decoded, &error)) << error.toStdString();
+
+  EXPECT_EQ(decoded.slot_name, record.slot_name);
+  EXPECT_EQ(decoded.title, record.title);
+  EXPECT_EQ(decoded.map_name, record.map_name);
+  EXPECT_EQ(decoded.map_path, record.map_path);
+  EXPECT_EQ(decoded.mode, record.mode);
+  EXPECT_EQ(decoded.campaign_id, record.campaign_id);
+  EXPECT_EQ(decoded.mission_id, record.mission_id);
+  EXPECT_EQ(decoded.difficulty, record.difficulty);
+  EXPECT_EQ(decoded.kind, record.kind);
+  EXPECT_DOUBLE_EQ(decoded.play_time_seconds, record.play_time_seconds);
+  EXPECT_EQ(decoded.created_at, record.created_at);
+  EXPECT_EQ(decoded.updated_at, record.updated_at);
+  EXPECT_EQ(decoded.metadata, record.metadata);
+  EXPECT_EQ(decoded.screenshot, record.screenshot);
+
+  QByteArray world;
+  ASSERT_TRUE(unpack(decoded.world, world, &error)) << error.toStdString();
+  EXPECT_EQ(world, sample_world());
+}
+
+TEST(SaveFormatTest, ForeignFileIsRejected) {
+  Record decoded;
+  QString error;
+  EXPECT_FALSE(decode_package(QByteArray("this is not a save file"), decoded, &error));
+  EXPECT_FALSE(error.isEmpty());
+}
+
+TEST(SaveFormatTest, TruncatedPackageIsRejected) {
+  QByteArray package = encode_package(sample_record());
+  package.truncate(package.size() - 64);
+
+  Record decoded;
+  QString error;
+  EXPECT_FALSE(decode_package(package, decoded, &error));
+  EXPECT_FALSE(error.isEmpty());
+}
+
+TEST(SaveFormatTest, TamperedPackageBodyIsRejected) {
+  QByteArray package = encode_package(sample_record());
+  const int index = package.size() - 32;
+  package[index] = static_cast<char>(package.at(index) ^ 0xFF);
+
+  Record decoded;
+  QString error;
+  EXPECT_FALSE(decode_package(package, decoded, &error));
+  EXPECT_FALSE(error.isEmpty());
+}
+
+TEST(SaveFormatTest, SlotKindNamesRoundTrip) {
+  for (const SlotKind kind :
+       {SlotKind::Manual, SlotKind::Quicksave, SlotKind::Autosave}) {
+    SlotKind parsed{};
+    ASSERT_TRUE(slot_kind_from_string(slot_kind_to_string(kind), parsed));
+    EXPECT_EQ(parsed, kind);
+  }
+
+  SlotKind parsed{};
+  EXPECT_FALSE(slot_kind_from_string(QStringLiteral("nonsense"), parsed));
+}
+
+TEST(SaveFormatTest, FileStemSanitizationStripsPathSeparators) {
+  EXPECT_EQ(sanitize_file_stem(QStringLiteral("../../etc/passwd")),
+            QString("______etc_passwd"));
+  EXPECT_EQ(sanitize_file_stem(QStringLiteral("Save 2026-07-25")),
+            QString("Save_2026-07-25"));
+  EXPECT_EQ(sanitize_file_stem(QStringLiteral("keep_me-1")), QString("keep_me-1"));
+  EXPECT_TRUE(sanitize_file_stem(QString()).isEmpty());
+}

--- a/tests/db/save_load_service_test.cpp
+++ b/tests/db/save_load_service_test.cpp
@@ -1,0 +1,253 @@
+#include <QCoreApplication>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStandardPaths>
+#include <QString>
+
+#include <gtest/gtest.h>
+
+#include "systems/save_format.h"
+#include "systems/save_load_service.h"
+
+using namespace Game::Systems;
+
+namespace {
+
+auto make_world_document(int entity_count) -> QJsonDocument {
+  QJsonArray entities;
+  for (int i = 0; i < entity_count; ++i) {
+    QJsonObject entity;
+    entity["id"] = i + 1;
+    entity["unit_type"] = QStringLiteral("archer");
+    entities.append(entity);
+  }
+
+  QJsonObject world;
+  world["entities"] = entities;
+  world["nextEntityId"] = entity_count + 1;
+  return QJsonDocument(world);
+}
+
+auto make_request(const QString& slot_name) -> SaveRequest {
+  SaveRequest request;
+  request.slot_name = slot_name;
+  request.title = slot_name;
+  request.map_name = QStringLiteral("River Crossing");
+  request.map_path = QStringLiteral("assets/maps/river.json");
+  request.mode = QStringLiteral("skirmish");
+  request.difficulty = QStringLiteral("normal");
+  request.metadata = QJsonObject{{"map_name", "River Crossing"}};
+  request.world = make_world_document(200);
+  return request;
+}
+
+void wait_for_saves(SaveLoadService& service) {
+  QElapsedTimer timer;
+  timer.start();
+  while (service.pending_save_count() > 0 && timer.elapsed() < 30000) {
+    QCoreApplication::processEvents();
+  }
+  ASSERT_TRUE(service.wait_for_pending_saves(30000));
+  QCoreApplication::processEvents();
+}
+
+} // namespace
+
+class SaveLoadServiceTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() { QStandardPaths::setTestModeEnabled(true); }
+  static void TearDownTestSuite() { QStandardPaths::setTestModeEnabled(false); }
+
+  void SetUp() override {
+    QDir(SaveLoadService::saves_directory()).removeRecursively();
+    service = std::make_unique<SaveLoadService>();
+  }
+
+  void TearDown() override {
+    if (service) {
+      service->shutdown();
+      service.reset();
+    }
+    QDir(SaveLoadService::saves_directory()).removeRecursively();
+  }
+
+  std::unique_ptr<SaveLoadService> service;
+};
+
+TEST_F(SaveLoadServiceTest, BackgroundSaveReportsProgressAndCompletes) {
+  int progress_events = 0;
+  int finished_events = 0;
+  quint64 finished_job = 0;
+  QString finished_slot;
+  bool finished_success = false;
+  QString finished_error;
+
+  QObject::connect(
+      service.get(),
+      &SaveLoadService::save_progress,
+      service.get(),
+      [&](quint64, const QString&, int, const QString&) { ++progress_events; });
+  QObject::connect(service.get(),
+                   &SaveLoadService::save_finished,
+                   service.get(),
+                   [&](quint64 job_id,
+                       const QString& slot_name,
+                       bool success,
+                       const QString& error) {
+                     ++finished_events;
+                     finished_job = job_id;
+                     finished_slot = slot_name;
+                     finished_success = success;
+                     finished_error = error;
+                   });
+
+  const quint64 job_id = service->begin_save(make_request("slot_a"));
+  ASSERT_NE(job_id, 0U);
+
+  wait_for_saves(*service);
+
+  ASSERT_EQ(finished_events, 1);
+  EXPECT_EQ(finished_job, job_id);
+  EXPECT_EQ(finished_slot, QString("slot_a"));
+  EXPECT_TRUE(finished_success) << finished_error.toStdString();
+
+  EXPECT_GT(progress_events, 1);
+  EXPECT_TRUE(service->slot_exists("slot_a"));
+  EXPECT_TRUE(service->verify_save_slot("slot_a"));
+}
+
+TEST_F(SaveLoadServiceTest, CancelledSaveLeavesPreviousSaveIntact) {
+  SaveRequest first = make_request("slot_b");
+  first.title = QStringLiteral("Original");
+  ASSERT_NE(service->begin_save(first), 0U);
+  wait_for_saves(*service);
+  ASSERT_TRUE(service->slot_exists("slot_b"));
+
+  SaveRequest second = make_request("slot_b");
+  second.title = QStringLiteral("Replacement");
+  const quint64 job_id = service->begin_save(second);
+  ASSERT_NE(job_id, 0U);
+  service->cancel_save(job_id);
+  wait_for_saves(*service);
+
+  EXPECT_TRUE(service->slot_exists("slot_b"));
+  EXPECT_TRUE(service->verify_save_slot("slot_b"));
+}
+
+TEST_F(SaveLoadServiceTest, AutosaveSlotsRotateWithinRetention) {
+  const int retention = 3;
+  QStringList used;
+  for (int i = 0; i < 5; ++i) {
+    const QString slot = service->next_autosave_slot(retention);
+    used.append(slot);
+    SaveRequest request = make_request(slot);
+    request.kind = Save::SlotKind::Autosave;
+    request.autosave_retention = retention;
+    ASSERT_NE(service->begin_save(request), 0U);
+    wait_for_saves(*service);
+  }
+
+  int autosave_count = 0;
+  for (const QVariant& entry : service->get_save_slots()) {
+    if (entry.toMap()["kind"].toString() == QLatin1String("autosave")) {
+      ++autosave_count;
+    }
+  }
+  EXPECT_EQ(autosave_count, retention);
+  EXPECT_EQ(used.at(0), QString("autosave_1"));
+  EXPECT_EQ(used.at(2), QString("autosave_3"));
+
+  EXPECT_TRUE(used.at(3).startsWith(QLatin1String("autosave_")));
+}
+
+TEST_F(SaveLoadServiceTest, LoweringRetentionPrunesOldAutosaves) {
+  for (int i = 1; i <= 4; ++i) {
+    SaveRequest request = make_request(QStringLiteral("autosave_%1").arg(i));
+    request.kind = Save::SlotKind::Autosave;
+    ASSERT_NE(service->begin_save(request), 0U);
+    wait_for_saves(*service);
+  }
+
+  EXPECT_EQ(service->prune_autosaves(2), 2);
+  EXPECT_FALSE(service->slot_exists("autosave_1"));
+  EXPECT_TRUE(service->slot_exists("autosave_4"));
+}
+
+TEST_F(SaveLoadServiceTest, ExportedSaveCanBeImportedBack) {
+  SaveRequest request = make_request("campaign_slot");
+  request.mode = QStringLiteral("campaign");
+  request.campaign_id = QStringLiteral("second_punic_war");
+  request.mission_id = QStringLiteral("trebia");
+  ASSERT_NE(service->begin_save(request), 0U);
+  wait_for_saves(*service);
+
+  const QString path = SaveLoadService::exports_directory() +
+                       QStringLiteral("/campaign_slot.") + Save::package_file_suffix();
+  QString error;
+  ASSERT_TRUE(service->export_slot("campaign_slot", path, &error))
+      << error.toStdString();
+  EXPECT_EQ(service->list_exported_packages().size(), 1);
+
+  ASSERT_TRUE(service->delete_save_slot("campaign_slot"));
+
+  QString imported_slot;
+  ASSERT_TRUE(service->import_package(path, imported_slot, &error))
+      << error.toStdString();
+  EXPECT_EQ(imported_slot, QString("campaign_slot"));
+  EXPECT_TRUE(service->verify_save_slot("campaign_slot"));
+}
+
+TEST_F(SaveLoadServiceTest, ImportingTwiceCreatesADistinctSlot) {
+  ASSERT_NE(service->begin_save(make_request("shared")), 0U);
+  wait_for_saves(*service);
+
+  const QString path = SaveLoadService::exports_directory() +
+                       QStringLiteral("/shared.") + Save::package_file_suffix();
+  QString error;
+  ASSERT_TRUE(service->export_slot("shared", path, &error)) << error.toStdString();
+
+  QString imported_slot;
+  ASSERT_TRUE(service->import_package(path, imported_slot, &error))
+      << error.toStdString();
+  EXPECT_EQ(imported_slot, QString("shared_2"));
+}
+
+TEST_F(SaveLoadServiceTest, EmptySlotNameIsRejected) {
+  EXPECT_EQ(service->begin_save(make_request("")), 0U);
+  EXPECT_FALSE(service->get_last_error().isEmpty());
+}
+
+TEST_F(SaveLoadServiceTest, ScreenshotQueuedRightAfterASaveLandsOnThatSave) {
+
+  const quint64 job_id = service->begin_save(make_request("with_preview"));
+  ASSERT_NE(job_id, 0U);
+
+  const QByteArray preview("fake-png-bytes");
+  service->attach_screenshot("with_preview", preview);
+
+  wait_for_saves(*service);
+
+  bool found = false;
+  for (const QVariant& entry : service->get_save_slots()) {
+    const QVariantMap slot = entry.toMap();
+    if (slot["slot_name"].toString() != QLatin1String("with_preview")) {
+      continue;
+    }
+    found = true;
+    EXPECT_EQ(slot["thumbnail"].toString(), QString::fromLatin1(preview.toBase64()));
+  }
+  EXPECT_TRUE(found);
+  EXPECT_TRUE(service->verify_save_slot("with_preview"));
+}
+
+TEST_F(SaveLoadServiceTest, EmptyScreenshotIsIgnored) {
+  ASSERT_NE(service->begin_save(make_request("no_preview")), 0U);
+  service->attach_screenshot("no_preview", QByteArray());
+  service->attach_screenshot(QString(), QByteArray("png"));
+  wait_for_saves(*service);
+
+  EXPECT_TRUE(service->slot_exists("no_preview"));
+}

--- a/tests/db/save_preview_test.cpp
+++ b/tests/db/save_preview_test.cpp
@@ -1,0 +1,120 @@
+#include <QByteArray>
+#include <QColor>
+#include <QImage>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
+#include <QOpenGLFramebufferObjectFormat>
+#include <QOpenGLFunctions>
+#include <QString>
+
+#include <gtest/gtest.h>
+
+#include "systems/save_format.h"
+#include "systems/save_storage.h"
+
+using namespace Game::Systems;
+
+namespace {
+
+auto decode(const QByteArray& png) -> QImage {
+  QImage image;
+  image.loadFromData(png, "PNG");
+  return image;
+}
+
+} // namespace
+
+TEST(SavePreviewTest, EncodePreviewDownscalesAndStaysDecodable) {
+  QImage frame(1920, 1080, QImage::Format_RGBA8888);
+  frame.fill(QColor(12, 34, 56));
+
+  const QByteArray png = Save::encode_preview(frame);
+  ASSERT_FALSE(png.isEmpty());
+
+  const QImage decoded = decode(png);
+  ASSERT_FALSE(decoded.isNull());
+  EXPECT_EQ(decoded.width(), Save::k_preview_width);
+  EXPECT_EQ(decoded.height(), 180);
+  EXPECT_EQ(decoded.pixelColor(decoded.width() / 2, decoded.height() / 2),
+            QColor(12, 34, 56));
+
+  EXPECT_LT(png.size(), 256 * 1024);
+}
+
+TEST(SavePreviewTest, SmallFrameIsNotUpscaled) {
+  QImage frame(64, 48, QImage::Format_RGBA8888);
+  frame.fill(Qt::red);
+
+  const QImage decoded = decode(Save::encode_preview(frame));
+  ASSERT_FALSE(decoded.isNull());
+  EXPECT_EQ(decoded.width(), 64);
+  EXPECT_EQ(decoded.height(), 48);
+}
+
+TEST(SavePreviewTest, NullFrameEncodesToNothing) {
+  EXPECT_TRUE(Save::encode_preview(QImage()).isEmpty());
+  EXPECT_TRUE(Save::encode_preview(QImage(8, 8, QImage::Format_RGBA8888), 0).isEmpty());
+}
+
+TEST(SavePreviewTest, FramebufferReadbackIsStoredAndReadBack) {
+  QOffscreenSurface surface;
+  surface.create();
+  if (!surface.isValid()) {
+    GTEST_SKIP() << "No offscreen surface available";
+  }
+
+  QOpenGLContext context;
+  if (!context.create() || !context.makeCurrent(&surface)) {
+    GTEST_SKIP() << "No OpenGL context available in this environment";
+  }
+
+  QOpenGLFramebufferObjectFormat format;
+  format.setAttachment(QOpenGLFramebufferObject::Depth);
+  QOpenGLFramebufferObject fbo(QSize(640, 360), format);
+  ASSERT_TRUE(fbo.isValid());
+  ASSERT_TRUE(fbo.bind());
+
+  auto* functions = context.functions();
+  functions->glViewport(0, 0, 640, 360);
+  functions->glClearColor(0.25F, 0.5F, 0.75F, 1.0F);
+  functions->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  functions->glFinish();
+
+  const QImage frame = fbo.toImage();
+  ASSERT_TRUE(fbo.release());
+  ASSERT_FALSE(frame.isNull());
+  EXPECT_EQ(frame.size(), QSize(640, 360));
+
+  const QByteArray png = Save::encode_preview(frame);
+  ASSERT_FALSE(png.isEmpty());
+
+  SaveStorage storage(":memory:");
+  QString error;
+  ASSERT_TRUE(storage.initialize(&error)) << error.toStdString();
+
+  Save::Record record;
+  record.slot_name = QStringLiteral("preview_slot");
+  record.title = QStringLiteral("Preview Slot");
+  record.map_name = QStringLiteral("Test Map");
+  record.map_path = QStringLiteral("assets/maps/test.json");
+  record.mode = QStringLiteral("skirmish");
+  record.difficulty = QStringLiteral("normal");
+  record.world = Save::pack(QByteArray("{\"entities\":[]}"));
+  ASSERT_TRUE(storage.write_slot(record, &error)) << error.toStdString();
+  ASSERT_TRUE(storage.update_screenshot("preview_slot", png, &error))
+      << error.toStdString();
+
+  Save::Record loaded;
+  ASSERT_TRUE(storage.read_slot("preview_slot", loaded, &error)) << error.toStdString();
+  EXPECT_EQ(loaded.screenshot, png);
+
+  const QImage decoded = decode(loaded.screenshot);
+  ASSERT_FALSE(decoded.isNull());
+  const QColor centre = decoded.pixelColor(decoded.width() / 2, decoded.height() / 2);
+  EXPECT_NEAR(centre.red(), 64, 3);
+  EXPECT_NEAR(centre.green(), 128, 3);
+  EXPECT_NEAR(centre.blue(), 191, 3);
+
+  context.doneCurrent();
+}

--- a/tests/db/save_storage_test.cpp
+++ b/tests/db/save_storage_test.cpp
@@ -1,22 +1,46 @@
 #include <QByteArray>
 #include <QJsonArray>
-#include <QJsonDocument>
 #include <QJsonObject>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
 #include <QString>
+#include <QTemporaryDir>
 
 #include <gtest/gtest.h>
+#include <numbers>
 
+#include "systems/save_format.h"
 #include "systems/save_storage.h"
 
 using namespace Game::Systems;
+
+namespace {
+
+auto make_record(const QString& slot_name,
+                 const QString& title,
+                 const QByteArray& world = QByteArray("{\"entities\":[]}"))
+    -> Save::Record {
+  Save::Record record;
+  record.slot_name = slot_name;
+  record.title = title;
+  record.map_name = QStringLiteral("Test Map");
+  record.map_path = QStringLiteral("assets/maps/test.json");
+  record.mode = QStringLiteral("skirmish");
+  record.difficulty = QStringLiteral("normal");
+  record.world = Save::pack(world);
+  return record;
+}
+
+} // namespace
 
 class SaveStorageTest : public ::testing::Test {
 protected:
   void SetUp() override {
     storage = std::make_unique<SaveStorage>(":memory:");
     QString error;
-    bool initialized = storage->initialize(&error);
-    ASSERT_TRUE(initialized) << "Failed to initialize: " << error.toStdString();
+    ASSERT_TRUE(storage->initialize(&error))
+        << "Failed to initialize: " << error.toStdString();
   }
 
   void TearDown() override { storage.reset(); }
@@ -24,407 +48,348 @@ protected:
   std::unique_ptr<SaveStorage> storage;
 };
 
-TEST_F(SaveStorageTest, InitializationSuccess) {
-  EXPECT_NE(storage, nullptr);
-}
-
-TEST_F(SaveStorageTest, SaveSlotBasic) {
-  QString slot_name = "test_slot";
-  QString title = "Test Save Game";
-
+TEST_F(SaveStorageTest, SaveAndLoadSlotRoundTrips) {
   QJsonObject metadata;
-  metadata["level"] = 5;
-  metadata["score"] = 1000;
+  metadata["player_name"] = "TestPlayer";
+  metadata["game_time"] = 3600;
 
-  QByteArray world_state("world_state_data");
-  QByteArray screenshot("screenshot_data");
+  Save::Record record = make_record("save_load_test", "Original Title");
+  record.metadata = metadata;
+  record.screenshot = QByteArray("screenshot-bytes");
+  record.play_time_seconds = 42.5;
 
   QString error;
-  bool saved =
-      storage->save_slot(slot_name, title, metadata, world_state, screenshot, &error);
+  ASSERT_TRUE(storage->write_slot(record, &error))
+      << "Save failed: " << error.toStdString();
 
-  EXPECT_TRUE(saved) << "Failed to save: " << error.toStdString();
+  Save::Record loaded;
+  ASSERT_TRUE(storage->read_slot("save_load_test", loaded, &error))
+      << "Load failed: " << error.toStdString();
+
+  EXPECT_EQ(loaded.title, QString("Original Title"));
+  EXPECT_EQ(loaded.screenshot, record.screenshot);
+  EXPECT_DOUBLE_EQ(loaded.play_time_seconds, 42.5);
+  EXPECT_EQ(loaded.metadata["player_name"].toString(), QString("TestPlayer"));
+  EXPECT_EQ(loaded.metadata["game_time"].toInt(), 3600);
+
+  QByteArray world;
+  ASSERT_TRUE(Save::unpack(loaded.world, world, &error))
+      << "Unpack failed: " << error.toStdString();
+  EXPECT_EQ(world, QByteArray("{\"entities\":[]}"));
 }
 
-TEST_F(SaveStorageTest, SaveAndLoadSlot) {
-  QString slot_name = "save_load_test";
-  QString original_title = "Original Title";
-
-  QJsonObject original_metadata;
-  original_metadata["player_name"] = "TestPlayer";
-  original_metadata["game_time"] = 3600;
-  original_metadata["difficulty"] = "hard";
-
-  QByteArray original_world_state("test_world_state_content");
-  QByteArray original_screenshot("test_screenshot_content");
-
+TEST_F(SaveStorageTest, WorldStateIsStoredCompressed) {
+  const QByteArray world(256 * 1024, 'A');
   QString error;
-  bool saved = storage->save_slot(slot_name,
-                                  original_title,
-                                  original_metadata,
-                                  original_world_state,
-                                  original_screenshot,
-                                  &error);
-  ASSERT_TRUE(saved) << "Save failed: " << error.toStdString();
+  ASSERT_TRUE(storage->write_slot(make_record("compressed", "Big", world), &error));
 
-  QByteArray loaded_world_state;
-  QJsonObject loaded_metadata;
-  QByteArray loaded_screenshot;
-  QString loaded_title;
+  Save::Record loaded;
+  ASSERT_TRUE(storage->read_slot("compressed", loaded, &error));
+  EXPECT_EQ(loaded.world.compression, Save::Compression::Zlib);
+  EXPECT_EQ(loaded.world.raw_size, world.size());
+  EXPECT_LT(loaded.world.blob.size(), world.size());
 
-  bool loaded = storage->load_slot(slot_name,
-                                   loaded_world_state,
-                                   loaded_metadata,
-                                   loaded_screenshot,
-                                   loaded_title,
-                                   &error);
-
-  ASSERT_TRUE(loaded) << "Load failed: " << error.toStdString();
-
-  EXPECT_EQ(loaded_title, original_title);
-  EXPECT_EQ(loaded_world_state, original_world_state);
-  EXPECT_EQ(loaded_screenshot, original_screenshot);
-
-  EXPECT_EQ(loaded_metadata["player_name"].toString(), QString("TestPlayer"));
-  EXPECT_EQ(loaded_metadata["game_time"].toInt(), 3600);
-  EXPECT_EQ(loaded_metadata["difficulty"].toString(), QString("hard"));
+  QByteArray restored;
+  ASSERT_TRUE(Save::unpack(loaded.world, restored, &error));
+  EXPECT_EQ(restored, world);
 }
 
-TEST_F(SaveStorageTest, OverwriteExistingSlot) {
-  QString slot_name = "overwrite_test";
-  QString title1 = "First Save";
-  QString title2 = "Second Save";
+TEST_F(SaveStorageTest, CampaignAndSkirmishStateAreStoredSeparately) {
+  Save::Record campaign = make_record("campaign_slot", "Campaign Save");
+  campaign.mode = QStringLiteral("campaign");
+  campaign.campaign_id = QStringLiteral("second_punic_war");
+  campaign.mission_id = QStringLiteral("cannae");
+  campaign.difficulty = QStringLiteral("hard");
+  campaign.kind = Save::SlotKind::Manual;
 
-  QJsonObject metadata1;
-  metadata1["version"] = 1;
-
-  QJsonObject metadata2;
-  metadata2["version"] = 2;
-
-  QByteArray world_state1("state1");
-  QByteArray world_state2("state2");
+  Save::Record skirmish = make_record("skirmish_slot", "Skirmish Save");
+  skirmish.mission_id = QStringLiteral("assets/maps/river.json");
+  skirmish.kind = Save::SlotKind::Autosave;
 
   QString error;
+  ASSERT_TRUE(storage->write_slot(campaign, &error)) << error.toStdString();
+  ASSERT_TRUE(storage->write_slot(skirmish, &error)) << error.toStdString();
 
-  bool saved1 = storage->save_slot(
-      slot_name, title1, metadata1, world_state1, QByteArray(), &error);
-  ASSERT_TRUE(saved1) << "First save failed: " << error.toStdString();
+  Save::Record loaded_campaign;
+  ASSERT_TRUE(storage->read_slot("campaign_slot", loaded_campaign, &error));
+  EXPECT_EQ(loaded_campaign.mode, QString("campaign"));
+  EXPECT_EQ(loaded_campaign.campaign_id, QString("second_punic_war"));
+  EXPECT_EQ(loaded_campaign.mission_id, QString("cannae"));
+  EXPECT_EQ(loaded_campaign.difficulty, QString("hard"));
+  EXPECT_EQ(loaded_campaign.kind, Save::SlotKind::Manual);
 
-  bool saved2 = storage->save_slot(
-      slot_name, title2, metadata2, world_state2, QByteArray(), &error);
-  ASSERT_TRUE(saved2) << "Second save failed: " << error.toStdString();
-
-  QByteArray loaded_world_state;
-  QJsonObject loaded_metadata;
-  QByteArray loaded_screenshot;
-  QString loaded_title;
-
-  bool loaded = storage->load_slot(slot_name,
-                                   loaded_world_state,
-                                   loaded_metadata,
-                                   loaded_screenshot,
-                                   loaded_title,
-                                   &error);
-
-  ASSERT_TRUE(loaded) << "Load failed: " << error.toStdString();
-
-  EXPECT_EQ(loaded_title, title2);
-  EXPECT_EQ(loaded_world_state, world_state2);
-  EXPECT_EQ(loaded_metadata["version"].toInt(), 2);
+  Save::Record loaded_skirmish;
+  ASSERT_TRUE(storage->read_slot("skirmish_slot", loaded_skirmish, &error));
+  EXPECT_EQ(loaded_skirmish.mode, QString("skirmish"));
+  EXPECT_TRUE(loaded_skirmish.campaign_id.isEmpty());
+  EXPECT_EQ(loaded_skirmish.kind, Save::SlotKind::Autosave);
 }
 
-TEST_F(SaveStorageTest, LoadNonExistentSlot) {
-  QString slot_name = "nonexistent_slot";
-
-  QByteArray loaded_world_state;
-  QJsonObject loaded_metadata;
-  QByteArray loaded_screenshot;
-  QString loaded_title;
+TEST_F(SaveStorageTest, OverwriteKeepsLatestContent) {
   QString error;
+  Save::Record first = make_record("overwrite", "First", QByteArray("state-one"));
+  first.metadata = QJsonObject{{"version", 1}};
+  ASSERT_TRUE(storage->write_slot(first, &error));
 
-  bool loaded = storage->load_slot(slot_name,
-                                   loaded_world_state,
-                                   loaded_metadata,
-                                   loaded_screenshot,
-                                   loaded_title,
-                                   &error);
+  Save::Record second = make_record("overwrite", "Second", QByteArray("state-two"));
+  second.metadata = QJsonObject{{"version", 2}};
+  ASSERT_TRUE(storage->write_slot(second, &error));
 
-  EXPECT_FALSE(loaded);
+  Save::Record loaded;
+  ASSERT_TRUE(storage->read_slot("overwrite", loaded, &error));
+  EXPECT_EQ(loaded.title, QString("Second"));
+  EXPECT_EQ(loaded.metadata["version"].toInt(), 2);
+
+  QByteArray world;
+  ASSERT_TRUE(Save::unpack(loaded.world, world, &error));
+  EXPECT_EQ(world, QByteArray("state-two"));
+}
+
+TEST_F(SaveStorageTest, LoadNonExistentSlotFails) {
+  Save::Record loaded;
+  QString error;
+  EXPECT_FALSE(storage->read_slot("nonexistent_slot", loaded, &error));
   EXPECT_FALSE(error.isEmpty());
 }
 
-TEST_F(SaveStorageTest, ListSlots) {
+TEST_F(SaveStorageTest, EmptySlotNameIsRejected) {
   QString error;
+  EXPECT_FALSE(storage->write_slot(make_record("", "No Slot"), &error));
+  EXPECT_FALSE(error.isEmpty());
+}
 
-  QByteArray non_empty_data("test_data");
-  storage->save_slot(
-      "slot1", "Title 1", QJsonObject(), non_empty_data, QByteArray(), &error);
-  storage->save_slot(
-      "slot2", "Title 2", QJsonObject(), non_empty_data, QByteArray(), &error);
-  storage->save_slot(
-      "slot3", "Title 3", QJsonObject(), non_empty_data, QByteArray(), &error);
+TEST_F(SaveStorageTest, ListSlotsExposesModeAndSizes) {
+  QString error;
+  ASSERT_TRUE(storage->write_slot(make_record("slot1", "Title 1"), &error));
+  ASSERT_TRUE(storage->write_slot(make_record("slot2", "Title 2"), &error));
 
-  QVariantList slot_list = storage->list_slots(&error);
+  const QVariantList slot_list = storage->list_slots(&error);
+  ASSERT_TRUE(error.isEmpty()) << error.toStdString();
+  ASSERT_EQ(slot_list.size(), 2);
 
-  EXPECT_TRUE(error.isEmpty()) << "List failed: " << error.toStdString();
-  EXPECT_EQ(slot_list.size(), 3);
-
-  bool found_slot1 = false;
-  bool found_slot2 = false;
-  bool found_slot3 = false;
-
-  for (const QVariant& slot_variant : slot_list) {
-    QVariantMap slot = slot_variant.toMap();
-    QString slot_name = slot["slotName"].toString();
-
-    if (slot_name == "slot1") {
-      found_slot1 = true;
-      EXPECT_EQ(slot["title"].toString(), QString("Title 1"));
-    } else if (slot_name == "slot2") {
-      found_slot2 = true;
-      EXPECT_EQ(slot["title"].toString(), QString("Title 2"));
-    } else if (slot_name == "slot3") {
-      found_slot3 = true;
-      EXPECT_EQ(slot["title"].toString(), QString("Title 3"));
+  bool found = false;
+  for (const QVariant& entry : slot_list) {
+    const QVariantMap slot = entry.toMap();
+    if (slot["slot_name"].toString() != "slot1") {
+      continue;
     }
+    found = true;
+    EXPECT_EQ(slot["title"].toString(), QString("Title 1"));
+    EXPECT_EQ(slot["mode"].toString(), QString("skirmish"));
+    EXPECT_EQ(slot["kind"].toString(), QString("manual"));
+    EXPECT_GT(slot["stored_size"].toLongLong(), 0);
+    EXPECT_GT(slot["uncompressed_size"].toLongLong(), 0);
   }
+  EXPECT_TRUE(found);
+}
 
-  EXPECT_TRUE(found_slot1);
-  EXPECT_TRUE(found_slot2);
-  EXPECT_TRUE(found_slot3);
+TEST_F(SaveStorageTest, SlotNamesByKindAreOrderedOldestFirst) {
+  QString error;
+  for (int i = 1; i <= 3; ++i) {
+    Save::Record record =
+        make_record(QStringLiteral("autosave_%1").arg(i), QStringLiteral("Auto"));
+    record.kind = Save::SlotKind::Autosave;
+    record.updated_at = QStringLiteral("2026-01-0%1T00:00:00.000").arg(i);
+    ASSERT_TRUE(storage->write_slot(record, &error)) << error.toStdString();
+  }
+  Save::Record const manual = make_record("manual_slot", "Manual");
+  ASSERT_TRUE(storage->write_slot(manual, &error));
+
+  const QStringList autosaves = storage->slot_names_by_kind(Save::SlotKind::Autosave);
+  ASSERT_EQ(autosaves.size(), 3);
+  EXPECT_EQ(autosaves.at(0), QString("autosave_1"));
+  EXPECT_EQ(autosaves.at(2), QString("autosave_3"));
+}
+
+TEST_F(SaveStorageTest, VerifySlotDetectsCorruptedPayload) {
+  QString error;
+  Save::Record record = make_record("corrupt", "Corrupt", QByteArray(4096, 'x'));
+
+  record.world.blob = record.world.blob.left(record.world.blob.size() / 2);
+  ASSERT_TRUE(storage->write_slot(record, &error));
+
+  EXPECT_FALSE(storage->verify_slot("corrupt", &error));
+  EXPECT_TRUE(error.contains("corrupted")) << error.toStdString();
 }
 
 TEST_F(SaveStorageTest, DeleteSlot) {
-  QString slot_name = "delete_test";
   QString error;
+  ASSERT_TRUE(storage->write_slot(make_record("delete_test", "Title"), &error));
+  EXPECT_TRUE(storage->slot_exists("delete_test"));
 
-  QByteArray non_empty_data("test_data");
-  storage->save_slot(
-      slot_name, "Title", QJsonObject(), non_empty_data, QByteArray(), &error);
-
-  QVariantList slots_before = storage->list_slots(&error);
-  EXPECT_EQ(slots_before.size(), 1);
-
-  bool deleted = storage->delete_slot(slot_name, &error);
-  EXPECT_TRUE(deleted) << "Delete failed: " << error.toStdString();
-
-  QVariantList slots_after = storage->list_slots(&error);
-  EXPECT_EQ(slots_after.size(), 0);
+  EXPECT_TRUE(storage->delete_slot("delete_test", &error))
+      << "Delete failed: " << error.toStdString();
+  EXPECT_FALSE(storage->slot_exists("delete_test"));
+  EXPECT_EQ(storage->list_slots(&error).size(), 0);
 }
 
-TEST_F(SaveStorageTest, DeleteNonExistentSlot) {
-  QString slot_name = "nonexistent_delete";
+TEST_F(SaveStorageTest, DeleteNonExistentSlotFails) {
   QString error;
-
-  bool deleted = storage->delete_slot(slot_name, &error);
-
-  EXPECT_FALSE(deleted);
+  EXPECT_FALSE(storage->delete_slot("nonexistent_delete", &error));
   EXPECT_FALSE(error.isEmpty());
 }
 
-TEST_F(SaveStorageTest, EmptyMetadataSave) {
-  QString slot_name = "empty_metadata";
-  QJsonObject empty_metadata;
-
-  QString error;
-  bool saved = storage->save_slot(
-      slot_name, "Title", empty_metadata, QByteArray("data"), QByteArray(), &error);
-
-  EXPECT_TRUE(saved) << "Failed to save: " << error.toStdString();
-
-  QByteArray loaded_world_state;
-  QJsonObject loaded_metadata;
-  QByteArray loaded_screenshot;
-  QString loaded_title;
-
-  bool loaded = storage->load_slot(slot_name,
-                                   loaded_world_state,
-                                   loaded_metadata,
-                                   loaded_screenshot,
-                                   loaded_title,
-                                   &error);
-
-  EXPECT_TRUE(loaded) << "Failed to load: " << error.toStdString();
-}
-
-TEST_F(SaveStorageTest, EmptyWorldStateSave) {
-  QString slot_name = "empty_world_state";
-  QByteArray minimal_world_state(" ");
-
-  QString error;
-  bool saved = storage->save_slot(
-      slot_name, "Title", QJsonObject(), minimal_world_state, QByteArray(), &error);
-
-  EXPECT_TRUE(saved) << "Failed to save: " << error.toStdString();
-
-  QByteArray loaded_world_state;
-  QJsonObject loaded_metadata;
-  QByteArray loaded_screenshot;
-  QString loaded_title;
-
-  bool loaded = storage->load_slot(slot_name,
-                                   loaded_world_state,
-                                   loaded_metadata,
-                                   loaded_screenshot,
-                                   loaded_title,
-                                   &error);
-
-  EXPECT_TRUE(loaded) << "Failed to load: " << error.toStdString();
-  EXPECT_EQ(loaded_world_state, minimal_world_state);
-}
-
-TEST_F(SaveStorageTest, LargeDataSave) {
-  QString slot_name = "large_data";
-
-  QByteArray large_world_state(1024 * 1024, 'A');
-  QByteArray large_screenshot(512 * 1024, 'B');
-
-  QJsonObject metadata;
-  metadata["size"] = "large";
-
-  QString error;
-  bool saved = storage->save_slot(slot_name,
-                                  "Large Data Test",
-                                  metadata,
-                                  large_world_state,
-                                  large_screenshot,
-                                  &error);
-
-  EXPECT_TRUE(saved) << "Failed to save large data: " << error.toStdString();
-
-  QByteArray loaded_world_state;
-  QJsonObject loaded_metadata;
-  QByteArray loaded_screenshot;
-  QString loaded_title;
-
-  bool loaded = storage->load_slot(slot_name,
-                                   loaded_world_state,
-                                   loaded_metadata,
-                                   loaded_screenshot,
-                                   loaded_title,
-                                   &error);
-
-  EXPECT_TRUE(loaded) << "Failed to load large data: " << error.toStdString();
-  EXPECT_EQ(loaded_world_state.size(), 1024 * 1024);
-  EXPECT_EQ(loaded_screenshot.size(), 512 * 1024);
-}
-
-TEST_F(SaveStorageTest, SpecialCharactersInSlotName) {
-  QString slot_name = "slot_with_special_chars_123";
-  QString title = "Title with special chars: !@#$%^&*()";
-
-  QJsonObject metadata;
-  metadata["description"] = "Test with special characters: <>&\"'";
-
-  QString error;
-  bool saved = storage->save_slot(
-      slot_name, title, metadata, QByteArray("data"), QByteArray(), &error);
-
-  EXPECT_TRUE(saved) << "Failed to save: " << error.toStdString();
-
-  QByteArray loaded_world_state;
-  QJsonObject loaded_metadata;
-  QByteArray loaded_screenshot;
-  QString loaded_title;
-
-  bool loaded = storage->load_slot(slot_name,
-                                   loaded_world_state,
-                                   loaded_metadata,
-                                   loaded_screenshot,
-                                   loaded_title,
-                                   &error);
-
-  EXPECT_TRUE(loaded) << "Failed to load: " << error.toStdString();
-  EXPECT_EQ(loaded_title, title);
-}
-
-TEST_F(SaveStorageTest, ComplexMetadataSave) {
-  QString slot_name = "complex_metadata";
-
-  QJsonObject metadata;
-  metadata["int_value"] = 42;
-  metadata["double_value"] = 3.14159;
-  metadata["string_value"] = "test_string";
-  metadata["bool_value"] = true;
-
-  QJsonObject nested_object;
-  nested_object["nested_field"] = "nested_value";
-  metadata["nested"] = nested_object;
+TEST_F(SaveStorageTest, ComplexMetadataSurvivesRoundTrip) {
+  QJsonObject nested;
+  nested["nested_field"] = "nested_value";
 
   QJsonArray array;
   array.append(1);
   array.append(2);
   array.append(3);
+
+  QJsonObject metadata;
+  metadata["int_value"] = 42;
+  metadata["double_value"] = std::numbers::pi;
+  metadata["string_value"] = "test_string";
+  metadata["bool_value"] = true;
+  metadata["nested"] = nested;
   metadata["array"] = array;
 
+  Save::Record record = make_record("complex_metadata", "Complex");
+  record.metadata = metadata;
+
   QString error;
-  bool saved = storage->save_slot(slot_name,
-                                  "Complex Metadata Test",
-                                  metadata,
-                                  QByteArray("data"),
-                                  QByteArray(),
-                                  &error);
+  ASSERT_TRUE(storage->write_slot(record, &error));
 
-  EXPECT_TRUE(saved) << "Failed to save: " << error.toStdString();
+  Save::Record loaded;
+  ASSERT_TRUE(storage->read_slot("complex_metadata", loaded, &error));
+  EXPECT_EQ(loaded.metadata["int_value"].toInt(), 42);
+  EXPECT_DOUBLE_EQ(loaded.metadata["double_value"].toDouble(), 3.14159);
+  EXPECT_EQ(loaded.metadata["string_value"].toString(), QString("test_string"));
+  EXPECT_TRUE(loaded.metadata["bool_value"].toBool());
+  EXPECT_EQ(loaded.metadata["nested"].toObject()["nested_field"].toString(),
+            QString("nested_value"));
+  EXPECT_EQ(loaded.metadata["array"].toArray().size(), 3);
+}
 
-  QByteArray loaded_world_state;
-  QJsonObject loaded_metadata;
-  QByteArray loaded_screenshot;
-  QString loaded_title;
+TEST_F(SaveStorageTest, LargeSaveRoundTrips) {
+  const QByteArray world(1024 * 1024, 'A');
+  Save::Record record = make_record("large_data", "Large", world);
+  record.screenshot = QByteArray(512 * 1024, 'B');
 
-  bool loaded = storage->load_slot(slot_name,
-                                   loaded_world_state,
-                                   loaded_metadata,
-                                   loaded_screenshot,
-                                   loaded_title,
-                                   &error);
+  QString error;
+  ASSERT_TRUE(storage->write_slot(record, &error))
+      << "Failed to save large data: " << error.toStdString();
 
-  EXPECT_TRUE(loaded) << "Failed to load: " << error.toStdString();
+  Save::Record loaded;
+  ASSERT_TRUE(storage->read_slot("large_data", loaded, &error));
+  EXPECT_EQ(loaded.screenshot.size(), 512 * 1024);
 
-  EXPECT_EQ(loaded_metadata["int_value"].toInt(), 42);
-  EXPECT_DOUBLE_EQ(loaded_metadata["double_value"].toDouble(), 3.14159);
-  EXPECT_EQ(loaded_metadata["string_value"].toString(), QString("test_string"));
-  EXPECT_TRUE(loaded_metadata["bool_value"].toBool());
-
-  QJsonObject loaded_nested = loaded_metadata["nested"].toObject();
-  EXPECT_EQ(loaded_nested["nested_field"].toString(), QString("nested_value"));
-
-  QJsonArray loaded_array = loaded_metadata["array"].toArray();
-  EXPECT_EQ(loaded_array.size(), 3);
-  EXPECT_EQ(loaded_array[0].toInt(), 1);
-  EXPECT_EQ(loaded_array[1].toInt(), 2);
-  EXPECT_EQ(loaded_array[2].toInt(), 3);
+  QByteArray restored;
+  ASSERT_TRUE(Save::unpack(loaded.world, restored, &error));
+  EXPECT_EQ(restored.size(), 1024 * 1024);
 }
 
 TEST_F(SaveStorageTest, MultipleSavesAndDeletes) {
   QString error;
-
   for (int i = 0; i < 10; i++) {
-    QString slot_name = QString("slot_%1").arg(i);
-    storage->save_slot(slot_name,
-                       QString("Title %1").arg(i),
-                       QJsonObject(),
-                       QByteArray("data"),
-                       QByteArray(),
-                       &error);
+    ASSERT_TRUE(storage->write_slot(
+        make_record(QString("slot_%1").arg(i), QString("Title %1").arg(i)), &error));
   }
 
-  QVariantList slot_list = storage->list_slots(&error);
-  EXPECT_EQ(slot_list.size(), 10);
+  EXPECT_EQ(storage->list_slots(&error).size(), 10);
 
   for (int i = 0; i < 5; i++) {
-    QString slot_name = QString("slot_%1").arg(i);
-    storage->delete_slot(slot_name, &error);
+    EXPECT_TRUE(storage->delete_slot(QString("slot_%1").arg(i), &error));
   }
 
-  slot_list = storage->list_slots(&error);
-  EXPECT_EQ(slot_list.size(), 5);
-
-  for (const QVariant& slot_variant : slot_list) {
-    QVariantMap slot = slot_variant.toMap();
-    QString slot_name = slot["slotName"].toString();
-    int slot_num = slot_name.mid(5).toInt();
+  const QVariantList remaining = storage->list_slots(&error);
+  EXPECT_EQ(remaining.size(), 5);
+  for (const QVariant& entry : remaining) {
+    const int slot_num = entry.toMap()["slot_name"].toString().mid(5).toInt();
     EXPECT_GE(slot_num, 5);
     EXPECT_LT(slot_num, 10);
   }
+}
+
+TEST(SaveStorageSchemaTest, DatabaseWithAForeignSchemaIsRebuiltFromScratch) {
+  QTemporaryDir const temp_dir;
+  ASSERT_TRUE(temp_dir.isValid());
+  const QString database_path = temp_dir.filePath(QStringLiteral("saves.sqlite"));
+
+  {
+    QSqlDatabase legacy = QSqlDatabase::addDatabase(
+        QStringLiteral("QSQLITE"), QStringLiteral("legacy_schema_fixture"));
+    legacy.setDatabaseName(database_path);
+    ASSERT_TRUE(legacy.open());
+
+    QSqlQuery query(legacy);
+    ASSERT_TRUE(query.exec(
+        QStringLiteral("CREATE TABLE saves (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                       "slot_name TEXT UNIQUE NOT NULL, title TEXT NOT NULL, "
+                       "world_state BLOB NOT NULL)")))
+        << query.lastError().text().toStdString();
+    ASSERT_TRUE(query.exec(
+        QStringLiteral("INSERT INTO saves (slot_name, title, world_state) "
+                       "VALUES ('old_slot', 'Legacy Save', 'legacy-bytes')")));
+    ASSERT_TRUE(query.exec(QStringLiteral("PRAGMA user_version = 3")));
+    legacy.close();
+  }
+  QSqlDatabase::removeDatabase(QStringLiteral("legacy_schema_fixture"));
+
+  SaveStorage storage(database_path);
+  QString error;
+  ASSERT_TRUE(storage.initialize(&error)) << error.toStdString();
+
+  EXPECT_TRUE(storage.list_slots(&error).isEmpty());
+  EXPECT_FALSE(storage.slot_exists("old_slot"));
+
+  ASSERT_TRUE(storage.write_slot(make_record("fresh", "Fresh Save"), &error))
+      << error.toStdString();
+  EXPECT_TRUE(storage.verify_slot("fresh", &error)) << error.toStdString();
+}
+
+TEST(SaveStorageSchemaTest, ReopeningACurrentDatabaseKeepsExistingSaves) {
+  QTemporaryDir const temp_dir;
+  ASSERT_TRUE(temp_dir.isValid());
+  const QString database_path = temp_dir.filePath(QStringLiteral("saves.sqlite"));
+
+  QString error;
+  {
+    SaveStorage storage(database_path);
+    ASSERT_TRUE(storage.initialize(&error)) << error.toStdString();
+    ASSERT_TRUE(storage.write_slot(make_record("kept", "Kept Save"), &error))
+        << error.toStdString();
+  }
+
+  SaveStorage const reopened(database_path);
+  ASSERT_TRUE(reopened.initialize(&error)) << error.toStdString();
+  EXPECT_TRUE(reopened.slot_exists("kept"));
+
+  Save::Record loaded;
+  ASSERT_TRUE(reopened.read_slot("kept", loaded, &error)) << error.toStdString();
+  EXPECT_EQ(loaded.title, QString("Kept Save"));
+}
+
+TEST_F(SaveStorageTest, ScreenshotCanBeAttachedAfterTheSaveIsWritten) {
+  QString error;
+  ASSERT_TRUE(storage->write_slot(make_record("with_preview", "Preview"), &error));
+
+  Save::Record before;
+  ASSERT_TRUE(storage->read_slot("with_preview", before, &error));
+  EXPECT_TRUE(before.screenshot.isEmpty());
+
+  const QByteArray preview("fake-png-bytes");
+  ASSERT_TRUE(storage->update_screenshot("with_preview", preview, &error))
+      << error.toStdString();
+
+  Save::Record after;
+  ASSERT_TRUE(storage->read_slot("with_preview", after, &error));
+  EXPECT_EQ(after.screenshot, preview);
+
+  EXPECT_EQ(after.title, before.title);
+  EXPECT_EQ(after.world.raw_checksum, before.world.raw_checksum);
+  EXPECT_TRUE(storage->verify_slot("with_preview", &error)) << error.toStdString();
+
+  const QVariantList slot_list = storage->list_slots(&error);
+  ASSERT_EQ(slot_list.size(), 1);
+  EXPECT_EQ(slot_list.at(0).toMap()["thumbnail"].toString(),
+            QString::fromLatin1(preview.toBase64()));
+}
+
+TEST_F(SaveStorageTest, AttachingAScreenshotToAMissingSlotFails) {
+  QString error;
+  EXPECT_FALSE(storage->update_screenshot("nope", QByteArray("png"), &error));
+  EXPECT_FALSE(error.isEmpty());
 }

--- a/tests/db/save_storage_test.cpp
+++ b/tests/db/save_storage_test.cpp
@@ -255,7 +255,7 @@ TEST_F(SaveStorageTest, ComplexMetadataSurvivesRoundTrip) {
   Save::Record loaded;
   ASSERT_TRUE(storage->read_slot("complex_metadata", loaded, &error));
   EXPECT_EQ(loaded.metadata["int_value"].toInt(), 42);
-  EXPECT_DOUBLE_EQ(loaded.metadata["double_value"].toDouble(), 3.14159);
+  EXPECT_DOUBLE_EQ(loaded.metadata["double_value"].toDouble(), std::numbers::pi);
   EXPECT_EQ(loaded.metadata["string_value"].toString(), QString("test_string"));
   EXPECT_TRUE(loaded.metadata["bool_value"].toBool());
   EXPECT_EQ(loaded.metadata["nested"].toObject()["nested_field"].toString(),

--- a/ui/gl_view.cpp
+++ b/ui/gl_view.cpp
@@ -5,12 +5,12 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QImage>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QStringList>
 #endif
+#include <QImage>
 #include <QMetaObject>
 #include <QOpenGLContext>
 #include <QOpenGLFramebufferObject>
@@ -223,6 +223,12 @@ void GLView::GLRenderer::render() {
     m_engine->update(dt);
     m_engine->render(m_size.width(), m_size.height());
 #endif
+
+    if (m_engine->consume_screenshot_request()) {
+      if (auto* fbo = framebufferObject()) {
+        m_engine->submit_frame_image(fbo->toImage());
+      }
+    }
 
     if (!m_ready_reported && m_view != nullptr) {
       m_ready_reported = true;

--- a/ui/qml/LoadGamePanel.qml
+++ b/ui/qml/LoadGamePanel.qml
@@ -10,6 +10,26 @@ Item {
     signal cancelled
     signal load_requested(string slot_name)
 
+    property string status_message: ""
+
+    function format_play_time(seconds) {
+        if (!seconds || seconds <= 0)
+            return "";
+        var total = Math.floor(seconds);
+        var hours = Math.floor(total / 3600);
+        var minutes = Math.floor((total % 3600) / 60);
+        return hours > 0 ? qsTr("%1h %2m").arg(hours).arg(minutes) : qsTr("%1m").arg(minutes);
+    }
+
+    function describe_mode(mode, kind) {
+        var mode_text = mode === "campaign" ? qsTr("Campaign") : qsTr("Skirmish");
+        if (kind === "autosave")
+            return qsTr("%1 - autosave").arg(mode_text);
+        if (kind === "quicksave")
+            return qsTr("%1 - quicksave").arg(mode_text);
+        return mode_text;
+    }
+
     anchors.fill: parent
     z: 25
     onVisibleChanged: {
@@ -155,21 +175,25 @@ Item {
                                             "title": "",
                                             "timestamp": 0,
                                             "map_name": "",
+                                            "mode": "",
+                                            "kind": "",
                                             "playTime": "",
                                             "thumbnail": "",
                                             "isEmpty": true
                                         });
                                     return;
                                 }
-                                var slots = game.get_save_slots();
-                                for (var i = 0; i < slots.length; i++) {
+                                var entries = game.get_save_slots();
+                                for (var i = 0; i < entries.length; i++) {
                                     append({
-                                            "slot_name": slots[i].slot_name || slots[i].name,
-                                            "title": slots[i].title || slots[i].name || slots[i].slot_name || "Untitled Save",
-                                            "timestamp": slots[i].timestamp,
-                                            "map_name": slots[i].map_name || "Unknown Map",
-                                            "playTime": slots[i].playTime || "",
-                                            "thumbnail": slots[i].thumbnail || "",
+                                            "slot_name": entries[i].slot_name,
+                                            "title": entries[i].title || entries[i].slot_name || "Untitled Save",
+                                            "timestamp": entries[i].timestamp,
+                                            "map_name": entries[i].map_name || "Unknown Map",
+                                            "mode": entries[i].mode || "",
+                                            "kind": entries[i].kind || "manual",
+                                            "playTime": root.format_play_time(entries[i].play_time_seconds),
+                                            "thumbnail": entries[i].thumbnail || "",
                                             "isEmpty": false
                                         });
                                 }
@@ -179,6 +203,8 @@ Item {
                                             "title": "",
                                             "timestamp": 0,
                                             "map_name": "",
+                                            "mode": "",
+                                            "kind": "",
                                             "playTime": "",
                                             "thumbnail": "",
                                             "isEmpty": true
@@ -258,7 +284,7 @@ Item {
                                     }
 
                                     Label {
-                                        text: model.map_name
+                                        text: model.isEmpty ? "" : qsTr("%1 - %2").arg(model.map_name).arg(root.describe_mode(model.mode, model.kind))
                                         color: Theme.textSub
                                         font.pointSize: Theme.fontSizeMedium
                                         Layout.fillWidth: true
@@ -305,6 +331,29 @@ Item {
                                 }
 
                                 StyledButton {
+                                    text: qsTr("Export")
+                                    button_style: "small"
+                                    visible: !model.isEmpty
+                                    onClicked: {
+                                        if (typeof game === 'undefined' || !game.export_save_slot)
+                                            return;
+                                        var path = game.export_save_slot(model.slot_name);
+                                        root.status_message = path !== "" ? qsTr("Exported to %1").arg(path) : qsTr("Export failed");
+                                    }
+                                }
+
+                                StyledButton {
+                                    text: qsTr("Verify")
+                                    button_style: "small"
+                                    visible: !model.isEmpty
+                                    onClicked: {
+                                        if (typeof game === 'undefined' || !game.verify_save_slot)
+                                            return;
+                                        root.status_message = game.verify_save_slot(model.slot_name) ? qsTr("\"%1\" is intact").arg(model.slot_name) : qsTr("\"%1\" is corrupted and cannot be loaded").arg(model.slot_name);
+                                    }
+                                }
+
+                                StyledButton {
                                     text: qsTr("Delete")
                                     button_style: "danger"
                                     implicitWidth: 80
@@ -340,8 +389,18 @@ Item {
                 Layout.fillWidth: true
                 spacing: Theme.spacingMedium
 
-                Item {
+                StyledButton {
+                    text: qsTr("Import...")
+                    button_style: "secondary"
+                    onClicked: importDialog.open()
+                }
+
+                Label {
+                    text: root.status_message
+                    color: Theme.textHint
+                    font.pointSize: Theme.fontSizeSmall
                     Layout.fillWidth: true
+                    elide: Label.ElideRight
                 }
 
                 Label {
@@ -410,6 +469,92 @@ Item {
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
                     font.pointSize: Theme.fontSizeMedium
+                }
+            }
+        }
+    }
+
+    Dialog {
+        id: importDialog
+
+        anchors.centerIn: parent
+        width: Math.min(parent.width * 0.6, 520)
+        title: qsTr("Import Save")
+        modal: true
+        standardButtons: Dialog.Close
+        onOpened: importModel.reload()
+
+        contentItem: Rectangle {
+            color: Theme.cardBase
+            implicitHeight: 260
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: Theme.spacingMedium
+                spacing: Theme.spacingSmall
+
+                Label {
+                    text: qsTr("Save files found in the exports folder:")
+                    color: Theme.textSub
+                    font.pointSize: Theme.fontSizeSmall
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                }
+
+                ListView {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    clip: true
+                    spacing: Theme.spacingTiny
+
+                    model: ListModel {
+                        id: importModel
+
+                        function reload() {
+                            clear();
+                            if (typeof game === 'undefined' || !game.list_exported_saves)
+                                return;
+                            var files = game.list_exported_saves();
+                            for (var i = 0; i < files.length; i++)
+                                append({
+                                        "path": files[i].path,
+                                        "name": files[i].name
+                                    });
+                        }
+                    }
+
+                    delegate: RowLayout {
+                        width: ListView.view ? ListView.view.width : 0
+                        spacing: Theme.spacingSmall
+
+                        Label {
+                            text: model.name
+                            color: Theme.textMain
+                            font.pointSize: Theme.fontSizeSmall
+                            Layout.fillWidth: true
+                            elide: Label.ElideMiddle
+                        }
+
+                        StyledButton {
+                            text: qsTr("Import")
+                            button_style: "small"
+                            onClicked: {
+                                var slot = game.import_save_file(model.path);
+                                root.status_message = slot !== "" ? qsTr("Imported as \"%1\"").arg(slot) : qsTr("Import failed");
+                                if (slot !== "")
+                                    importDialog.close();
+                            }
+                        }
+                    }
+                }
+
+                Label {
+                    text: importModel.count === 0 ? qsTr("No importable save files were found.") : ""
+                    color: Theme.textHint
+                    font.pointSize: Theme.fontSizeSmall
+                    visible: importModel.count === 0
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
                 }
             }
         }

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -323,8 +323,8 @@ ApplicationWindow {
         }
         onSave_requested: function (slot_name) {
             console.log("Main: Save requested for slot:", slot_name);
-            if (typeof game !== 'undefined' && game.save_gameToSlot)
-                game.save_gameToSlot(slot_name);
+            if (typeof game !== 'undefined' && game.save_game_to_slot)
+                game.save_game_to_slot(slot_name);
             save_game_panel.visible = false;
             mainWindow.menu_visible = true;
         }
@@ -406,6 +406,13 @@ ApplicationWindow {
                 mainWindow.menu_visible = true;
             }
         }
+    }
+
+    SaveProgressOverlay {
+        id: save_progress_overlay
+
+        anchors.fill: parent
+        z: 30
     }
 
     Item {

--- a/ui/qml/RtsInputLayer.qml
+++ b/ui/qml/RtsInputLayer.qml
@@ -126,6 +126,16 @@ Item {
                 root.game.select_all_troops();
             event.accepted = true;
             break;
+        case Qt.Key_F5:
+            if (root.game.quicksave)
+                root.game.quicksave();
+            event.accepted = true;
+            break;
+        case Qt.Key_F9:
+            if (root.game.has_save_slot && root.game.has_save_slot("quicksave"))
+                root.game.load_game_from_slot("quicksave");
+            event.accepted = true;
+            break;
         case Qt.Key_P:
             if (root.game.has_units_selected) {
                 root.game.cursor_mode = "patrol";

--- a/ui/qml/SaveGamePanel.qml
+++ b/ui/qml/SaveGamePanel.qml
@@ -166,14 +166,18 @@ Item {
                                 clear();
                                 if (typeof game === 'undefined' || !game.get_save_slots)
                                     return;
-                                var slots = game.get_save_slots();
-                                for (var i = 0; i < slots.length; i++) {
+                                var entries = game.get_save_slots();
+                                for (var i = 0; i < entries.length; i++) {
                                     append({
-                                            "slot_name": slots[i].slot_name || slots[i].name,
-                                            "title": slots[i].title || slots[i].name || slots[i].slot_name || "Untitled Save",
-                                            "timestamp": slots[i].timestamp,
-                                            "map_name": slots[i].map_name || "Unknown Map",
-                                            "thumbnail": slots[i].thumbnail || ""
+                                            "slot_name": entries[i].slot_name,
+                                            "title": entries[i].title || entries[i].slot_name || "Untitled Save",
+                                            "timestamp": entries[i].timestamp,
+                                            "map_name": entries[i].map_name || "Unknown Map",
+                                            "mode": entries[i].mode || "",
+                                            "kind": entries[i].kind || "manual",
+                                            "stored_size": entries[i].stored_size || 0,
+                                            "uncompressed_size": entries[i].uncompressed_size || 0,
+                                            "thumbnail": entries[i].thumbnail || ""
                                         });
                                 }
                             }
@@ -248,7 +252,7 @@ Item {
                                     }
 
                                     Label {
-                                        text: model.map_name
+                                        text: model.uncompressed_size > 0 ? qsTr("%1 - %2 (%3 KB on disk)").arg(model.map_name).arg(model.mode === "campaign" ? qsTr("Campaign") : qsTr("Skirmish")).arg(Math.max(1, Math.round(model.stored_size / 1024))) : model.map_name
                                         color: Theme.textSub
                                         font.pointSize: Theme.fontSizeSmall
                                         Layout.fillWidth: true

--- a/ui/qml/SaveProgressOverlay.qml
+++ b/ui/qml/SaveProgressOverlay.qml
@@ -1,0 +1,96 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.3
+import StandardOfIron 1.0
+
+Item {
+    id: root
+
+    property string last_error: ""
+    property bool show_error: false
+
+    anchors.fill: parent
+    visible: (typeof game !== 'undefined' && game.save_in_progress) || root.show_error
+
+    Connections {
+        function onSave_completed(slot_name, success, error) {
+            if (success) {
+                root.show_error = false;
+                root.last_error = "";
+                error_timer.stop();
+                return;
+            }
+            root.last_error = error;
+            root.show_error = true;
+            error_timer.restart();
+        }
+
+        target: typeof game !== 'undefined' ? game : null
+    }
+
+    Timer {
+        id: error_timer
+
+        interval: 6000
+        onTriggered: root.show_error = false
+    }
+
+    Rectangle {
+        id: card
+
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: Theme.spacingLarge
+        width: 320
+        height: content.implicitHeight + Theme.spacingLarge * 2
+        radius: Theme.radiusPanel
+        color: Theme.panelBase
+        border.color: root.show_error ? Theme.dangerBr : Theme.panelBr
+        border.width: 1
+        opacity: 0.96
+
+        ColumnLayout {
+            id: content
+
+            anchors.fill: parent
+            anchors.margins: Theme.spacingLarge
+            spacing: Theme.spacingSmall
+
+            Label {
+                text: root.show_error ? qsTr("Save failed") : qsTr("Saving \"%1\"").arg(typeof game !== 'undefined' ? game.save_progress_slot : "")
+                color: Theme.textMain
+                font.pointSize: Theme.fontSizeMedium
+                font.bold: true
+                Layout.fillWidth: true
+                elide: Label.ElideRight
+            }
+
+            Label {
+                text: root.show_error ? root.last_error : (typeof game !== 'undefined' ? game.save_progress_stage : "")
+                color: root.show_error ? Theme.dangerBr : Theme.textSub
+                font.pointSize: Theme.fontSizeSmall
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+            }
+
+            ProgressBar {
+                visible: !root.show_error
+                from: 0
+                to: 100
+                value: typeof game !== 'undefined' ? game.save_progress_percent : 0
+                Layout.fillWidth: true
+            }
+
+            StyledButton {
+                text: qsTr("Cancel")
+                button_style: "secondary"
+                visible: !root.show_error
+                Layout.alignment: Qt.AlignRight
+                onClicked: {
+                    if (typeof game !== 'undefined' && game.cancel_active_save)
+                        game.cancel_active_save();
+                }
+            }
+        }
+    }
+}

--- a/ui/qml/SettingsPanel.qml
+++ b/ui/qml/SettingsPanel.qml
@@ -369,6 +369,116 @@ Item {
                         spacing: Theme.spacingMedium
 
                         Label {
+                            text: qsTr("Autosave")
+                            color: Theme.textMain
+                            font.pointSize: Theme.fontSizeLarge
+                            font.bold: true
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 2
+                            color: Theme.border
+                            opacity: 0.5
+                        }
+
+                        GridLayout {
+                            Layout.fillWidth: true
+                            columns: 2
+                            rowSpacing: Theme.spacingMedium
+                            columnSpacing: Theme.spacingMedium
+
+                            Label {
+                                text: qsTr("Autosaves to keep:")
+                                color: Theme.textSub
+                                font.pointSize: Theme.fontSizeMedium
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: Theme.spacingMedium
+
+                                Slider {
+                                    id: autosave_slot_slider
+
+                                    Layout.fillWidth: true
+                                    from: 1
+                                    to: 10
+                                    stepSize: 1
+                                    snapMode: Slider.SnapAlways
+                                    value: typeof game !== 'undefined' ? game.autosave_slot_count : 3
+                                    onMoved: {
+                                        if (typeof game !== 'undefined')
+                                            game.autosave_slot_count = Math.round(value);
+                                    }
+                                }
+
+                                Label {
+                                    text: Math.round(autosave_slot_slider.value)
+                                    color: Theme.textMain
+                                    font.pointSize: Theme.fontSizeMedium
+                                    Layout.preferredWidth: 32
+                                    horizontalAlignment: Text.AlignRight
+                                }
+                            }
+
+                            Label {
+                                text: qsTr("Autosave every:")
+                                color: Theme.textSub
+                                font.pointSize: Theme.fontSizeMedium
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: Theme.spacingMedium
+
+                                Slider {
+                                    id: autosave_interval_slider
+
+                                    Layout.fillWidth: true
+                                    from: 0
+                                    to: 60
+                                    stepSize: 5
+                                    snapMode: Slider.SnapAlways
+                                    value: typeof game !== 'undefined' ? game.autosave_interval_minutes : 5
+                                    onMoved: {
+                                        if (typeof game !== 'undefined')
+                                            game.autosave_interval_minutes = Math.round(value);
+                                    }
+                                }
+
+                                Label {
+                                    text: autosave_interval_slider.value <= 0 ? qsTr("Off") : qsTr("%1 min").arg(Math.round(autosave_interval_slider.value))
+                                    color: Theme.textMain
+                                    font.pointSize: Theme.fontSizeMedium
+                                    Layout.preferredWidth: 64
+                                    horizontalAlignment: Text.AlignRight
+                                }
+                            }
+
+                            Label {
+                                text: qsTr("Older autosaves beyond this count are deleted automatically.")
+                                color: Theme.textSub
+                                font.pointSize: Theme.fontSizeSmall
+                                opacity: 0.7
+                                wrapMode: Text.WordWrap
+                                Layout.columnSpan: 2
+                                Layout.fillWidth: true
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 1
+                        color: Theme.border
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.spacingMedium
+
+                        Label {
                             text: qsTr("Language")
                             color: Theme.textMain
                             font.pointSize: Theme.fontSizeLarge

--- a/ui/qml/qmldir
+++ b/ui/qml/qmldir
@@ -4,6 +4,7 @@ StyledComboBox 1.0 StyledComboBox.qml
 ProductionPanel 1.0 ProductionPanel.qml
 SaveGamePanel 1.0 SaveGamePanel.qml
 LoadGamePanel 1.0 LoadGamePanel.qml
+SaveProgressOverlay 1.0 SaveProgressOverlay.qml
 MapPreview 1.0 MapPreview.qml
 ObjectivesPanel 1.0 ObjectivesPanel.qml
 HUDBottomCommander 1.0 HUDBottomCommander.qml


### PR DESCRIPTION
- SaveLoadService is now a singleton with a background worker thread; saves are queued as cancellable jobs with progress reporting
- New .soisave binary package format with zlib compression, SHA-256 checksums, embedded screenshots, and integrity verification
- Save kinds: Manual, Quicksave (F5), Autoload (F9), and timer-driven Autosave with configurable interval and slot retention
- Export saves as .soisave files and import them back via the load panel
- QML: save progress overlay, play-time display, mode/kind labels, Export/Verify buttons, and import dialog in LoadGamePanel
- Clean up unused parameters, dead includes, and redundant patterns