### PR TITLE
feat: weather wind, particle budgets, and lighting fades

### DIFF
--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -3116,6 +3116,7 @@ void GameEngine::configure_rain_system() {
   m_rain->configure(world_width, world_height, m_level.biome_seed, m_level.rain.type);
   m_rain->set_enabled(m_level.rain.enabled);
   m_rain->set_wind_strength(m_level.rain.wind_strength);
+  m_rain->set_wind_direction_deg(m_level.rain.wind_direction_deg);
 
   const float initial_intensity =
       m_rain_manager ? m_rain_manager->get_intensity()
@@ -3305,6 +3306,9 @@ void GameEngine::begin_save(const QString& slot_name,
     level_snapshot.environment = m_environment_clock->definition();
     level_snapshot.environment_clock = m_environment_clock->snapshot();
   }
+  if (m_rain_manager) {
+    level_snapshot.weather_runtime = m_rain_manager->snapshot();
+  }
   std::optional<Game::Mission::MissionContext> mission_context;
   if (m_campaign_manager) {
     mission_context = m_campaign_manager->current_mission_context();
@@ -3427,6 +3431,15 @@ void GameEngine::load_game_from_slot(const QString& slot_name) {
     m_environment_clock->restore(m_level.environment, m_level.environment_clock);
     if (m_renderer) {
       m_renderer->set_environment_lighting(m_environment_clock->lighting());
+    }
+  }
+
+  if (m_rain_manager) {
+
+    configure_rain_system();
+    m_rain_manager->restore(m_level.weather_runtime);
+    if (m_rain) {
+      m_rain->set_intensity(m_rain_manager->get_intensity());
     }
   }
 

--- a/app/core/runtime_frame_orchestrator.cpp
+++ b/app/core/runtime_frame_orchestrator.cpp
@@ -107,6 +107,7 @@ void RuntimeFrameOrchestrator::update(const AppSceneContext& scene,
       scene.rain->set_intensity(scene.rain_manager->get_intensity());
       scene.rain->set_weather_type(scene.rain_manager->get_weather_type());
       scene.rain->set_wind_strength(scene.rain_manager->get_wind_strength());
+      scene.rain->set_wind_direction_deg(scene.rain_manager->get_wind_direction_deg());
       if (scene.active_camera != nullptr) {
         scene.rain->set_camera_position(scene.active_camera->get_position());
       }

--- a/assets/maps/map_battle_cannae.json
+++ b/assets/maps/map_battle_cannae.json
@@ -3885,5 +3885,8 @@
       "nation": "roman_republic",
       "max_population": 160
     }
-  ]
+  ],
+  "rain": {
+    "enabled": false
+  }
 }

--- a/assets/maps/map_battle_ticino.json
+++ b/assets/maps/map_battle_ticino.json
@@ -4947,5 +4947,15 @@
       "max_population": 150,
       "on_hill": false
     }
-  ]
+  ],
+  "rain": {
+    "enabled": true,
+    "type": "rain",
+    "intensity": "light",
+    "cycle_duration": 340.0,
+    "active_duration": 80.0,
+    "fade_duration": 7.0,
+    "wind_strength": 0.18,
+    "wind_direction": 20.0
+  }
 }

--- a/assets/maps/map_battle_trasimene.json
+++ b/assets/maps/map_battle_trasimene.json
@@ -3492,5 +3492,8 @@
       "nation": "roman_republic",
       "max_population": 160
     }
-  ]
+  ],
+  "rain": {
+    "enabled": false
+  }
 }

--- a/assets/maps/map_battle_trebia.json
+++ b/assets/maps/map_battle_trebia.json
@@ -3539,10 +3539,12 @@
   "rain": {
     "enabled": true,
     "type": "snow",
-    "intensity": 0.72,
+    "intensity": "medium",
     "cycle_duration": 300.0,
     "active_duration": 120.0,
-    "fade_duration": 8.0
+    "fade_duration": 8.0,
+    "wind_strength": 0.45,
+    "wind_direction": 15.0
   },
   "undead_zones": [
     {

--- a/assets/maps/map_battle_zama.json
+++ b/assets/maps/map_battle_zama.json
@@ -5189,5 +5189,8 @@
       "nation": "roman_republic",
       "max_population": 170
     }
-  ]
+  ],
+  "rain": {
+    "enabled": false
+  }
 }

--- a/assets/maps/map_campania_campaign.json
+++ b/assets/maps/map_campania_campaign.json
@@ -5810,5 +5810,8 @@
       "nation": "roman_republic",
       "max_population": 150
     }
-  ]
+  ],
+  "rain": {
+    "enabled": false
+  }
 }

--- a/assets/maps/map_crossing_alps.json
+++ b/assets/maps/map_crossing_alps.json
@@ -2155,10 +2155,12 @@
   "rain": {
     "enabled": true,
     "type": "snow",
-    "intensity": 0.82,
+    "intensity": "heavy",
     "cycle_duration": 300.0,
-    "active_duration": 120.0,
-    "fade_duration": 8.0
+    "active_duration": 150.0,
+    "fade_duration": 10.0,
+    "wind_strength": 0.65,
+    "wind_direction": 330.0
   },
   "undead_zones": [
     {

--- a/assets/maps/map_crossing_rhone.json
+++ b/assets/maps/map_crossing_rhone.json
@@ -202,6 +202,16 @@
     },
     "max_troops_per_player": 2200,
     "name": "Crossing the Rhone - Polished Maze Version",
+    "rain": {
+        "active_duration": 70.0,
+        "cycle_duration": 300.0,
+        "enabled": true,
+        "fade_duration": 6.0,
+        "intensity": "light",
+        "type": "rain",
+        "wind_direction": 200.0,
+        "wind_strength": 0.22
+    },
     "rivers": [
         {
             "end": [

--- a/assets/maps/map_forest.json
+++ b/assets/maps/map_forest.json
@@ -78,10 +78,13 @@
   },
   "rain": {
     "enabled": true,
+    "type": "rain",
+    "intensity": "medium",
     "cycle_duration": 320.0,
     "active_duration": 75.0,
-    "intensity": 0.55,
-    "fade_duration": 6.0
+    "fade_duration": 6.0,
+    "wind_strength": 0.2,
+    "wind_direction": 250.0
   },
   "rivers": [],
   "bridges": [],

--- a/assets/maps/map_iron_sepulcher_watch.json
+++ b/assets/maps/map_iron_sepulcher_watch.json
@@ -144,5 +144,15 @@
       "nation": "roman_republic",
       "max_population": 180
     }
-  ]
+  ],
+  "rain": {
+    "enabled": true,
+    "type": "rain",
+    "intensity": "light",
+    "cycle_duration": 360.0,
+    "active_duration": 110.0,
+    "fade_duration": 10.0,
+    "wind_strength": 0.14,
+    "wind_direction": 300.0
+  }
 }

--- a/assets/maps/map_mountain.json
+++ b/assets/maps/map_mountain.json
@@ -79,11 +79,12 @@
   "rain": {
     "enabled": true,
     "type": "snow",
+    "intensity": "medium",
     "cycle_duration": 420.0,
     "active_duration": 115.0,
-    "intensity": 0.62,
     "fade_duration": 8.0,
-    "wind_strength": 0.32
+    "wind_strength": 0.32,
+    "wind_direction": 70.0
   },
   "terrain": [
     {

--- a/assets/maps/map_rivers.json
+++ b/assets/maps/map_rivers.json
@@ -1059,5 +1059,15 @@
       "x": 100,
       "z": 20
     }
-  ]
+  ],
+  "rain": {
+    "enabled": true,
+    "type": "rain",
+    "intensity": "medium",
+    "cycle_duration": 280.0,
+    "active_duration": 90.0,
+    "fade_duration": 6.0,
+    "wind_strength": 0.3,
+    "wind_direction": 145.0
+  }
 }

--- a/assets/maps/map_spanish_grove.json
+++ b/assets/maps/map_spanish_grove.json
@@ -1179,5 +1179,8 @@
       "nation": "roman_republic",
       "description": "Player 2 Roman barracks"
     }
-  ]
+  ],
+  "rain": {
+    "enabled": false
+  }
 }

--- a/assets/shaders/rain.vert
+++ b/assets/shaders/rain.vert
@@ -3,6 +3,7 @@
 layout(location = 0) in vec3 a_position;
 layout(location = 1) in vec3 a_offset;
 layout(location = 2) in float a_alpha;
+layout(location = 3) in float a_rank;
 
 uniform mat4 u_view_proj;
 uniform float u_time;
@@ -11,6 +12,7 @@ uniform vec3 u_camera_pos;
 uniform vec3 u_wind;
 uniform int u_weather_type;
 uniform float u_wind_strength;
+uniform float u_density;
 
 out float v_alpha;
 out float v_rotation;
@@ -28,6 +30,8 @@ const float SNOW_DRIFT_AMPLITUDE_X = 0.15;
 const float SNOW_DRIFT_AMPLITUDE_Z = 0.1;
 
 const float SNOW_POINT_SIZE = 22.0;
+
+const float DENSITY_FADE_BAND = 0.12;
 
 void main() {
   float speed = a_offset.z;
@@ -55,11 +59,14 @@ void main() {
   pos.z += u_wind.z * height_factor * wind_factor * (1.0 + u_wind_strength);
 
   if (u_weather_type == 1) {
-    float drift = sin(u_time * SNOW_DRIFT_FREQ_X + a_position.x * SNOW_DRIFT_SCALE_X) *
+
+    vec2 wind_dir = normalize(u_wind.xz + vec2(1e-4, 0.0));
+    vec2 wind_tangent = vec2(-wind_dir.y, wind_dir.x);
+    float along = sin(u_time * SNOW_DRIFT_FREQ_X + a_position.x * SNOW_DRIFT_SCALE_X) *
                   SNOW_DRIFT_AMPLITUDE_X;
-    pos.x += drift;
-    pos.z += cos(u_time * SNOW_DRIFT_FREQ_Z + a_position.z * SNOW_DRIFT_SCALE_X) *
-             SNOW_DRIFT_AMPLITUDE_Z;
+    float across = cos(u_time * SNOW_DRIFT_FREQ_Z + a_position.z * SNOW_DRIFT_SCALE_X) *
+                   SNOW_DRIFT_AMPLITUDE_Z;
+    pos.xz += wind_dir * along + wind_tangent * across;
 
     gl_PointSize = SNOW_POINT_SIZE;
 
@@ -68,5 +75,6 @@ void main() {
 
   gl_Position = u_view_proj * vec4(pos, 1.0);
 
-  v_alpha = a_alpha * u_intensity;
+  float density_fade = clamp((u_density - a_rank) / DENSITY_FADE_BAND, 0.0, 1.0);
+  v_alpha = a_alpha * u_intensity * density_fade;
 }

--- a/docs/RENDERING_ARCHITECTURE.md
+++ b/docs/RENDERING_ARCHITECTURE.md
@@ -48,12 +48,20 @@ Shaders pull from it through `assets/shaders/include/environment_lighting.glsl` 
 
 Time of day is a continuous decimal hour with `locked`, `scripted` and `continuous` modes, not four fixed presets; the legacy `morning`/`day`/`afternoon`/`night` strings still load and alias onto hours. Weather feeds the same state, so rain and snow shift cloud cover, wetness, fog and sky tint coherently.
 
-Directional shadows are cascaded (up to four, quality-dependent) with texel snapping and cascade blending. Contact shadows remain as a cheap grounding effect and a low-quality fallback.
+Directional shadows are cascaded (up to four, quality-dependent) with texel snapping and cascade blending. Contact shadows remain as a cheap grounding effect and a low-quality fallback: `render/contact_shadow.h` derives their compass direction and length from the same `EnvironmentLightingState` sun rather than a baked constant, so a blob points and stretches the way the map's clock says it should. The same helper fades them out -- towards a subtle patch directly under the feet where a real cascade already covers the unit, and towards zero at the contact-shadow distance limit -- so nothing pops in or doubles up.
+
+Local lights are budgeted (`Render::k_max_local_lights`) and go through `Render::LocalLightFader`, which holds a slot until its light has ramped down. Entering and leaving the budget is a fade over `k_local_light_fade_seconds`, never a pop, and `Renderer::clear_entity_render_caches()` resets the fader so a new map never inherits the previous map's fires.
 
 Two practical notes:
 
 - **Texture units are a shared, program-wide namespace.** Two samplers of different types resolving to the same unit make every draw using that program raise `GL_INVALID_OPERATION`. The units in play are listed in `Render::GL::TextureUnit` (`render/gl/render_constants.h`) -- add new long-lived samplers there rather than picking a number.
 - **Instanced emitters can't be recovered from draw commands.** Fire camps and shrines reach the GPU as instance buffers, so the backend cannot read their positions back to build local lights. They advertise themselves through `Renderer::local_light()` instead, and the backend budgets those alongside effect-driven lights.
+
+## Precipitation
+
+Every shipped map states its weather explicitly in a `"rain"` block -- `enabled`, `type` (`rain` or `snow`), `intensity` (a number, or the words `light`/`medium`/`heavy`), the cycle timings, and `wind_strength` plus `wind_direction` in compass degrees. `Game::Systems::RainManager` runs the cycle; its state, cycle position and transition progress round-trip through the save metadata's `weather` object, so loading mid-downpour resumes mid-downpour.
+
+Particles live in one fixed pool owned by `RainPipeline` and are recycled in the vertex shader, positioned relative to the camera rather than across the map. How much of that pool is drawn each frame is `RainBatchParams::density`, computed by `Render::GL::weather_particle_density()` from the active intensity, the quality preset's `WeatherBudget::particle_scale`, and how far the camera has pulled back. Each particle carries a `rank` in the pool and fades out as the density cutoff approaches it, so raising or lowering the budget dissolves particles instead of popping them.
 
 ## QSG render-thread stages
 
@@ -742,6 +750,8 @@ Here's a quick reference for common tasks:
 | Tune battle performance                  | [render/battle_render_optimizer.h](https://github.com/djeada/Standard-of-Iron/blob/main/render/battle_render_optimizer.h) for temporal culling and animation throttling                                                                                    |
 | Share a type between gameplay and render | Put it in `scene/` (view data), `animation/rig/` (skeleton, reach) or `animation/bpat/` (baked poses) -- never include `render/` from `game/`                                                                                                              |
 | Change lighting or time of day           | `scene/environment_lighting.h` for the state, `game/map/environment_lighting.cpp` for the curves, `assets/shaders/include/environment_lighting.glsl` for shader access                                                                                     |
+| Tune unit blob shadows                   | `render/contact_shadow.h` -- direction, length and fade all derive from the environment sun and the directional-shadow settings                                                                                                                            |
+| Change a map's weather                   | The map's `"rain"` block (or the map editor's Weather panel); particle budgets live in `Render::GL::weather_particle_density` and `GraphicsSettings::weather_budget`                                                                                       |
 | Add a shader sampler                     | Register the unit in `Render::GL::TextureUnit` ([render/gl/render_constants.h](https://github.com/djeada/Standard-of-Iron/blob/main/render/gl/render_constants.h)) so it cannot collide                                                                    |
 | Make a prop cast light                   | Call `Renderer::local_light()` from its renderer; instanced props cannot be recovered from draw commands                                                                                                                                                   |
 | Review props or lighting visually        | `arena_app --batch --scenario world_prop_lineup` (or any `lighting_*` scenario) `--clean-capture --artifact-dir <dir>`; compare with `scripts/compare-arena-captures.py`                                                                                   |

--- a/game/map/json_keys.h
+++ b/game/map/json_keys.h
@@ -125,6 +125,7 @@ inline constexpr const char* RAIN_ACTIVE_DURATION = "active_duration";
 inline constexpr const char* RAIN_INTENSITY = "intensity";
 inline constexpr const char* RAIN_FADE_DURATION = "fade_duration";
 inline constexpr const char* RAIN_WIND_STRENGTH = "wind_strength";
+inline constexpr const char* RAIN_WIND_DIRECTION = "wind_direction";
 
 inline constexpr const char* WORLD_PROPS = "world_props";
 inline constexpr const char* FOG_ZONES = "fog_zones";

--- a/game/map/map_definition.h
+++ b/game/map/map_definition.h
@@ -4,7 +4,9 @@
 #include <QVector3D>
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
+#include <numbers>
 #include <optional>
 #include <variant>
 #include <vector>
@@ -303,6 +305,10 @@ enum class WeatherType {
   Snow
 };
 
+inline constexpr float k_weather_intensity_light = 0.3F;
+inline constexpr float k_weather_intensity_medium = 0.6F;
+inline constexpr float k_weather_intensity_heavy = 0.9F;
+
 struct RainSettings {
   bool enabled = false;
   WeatherType type = WeatherType::Rain;
@@ -311,7 +317,46 @@ struct RainSettings {
   float intensity = 0.5F;
   float fade_duration = 5.0F;
   float wind_strength = 0.0F;
+
+  float wind_direction_deg = 45.0F;
 };
+
+[[nodiscard]] inline auto parse_weather_intensity(const QString& value,
+                                                  float fallback) -> float {
+  const QString normalized = value.trimmed().toLower();
+  if (normalized == QStringLiteral("light")) {
+    return k_weather_intensity_light;
+  }
+  if (normalized == QStringLiteral("medium")) {
+    return k_weather_intensity_medium;
+  }
+  if (normalized == QStringLiteral("heavy")) {
+    return k_weather_intensity_heavy;
+  }
+  bool parsed = false;
+  const float numeric = normalized.toFloat(&parsed);
+  return parsed ? std::clamp(numeric, 0.0F, 1.0F) : fallback;
+}
+
+[[nodiscard]] inline auto weather_intensity_name(float intensity) -> const char* {
+  const float midpoint_light_medium =
+      (k_weather_intensity_light + k_weather_intensity_medium) * 0.5F;
+  const float midpoint_medium_heavy =
+      (k_weather_intensity_medium + k_weather_intensity_heavy) * 0.5F;
+  if (intensity < midpoint_light_medium) {
+    return "light";
+  }
+  if (intensity < midpoint_medium_heavy) {
+    return "medium";
+  }
+  return "heavy";
+}
+
+[[nodiscard]] inline auto
+weather_wind_vector(float wind_direction_deg) noexcept -> QVector3D {
+  const float radians = wind_direction_deg * std::numbers::pi_v<float> / 180.0F;
+  return {std::sin(radians), 0.0F, std::cos(radians)};
+}
 
 struct FogZone {
   float x = 0.0F;

--- a/game/map/map_loader.cpp
+++ b/game/map/map_loader.cpp
@@ -356,7 +356,12 @@ void read_rain_config(const QJsonObject& obj, RainSettings& out) {
         float(obj.value(RAIN_ACTIVE_DURATION).toDouble(out.active_duration));
   }
   if (obj.contains(RAIN_INTENSITY)) {
-    out.intensity = float(obj.value(RAIN_INTENSITY).toDouble(out.intensity));
+    const QJsonValue intensity = obj.value(RAIN_INTENSITY);
+    if (intensity.isString()) {
+      out.intensity = parse_weather_intensity(intensity.toString(), out.intensity);
+    } else {
+      out.intensity = float(intensity.toDouble(out.intensity));
+    }
   }
   if (obj.contains(RAIN_FADE_DURATION)) {
     out.fade_duration =
@@ -366,6 +371,12 @@ void read_rain_config(const QJsonObject& obj, RainSettings& out) {
     out.wind_strength =
         float(obj.value(RAIN_WIND_STRENGTH).toDouble(out.wind_strength));
   }
+  if (obj.contains(RAIN_WIND_DIRECTION)) {
+    out.wind_direction_deg =
+        float(obj.value(RAIN_WIND_DIRECTION).toDouble(out.wind_direction_deg));
+  }
+  out.intensity = std::clamp(out.intensity, 0.0F, 1.0F);
+  out.wind_strength = std::max(0.0F, out.wind_strength);
 }
 
 void read_spawns(const QJsonArray& arr, std::vector<UnitSpawn>& out) {

--- a/game/systems/game_state_serializer.cpp
+++ b/game/systems/game_state_serializer.cpp
@@ -96,6 +96,20 @@ auto GameStateSerializer::build_metadata(const Engine::Core::World&,
   environment_obj["transition_elapsed"] = level.environment_clock.transition_elapsed;
   metadata["environment"] = environment_obj;
 
+  QJsonObject weather_obj;
+  weather_obj["enabled"] = level.rain.enabled;
+  weather_obj["type"] = level.rain.type == Game::Map::WeatherType::Snow
+                            ? QStringLiteral("snow")
+                            : QStringLiteral("rain");
+  weather_obj["state"] =
+      QString::fromLatin1(rain_state_name(level.weather_runtime.state));
+  weather_obj["cycle_time"] = level.weather_runtime.cycle_time;
+  weather_obj["state_time"] = level.weather_runtime.state_time;
+  weather_obj["intensity"] = level.weather_runtime.intensity;
+  weather_obj["wind_strength"] = level.rain.wind_strength;
+  weather_obj["wind_direction"] = level.rain.wind_direction_deg;
+  metadata["weather"] = weather_obj;
+
   metadata["game_max_troops_per_player"] =
       Game::GameConfig::instance().get_max_troops_per_player();
 
@@ -363,6 +377,28 @@ void GameStateSerializer::restore_level_from_metadata(const QJsonObject& metadat
         static_cast<float>(environment.value("transition_elapsed").toDouble(0.0)),
         0.0F,
         level.environment_clock.transition_duration);
+  }
+
+  if (metadata.value("weather").isObject()) {
+    const QJsonObject weather = metadata.value("weather").toObject();
+    level.rain.enabled = weather.value("enabled").toBool(level.rain.enabled);
+    level.rain.type =
+        weather.value("type").toString().trimmed().toLower() == QStringLiteral("snow")
+            ? Game::Map::WeatherType::Snow
+            : Game::Map::WeatherType::Rain;
+    level.rain.wind_strength = std::max(
+        0.0F,
+        static_cast<float>(
+            weather.value("wind_strength").toDouble(level.rain.wind_strength)));
+    level.rain.wind_direction_deg = static_cast<float>(
+        weather.value("wind_direction").toDouble(level.rain.wind_direction_deg));
+    level.weather_runtime.state = parse_rain_state(weather.value("state").toString());
+    level.weather_runtime.cycle_time =
+        std::max(0.0F, static_cast<float>(weather.value("cycle_time").toDouble(0.0)));
+    level.weather_runtime.state_time =
+        std::max(0.0F, static_cast<float>(weather.value("state_time").toDouble(0.0)));
+    level.weather_runtime.intensity = std::clamp(
+        static_cast<float>(weather.value("intensity").toDouble(0.0)), 0.0F, 1.0F);
   }
 
   int max_troops = metadata.value("max_troops_per_player")

--- a/game/systems/game_state_serializer.h
+++ b/game/systems/game_state_serializer.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "../map/map_definition.h"
+#include "rain_manager.h"
 #include "resource_types.h"
 
 namespace Engine::Core {
@@ -35,6 +36,7 @@ struct LevelSnapshot {
   float tile_size = 1.0F;
   bool is_spectator_mode = false;
   Game::Map::RainSettings rain;
+  RainRuntimeState weather_runtime;
   std::uint32_t biome_seed = 0;
   Game::Map::EnvironmentLightingState lighting;
   Game::Map::EnvironmentDefinition environment;

--- a/game/systems/rain_manager.cpp
+++ b/game/systems/rain_manager.cpp
@@ -4,6 +4,34 @@
 
 namespace Game::Systems {
 
+auto parse_rain_state(const QString& value) noexcept -> RainState {
+  const QString normalized = value.trimmed().toLower();
+  if (normalized == QStringLiteral("fading_in")) {
+    return RainState::FadingIn;
+  }
+  if (normalized == QStringLiteral("active")) {
+    return RainState::Active;
+  }
+  if (normalized == QStringLiteral("fading_out")) {
+    return RainState::FadingOut;
+  }
+  return RainState::Clear;
+}
+
+auto rain_state_name(RainState state) noexcept -> const char* {
+  switch (state) {
+  case RainState::Clear:
+    return "clear";
+  case RainState::FadingIn:
+    return "fading_in";
+  case RainState::Active:
+    return "active";
+  case RainState::FadingOut:
+    return "fading_out";
+  }
+  return "clear";
+}
+
 RainManager::RainManager() = default;
 
 void RainManager::configure(const Game::Map::RainSettings& settings,
@@ -24,6 +52,25 @@ void RainManager::reset() {
     m_cycle_time = static_cast<float>(m_seed % cycle_ms) / 1000.0F;
   } else {
     m_cycle_time = 0.0F;
+  }
+}
+
+auto RainManager::snapshot() const noexcept -> RainRuntimeState {
+  return {.state = m_state,
+          .cycle_time = m_cycle_time,
+          .state_time = m_state_time,
+          .intensity = m_current_intensity};
+}
+
+void RainManager::restore(const RainRuntimeState& state) noexcept {
+  const float cycle_duration = std::max(0.001F, m_settings.cycle_duration);
+  m_state = state.state;
+  m_cycle_time = std::clamp(state.cycle_time, 0.0F, cycle_duration);
+  m_state_time = std::max(0.0F, state.state_time);
+  m_current_intensity = std::clamp(state.intensity, 0.0F, 1.0F);
+  if (!m_settings.enabled) {
+    m_state = RainState::Clear;
+    m_current_intensity = 0.0F;
   }
 }
 

--- a/game/systems/rain_manager.h
+++ b/game/systems/rain_manager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QString>
+
 #include <cstdint>
 #include <functional>
 
@@ -14,6 +16,16 @@ enum class RainState {
   FadingOut
 };
 
+struct RainRuntimeState {
+  RainState state = RainState::Clear;
+  float cycle_time = 0.0F;
+  float state_time = 0.0F;
+  float intensity = 0.0F;
+};
+
+[[nodiscard]] auto parse_rain_state(const QString& value) noexcept -> RainState;
+[[nodiscard]] auto rain_state_name(RainState state) noexcept -> const char*;
+
 class RainManager {
 public:
   RainManager();
@@ -22,6 +34,9 @@ public:
   void configure(const Game::Map::RainSettings& settings, std::uint32_t map_seed);
 
   void reset();
+
+  [[nodiscard]] auto snapshot() const noexcept -> RainRuntimeState;
+  void restore(const RainRuntimeState& state) noexcept;
 
   void update(float delta_time);
 
@@ -48,6 +63,10 @@ public:
 
   [[nodiscard]] auto get_wind_strength() const -> float {
     return m_settings.wind_strength;
+  }
+
+  [[nodiscard]] auto get_wind_direction_deg() const -> float {
+    return m_settings.wind_direction_deg;
   }
 
   using StateChangeCallback = std::function<void(RainState new_state)>;

--- a/render/contact_shadow.h
+++ b/render/contact_shadow.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <QVector2D>
+#include <QVector3D>
+
+#include <algorithm>
+#include <cmath>
+
+#include "scene/environment_lighting.h"
+
+namespace Render {
+
+struct ContactShadowPlacement {
+
+  QVector2D direction{0.0F, 1.0F};
+
+  float offset_scale = 1.0F;
+
+  float opacity = 1.0F;
+};
+
+struct ContactShadowInputs {
+  float camera_distance = 0.0F;
+  float fade_distance = 1.0F;
+  bool directional_shadows_enabled = false;
+  float directional_distance = 0.0F;
+};
+
+inline constexpr float k_contact_shadow_min_sun_elevation = 0.12F;
+inline constexpr float k_contact_shadow_max_offset_scale = 2.6F;
+inline constexpr float k_contact_shadow_grounded_opacity = 0.42F;
+inline constexpr float k_contact_shadow_grounded_offset = 0.35F;
+
+[[nodiscard]] inline auto
+contact_shadow_fade(float edge0, float edge1, float value) noexcept -> float {
+  if (edge1 <= edge0) {
+    return value >= edge1 ? 1.0F : 0.0F;
+  }
+  const float t = std::clamp((value - edge0) / (edge1 - edge0), 0.0F, 1.0F);
+  return t * t * (3.0F - (2.0F * t));
+}
+
+[[nodiscard]] inline auto contact_shadow_placement(
+    const EnvironmentLightingState& environment,
+    const ContactShadowInputs& inputs) noexcept -> ContactShadowPlacement {
+  ContactShadowPlacement placement;
+
+  const QVector3D sun = environment.sanitized().primary_direction;
+  QVector2D horizontal(sun.x(), sun.z());
+  const float horizontal_length = horizontal.length();
+  if (horizontal_length > 1e-4F) {
+
+    placement.direction = -(horizontal / horizontal_length);
+  }
+
+  const float elevation =
+      std::max(std::abs(sun.y()), k_contact_shadow_min_sun_elevation);
+  placement.offset_scale = std::clamp(
+      horizontal_length / elevation, 0.0F, k_contact_shadow_max_offset_scale);
+
+  const float fade_distance = std::max(inputs.fade_distance, 0.001F);
+  placement.opacity =
+      1.0F -
+      contact_shadow_fade(fade_distance * 0.75F, fade_distance, inputs.camera_distance);
+
+  if (inputs.directional_shadows_enabled && inputs.directional_distance > 0.0F) {
+
+    const float takeover =
+        1.0F - contact_shadow_fade(inputs.directional_distance * 0.6F,
+                                   inputs.directional_distance,
+                                   inputs.camera_distance);
+    placement.opacity *= 1.0F + ((k_contact_shadow_grounded_opacity - 1.0F) * takeover);
+    placement.offset_scale *=
+        1.0F + ((k_contact_shadow_grounded_offset - 1.0F) * takeover);
+  }
+
+  placement.opacity = std::clamp(placement.opacity, 0.0F, 1.0F);
+  return placement;
+}
+
+} // namespace Render

--- a/render/creature/pipeline/creature_prepared_state.cpp
+++ b/render/creature/pipeline/creature_prepared_state.cpp
@@ -10,6 +10,7 @@
 #include "../../../game/core/entity.h"
 #include "../../../game/map/terrain_service.h"
 #include "../../../game/units/spawn_type.h"
+#include "../../contact_shadow.h"
 #include "../../entity/registry.h"
 #include "../../gl/backend.h"
 #include "../../gl/humanoid/animation/animation_inputs.h"
@@ -29,17 +30,21 @@ constexpr float k_shadow_size_horse = 0.38F;
 constexpr float k_shadow_size_elephant = 0.55F;
 constexpr float k_shadow_ground_offset = 0.02F;
 constexpr float k_shadow_base_alpha = 0.32F;
-const QVector3D k_shadow_light_dir(0.65F, 0.50F, 0.40F);
+constexpr float k_shadow_min_visible_alpha = 0.004F;
 
-const QVector3D k_shadow_light_dir_normalized = k_shadow_light_dir.normalized();
-const QVector2D k_shadow_dir_xz_normalized = []() {
-  QVector2D v(k_shadow_light_dir_normalized.x(), k_shadow_light_dir_normalized.z());
-  if (v.lengthSquared() < 1e-6F) {
-    return QVector2D(0.0F, 1.0F);
-  }
-  v.normalize();
-  return v;
-}();
+auto resolve_contact_shadow_placement(const Render::GL::DrawContext& ctx,
+                                      float camera_distance)
+    -> Render::ContactShadowPlacement {
+  const auto& graphics = Render::GraphicsSettings::instance();
+  const auto& directional = graphics.directional_shadows();
+  const Render::ContactShadowInputs inputs{
+      .camera_distance = camera_distance,
+      .fade_distance = graphics.shadow_max_distance(),
+      .directional_shadows_enabled = directional.enabled,
+      .directional_distance = directional.distance};
+  const auto& environment = ctx.backend->environment_lighting();
+  return Render::contact_shadow_placement(environment, inputs);
+}
 
 auto admits_contact_shadow(const Render::GL::DrawContext& ctx,
                            Render::Creature::CreatureLOD lod,
@@ -134,8 +139,11 @@ auto prepare_humanoid_shadow_state(const HumanoidShadowStateInputs& inputs)
     return state;
   }
 
+  const auto placement = resolve_contact_shadow_placement(ctx, inputs.camera_distance);
+  const float shadow_alpha = k_shadow_base_alpha * placement.opacity;
+
   auto& terrain_service = Game::Map::TerrainService::instance();
-  if (!terrain_service.is_initialized() ||
+  if (!terrain_service.is_initialized() || shadow_alpha < k_shadow_min_visible_alpha ||
       !admits_contact_shadow(ctx,
                              inputs.lod,
                              inputs.camera_distance,
@@ -182,13 +190,12 @@ auto prepare_humanoid_shadow_state(const HumanoidShadowStateInputs& inputs)
                                                     0.0F,
                                                     inputs.soldier_world_pos.y());
 
-  QVector2D const shadow_dir = -k_shadow_dir_xz_normalized;
-  QVector2D dir_for_use = shadow_dir;
+  QVector2D dir_for_use = placement.direction;
   if (dir_for_use.lengthSquared() < 1e-6F) {
     dir_for_use = QVector2D(0.0F, 1.0F);
   }
 
-  float const shadow_offset = shadow_depth * 1.25F;
+  float const shadow_offset = shadow_depth * 1.25F * placement.offset_scale;
   QVector2D const offset_2d = dir_for_use * shadow_offset;
   float const light_yaw_deg =
       qRadiansToDegrees(std::atan2(double(dir_for_use.x()), double(dir_for_use.y())));
@@ -200,7 +207,7 @@ auto prepare_humanoid_shadow_state(const HumanoidShadowStateInputs& inputs)
   state.model.rotate(-90.0F, 1.0F, 0.0F, 0.0F);
   state.model.scale(shadow_width, shadow_depth, 1.0F);
   state.light_dir = dir_for_use;
-  state.alpha = k_shadow_base_alpha;
+  state.alpha = shadow_alpha;
   state.pass = graph.pass_intent;
   state.enabled = true;
   return state;
@@ -227,8 +234,11 @@ auto prepare_quadruped_shadow_state(const QuadrupedShadowStateInputs& inputs)
     return state;
   }
 
+  const auto placement = resolve_contact_shadow_placement(ctx, inputs.camera_distance);
+  const float shadow_alpha = k_shadow_base_alpha * placement.opacity;
+
   auto& terrain_service = Game::Map::TerrainService::instance();
-  if (!terrain_service.is_initialized() ||
+  if (!terrain_service.is_initialized() || shadow_alpha < k_shadow_min_visible_alpha ||
       !admits_contact_shadow(ctx,
                              inputs.lod,
                              inputs.camera_distance,
@@ -255,13 +265,12 @@ auto prepare_quadruped_shadow_state(const QuadrupedShadowStateInputs& inputs)
           : terrain_service.resolve_surface_world_y(
                 inputs.world_pos.x(), inputs.world_pos.z(), 0.0F, inputs.world_pos.y());
 
-  QVector2D const shadow_dir = -k_shadow_dir_xz_normalized;
-  QVector2D dir_for_use = shadow_dir;
+  QVector2D dir_for_use = placement.direction;
   if (dir_for_use.lengthSquared() < 1e-6F) {
     dir_for_use = QVector2D(0.0F, 1.0F);
   }
 
-  float const shadow_offset = shadow_depth * 1.25F;
+  float const shadow_offset = shadow_depth * 1.25F * placement.offset_scale;
   QVector2D const offset_2d = dir_for_use * shadow_offset;
   float const light_yaw_deg =
       qRadiansToDegrees(std::atan2(double(dir_for_use.x()), double(dir_for_use.y())));
@@ -273,7 +282,7 @@ auto prepare_quadruped_shadow_state(const QuadrupedShadowStateInputs& inputs)
   state.model.rotate(-90.0F, 1.0F, 0.0F, 0.0F);
   state.model.scale(shadow_width, shadow_depth, 1.0F);
   state.light_dir = dir_for_use;
-  state.alpha = k_shadow_base_alpha;
+  state.alpha = shadow_alpha;
   state.pass = graph.pass_intent;
   state.enabled = true;
   return state;

--- a/render/draw_queue.h
+++ b/render/draw_queue.h
@@ -134,8 +134,6 @@ struct TerrainScatterCmd {
 };
 
 struct RainBatchCmd {
-  Buffer* instance_buffer = nullptr;
-  std::size_t instance_count = 0;
   RainBatchParams params;
   CommandPriority priority{CommandPriority::Low};
 };

--- a/render/gl/backend.cpp
+++ b/render/gl/backend.cpp
@@ -850,19 +850,20 @@ void Backend::execute(const DrawQueue& queue, const Camera& cam) {
     const auto& submitted_lights = queue.local_lights();
     candidates.insert(
         candidates.end(), submitted_lights.begin(), submitted_lights.end());
-    const auto selected = Render::select_local_lights(candidates, cam.get_position());
+    const auto selected =
+        m_local_light_fader.update(candidates, cam.get_position(), m_animation_time);
     std::array<float, (Render::k_max_local_lights * 8) + 4> packed{};
     std::size_t active_count = 0;
-    for (std::size_t i = 0; i < selected.size(); ++i) {
-      const auto& light = selected[i];
+    for (const auto& light : selected) {
       if (light.intensity <= 0.0F || light.radius <= 0.0F) {
         continue;
       }
-      packed[(i * 4) + 0] = light.position.x();
-      packed[(i * 4) + 1] = light.position.y();
-      packed[(i * 4) + 2] = light.position.z();
-      packed[(i * 4) + 3] = light.radius;
-      const std::size_t color_offset = (Render::k_max_local_lights * 4) + (i * 4);
+      packed[(active_count * 4) + 0] = light.position.x();
+      packed[(active_count * 4) + 1] = light.position.y();
+      packed[(active_count * 4) + 2] = light.position.z();
+      packed[(active_count * 4) + 3] = light.radius;
+      const std::size_t color_offset =
+          (Render::k_max_local_lights * 4) + (active_count * 4);
       packed[color_offset + 0] = light.color.x();
       packed[color_offset + 1] = light.color.y();
       packed[color_offset + 2] = light.color.z();

--- a/render/gl/backend.h
+++ b/render/gl/backend.h
@@ -13,6 +13,7 @@
 #include "../draw_queue.h"
 #include "../frame_budget.h"
 #include "../i_render_backend.h"
+#include "../local_lighting.h"
 #include "../world_chunk.h"
 #include "persistent_buffer.h"
 #include "resources.h"
@@ -71,6 +72,7 @@ public:
   environment_lighting() const noexcept -> const EnvironmentLightingState& {
     return m_environment_lighting;
   }
+  void reset_local_lights() noexcept { m_local_light_fader.reset(); }
   [[nodiscard]] auto light_direction() const noexcept -> const QVector3D& {
     return m_light_dir;
   }
@@ -237,6 +239,7 @@ private:
   GLuint m_frame_ubo{0};
   GLuint m_environment_lighting_ubo{0};
   GLuint m_local_lighting_ubo{0};
+  Render::LocalLightFader m_local_light_fader{};
   GLuint m_directional_shadow_ubo{0};
   GLuint m_directional_shadow_fbo{0};
   GLuint m_directional_shadow_texture{0};

--- a/render/gl/backend/rain_pipeline.cpp
+++ b/render/gl/backend/rain_pipeline.cpp
@@ -27,6 +27,8 @@ constexpr float k_snow_color_r = 1.0F;
 constexpr float k_snow_color_g = 1.0F;
 constexpr float k_snow_color_b = 1.0F;
 
+constexpr int k_rank_attrib_location = 3;
+
 void clear_gl_errors() {
 #ifndef NDEBUG
   while (glGetError() != GL_NO_ERROR) {
@@ -126,6 +128,7 @@ void RainPipeline::cache_uniforms() {
   m_uniforms.wind = m_rain_shader->uniform_handle("u_wind");
   m_uniforms.weather_type = m_rain_shader->uniform_handle("u_weather_type");
   m_uniforms.wind_strength = m_rain_shader->uniform_handle("u_wind_strength");
+  m_uniforms.density = m_rain_shader->uniform_handle("u_density");
 }
 
 auto RainPipeline::is_initialized() const -> bool {
@@ -156,6 +159,7 @@ struct RainVertex {
   float position[3];
   float offset[3];
   float alpha;
+  float rank;
 };
 
 auto RainPipeline::create_rain_geometry() -> bool {
@@ -172,6 +176,9 @@ auto RainPipeline::create_rain_geometry() -> bool {
   for (std::size_t i = 0; i < m_rain_drops.size(); ++i) {
     const auto& drop = m_rain_drops[i];
 
+    const float rank = static_cast<float>(i) /
+                       static_cast<float>(std::max<std::size_t>(1, k_max_drops));
+
     RainVertex top;
     top.position[0] = drop.position.x();
     top.position[1] = drop.position.y();
@@ -180,6 +187,7 @@ auto RainPipeline::create_rain_geometry() -> bool {
     top.offset[1] = 0.0F;
     top.offset[2] = drop.speed;
     top.alpha = drop.alpha;
+    top.rank = rank;
     vertices.push_back(top);
 
     RainVertex bottom;
@@ -190,6 +198,7 @@ auto RainPipeline::create_rain_geometry() -> bool {
     bottom.offset[1] = -drop.length;
     bottom.offset[2] = drop.speed;
     bottom.alpha = drop.alpha * 0.3F;
+    bottom.rank = rank;
     vertices.push_back(bottom);
 
     auto base = static_cast<unsigned int>(i * 2);
@@ -257,6 +266,14 @@ auto RainPipeline::create_rain_geometry() -> bool {
                         sizeof(RainVertex),
                         reinterpret_cast<void*>(offsetof(RainVertex, alpha)));
 
+  glEnableVertexAttribArray(k_rank_attrib_location);
+  glVertexAttribPointer(k_rank_attrib_location,
+                        1,
+                        GL_FLOAT,
+                        GL_FALSE,
+                        sizeof(RainVertex),
+                        reinterpret_cast<void*>(offsetof(RainVertex, rank)));
+
   glBindVertexArray(0);
 
   if (!check_gl_error("vertex attributes")) {
@@ -312,13 +329,21 @@ void RainPipeline::render(const Camera& cam, const RainBatchParams& params) {
   m_rain_shader->set_uniform(m_uniforms.weather_type,
                              static_cast<int>(params.weather_type));
   m_rain_shader->set_uniform(m_uniforms.wind_strength, params.wind_strength);
+  m_rain_shader->set_uniform(m_uniforms.density, params.density);
+
+  const float density = std::clamp(params.density, 0.0F, 1.0F);
+  const auto budgeted_drops =
+      static_cast<GLsizei>(std::ceil(static_cast<float>(k_max_drops) * density));
 
   if (params.weather_type == Game::Map::WeatherType::Snow) {
 
-    glDrawElements(GL_POINTS, m_index_count / 2, GL_UNSIGNED_INT, nullptr);
+    const GLsizei points = std::clamp(budgeted_drops, GLsizei{0}, m_index_count / 2);
+    glDrawElements(GL_POINTS, points, GL_UNSIGNED_INT, nullptr);
   } else {
 
-    glDrawElements(GL_LINES, m_index_count, GL_UNSIGNED_INT, nullptr);
+    const GLsizei line_indices =
+        std::clamp(budgeted_drops * 2, GLsizei{0}, m_index_count);
+    glDrawElements(GL_LINES, line_indices, GL_UNSIGNED_INT, nullptr);
   }
 
   glBindVertexArray(0);

--- a/render/gl/backend/rain_pipeline.h
+++ b/render/gl/backend/rain_pipeline.h
@@ -74,6 +74,7 @@ private:
     GL::Shader::UniformHandle wind{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle weather_type{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle wind_strength{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle density{GL::Shader::InvalidUniform};
   };
 
   RainUniforms m_uniforms;

--- a/render/graphics_settings.h
+++ b/render/graphics_settings.h
@@ -59,6 +59,11 @@ struct ContactShadowBudget {
   int max_casters_per_formation;
 };
 
+struct WeatherBudget {
+
+  float particle_scale = 1.0F;
+};
+
 struct DirectionalShadowSettings {
   bool enabled = true;
   int cascade_count = 3;
@@ -107,6 +112,9 @@ public:
   [[nodiscard]] auto
   directional_shadows() const noexcept -> const DirectionalShadowSettings& {
     return m_directional_shadows;
+  }
+  [[nodiscard]] auto weather_budget() const noexcept -> const WeatherBudget& {
+    return m_weather_budget;
   }
 
   [[nodiscard]] auto creature_lod_enabled() const noexcept -> bool {
@@ -227,6 +235,7 @@ private:
                                .depth_bias = 0.0018F,
                                .normal_bias = 0.025F,
                                .cascade_blend = 0.0F};
+      m_weather_budget = {.particle_scale = 0.35F};
       break;
 
     case GraphicsQuality::Medium:
@@ -265,6 +274,7 @@ private:
                                .depth_bias = 0.0016F,
                                .normal_bias = 0.022F,
                                .cascade_blend = 0.08F};
+      m_weather_budget = {.particle_scale = 0.60F};
       break;
 
     case GraphicsQuality::High:
@@ -303,6 +313,7 @@ private:
                                .depth_bias = 0.0012F,
                                .normal_bias = 0.018F,
                                .cascade_blend = 0.12F};
+      m_weather_budget = {.particle_scale = 0.85F};
       break;
 
     case GraphicsQuality::Ultra:
@@ -341,6 +352,7 @@ private:
                                .depth_bias = 0.0009F,
                                .normal_bias = 0.014F,
                                .cascade_blend = 0.15F};
+      m_weather_budget = {.particle_scale = 1.00F};
       break;
     }
   }
@@ -366,6 +378,7 @@ private:
   VisibilityBudget m_visibility_budget{};
   ContactShadowBudget m_contact_shadow_budget{};
   DirectionalShadowSettings m_directional_shadows{};
+  WeatherBudget m_weather_budget{};
 };
 
 } // namespace Render

--- a/render/ground/rain_renderer.cpp
+++ b/render/ground/rain_renderer.cpp
@@ -1,21 +1,9 @@
 #include "rain_renderer.h"
 
-#include <QDebug>
-
 #include <algorithm>
-#include <cmath>
-#include <cstddef>
 
-#include "../gl/buffer.h"
+#include "../graphics_settings.h"
 #include "../scene_renderer.h"
-#include "game/map/scatter/ground_utils.h"
-
-namespace {
-
-using std::uint32_t;
-using namespace Render::Ground;
-
-} // namespace
 
 namespace Render::GL {
 
@@ -30,17 +18,13 @@ void RainRenderer::configure(float world_width,
   m_world_height = std::max(1.0F, world_height);
   m_seed = seed;
 
-  m_rain_drops.clear();
-  m_instance_buffer.reset();
-  m_instance_count = 0;
-
   m_params.weather_type = type;
   m_params.time = 0.0F;
   m_params.intensity = 0.0F;
   m_params.wind_strength = 0.0F;
+  m_params.density = 0.0F;
 
   update_weather_params();
-  generate_rain_drops();
 }
 
 void RainRenderer::set_intensity(float intensity) {
@@ -67,7 +51,11 @@ void RainRenderer::update_weather_params() {
 }
 
 void RainRenderer::set_wind_strength(float strength) {
-  m_params.wind_strength = strength;
+  m_params.wind_strength = std::max(0.0F, strength);
+}
+
+void RainRenderer::set_wind_direction_deg(float degrees) {
+  m_params.wind_direction = Game::Map::weather_wind_vector(degrees);
 }
 
 void RainRenderer::set_camera_position(const QVector3D& position) {
@@ -94,79 +82,24 @@ void RainRenderer::submit(Renderer& renderer, ResourceManager* resources) {
     return;
   }
 
-  const float time = renderer.get_animation_time();
+  m_params.time = renderer.get_animation_time();
+  m_params.intensity = m_intensity;
+  m_params.density = weather_particle_density(
+      {.intensity = m_intensity,
+       .quality_scale = GraphicsSettings::instance().weather_budget().particle_scale,
+       .camera_height = m_camera_position.y()});
 
-  const auto visible_count =
-      static_cast<std::size_t>(static_cast<float>(m_rain_drops.size()) * m_intensity);
-
-  if (visible_count == 0) {
+  if (m_params.density < 0.001F) {
     return;
   }
 
-  if (!m_instance_buffer) {
-    m_instance_buffer = std::make_unique<Buffer>(Buffer::Type::Vertex);
-  }
-
-  m_instance_buffer->set_data(m_rain_drops.data(),
-                              visible_count * sizeof(RainDropInstanceGpu),
-                              Buffer::Usage::Dynamic);
-
-  m_params.time = time;
-  m_params.intensity = m_intensity;
-
-  renderer.rain_batch(m_instance_buffer.get(), visible_count, m_params);
+  renderer.rain_batch(m_params);
 }
 
 void RainRenderer::clear() {
-  m_rain_drops.clear();
-  m_instance_buffer.reset();
-  m_instance_count = 0;
   m_intensity = 0.0F;
   m_target_intensity = 0.0F;
-}
-
-void RainRenderer::generate_rain_drops() {
-  m_rain_drops.clear();
-
-  const std::size_t max_drops = (m_params.weather_type == Game::Map::WeatherType::Snow)
-                                    ? k_max_snow_drops
-                                    : k_max_rain_drops;
-
-  m_rain_drops.reserve(max_drops);
-
-  uint32_t state = m_seed;
-
-  for (std::size_t i = 0; i < max_drops; ++i) {
-    state = hash_coords(
-        static_cast<int>(i), static_cast<int>(i * 17), m_seed ^ 0xDA1A1234U);
-
-    const float x = (rand_01(state) - 0.5F) * m_rain_area_radius * 2.0F;
-    state = hash_coords(static_cast<int>(i * 31), static_cast<int>(i), state);
-    const float z = (rand_01(state) - 0.5F) * m_rain_area_radius * 2.0F;
-    state = hash_coords(static_cast<int>(i * 7), static_cast<int>(i * 13), state);
-    const float y = rand_01(state) * m_rain_height;
-
-    state = hash_coords(static_cast<int>(i), static_cast<int>(i * 23), state);
-
-    float speed_variation;
-    if (m_params.weather_type == Game::Map::WeatherType::Snow) {
-
-      speed_variation = RainBatchParams::k_snow_speed_variation_min +
-                        rand_01(state) * RainBatchParams::k_snow_speed_variation_range;
-    } else {
-
-      speed_variation = RainBatchParams::k_rain_speed_variation_min +
-                        rand_01(state) * RainBatchParams::k_rain_speed_variation_range;
-    }
-
-    RainDropInstanceGpu drop;
-    drop.pos_velocity = QVector4D(x, y, z, m_params.drop_speed * speed_variation);
-    drop.size_alpha = QVector4D(m_params.drop_length, m_params.drop_width, 1.0F, 0.0F);
-
-    m_rain_drops.push_back(drop);
-  }
-
-  m_instance_count = m_rain_drops.size();
+  m_params.density = 0.0F;
 }
 
 } // namespace Render::GL

--- a/render/ground/rain_renderer.h
+++ b/render/ground/rain_renderer.h
@@ -3,8 +3,6 @@
 #include <QVector3D>
 
 #include <cstdint>
-#include <memory>
-#include <vector>
 
 #include "../i_render_pass.h"
 #include "../rain_gpu.h"
@@ -14,7 +12,6 @@ class RainManager;
 }
 
 namespace Render::GL {
-class Buffer;
 class Renderer;
 
 class RainRenderer : public IRenderPass {
@@ -33,14 +30,19 @@ public:
   void set_intensity(float intensity);
   void set_weather_type(Game::Map::WeatherType type);
   void set_wind_strength(float strength);
+  void set_wind_direction_deg(float degrees);
   void set_camera_position(const QVector3D& position);
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
   void clear();
 
+  [[nodiscard]] auto intensity() const noexcept -> float { return m_intensity; }
+  [[nodiscard]] auto params() const noexcept -> const RainBatchParams& {
+    return m_params;
+  }
+
 private:
-  void generate_rain_drops();
   void update_weather_params();
 
   bool m_enabled = false;
@@ -51,16 +53,9 @@ private:
   std::uint32_t m_seed = 12345U;
 
   QVector3D m_camera_position{0.0F, 0.0F, 0.0F};
-  float m_rain_area_radius = 50.0F;
-  float m_rain_height = 30.0F;
 
-  std::vector<RainDropInstanceGpu> m_rain_drops;
-  std::unique_ptr<Buffer> m_instance_buffer;
-  std::size_t m_instance_count = 0;
   RainBatchParams m_params;
 
-  static constexpr std::size_t k_max_rain_drops = 5000;
-  static constexpr std::size_t k_max_snow_drops = 3000;
   static constexpr float k_intensity_lerp_speed = 2.0F;
 };
 

--- a/render/local_lighting.h
+++ b/render/local_lighting.h
@@ -73,4 +73,102 @@ struct LocalLight {
   return result;
 }
 
+inline constexpr float k_local_light_fade_seconds = 0.35F;
+inline constexpr float k_local_light_match_distance = 0.75F;
+
+class LocalLightFader {
+public:
+  [[nodiscard]] auto
+  update(const std::vector<LocalLight>& candidates,
+         const QVector3D& camera_position,
+         float elapsed_seconds) -> std::array<LocalLight, k_max_local_lights> {
+    const float delta = m_has_previous_time
+                            ? std::clamp(elapsed_seconds - m_previous_time, 0.0F, 0.25F)
+                            : 0.0F;
+    m_previous_time = elapsed_seconds;
+    m_has_previous_time = true;
+
+    const auto selected = select_local_lights(candidates, camera_position);
+    std::array<bool, k_max_local_lights> claimed{};
+
+    for (auto& slot : m_slots) {
+      if (!slot.occupied) {
+        continue;
+      }
+      slot.target = 0.0F;
+      for (std::size_t i = 0; i < selected.size(); ++i) {
+        if (claimed[i] || selected[i].radius <= 0.0F || selected[i].intensity <= 0.0F) {
+          continue;
+        }
+        if ((selected[i].position - slot.light.position).length() >
+            k_local_light_match_distance) {
+          continue;
+        }
+        claimed[i] = true;
+        slot.light = selected[i];
+        slot.target = 1.0F;
+        break;
+      }
+    }
+
+    for (std::size_t i = 0; i < selected.size(); ++i) {
+      if (claimed[i] || selected[i].radius <= 0.0F || selected[i].intensity <= 0.0F) {
+        continue;
+      }
+      for (auto& slot : m_slots) {
+        if (slot.occupied) {
+          continue;
+        }
+        slot.occupied = true;
+        slot.light = selected[i];
+        slot.weight = 0.0F;
+        slot.target = 1.0F;
+        claimed[i] = true;
+        break;
+      }
+    }
+
+    const float step = delta <= 0.0F ? 1.0F : delta / k_local_light_fade_seconds;
+    std::array<LocalLight, k_max_local_lights> result{};
+    std::size_t emitted = 0;
+    for (auto& slot : m_slots) {
+      if (!slot.occupied) {
+        continue;
+      }
+      slot.weight = std::clamp(
+          slot.weight + std::clamp(slot.target - slot.weight, -step, step), 0.0F, 1.0F);
+      if (slot.weight <= 0.0F && slot.target <= 0.0F) {
+        slot = Slot{};
+        continue;
+      }
+      result[emitted] = slot.light;
+      result[emitted].intensity = slot.light.intensity * slot.weight;
+      ++emitted;
+    }
+    for (std::size_t i = emitted; i < result.size(); ++i) {
+      result[i].radius = 0.0F;
+      result[i].intensity = 0.0F;
+    }
+    return result;
+  }
+
+  void reset() noexcept {
+    m_slots = {};
+    m_previous_time = 0.0F;
+    m_has_previous_time = false;
+  }
+
+private:
+  struct Slot {
+    LocalLight light;
+    float weight = 0.0F;
+    float target = 0.0F;
+    bool occupied = false;
+  };
+
+  std::array<Slot, k_max_local_lights> m_slots{};
+  float m_previous_time = 0.0F;
+  bool m_has_previous_time = false;
+};
+
 } // namespace Render

--- a/render/rain_gpu.h
+++ b/render/rain_gpu.h
@@ -3,6 +3,7 @@
 #include <QVector3D>
 #include <QVector4D>
 
+#include <algorithm>
 #include <cstdint>
 
 #include "../game/map/map_definition.h"
@@ -35,6 +36,33 @@ struct RainBatchParams {
   float drop_width = k_default_rain_drop_width;
   float wind_strength = 0.0F;
   QVector3D wind_direction{1.0F, 0.0F, 0.3F};
+
+  float density = 1.0F;
 };
+
+inline constexpr float k_weather_density_fade_band = 0.12F;
+inline constexpr float k_weather_density_near_height = 40.0F;
+inline constexpr float k_weather_density_far_height = 160.0F;
+inline constexpr float k_weather_density_far_scale = 0.45F;
+
+struct WeatherDensityInputs {
+  float intensity = 0.0F;
+  float quality_scale = 1.0F;
+  float camera_height = 0.0F;
+};
+
+[[nodiscard]] inline auto
+weather_particle_density(const WeatherDensityInputs& inputs) noexcept -> float {
+  const float intensity = std::clamp(inputs.intensity, 0.0F, 1.0F);
+  const float quality = std::clamp(inputs.quality_scale, 0.0F, 1.0F);
+
+  const float span = k_weather_density_far_height - k_weather_density_near_height;
+  const float travelled = std::clamp(
+      (inputs.camera_height - k_weather_density_near_height) / span, 0.0F, 1.0F);
+  const float distance_scale =
+      1.0F + ((k_weather_density_far_scale - 1.0F) * travelled);
+
+  return std::clamp(intensity * quality * distance_scale, 0.0F, 1.0F);
+}
 
 } // namespace Render::GL

--- a/render/scene_renderer.cpp
+++ b/render/scene_renderer.cpp
@@ -505,16 +505,11 @@ void Renderer::fog_batch(Buffer* instance_buffer,
   m_active_queue->submit(std::move(cmd));
 }
 
-void Renderer::rain_batch(Buffer* instance_buffer,
-                          std::size_t instance_count,
-                          const RainBatchParams& params) {
-  if ((instance_buffer == nullptr) || instance_count == 0 ||
-      (m_active_queue == nullptr)) {
+void Renderer::rain_batch(const RainBatchParams& params) {
+  if (m_active_queue == nullptr || params.density <= 0.0F) {
     return;
   }
   RainBatchCmd cmd;
-  cmd.instance_buffer = instance_buffer;
-  cmd.instance_count = instance_count;
   cmd.params = params;
   cmd.params.time = m_accumulated_time;
   m_active_queue->submit(std::move(cmd));

--- a/render/scene_renderer.h
+++ b/render/scene_renderer.h
@@ -214,6 +214,9 @@ public:
     m_rigged_mesh_cache.clear();
     m_snapshot_mesh_cache.clear();
     m_animation_time_cache.clear();
+    if (m_gl_backend != nullptr) {
+      m_gl_backend->reset_local_lights();
+    }
   }
 
   [[nodiscard]] auto render_software_preview(int width, int height) -> QImage;
@@ -346,9 +349,7 @@ public:
   void fog_batch(Buffer* instance_buffer,
                  std::size_t count,
                  const FogMaskResources& mask = {});
-  void rain_batch(Buffer* instance_buffer,
-                  std::size_t instance_count,
-                  const RainBatchParams& params);
+  void rain_batch(const RainBatchParams& params);
 
   void render_construction_previews_public(Engine::Core::World* world,
                                            const Game::Map::VisibilityService* vis,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(
     map/explored_mask_codec_test.cpp
     map/visibility_restore_test.cpp
     map/map_catalog_test.cpp
+    map/map_weather_coverage_test.cpp
     map/iron_sepulcher_skirmish_test.cpp
     map/terrain_topology_audit_test.cpp
     map/map_transformer_test.cpp
@@ -126,6 +127,8 @@ add_executable(
     architecture/qml_surface_test.cpp
     architecture/documentation_accuracy_test.cpp
     render/local_lighting_test.cpp
+    render/contact_shadow_test.cpp
+    render/weather_particle_budget_test.cpp
     render/graphics_lighting_settings_test.cpp
     render/scatter_composition_test.cpp
     render/scatter_runtime_test.cpp

--- a/tests/map/map_loader_test.cpp
+++ b/tests/map/map_loader_test.cpp
@@ -560,6 +560,61 @@ TEST(MapLoaderTest, ReusingDefinitionCannotRetainPreviousEnvironment) {
   EXPECT_EQ(map.environment.time_mode, Game::Map::TimeMode::Locked);
 }
 
+namespace {
+
+auto load_weather(const QJsonObject& rain) -> Game::Map::RainSettings {
+  QTemporaryFile temp_file;
+  EXPECT_TRUE(temp_file.open());
+  const QJsonObject root{
+      {"name", "Weather Test"},
+      {"grid", QJsonObject{{"width", 16}, {"height", 16}, {"tile_size", 1.0}}},
+      {"rain", rain}};
+  temp_file.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+  temp_file.flush();
+
+  Game::Map::MapDefinition map;
+  QString error;
+  EXPECT_TRUE(
+      Game::Map::MapLoader::load_from_json_file(temp_file.fileName(), map, &error))
+      << error.toStdString();
+  return map.rain;
+}
+
+} // namespace
+
+TEST(MapLoaderTest, ReadsNamedPrecipitationIntensities) {
+  EXPECT_FLOAT_EQ(load_weather({{"enabled", true}, {"intensity", "light"}}).intensity,
+                  Game::Map::k_weather_intensity_light);
+  EXPECT_FLOAT_EQ(load_weather({{"enabled", true}, {"intensity", "Medium"}}).intensity,
+                  Game::Map::k_weather_intensity_medium);
+  EXPECT_FLOAT_EQ(load_weather({{"enabled", true}, {"intensity", "HEAVY"}}).intensity,
+                  Game::Map::k_weather_intensity_heavy);
+}
+
+TEST(MapLoaderTest, NumericPrecipitationIntensityStillLoadsAndIsClamped) {
+  EXPECT_FLOAT_EQ(load_weather({{"enabled", true}, {"intensity", 0.42}}).intensity,
+                  0.42F);
+  EXPECT_FLOAT_EQ(load_weather({{"enabled", true}, {"intensity", 4.0}}).intensity,
+                  1.0F);
+  EXPECT_FLOAT_EQ(load_weather({{"enabled", true}, {"intensity", -1.0}}).intensity,
+                  0.0F);
+}
+
+TEST(MapLoaderTest, UnknownIntensityWordKeepsTheDefault) {
+  const auto settings = load_weather({{"enabled", true}, {"intensity", "torrential"}});
+  EXPECT_FLOAT_EQ(settings.intensity, Game::Map::RainSettings{}.intensity);
+}
+
+TEST(MapLoaderTest, ReadsWindDirectionAndStrength) {
+  const auto settings = load_weather({{"enabled", true},
+                                      {"type", "snow"},
+                                      {"wind_strength", 0.65},
+                                      {"wind_direction", 330.0}});
+  EXPECT_EQ(settings.type, Game::Map::WeatherType::Snow);
+  EXPECT_FLOAT_EQ(settings.wind_strength, 0.65F);
+  EXPECT_FLOAT_EQ(settings.wind_direction_deg, 330.0F);
+}
+
 TEST(MapLoaderTest, FailedLoadClearsPreviouslyLoadedDefinition) {
   Game::Map::MapDefinition map;
   map.name = QStringLiteral("Previous map");

--- a/tests/map/map_weather_coverage_test.cpp
+++ b/tests/map/map_weather_coverage_test.cpp
@@ -1,0 +1,101 @@
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSet>
+#include <QString>
+
+#include <gtest/gtest.h>
+
+#include "game/map/map_loader.h"
+
+namespace {
+
+auto maps_directory() -> QDir {
+  QDir dir(QStringLiteral("assets/maps"));
+  EXPECT_TRUE(dir.exists()) << dir.absolutePath().toStdString();
+  return dir;
+}
+
+auto shipped_maps() -> QStringList {
+  return maps_directory().entryList(
+      {QStringLiteral("map_*.json")}, QDir::Files, QDir::Name);
+}
+
+auto raw_rain_object(const QString& file_name) -> QJsonObject {
+  QFile file(maps_directory().filePath(file_name));
+  EXPECT_TRUE(file.open(QIODevice::ReadOnly)) << file_name.toStdString();
+  const QJsonDocument document = QJsonDocument::fromJson(file.readAll());
+  return document.object().value(QStringLiteral("rain")).toObject();
+}
+
+auto load_map(const QString& file_name) -> Game::Map::MapDefinition {
+  Game::Map::MapDefinition map;
+  QString error;
+  EXPECT_TRUE(Game::Map::MapLoader::load_from_json_file(
+      maps_directory().filePath(file_name), map, &error))
+      << file_name.toStdString() << ": " << error.toStdString();
+  return map;
+}
+
+} // namespace
+
+TEST(MapWeatherCoverageTest, EveryShippedMapDeclaresAWeatherChoice) {
+  const QStringList maps = shipped_maps();
+  ASSERT_FALSE(maps.isEmpty());
+
+  for (const QString& file_name : maps) {
+    const QJsonObject rain = raw_rain_object(file_name);
+    EXPECT_FALSE(rain.isEmpty())
+        << file_name.toStdString()
+        << " has no \"rain\" block; clear weather must be stated explicitly";
+    EXPECT_TRUE(rain.contains(QStringLiteral("enabled")))
+        << file_name.toStdString() << " does not say whether weather is enabled";
+  }
+}
+
+TEST(MapWeatherCoverageTest, TheShippedSetSpansClearRainAndSnow) {
+  bool has_clear = false;
+  bool has_rain = false;
+  bool has_snow = false;
+
+  for (const QString& file_name : shipped_maps()) {
+    const auto map = load_map(file_name);
+    if (!map.rain.enabled) {
+      has_clear = true;
+      continue;
+    }
+    if (map.rain.type == Game::Map::WeatherType::Snow) {
+      has_snow = true;
+    } else {
+      has_rain = true;
+    }
+  }
+
+  EXPECT_TRUE(has_clear) << "no map ships with clear skies";
+  EXPECT_TRUE(has_rain) << "no map ships with rain";
+  EXPECT_TRUE(has_snow) << "no map ships with snow";
+}
+
+TEST(MapWeatherCoverageTest, TheAlpineCrossingSnows) {
+  const auto map = load_map(QStringLiteral("map_crossing_alps.json"));
+
+  ASSERT_TRUE(map.rain.enabled);
+  EXPECT_EQ(map.rain.type, Game::Map::WeatherType::Snow);
+  EXPECT_GE(map.rain.intensity, Game::Map::k_weather_intensity_heavy);
+  EXPECT_GT(map.rain.wind_strength, 0.0F);
+}
+
+TEST(MapWeatherCoverageTest, EveryPrecipitatingMapAuthorsItsWind) {
+  for (const QString& file_name : shipped_maps()) {
+    const auto map = load_map(file_name);
+    if (!map.rain.enabled) {
+      continue;
+    }
+    EXPECT_GT(map.rain.intensity, 0.0F) << file_name.toStdString();
+    EXPECT_GT(map.rain.wind_strength, 0.0F)
+        << file_name.toStdString() << " enables weather but leaves the wind still";
+    EXPECT_GE(map.rain.wind_direction_deg, 0.0F) << file_name.toStdString();
+    EXPECT_LT(map.rain.wind_direction_deg, 360.0F) << file_name.toStdString();
+  }
+}

--- a/tests/render/contact_shadow_test.cpp
+++ b/tests/render/contact_shadow_test.cpp
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+
+#include "render/contact_shadow.h"
+
+namespace {
+
+auto morning_sun() -> Render::EnvironmentLightingState {
+  Render::EnvironmentLightingState environment;
+  environment.primary_direction = QVector3D(0.60F, 0.30F, 0.20F);
+  return environment.sanitized();
+}
+
+auto midday_sun() -> Render::EnvironmentLightingState {
+  Render::EnvironmentLightingState environment;
+  environment.primary_direction = QVector3D(0.05F, 0.99F, 0.05F);
+  return environment.sanitized();
+}
+
+auto evening_sun() -> Render::EnvironmentLightingState {
+  Render::EnvironmentLightingState environment;
+  environment.primary_direction = QVector3D(-0.58F, 0.16F, 0.30F);
+  return environment.sanitized();
+}
+
+} // namespace
+
+TEST(ContactShadowTest, BlobFollowsTheEnvironmentSunAcrossTheDay) {
+  const Render::ContactShadowInputs inputs{.camera_distance = 5.0F,
+                                           .fade_distance = 60.0F};
+
+  const auto morning = Render::contact_shadow_placement(morning_sun(), inputs);
+  const auto evening = Render::contact_shadow_placement(evening_sun(), inputs);
+
+  EXPECT_LT(morning.direction.x(), 0.0F);
+  EXPECT_GT(evening.direction.x(), 0.0F);
+  EXPECT_LT(QVector2D::dotProduct(morning.direction, evening.direction), 0.0F)
+      << "morning and evening blobs must not point the same way";
+}
+
+TEST(ContactShadowTest, LowSunStretchesTheBlobAndHighSunGroundsIt) {
+  const Render::ContactShadowInputs inputs{.camera_distance = 5.0F,
+                                           .fade_distance = 60.0F};
+
+  const auto midday = Render::contact_shadow_placement(midday_sun(), inputs);
+  const auto evening = Render::contact_shadow_placement(evening_sun(), inputs);
+
+  EXPECT_LT(midday.offset_scale, 0.2F);
+  EXPECT_GT(evening.offset_scale, midday.offset_scale);
+  EXPECT_LE(evening.offset_scale, Render::k_contact_shadow_max_offset_scale);
+}
+
+TEST(ContactShadowTest, OpacityFadesOutInsteadOfPoppingAtTheDistanceLimit) {
+  const auto environment = morning_sun();
+  constexpr float k_fade_distance = 60.0F;
+
+  const auto near_camera = Render::contact_shadow_placement(
+      environment, {.camera_distance = 10.0F, .fade_distance = k_fade_distance});
+  const auto mid_fade = Render::contact_shadow_placement(
+      environment,
+      {.camera_distance = k_fade_distance * 0.88F, .fade_distance = k_fade_distance});
+  const auto at_limit = Render::contact_shadow_placement(
+      environment,
+      {.camera_distance = k_fade_distance, .fade_distance = k_fade_distance});
+
+  EXPECT_FLOAT_EQ(near_camera.opacity, 1.0F);
+  EXPECT_GT(mid_fade.opacity, 0.0F);
+  EXPECT_LT(mid_fade.opacity, near_camera.opacity);
+  EXPECT_FLOAT_EQ(at_limit.opacity, 0.0F);
+}
+
+TEST(ContactShadowTest, DirectionalShadowsTakeOverSmoothlyNearTheCamera) {
+  const auto environment = evening_sun();
+  const auto make_inputs = [](float camera_distance) {
+    return Render::ContactShadowInputs{.camera_distance = camera_distance,
+                                       .fade_distance = 200.0F,
+                                       .directional_shadows_enabled = true,
+                                       .directional_distance = 80.0F};
+  };
+
+  const auto close = Render::contact_shadow_placement(environment, make_inputs(10.0F));
+  const auto handing_over =
+      Render::contact_shadow_placement(environment, make_inputs(64.0F));
+  const auto beyond_directional =
+      Render::contact_shadow_placement(environment, make_inputs(90.0F));
+
+  EXPECT_NEAR(close.opacity, Render::k_contact_shadow_grounded_opacity, 1e-5F);
+  EXPECT_GT(handing_over.opacity, close.opacity);
+  EXPECT_LT(handing_over.opacity, beyond_directional.opacity);
+  EXPECT_FLOAT_EQ(beyond_directional.opacity, 1.0F);
+
+  EXPECT_LT(close.offset_scale, beyond_directional.offset_scale)
+      << "a real directional shadow should pull the blob under the feet";
+}
+
+TEST(ContactShadowTest, DisabledDirectionalShadowsKeepTheBlobAtFullStrength) {
+  const auto environment = evening_sun();
+  const auto placement =
+      Render::contact_shadow_placement(environment,
+                                       {.camera_distance = 10.0F,
+                                        .fade_distance = 200.0F,
+                                        .directional_shadows_enabled = false,
+                                        .directional_distance = 80.0F});
+
+  EXPECT_FLOAT_EQ(placement.opacity, 1.0F);
+}

--- a/tests/render/local_lighting_test.cpp
+++ b/tests/render/local_lighting_test.cpp
@@ -55,6 +55,92 @@ TEST(LocalLightingTest, SanitizesNegativeRadiusAndIntensity) {
   EXPECT_FLOAT_EQ(selected.front().intensity, 0.0F);
 }
 
+TEST(LocalLightingTest, FaderRampsNewLightsInInsteadOfPoppingThem) {
+  Render::LocalLightFader fader;
+  Render::LocalLight camp;
+  camp.position = QVector3D(0.0F, 1.0F, 0.0F);
+  camp.radius = 8.0F;
+  camp.intensity = 1.0F;
+
+  const auto first_frame = fader.update({}, QVector3D(), 0.0F);
+  EXPECT_FLOAT_EQ(first_frame.front().intensity, 0.0F);
+
+  const auto appearing = fader.update({camp}, QVector3D(), 0.05F);
+  EXPECT_GT(appearing.front().intensity, 0.0F);
+  EXPECT_LT(appearing.front().intensity, camp.intensity)
+      << "a light entering the budget must ramp up, not pop";
+
+  auto settled = appearing;
+  for (int frame = 2; frame < 30; ++frame) {
+    settled = fader.update({camp}, QVector3D(), 0.05F * static_cast<float>(frame));
+  }
+  EXPECT_FLOAT_EQ(settled.front().intensity, camp.intensity);
+}
+
+TEST(LocalLightingTest, FaderRampsDroppedLightsOutInsteadOfPoppingThem) {
+  Render::LocalLightFader fader;
+  Render::LocalLight camp;
+  camp.position = QVector3D(0.0F, 1.0F, 0.0F);
+  camp.radius = 8.0F;
+  camp.intensity = 1.0F;
+
+  float time = 0.0F;
+  auto lit = fader.update({camp}, QVector3D(), time);
+  ASSERT_FLOAT_EQ(lit.front().intensity, camp.intensity);
+
+  time += 0.05F;
+  const auto fading = fader.update({}, QVector3D(), time);
+  EXPECT_GT(fading.front().intensity, 0.0F)
+      << "a light leaving the budget must ramp down, not pop";
+  EXPECT_LT(fading.front().intensity, camp.intensity);
+
+  auto dark = fading;
+  for (int frame = 2; frame < 30; ++frame) {
+    time += 0.05F;
+    dark = fader.update({}, QVector3D(), time);
+  }
+  EXPECT_FLOAT_EQ(dark.front().intensity, 0.0F);
+  EXPECT_FLOAT_EQ(dark.front().radius, 0.0F);
+}
+
+TEST(LocalLightingTest, FaderResetDropsLightsFromThePreviousMap) {
+  Render::LocalLightFader fader;
+  Render::LocalLight camp;
+  camp.position = QVector3D(12.0F, 1.0F, -4.0F);
+  camp.radius = 8.0F;
+  camp.intensity = 1.0F;
+
+  ASSERT_FLOAT_EQ(fader.update({camp}, QVector3D(), 0.0F).front().intensity,
+                  camp.intensity);
+
+  fader.reset();
+  const auto after_reset = fader.update({}, QVector3D(), 0.05F);
+  EXPECT_FLOAT_EQ(after_reset.front().intensity, 0.0F);
+  EXPECT_FLOAT_EQ(after_reset.front().radius, 0.0F);
+}
+
+TEST(LocalLightingTest, FaderPacksActiveLightsContiguously) {
+  Render::LocalLightFader fader;
+  std::vector<Render::LocalLight> lights;
+  for (int i = 0; i < 3; ++i) {
+    Render::LocalLight light;
+    light.position = QVector3D(static_cast<float>(i) * 10.0F, 1.0F, 0.0F);
+    light.radius = 6.0F;
+    light.intensity = 1.0F;
+    lights.push_back(light);
+  }
+
+  const auto selected = fader.update(lights, QVector3D(), 0.0F);
+  for (std::size_t i = 0; i < selected.size(); ++i) {
+    if (i < lights.size()) {
+      EXPECT_GT(selected[i].intensity, 0.0F) << "slot " << i;
+    } else {
+      EXPECT_FLOAT_EQ(selected[i].intensity, 0.0F) << "slot " << i;
+      EXPECT_FLOAT_EQ(selected[i].radius, 0.0F) << "slot " << i;
+    }
+  }
+}
+
 TEST(LocalLightingTest, EqualScoresKeepInputOrderSoLightsDoNotSwap) {
 
   std::vector<Render::LocalLight> lights;

--- a/tests/render/weather_particle_budget_test.cpp
+++ b/tests/render/weather_particle_budget_test.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include "render/graphics_settings.h"
+#include "render/rain_gpu.h"
+
+namespace {
+
+auto density_at(float intensity, float quality_scale, float camera_height) -> float {
+  return Render::GL::weather_particle_density({.intensity = intensity,
+                                               .quality_scale = quality_scale,
+                                               .camera_height = camera_height});
+}
+
+} // namespace
+
+TEST(WeatherParticleBudgetTest, LightMediumAndHeavyProduceDistinctDensities) {
+  const float light = density_at(Game::Map::k_weather_intensity_light, 1.0F, 0.0F);
+  const float medium = density_at(Game::Map::k_weather_intensity_medium, 1.0F, 0.0F);
+  const float heavy = density_at(Game::Map::k_weather_intensity_heavy, 1.0F, 0.0F);
+
+  EXPECT_LT(light, medium);
+  EXPECT_LT(medium, heavy);
+  EXPECT_LE(heavy, 1.0F);
+}
+
+TEST(WeatherParticleBudgetTest, QualityPresetsScaleTheParticlePool) {
+  auto& graphics = Render::GraphicsSettings::instance();
+
+  graphics.set_quality(Render::GraphicsQuality::Low);
+  const float low = graphics.weather_budget().particle_scale;
+  graphics.set_quality(Render::GraphicsQuality::Medium);
+  const float medium = graphics.weather_budget().particle_scale;
+  graphics.set_quality(Render::GraphicsQuality::High);
+  const float high = graphics.weather_budget().particle_scale;
+  graphics.set_quality(Render::GraphicsQuality::Ultra);
+  const float ultra = graphics.weather_budget().particle_scale;
+
+  EXPECT_LT(low, medium);
+  EXPECT_LT(medium, high);
+  EXPECT_LT(high, ultra);
+  EXPECT_FLOAT_EQ(ultra, 1.0F);
+
+  EXPECT_LT(density_at(1.0F, low, 0.0F), density_at(1.0F, ultra, 0.0F));
+
+  graphics.set_quality(Render::GraphicsQuality::High);
+}
+
+TEST(WeatherParticleBudgetTest, DensityThinsOutAsTheCameraPullsBack) {
+  const float close = density_at(1.0F, 1.0F, Render::GL::k_weather_density_near_height);
+  const float far = density_at(1.0F, 1.0F, Render::GL::k_weather_density_far_height);
+  const float beyond = density_at(1.0F, 1.0F, 1000.0F);
+
+  EXPECT_FLOAT_EQ(close, 1.0F);
+  EXPECT_NEAR(far, Render::GL::k_weather_density_far_scale, 1e-5F);
+  EXPECT_FLOAT_EQ(beyond, far) << "density must clamp rather than invert";
+  EXPECT_GT(far, 0.0F) << "distant weather thins out but never disappears outright";
+}
+
+TEST(WeatherParticleBudgetTest, ClearWeatherSubmitsNothing) {
+  EXPECT_FLOAT_EQ(density_at(0.0F, 1.0F, 0.0F), 0.0F);
+}

--- a/tests/systems/rain_manager_test.cpp
+++ b/tests/systems/rain_manager_test.cpp
@@ -272,3 +272,67 @@ TEST_F(RainManagerTest, WindStrengthCanBeConfigured) {
 
   EXPECT_FLOAT_EQ(rain_manager->get_wind_strength(), 0.5F);
 }
+
+TEST_F(RainManagerTest, WindDirectionIsCarriedFromTheMapDefinition) {
+  RainSettings settings;
+  settings.enabled = true;
+  settings.wind_direction_deg = 270.0F;
+
+  rain_manager->configure(settings, 12345);
+
+  EXPECT_FLOAT_EQ(rain_manager->get_wind_direction_deg(), 270.0F);
+
+  const QVector3D wind = weather_wind_vector(270.0F);
+  EXPECT_NEAR(wind.x(), -1.0F, 1e-5F);
+  EXPECT_NEAR(wind.y(), 0.0F, 1e-5F);
+  EXPECT_NEAR(wind.z(), 0.0F, 1e-5F);
+}
+
+TEST_F(RainManagerTest, SnapshotAndRestoreResumeAnInterruptedCycle) {
+  RainSettings settings;
+  settings.enabled = true;
+  settings.cycle_duration = 100.0F;
+  settings.active_duration = 30.0F;
+  settings.intensity = 1.0F;
+  settings.fade_duration = 5.0F;
+
+  rain_manager->configure(settings, 0);
+  rain_manager->update(2.5F);
+  ASSERT_EQ(rain_manager->get_state(), RainState::FadingIn);
+  const RainRuntimeState saved = rain_manager->snapshot();
+  const float saved_intensity = rain_manager->get_intensity();
+
+  RainManager reloaded;
+  reloaded.configure(settings, 0);
+  EXPECT_EQ(reloaded.get_state(), RainState::Clear);
+
+  reloaded.restore(saved);
+
+  EXPECT_EQ(reloaded.get_state(), RainState::FadingIn);
+  EXPECT_FLOAT_EQ(reloaded.get_cycle_time(), rain_manager->get_cycle_time());
+  EXPECT_FLOAT_EQ(reloaded.get_intensity(), saved_intensity);
+}
+
+TEST_F(RainManagerTest, RestoreOnAClearMapCannotResurrectWeather) {
+  RainSettings settings;
+  settings.enabled = false;
+
+  rain_manager->configure(settings, 0);
+  rain_manager->restore({.state = RainState::Active,
+                         .cycle_time = 10.0F,
+                         .state_time = 4.0F,
+                         .intensity = 0.9F});
+
+  EXPECT_EQ(rain_manager->get_state(), RainState::Clear);
+  EXPECT_FLOAT_EQ(rain_manager->get_intensity(), 0.0F);
+}
+
+TEST_F(RainManagerTest, RainStateNamesRoundTrip) {
+  for (const RainState state : {RainState::Clear,
+                                RainState::FadingIn,
+                                RainState::Active,
+                                RainState::FadingOut}) {
+    EXPECT_EQ(parse_rain_state(QString::fromLatin1(rain_state_name(state))), state);
+  }
+  EXPECT_EQ(parse_rain_state(QStringLiteral("nonsense")), RainState::Clear);
+}

--- a/tools/arena/arena_scenario.h
+++ b/tools/arena/arena_scenario.h
@@ -217,6 +217,7 @@ struct ArenaScenarioDefinition {
   Render::GraphicsQuality graphics_quality{Render::GraphicsQuality::High};
   Game::Map::EnvironmentDefinition environment{};
   Game::Map::WeatherLightingInput weather{};
+  Game::Map::RainSettings precipitation{};
   std::vector<Game::Map::RiverSegment> rivers;
   std::vector<Game::Map::Lake> lakes;
   std::vector<Game::Map::Bridge> bridges;

--- a/tools/arena/arena_scenario_catalog.cpp
+++ b/tools/arena/arena_scenario_catalog.cpp
@@ -4659,6 +4659,143 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
     result.push_back(std::move(s));
   }
 
+  struct PrecipitationFixture {
+    const char* id;
+    const char* title;
+    bool snow;
+    float intensity;
+    float wind_strength;
+    float wind_direction_deg;
+    float hour;
+    Render::GraphicsQuality quality;
+  };
+
+  for (const auto& fixture :
+       std::array{PrecipitationFixture{k_weather_rain_light_id,
+                                       "Weather: Light Rain",
+                                       false,
+                                       Game::Map::k_weather_intensity_light,
+                                       0.15F,
+                                       20.0F,
+                                       14.0F,
+                                       Render::GraphicsQuality::High},
+                  PrecipitationFixture{k_weather_rain_medium_id,
+                                       "Weather: Medium Rain",
+                                       false,
+                                       Game::Map::k_weather_intensity_medium,
+                                       0.30F,
+                                       145.0F,
+                                       14.0F,
+                                       Render::GraphicsQuality::High},
+                  PrecipitationFixture{k_weather_rain_heavy_id,
+                                       "Weather: Heavy Rain",
+                                       false,
+                                       Game::Map::k_weather_intensity_heavy,
+                                       0.60F,
+                                       250.0F,
+                                       14.0F,
+                                       Render::GraphicsQuality::High},
+                  PrecipitationFixture{k_weather_snow_light_id,
+                                       "Weather: Light Snow",
+                                       true,
+                                       Game::Map::k_weather_intensity_light,
+                                       0.15F,
+                                       70.0F,
+                                       11.0F,
+                                       Render::GraphicsQuality::High},
+                  PrecipitationFixture{k_weather_snow_medium_id,
+                                       "Weather: Medium Snow",
+                                       true,
+                                       Game::Map::k_weather_intensity_medium,
+                                       0.32F,
+                                       70.0F,
+                                       11.0F,
+                                       Render::GraphicsQuality::High},
+                  PrecipitationFixture{k_weather_snow_heavy_id,
+                                       "Weather: Heavy Snow",
+                                       true,
+                                       Game::Map::k_weather_intensity_heavy,
+                                       0.65F,
+                                       330.0F,
+                                       11.0F,
+                                       Render::GraphicsQuality::High},
+                  PrecipitationFixture{k_weather_snow_crosswind_id,
+                                       "Weather: Snow Crosswind",
+                                       true,
+                                       Game::Map::k_weather_intensity_medium,
+                                       1.20F,
+                                       270.0F,
+                                       17.0F,
+                                       Render::GraphicsQuality::High},
+                  PrecipitationFixture{k_weather_rain_budget_low_id,
+                                       "Weather: Rain Budget (Low)",
+                                       false,
+                                       Game::Map::k_weather_intensity_heavy,
+                                       0.35F,
+                                       145.0F,
+                                       14.0F,
+                                       Render::GraphicsQuality::Low},
+                  PrecipitationFixture{k_weather_rain_budget_ultra_id,
+                                       "Weather: Rain Budget (Ultra)",
+                                       false,
+                                       Game::Map::k_weather_intensity_heavy,
+                                       0.35F,
+                                       145.0F,
+                                       14.0F,
+                                       Render::GraphicsQuality::Ultra}}) {
+    auto s = definition(
+        QString::fromLatin1(fixture.id),
+        QString::fromLatin1(fixture.title),
+        QStringLiteral("Locked-camera precipitation fixture: troops, structures and "
+                       "vegetation under one authored weather setting."),
+        8.0F,
+        {24.0F, 48.0F, 32.0F});
+    s.environment.start_time = fixture.hour;
+    s.environment.time_mode = Game::Map::TimeMode::Locked;
+    s.graphics_quality = fixture.quality;
+    if (fixture.snow) {
+      s.weather.snow = fixture.intensity;
+    } else {
+      s.weather.rain = fixture.intensity;
+      s.weather.storm = fixture.intensity * 0.35F;
+    }
+    s.precipitation.enabled = true;
+    s.precipitation.type =
+        fixture.snow ? Game::Map::WeatherType::Snow : Game::Map::WeatherType::Rain;
+    s.precipitation.intensity = fixture.intensity;
+    s.precipitation.wind_strength = fixture.wind_strength;
+    s.precipitation.wind_direction_deg = fixture.wind_direction_deg;
+    s.groups = {group(QStringLiteral("roman_line"),
+                      Troop::Swordsman,
+                      1,
+                      3,
+                      {-5.0F, 0.0F, 0.0F},
+                      8,
+                      {0.0F, 0.0F, 2.5F}),
+                nation_group(QStringLiteral("carthage_line"),
+                             Troop::Spearman,
+                             Nation::Carthage,
+                             2,
+                             3,
+                             {5.0F, 0.0F, 0.0F},
+                             8,
+                             {0.0F, 0.0F, 2.5F}),
+                building(QStringLiteral("home"),
+                         Game::Units::SpawnType::Home,
+                         Nation::RomanRepublic,
+                         1,
+                         1,
+                         {-10.0F, 0.0F, 6.0F})};
+    s.resource_patches = {{QStringLiteral("pine"),
+                           4,
+                           QVector3D(10.0F, 0.0F, 4.0F),
+                           QVector3D(2.0F, 0.0F, 1.0F),
+                           1.0F}};
+    add_visual_stability(
+        s, {QStringLiteral("roman_line"), QStringLiteral("carthage_line")});
+    result.push_back(std::move(s));
+  }
+
   for (const auto& transition : std::array{
            std::tuple{k_lighting_dawn_to_day_id,
                       "Lighting: Dawn To Day",

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -133,6 +133,16 @@ inline constexpr char k_lighting_shadow_quality_medium_id[] =
 inline constexpr char k_lighting_shadow_quality_high_id[] =
     "lighting_shadow_quality_high";
 
+inline constexpr char k_weather_rain_light_id[] = "weather_rain_light";
+inline constexpr char k_weather_rain_medium_id[] = "weather_rain_medium";
+inline constexpr char k_weather_rain_heavy_id[] = "weather_rain_heavy";
+inline constexpr char k_weather_snow_light_id[] = "weather_snow_light";
+inline constexpr char k_weather_snow_medium_id[] = "weather_snow_medium";
+inline constexpr char k_weather_snow_heavy_id[] = "weather_snow_heavy";
+inline constexpr char k_weather_snow_crosswind_id[] = "weather_snow_crosswind";
+inline constexpr char k_weather_rain_budget_low_id[] = "weather_rain_budget_low";
+inline constexpr char k_weather_rain_budget_ultra_id[] = "weather_rain_budget_ultra";
+
 struct ScenarioOption {
   QString id;
   QString label;

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -1533,7 +1533,8 @@ void ArenaViewport::configure_rendering_from_terrain() {
         static_cast<float>(height_map->get_height()) * height_map->get_tile_size();
     m_rain->configure(world_width,
                       world_height,
-                      static_cast<std::uint32_t>(std::max(0, m_terrain_settings.seed)));
+                      static_cast<std::uint32_t>(std::max(0, m_terrain_settings.seed)),
+                      m_weather_type);
   }
   if (m_boundary_fog != nullptr) {
     m_boundary_fog->configure(
@@ -1632,7 +1633,14 @@ void ArenaViewport::set_shadow_quality(const QString& quality) {
 
 auto ArenaViewport::active_lighting() const -> Game::Map::EnvironmentLightingState {
   auto weather = m_weather_lighting;
-  weather.rain = m_rain_enabled ? m_rain_intensity : 0.0F;
+  const float active = m_rain_enabled ? m_rain_intensity : 0.0F;
+  if (m_weather_type == Game::Map::WeatherType::Snow) {
+    weather.snow = active;
+    weather.rain = 0.0F;
+  } else {
+    weather.rain = active;
+    weather.snow = 0.0F;
+  }
   return Game::Map::lighting_for_hour(m_environment_hour, m_lighting_profile, weather);
 }
 
@@ -1703,6 +1711,7 @@ void ArenaViewport::set_rain_enabled(bool enabled) {
   if (!enabled) {
     m_weather_lighting.rain = 0.0F;
     m_weather_lighting.storm = 0.0F;
+    m_weather_lighting.snow = 0.0F;
   }
   if (m_rain != nullptr) {
     m_rain->set_enabled(enabled);
@@ -1716,7 +1725,11 @@ void ArenaViewport::set_rain_enabled(bool enabled) {
 
 void ArenaViewport::set_rain_intensity(float intensity) {
   m_rain_intensity = std::clamp(intensity, 0.0F, 1.0F);
-  m_weather_lighting.rain = m_rain_intensity;
+  if (m_weather_type == Game::Map::WeatherType::Snow) {
+    m_weather_lighting.snow = m_rain_intensity;
+  } else {
+    m_weather_lighting.rain = m_rain_intensity;
+  }
   if (m_rain != nullptr) {
     m_rain->set_intensity(m_rain_intensity);
   }
@@ -2746,12 +2759,19 @@ void ArenaViewport::load_scenario(const QString& scenario_id) {
   m_environment_hour = definition->environment.start_time;
   m_lighting_profile = definition->environment.lighting_profile;
   m_environment_clock.reset(definition->environment);
-  m_rain_enabled = definition->weather.rain > 0.0F || definition->weather.storm > 0.0F;
-  m_rain_intensity = std::max(definition->weather.rain, definition->weather.storm);
+  m_rain_enabled = definition->weather.rain > 0.0F ||
+                   definition->weather.storm > 0.0F || definition->weather.snow > 0.0F;
+  m_rain_intensity = std::max(
+      {definition->weather.rain, definition->weather.storm, definition->weather.snow});
+  m_weather_type = definition->weather.snow > 0.0F ? Game::Map::WeatherType::Snow
+                                                   : Game::Map::WeatherType::Rain;
   m_weather_lighting = definition->weather;
   if (m_rain != nullptr) {
     m_rain->set_enabled(m_rain_enabled);
     m_rain->set_intensity(m_rain_intensity);
+    m_rain->set_weather_type(m_weather_type);
+    m_rain->set_wind_strength(definition->precipitation.wind_strength);
+    m_rain->set_wind_direction_deg(definition->precipitation.wind_direction_deg);
   }
   clear_camera_key_state();
   m_arena_rivers = definition->rivers;

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -305,6 +305,7 @@ private:
   Game::Map::EnvironmentClock m_environment_clock;
   bool m_rain_enabled = false;
   float m_rain_intensity = 0.5F;
+  Game::Map::WeatherType m_weather_type = Game::Map::WeatherType::Rain;
   Game::Map::WeatherLightingInput m_weather_lighting{};
   QString m_animation_name = QStringLiteral("Idle");
 

--- a/tools/map_editor/editor_window.cpp
+++ b/tools/map_editor/editor_window.cpp
@@ -36,6 +36,7 @@
 #include <cmath>
 
 #include "game/map/environment_lighting.h"
+#include "game/map/map_definition.h"
 #include "json_edit_dialog.h"
 #include "json_schema.h"
 #include "map_json_keys.h"
@@ -211,6 +212,19 @@ auto createEnvironmentPanel(MapEditor::MapData* map_data, QWidget* parent) -> QW
   weather_intensity->setDecimals(2);
   weather_intensity->setSingleStep(0.05);
   weather_form->addRow("Intensity", weather_intensity);
+  auto* wind_strength = new QDoubleSpinBox(weather_group);
+  wind_strength->setRange(0.0, 3.0);
+  wind_strength->setDecimals(2);
+  wind_strength->setSingleStep(0.05);
+  weather_form->addRow("Wind strength", wind_strength);
+  auto* wind_direction = new QDoubleSpinBox(weather_group);
+  wind_direction->setRange(0.0, 359.0);
+  wind_direction->setDecimals(0);
+  wind_direction->setSingleStep(15.0);
+  wind_direction->setSuffix("°");
+  wind_direction->setToolTip(
+      "Compass bearing the wind blows towards; drives both particles and drift.");
+  weather_form->addRow("Wind direction", wind_direction);
   auto* shadow_quality = new QComboBox(weather_group);
   shadow_quality->addItems({"Low", "Medium", "High", "Ultra"});
   shadow_quality->setCurrentText("High");
@@ -260,8 +274,17 @@ auto createEnvironmentPanel(MapEditor::MapData* map_data, QWidget* parent) -> QW
     const QString weather_value =
         enabled ? rain.value("type").toString("rain") : QStringLiteral("off");
     weather->setCurrentIndex(std::max(0, weather->findData(weather_value)));
-    weather_intensity->setValue(rain.value("intensity").toDouble(0.5));
+    const QJsonValue intensity_value = rain.value("intensity");
+    weather_intensity->setValue(
+        intensity_value.isString()
+            ? static_cast<double>(
+                  Game::Map::parse_weather_intensity(intensity_value.toString(), 0.5F))
+            : intensity_value.toDouble(0.5));
     weather_intensity->setEnabled(enabled);
+    wind_strength->setValue(rain.value("wind_strength").toDouble(0.0));
+    wind_strength->setEnabled(enabled);
+    wind_direction->setValue(rain.value("wind_direction").toDouble(45.0));
+    wind_direction->setEnabled(enabled);
 
     const auto lighting =
         Game::Map::lighting_for_hour(static_cast<float>(hour), profile->currentText());
@@ -332,6 +355,8 @@ auto createEnvironmentPanel(MapEditor::MapData* map_data, QWidget* parent) -> QW
     rain["enabled"] = selected != QStringLiteral("off");
     rain["type"] = selected == QStringLiteral("snow") ? "snow" : "rain";
     rain["intensity"] = weather_intensity->value();
+    rain["wind_strength"] = wind_strength->value();
+    rain["wind_direction"] = wind_direction->value();
     map_data->set_rain(rain);
   };
   QObject::connect(weather,
@@ -339,6 +364,14 @@ auto createEnvironmentPanel(MapEditor::MapData* map_data, QWidget* parent) -> QW
                    panel,
                    [=](int) { write_weather(); });
   QObject::connect(weather_intensity,
+                   qOverload<double>(&QDoubleSpinBox::valueChanged),
+                   panel,
+                   [=](double) { write_weather(); });
+  QObject::connect(wind_strength,
+                   qOverload<double>(&QDoubleSpinBox::valueChanged),
+                   panel,
+                   [=](double) { write_weather(); });
+  QObject::connect(wind_direction,
                    qOverload<double>(&QDoubleSpinBox::valueChanged),
                    panel,
                    [=](double) { write_weather(); });


### PR DESCRIPTION
- Add named precipitation intensities (light/medium/heavy) and wind_direction (compass degrees) to map rain blocks; all shipped maps now declare explicit weather with wind settings.
- RainManager gains snapshot()/restore() so save metadata round-trips the weather cycle and loading mid-downpour resumes mid-downpour.
- Rework precipitation particles: fixed pool owned by RainPipeline with a per- vertex rank that fades as the density cutoff approaches, so budgets change without popping. Density derives from intensity, quality preset (WeatherBudget::particle_scale) and camera height.
- Add Render::LocalLightFader so lights entering/leaving the local light budget ramp over ~0.35s instead of popping; reset when entity render caches clear.
- Derive contact shadow direction, length and opacity from the environment sun (render/contact_shadow.h) instead of a baked constant.
- Map editor weather panel gains wind strength/direction controls; arena gains precipitation fixtures (rain/snow intensities, crosswind, budget comparisons).
- Tests for contact shadows, weather particle budgets, map weather coverage, weather intensity parsing, wind direction, and save/restore round-trips.