### PR TITLE
Redesign selection summary panel and simplify stale-save purge

### DIFF
--- a/scripts/purge-stale-saves.py
+++ b/scripts/purge-stale-saves.py
@@ -11,7 +11,6 @@ This script runs automatically before `make run` and deletes any saves that
 would load an outdated map.
 """
 
-import json
 import os
 import pathlib
 import sqlite3
@@ -53,19 +52,13 @@ def main() -> int:
     conn = sqlite3.connect(db_path)
     try:
         cur = conn.cursor()
-        cur.execute("SELECT slot_name, timestamp, metadata FROM saves")
+        cur.execute("SELECT slot_name, updated_at, map_path FROM saves")
         rows = cur.fetchall()
     finally:
         conn.close()
 
-    stale_slots: list[str] = []
-    for slot_name, ts_str, metadata_raw in rows:
-        try:
-            meta = json.loads(metadata_raw or "{}")
-        except json.JSONDecodeError:
-            continue
-
-        raw_map_path = meta.get("map_path", "")
+    stale_slots: list[tuple[str, str, datetime, datetime]] = []
+    for slot_name, ts_str, raw_map_path in rows:
         if not raw_map_path:
             continue
 

--- a/tests/ui/qml/tst_selection_summary.qml
+++ b/tests/ui/qml/tst_selection_summary.qml
@@ -54,12 +54,33 @@ TestCase {
         summary.destroy();
     }
 
-    function test_a_squad_stays_in_per_unit_chips() {
+    function test_a_single_type_squad_stays_in_per_unit_chips() {
         var summary = makeSummary(6, makeGroups([{
                         "typeKey": "archer",
                         "count": 6
                     }]));
         verify(summary.squad);
+        verify(!summary.groupedSquad);
+        verify(!summary.army);
+        summary.destroy();
+    }
+
+    function test_a_mixed_squad_switches_to_group_cards() {
+        var summary = makeSummary(9, makeGroups([{
+                        "typeKey": "spearman",
+                        "count": 2
+                    }, {
+                        "typeKey": "archer",
+                        "count": 3
+                    }, {
+                        "typeKey": "healer",
+                        "count": 1
+                    }, {
+                        "typeKey": "swordsman",
+                        "count": 3
+                    }]));
+        verify(summary.squad);
+        verify(summary.groupedSquad);
         verify(!summary.army);
         summary.destroy();
     }

--- a/ui/qml/HUDBottom.qml
+++ b/ui/qml/HUDBottom.qml
@@ -225,23 +225,6 @@ RowLayout {
             }
         }]
 
-    property bool ordersCompact: true
-
-    function measure_widest_label() {
-        orderLabelMetrics.font.pixelSize = Design.Typography.label;
-        var widest = 0;
-        for (var i = 0; i < commands.length; ++i) {
-            orderLabelMetrics.text = commands[i].label;
-            widest = Math.max(widest, orderLabelMetrics.advanceWidth);
-        }
-        return widest;
-    }
-
-    function refresh_order_density(buttonWidth) {
-        var needed = Design.Metrics.iconMedium + measure_widest_label() + Design.Metrics.space24 * 2;
-        ordersCompact = buttonWidth < needed;
-    }
-
     function invoke_command(entry) {
         if (entry.invoke) {
             entry.invoke();
@@ -325,13 +308,6 @@ RowLayout {
             }
         }
 
-        TextMetrics {
-            id: orderLabelMetrics
-
-            font.family: Design.Typography.family
-            font.weight: Design.Typography.medium
-        }
-
         GridLayout {
             id: orderGrid
 
@@ -340,8 +316,6 @@ RowLayout {
             columns: 6
             rowSpacing: Design.Metrics.space4
             columnSpacing: Design.Metrics.space4
-            onWidthChanged: bottomRoot.refresh_order_density((width - columnSpacing * (columns - 1)) / columns)
-            Component.onCompleted: bottomRoot.refresh_order_density((width - columnSpacing * (columns - 1)) / columns)
 
             Repeater {
                 model: bottomRoot.commands
@@ -355,7 +329,6 @@ RowLayout {
 
                     Layout.fillWidth: true
                     Layout.preferredHeight: Design.Metrics.commandButtonSize
-                    compact: bottomRoot.ordersCompact
 
                     actionId: modelData.id
                     label: modelData.label

--- a/ui/qml/design/controls/IronSelectionSummary.qml
+++ b/ui/qml/design/controls/IronSelectionSummary.qml
@@ -16,6 +16,7 @@ Design.IronPanel {
     readonly property bool singleUnit: unitCount === 1
     readonly property bool squad: unitCount > 1 && unitCount <= detailCap
     readonly property bool army: unitCount > detailCap
+    readonly property bool groupedSquad: squad && groups.length >= 4
 
     signal unitActivated(var unitId)
 
@@ -43,29 +44,48 @@ Design.IronPanel {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        spacing: Design.Metrics.space8
+        spacing: Design.Metrics.space12
 
         Item {
             width: parent.width
-            height: header.implicitHeight
+            height: Math.max(headerBlock.implicitHeight, selectionCountBadge.implicitHeight)
 
-            Text {
-                id: header
+            Column {
+                id: headerBlock
 
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
-                text: root.empty ? qsTr("No units selected") : root.singleUnit ? qsTr("1 unit selected") : qsTr("%1 units selected").arg(root.unitCount)
-                color: Design.Theme.textSecondary
-                font.family: Design.Typography.family
-                font.pixelSize: Design.Typography.caption
-                font.weight: Design.Typography.medium
+                spacing: 0
+
+                Text {
+                    id: header
+
+                    text: root.empty ? qsTr("SELECTION") : root.singleUnit ? qsTr("SELECTED UNIT") : qsTr("SELECTED FORCE")
+                    color: Design.Theme.textSecondary
+                    font.family: Design.Typography.family
+                    font.pixelSize: Design.Typography.caption
+                    font.weight: Design.Typography.bold
+                    font.letterSpacing: Design.Typography.trackingWide
+                }
+
+                Text {
+                    visible: !root.empty
+                    text: root.singleUnit && root.groups.length > 0 ? root.groups[0].name : qsTr("%1 soldiers ready").arg(root.unitCount)
+                    color: Design.Theme.textPrimary
+                    font.family: Design.Typography.displayFamily
+                    font.pixelSize: Design.Typography.label
+                    font.weight: Design.Typography.bold
+                }
             }
 
             Design.IronBadge {
+                id: selectionCountBadge
+
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
-                visible: root.groups.length > 1
-                text: qsTr("%1 types").arg(root.groups.length)
+                visible: !root.empty
+                tone: Design.Theme.accent
+                text: root.singleUnit ? qsTr("1 unit") : root.groups.length === 1 ? qsTr("%1 units").arg(root.unitCount) : qsTr("%1 units  ·  %2 types").arg(root.unitCount).arg(root.groups.length)
             }
         }
 
@@ -85,14 +105,14 @@ Design.IronPanel {
 
         Loader {
             width: parent.width
-            active: root.squad
+            active: root.squad && !root.groupedSquad
             visible: active
             sourceComponent: chipView
         }
 
         Loader {
             width: parent.width
-            active: root.army
+            active: root.army || root.groupedSquad
             visible: active
             sourceComponent: rosterView
         }
@@ -125,40 +145,72 @@ Design.IronPanel {
     Component {
         id: singleUnitView
 
-        Row {
-            spacing: Design.Metrics.space8
+        Rectangle {
+            width: parent.width
+            height: Design.Metrics.space24 * 3
+            radius: Design.Metrics.radiusMedium
+            color: Design.Theme.backgroundDeep
+            border.width: Design.Metrics.borderThin
+            border.color: Design.Theme.borderSubtle
 
-            Image {
-                width: Design.Metrics.iconMedium
-                height: width
-                fillMode: Image.PreserveAspectFit
-                source: root.iconFor(root.groups[0].typeKey, root.groups[0].nation, root.groups[0].name)
+            Rectangle {
+                id: singlePortrait
+
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                anchors.margins: Design.Metrics.space8
+                width: height
+                radius: Design.Metrics.radiusSmall
+                color: Design.Theme.panelLeather
+                border.width: Design.Metrics.borderThin
+                border.color: Design.Theme.borderStrong
+
+                Image {
+                    anchors.fill: parent
+                    anchors.margins: Design.Metrics.space4
+                    fillMode: Image.PreserveAspectFit
+                    source: root.iconFor(root.groups[0].typeKey, root.groups[0].nation, root.groups[0].name)
+                    smooth: true
+                    mipmap: true
+                }
             }
 
             Column {
+                anchors.left: singlePortrait.right
+                anchors.leftMargin: Design.Metrics.space12
+                anchors.right: healthPercent.left
+                anchors.rightMargin: Design.Metrics.space12
+                anchors.verticalCenter: parent.verticalCenter
                 spacing: Design.Metrics.space2
 
                 Text {
-                    text: root.groups[0].name
-                    color: Design.Theme.textPrimary
-                    font.family: Design.Typography.family
-                    font.pixelSize: Design.Typography.label
-                    font.weight: Design.Typography.medium
-                }
-
-                Design.IronProgressBar {
-                    width: Design.Metrics.space24 * 5
-                    value: root.groups[0].health
-                    fillColor: root.healthColor(value)
-                }
-
-                Text {
-
-                    text: Math.round(root.groups[0].health * 100) + "%"
+                    width: parent.width
+                    text: qsTr("Ready for orders")
                     color: Design.Theme.textSecondary
                     font.family: Design.Typography.family
                     font.pixelSize: Design.Typography.caption
+                    elide: Text.ElideRight
                 }
+
+                Design.IronProgressBar {
+                    width: parent.width
+                    value: root.groups[0].health
+                    fillColor: root.healthColor(value)
+                }
+            }
+
+            Text {
+                id: healthPercent
+
+                anchors.right: parent.right
+                anchors.rightMargin: Design.Metrics.space12
+                anchors.verticalCenter: parent.verticalCenter
+                text: Math.round(root.groups[0].health * 100) + "%"
+                color: root.healthColor(root.groups[0].health)
+                font.family: Design.Typography.family
+                font.pixelSize: Design.Typography.label
+                font.weight: Design.Typography.bold
             }
         }
     }
@@ -177,8 +229,8 @@ Design.IronPanel {
 
                     required property var model
 
-                    width: Design.Metrics.iconMedium + Design.Metrics.space8
-                    height: Design.Metrics.iconMedium + Design.Metrics.space8
+                    width: Design.Metrics.space24 * 2
+                    height: Design.Metrics.space24 * 2
 
                     Accessible.role: Accessible.Button
                     Accessible.name: chip.model.name
@@ -188,28 +240,32 @@ Design.IronPanel {
                         anchors.fill: parent
                         radius: Design.Metrics.radiusSmall
                         color: chipMouse.containsMouse ? Design.Theme.panelLeather : Design.Theme.backgroundDeep
-                        border.width: Design.Metrics.borderThin
-                        border.color: root.healthColor(chip.model.health_ratio)
+                        border.width: chipMouse.containsMouse ? Design.Metrics.borderFocus : Design.Metrics.borderThin
+                        border.color: chipMouse.containsMouse ? Design.Theme.selection : Design.Theme.borderSubtle
                     }
 
                     Image {
                         anchors.centerIn: parent
-                        width: Design.Metrics.iconSmall
+                        anchors.verticalCenterOffset: -Design.Metrics.space2
+                        width: Design.Metrics.iconMedium
                         height: width
                         fillMode: Image.PreserveAspectFit
                         source: root.iconFor(chip.model.unit_type, chip.model.nation, chip.model.name)
+                        smooth: true
+                        mipmap: true
                     }
 
                     Item {
                         anchors.left: parent.left
                         anchors.right: parent.right
                         anchors.bottom: parent.bottom
-                        anchors.margins: Design.Metrics.borderThin
-                        height: Design.Metrics.space2
+                        anchors.margins: Design.Metrics.space4
+                        height: Design.Metrics.space4
 
                         Rectangle {
                             width: parent.width * chip.model.health_ratio
                             height: parent.height
+                            radius: height / 2
                             color: root.healthColor(chip.model.health_ratio)
                         }
                     }
@@ -234,60 +290,119 @@ Design.IronPanel {
     Component {
         id: rosterView
 
-        Column {
-            spacing: Design.Metrics.space2
+        Flow {
+            id: groupFlow
+
+            width: parent.width
+            spacing: Design.Metrics.space8
+
+            readonly property int columnCount: root.groups.length > 8 ? 4 : Math.min(4, Math.max(1, root.groups.length))
+            readonly property real cardWidth: Math.floor((width - spacing * (columnCount - 1)) / columnCount)
+            readonly property real cardHeight: root.groups.length > 8 ? Design.Metrics.space24 * 2 : Design.Metrics.space24 * 3
 
             Repeater {
                 model: root.groups
 
-                delegate: Row {
-                    id: rosterRow
+                delegate: Rectangle {
+                    id: groupCard
 
                     required property var modelData
 
-                    spacing: Design.Metrics.space8
+                    width: groupFlow.cardWidth
+                    height: groupFlow.cardHeight
+                    radius: Design.Metrics.radiusMedium
+                    color: Design.Theme.backgroundDeep
+                    border.width: Design.Metrics.borderThin
+                    border.color: groupCard.modelData.woundedCount > 0 ? root.healthColor(groupCard.modelData.health) : Design.Theme.borderSubtle
 
                     Accessible.role: Accessible.StaticText
-                    Accessible.name: rosterRow.modelData.name + " ×" + rosterRow.modelData.count
+                    Accessible.name: groupCard.modelData.name + " ×" + groupCard.modelData.count
+                    Accessible.description: Math.round(groupCard.modelData.health * 100) + "%"
 
-                    Image {
-                        width: Design.Metrics.iconSmall
-                        height: width
+                    Rectangle {
+                        id: portraitFrame
+
+                        anchors.left: parent.left
+                        anchors.leftMargin: Design.Metrics.space8
                         anchors.verticalCenter: parent.verticalCenter
-                        fillMode: Image.PreserveAspectFit
-                        source: root.iconFor(rosterRow.modelData.typeKey, rosterRow.modelData.nation, rosterRow.modelData.name)
+                        width: Math.min(Design.Metrics.space24 * 2, parent.height - Design.Metrics.space12)
+                        height: width
+                        radius: Design.Metrics.radiusSmall
+                        color: Design.Theme.panelLeather
+                        border.width: Design.Metrics.borderThin
+                        border.color: Design.Theme.borderStrong
+
+                        Image {
+                            anchors.fill: parent
+                            anchors.margins: Design.Metrics.space4
+                            fillMode: Image.PreserveAspectFit
+                            source: root.iconFor(groupCard.modelData.typeKey, groupCard.modelData.nation, groupCard.modelData.name)
+                            smooth: true
+                            mipmap: true
+                        }
+
+                        Rectangle {
+                            anchors.right: parent.right
+                            anchors.rightMargin: -Design.Metrics.space4
+                            anchors.top: parent.top
+                            anchors.topMargin: -Design.Metrics.space4
+                            width: Math.max(Design.Metrics.space16, groupCount.implicitWidth + Design.Metrics.space8)
+                            height: Design.Metrics.space16
+                            radius: height / 2
+                            color: Design.Theme.panelLeather
+                            border.width: Design.Metrics.borderThin
+                            border.color: Design.Theme.accent
+
+                            Text {
+                                id: groupCount
+
+                                anchors.centerIn: parent
+                                text: "×" + groupCard.modelData.count
+                                color: Design.Theme.accent
+                                font.family: Design.Typography.family
+                                font.pixelSize: Design.Typography.caption
+                                font.weight: Design.Typography.bold
+                            }
+                        }
                     }
 
                     Text {
-                        width: Design.Metrics.space24 * 4
-                        anchors.verticalCenter: parent.verticalCenter
-                        text: rosterRow.modelData.name
+                        id: groupName
+
+                        anchors.left: portraitFrame.right
+                        anchors.leftMargin: Design.Metrics.space8
+                        anchors.right: parent.right
+                        anchors.rightMargin: Design.Metrics.space8
+                        anchors.top: parent.top
+                        anchors.topMargin: Design.Metrics.space8
+                        text: groupCard.modelData.name
                         color: Design.Theme.textPrimary
                         font.family: Design.Typography.family
                         font.pixelSize: Design.Typography.caption
+                        font.weight: Design.Typography.medium
                         elide: Text.ElideRight
                     }
 
-                    Text {
-                        anchors.verticalCenter: parent.verticalCenter
-                        text: "×" + rosterRow.modelData.count
-                        color: Design.Theme.textSecondary
-                        font.family: Design.Typography.family
-                        font.pixelSize: Design.Typography.caption
-                        font.weight: Design.Typography.bold
-                    }
-
                     Design.IronProgressBar {
-                        width: Design.Metrics.space24 * 3
-                        anchors.verticalCenter: parent.verticalCenter
-                        value: rosterRow.modelData.health
+                        id: groupHealth
+
+                        anchors.left: portraitFrame.right
+                        anchors.leftMargin: Design.Metrics.space8
+                        anchors.right: parent.right
+                        anchors.rightMargin: Design.Metrics.space8
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: Design.Metrics.space8
+                        value: groupCard.modelData.health
                         fillColor: root.healthColor(value)
                     }
 
                     Text {
-                        anchors.verticalCenter: parent.verticalCenter
-                        visible: rosterRow.modelData.woundedCount > 0
-                        text: qsTr("%1 hurt").arg(rosterRow.modelData.woundedCount)
+                        anchors.left: portraitFrame.right
+                        anchors.leftMargin: Design.Metrics.space8
+                        anchors.bottom: groupHealth.top
+                        anchors.bottomMargin: Design.Metrics.space2
+                        visible: groupCard.modelData.woundedCount > 0 && groupCard.height >= Design.Metrics.space24 * 3
+                        text: qsTr("%1 wounded").arg(groupCard.modelData.woundedCount)
                         color: Design.Theme.warning
                         font.family: Design.Typography.family
                         font.pixelSize: Design.Typography.caption


### PR DESCRIPTION
Selection summary:
- Two-line header with context-aware labels (Selection/Selected Unit/Selected Force)
- New groupedSquad mode: squads with 4+ types use roster cards instead of chips
- Single-unit view upgraded to a styled card with portrait, health bar, and percentage
- Chip view gets larger sizes, hover states, smooth scaling, and rounded health bars
- Roster view redesigned as a responsive Flow grid of cards with count badges

Orders bar:
- Remove adaptive compact layout logic; buttons always render in full mode

Stale-save purge:
- Read map_path directly from a dedicated DB column instead of parsing metadata JSON

Tests:
- Rename existing squad test, add mixed-squad groupedSquad test