### PR TITLE
Extract placement into a view model and split the test suite by link …

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Unit tests
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ./build/bin/standard_of_iron_tests
+        run: bash scripts/run-tests.sh build
 
       - name: Validate OpenGL requirements
         run: python3 scripts/validate_opengl_requirements.py

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Unit tests
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ./build/bin/standard_of_iron_tests
+        run: bash scripts/run-tests.sh build
 
       - name: Validate OpenGL requirements
         run: python3 scripts/validate_opengl_requirements.py

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -151,11 +151,13 @@ jobs:
       - name: Build
         run: cmake --build build
 
+      # bash rather than pwsh so this runs the same suite list as every other
+      # platform; the runner ships Git bash.
       - name: Unit tests
-        shell: pwsh
+        shell: bash
         env:
           QT_QPA_PLATFORM: offscreen
-        run: .\build\bin\standard_of_iron_tests.exe
+        run: bash scripts/run-tests.sh build
 
       # Code signing (optional: signs .exe with Authenticode)
       - name: Sign executable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,12 +89,12 @@ jobs:
       - name: Build test targets
         run: |
           cmake --build build --parallel \
-            --target standard_of_iron_tests content_validator
+            --target soi_test_binaries content_validator
 
       - name: Unit tests
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ./build/bin/standard_of_iron_tests --gtest_brief=1
+        run: bash scripts/run-tests.sh build --gtest_brief=1
 
       - name: Content validation
         run: ./build/bin/content_validator assets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ add_library(
     STATIC
     app/controllers/action_vfx.cpp
     app/viewmodels/save_slots_view_model.cpp
+    app/viewmodels/placement_view_model.cpp
     app/controllers/command_controller.cpp
     app/core/ambient_state_manager.cpp
     app/core/audio_coordinator.cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ the point at which every supported platform must actually ship.
 - `quality` - formatting, linting, quality markers and the static content
   validators. No compiler, fails in about a minute.
 - `test` - Linux configure and build of the test targets only
-  (`standard_of_iron_tests`, `content_validator`), then unit tests, content
+  (`soi_test_binaries`, `content_validator`), then unit tests, content
   validation, the validator integration tests, and advisory clang-tidy over
   the changed files. The game binary, map editor, arena and preview tools are
   not built here.

--- a/Makefile
+++ b/Makefile
@@ -325,31 +325,13 @@ test: test-build
 	@$(MAKE) --no-print-directory test-only
 
 # Run tests without configuring or compiling.
+#
+# scripts/run-tests.sh owns the suite list so the Makefile and the CI workflows
+# cannot disagree about what running the tests means.
 .PHONY: test-only
 test-only:
 	@echo "$(BOLD)$(BLUE)Running tests...$(RESET)"
-	@if [ -f "$(BUILD_DIR)/bin/standard_of_iron_tests" ]; then \
-		echo "$(BOLD)--- C++ tests (standard_of_iron_tests) ---$(RESET)"; \
-		QT_QPA_PLATFORM=offscreen \
-			./$(BUILD_DIR)/bin/standard_of_iron_tests --gtest_brief=1 $(TEST_ARGS); \
-		_status=$$?; \
-		echo "$(BOLD)--- C++ tests complete (exit code: $$_status) ---$(RESET)"; \
-		if [ $$_status -ne 0 ]; then exit $$_status; fi; \
-	else \
-		echo "$(RED)Test executable not found. Run 'make test' first.$(RESET)"; \
-		exit 1; \
-	fi
-	@# The QML design-system suite is skipped when Qt QuickTest is unavailable,
-	@# so a missing binary is not a build failure here.
-	@if [ -f "$(BUILD_DIR)/bin/design_system_qml_tests" ]; then \
-		echo ""; \
-		echo "$(BOLD)--- QML design system tests (design_system_qml_tests) ---$(RESET)"; \
-		QT_QPA_PLATFORM=offscreen ./$(BUILD_DIR)/bin/design_system_qml_tests \
-			-input tests/ui/qml; \
-		echo "$(BOLD)--- QML tests complete ---$(RESET)"; \
-	else \
-		echo "$(YELLOW)⚠ design_system_qml_tests not built (Qt QuickTest missing). Skipping.$(RESET)"; \
-	fi
+	@bash scripts/run-tests.sh $(BUILD_DIR) --gtest_brief=1 $(TEST_ARGS)
 
 # Validate mission and campaign content
 .PHONY: validate-content

--- a/README.md
+++ b/README.md
@@ -152,15 +152,15 @@ make run-map-pipeline map_pipeline_rebuild=1
 ### Running Tests
 
 ```bash
-# Execute the full test suite
+# Execute the full test suite (five binaries, split by link surface)
 make test
 
-# Build the test binary only (useful for IDE integration)
-cd build && make standard_of_iron_tests
+# Build the test binaries only (useful for IDE integration)
+cd build && make soi_test_binaries
 
 # Filter to specific test suites
-./build/bin/standard_of_iron_tests --gtest_filter=SerializationTest.*
-./build/bin/standard_of_iron_tests --gtest_filter=SaveStorageTest.*
+./build/bin/simulation_tests --gtest_filter=SerializationTest.*
+./build/bin/persistence_tests --gtest_filter=SaveStorageTest.*
 ```
 
 See [tests/README.md](https://github.com/djeada/Standard-of-Iron/blob/main/tests/README.md) for additional testing documentation.
@@ -495,7 +495,7 @@ The engine is moving from a single hardcoded nation toward a scalable multi-fact
 - Multiple _map files_ are playable with distinct layouts and objectives.
 - A _resource economy_ with gathering, spending, and marketplace trade.
 - _Campaign progression_ with mission unlocking and per-slot save metadata.
-- A _simulation kernel_ (`game_sim`) that builds and runs with no renderer linked, exercised by `bin/headless_simulation_tests`.
+- A _simulation kernel_ (`game_sim`) that builds and runs with no renderer linked, exercised by `bin/simulation_tests`, which links that kernel and nothing else.
 - A _session context_ that owns all per-match state, so two matches can run in one process and tests get isolation.
 - A _canonical command pipeline_: player, AI and scripted orders share one validation pass, one queue and one execution point per tick.
 - A _fixed-tick simulation clock_ and a seeded deterministic RNG, both persisted in saves.
@@ -504,7 +504,7 @@ The engine is moving from a single hardcoded nation toward a scalable multi-fact
 **In progress:**
 
 - Migrating gameplay call sites from the ambient `instance()` accessors to explicit `SessionContext&` parameters.
-- Moving `GameEngine`'s QML surface onto focused view models; the save-slot browser has moved, placement and campaign are next.
+- Moving `GameEngine`'s QML surface onto focused view models; the save-slot browser and placement have moved, campaign and camera control are next.
 
 **Planned:**
 

--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -286,6 +286,10 @@ GameEngine::GameEngine(QObject* parent)
           this,
           [this] { restart_autosave_timer(); });
 
+  App::ViewModels::PlacementHost& placement_host = *this;
+  m_placement_view_model =
+      std::make_unique<App::ViewModels::PlacementViewModel>(placement_host, this);
+
   m_session = std::make_unique<Game::Session::SessionContext>();
   m_session_scope = std::make_unique<Game::Session::ScopedSession>(*m_session);
   m_world = &m_session->world();
@@ -388,20 +392,20 @@ GameEngine::GameEngine(QObject* parent)
       m_world, m_picking_service.get(), m_rts_camera.get(), this);
   connect(m_production_manager.get(),
           &ProductionManager::placing_construction_changed,
-          this,
-          &GameEngine::placing_construction_changed);
+          m_placement_view_model.get(),
+          &App::ViewModels::PlacementViewModel::placing_construction_changed);
   connect(m_production_manager.get(),
           &ProductionManager::construction_preview_active_changed,
-          this,
-          &GameEngine::construction_preview_active_changed);
+          m_placement_view_model.get(),
+          &App::ViewModels::PlacementViewModel::construction_preview_active_changed);
   connect(m_production_manager.get(),
           &ProductionManager::construction_preview_valid_changed,
-          this,
-          &GameEngine::construction_preview_valid_changed);
+          m_placement_view_model.get(),
+          &App::ViewModels::PlacementViewModel::construction_preview_valid_changed);
   connect(m_production_manager.get(),
           &ProductionManager::construction_preview_summary_changed,
-          this,
-          &GameEngine::construction_preview_summary_changed);
+          m_placement_view_model.get(),
+          &App::ViewModels::PlacementViewModel::construction_preview_summary_changed);
   connect(m_production_manager.get(),
           &ProductionManager::construction_placement_rejected,
           this,
@@ -522,10 +526,12 @@ GameEngine::GameEngine(QObject* parent)
           &GameEngine::formation_mode_changed);
   connect(m_command_controller.get(),
           &App::Controllers::CommandController::formation_placement_started,
-          [this]() { emit placing_formation_changed(); });
+          m_placement_view_model.get(),
+          &App::ViewModels::PlacementViewModel::placing_formation_changed);
   connect(m_command_controller.get(),
           &App::Controllers::CommandController::formation_placement_ended,
-          [this]() { emit placing_formation_changed(); });
+          m_placement_view_model.get(),
+          &App::ViewModels::PlacementViewModel::placing_formation_changed);
 
   connect(
       this, SIGNAL(selected_units_changed()), m_selected_units_model, SLOT(refresh()));
@@ -700,7 +706,7 @@ void GameEngine::on_right_double_click(qreal sx, qreal sy) {
   if (started_formation_placement) {
     m_input_handler->on_formation_cancel();
   } else if (m_right_mouse_gesture.suppress_release_click ||
-             is_placing_construction()) {
+             m_placement_view_model->is_placing_construction()) {
     m_right_mouse_gesture.double_click_handled = true;
     return;
   }
@@ -721,15 +727,16 @@ auto GameEngine::on_right_press(qreal sx, qreal sy) -> bool {
   m_right_mouse_gesture.active = true;
   m_right_mouse_gesture.press_position = QPointF(sx, sy);
   m_right_mouse_gesture.placement_was_active_on_press =
-      is_placing_formation() || is_placing_construction();
+      m_placement_view_model->is_placing_formation() ||
+      m_placement_view_model->is_placing_construction();
 
-  if (is_placing_formation()) {
-    on_formation_cancel();
+  if (m_placement_view_model->is_placing_formation()) {
+    m_placement_view_model->on_formation_cancel();
     m_right_mouse_gesture.suppress_release_click = true;
     return true;
   }
-  if (is_placing_construction()) {
-    on_construction_cancel();
+  if (m_placement_view_model->is_placing_construction()) {
+    m_placement_view_model->on_construction_cancel();
     m_right_mouse_gesture.suppress_release_click = true;
     return true;
   }
@@ -840,14 +847,6 @@ void GameEngine::on_guard_command() {
   m_input_handler->on_guard_command();
 }
 
-void GameEngine::on_formation_command() {
-  if (!m_input_handler) {
-    return;
-  }
-  ensure_initialized();
-  m_input_handler->on_formation_command();
-}
-
 void GameEngine::on_run_command() {
   if (!m_input_handler) {
     return;
@@ -909,25 +908,11 @@ auto GameEngine::any_selected_in_guard_mode() const -> bool {
   return m_input_handler->any_selected_in_guard_mode();
 }
 
-auto GameEngine::any_selected_in_formation_mode() const -> bool {
-  if (!m_input_handler) {
-    return false;
-  }
-  return m_input_handler->any_selected_in_formation_mode();
-}
-
 auto GameEngine::any_selected_in_run_mode() const -> bool {
   if (!m_input_handler) {
     return false;
   }
   return m_input_handler->any_selected_in_run_mode();
-}
-
-auto GameEngine::is_placing_formation() const -> bool {
-  if (m_command_controller) {
-    return m_command_controller->is_placing_formation();
-  }
-  return false;
 }
 
 bool GameEngine::is_campaign_mission() const {
@@ -954,136 +939,6 @@ bool GameEngine::campaign_completed() const {
     }
   }
   return false;
-}
-
-void GameEngine::on_formation_mouse_move(qreal sx, qreal sy) {
-  if (!m_input_handler) {
-    return;
-  }
-  ensure_initialized();
-  m_input_handler->on_formation_mouse_move(sx, sy, m_viewport);
-}
-
-void GameEngine::on_formation_scroll(float delta) {
-  if (!m_input_handler) {
-    return;
-  }
-  ensure_initialized();
-  m_input_handler->on_formation_scroll(delta);
-}
-
-void GameEngine::on_formation_confirm() {
-  if (!m_input_handler) {
-    return;
-  }
-  ensure_initialized();
-  m_input_handler->on_formation_confirm();
-}
-
-void GameEngine::on_formation_cancel() {
-  if (!m_input_handler) {
-    return;
-  }
-  ensure_initialized();
-  m_input_handler->on_formation_cancel();
-}
-
-auto GameEngine::is_placing_construction() const -> bool {
-  return m_production_manager ? m_production_manager->is_placing_construction() : false;
-}
-
-auto GameEngine::pending_builder_construction_type() const -> QString {
-  return m_production_manager
-             ? m_production_manager->pending_builder_construction_type()
-             : QString();
-}
-
-auto GameEngine::construction_preview_active() const -> bool {
-  return m_production_manager ? m_production_manager->construction_preview_active()
-                              : false;
-}
-
-auto GameEngine::construction_preview_valid() const -> bool {
-  return m_production_manager ? m_production_manager->construction_preview_valid()
-                              : false;
-}
-
-auto GameEngine::construction_preview_rotatable() const -> bool {
-  return m_production_manager ? m_production_manager->construction_preview_rotatable()
-                              : false;
-}
-
-auto GameEngine::construction_preview_segment_count() const -> int {
-  return m_production_manager
-             ? m_production_manager->construction_preview_segment_count()
-             : 0;
-}
-
-auto GameEngine::construction_preview_valid_segment_count() const -> int {
-  return m_production_manager
-             ? m_production_manager->construction_preview_valid_segment_count()
-             : 0;
-}
-
-auto GameEngine::construction_preview_total_cost() const -> int {
-  return m_production_manager ? m_production_manager->construction_preview_total_cost()
-                              : 0;
-}
-
-void GameEngine::on_construction_mouse_move(qreal sx, qreal sy) {
-  ensure_initialized();
-  if (m_production_manager) {
-    QPointF const viewport_point = map_input_to_viewport(sx, sy);
-    m_production_manager->on_construction_mouse_move(
-        viewport_point.x(), viewport_point.y(), m_viewport);
-  }
-}
-
-void GameEngine::on_construction_pointer_pressed(qreal sx, qreal sy) {
-  ensure_initialized();
-  if (m_production_manager) {
-    QPointF const viewport_point = map_input_to_viewport(sx, sy);
-    m_production_manager->on_construction_pointer_pressed(
-        viewport_point.x(), viewport_point.y(), m_viewport);
-  }
-}
-
-void GameEngine::on_construction_pointer_released(qreal sx, qreal sy) {
-  ensure_initialized();
-  if (m_production_manager) {
-    QPointF const viewport_point = map_input_to_viewport(sx, sy);
-    m_production_manager->on_construction_pointer_released(
-        viewport_point.x(), viewport_point.y(), m_viewport);
-  }
-  if (!is_placing_construction()) {
-    set_cursor_mode(CursorMode::Normal);
-  }
-}
-
-void GameEngine::on_construction_scroll(float delta) {
-  ensure_initialized();
-  if (m_production_manager) {
-    m_production_manager->on_construction_scroll(delta);
-  }
-}
-
-void GameEngine::on_construction_confirm() {
-  ensure_initialized();
-  if (m_production_manager) {
-    m_production_manager->on_construction_confirm();
-  }
-  if (!is_placing_construction()) {
-    set_cursor_mode(CursorMode::Normal);
-  }
-}
-
-void GameEngine::on_construction_cancel() {
-  if (m_production_manager) {
-    m_production_manager->on_construction_cancel();
-  }
-  if (!is_placing_construction()) {
-    set_cursor_mode(CursorMode::Normal);
-  }
 }
 
 void GameEngine::on_patrol_click(qreal sx, qreal sy) {
@@ -1201,11 +1056,11 @@ void GameEngine::request_enter_commander_control_mode() {
     return;
   }
 
-  if (is_placing_formation()) {
-    on_formation_cancel();
+  if (m_placement_view_model->is_placing_formation()) {
+    m_placement_view_model->on_formation_cancel();
   }
-  if (is_placing_construction()) {
-    on_construction_cancel();
+  if (m_placement_view_model->is_placing_construction()) {
+    m_placement_view_model->on_construction_cancel();
   }
   set_cursor_mode(CursorMode::Normal);
 
@@ -2217,10 +2072,10 @@ void GameEngine::sync_selection_flags() {
            .local_owner_id = m_runtime.local_owner_id,
            .hud_action_states = get_hud_action_states()});
   if (prune_effects.cancel_construction) {
-    on_construction_cancel();
+    m_placement_view_model->on_construction_cancel();
   }
   if (prune_effects.cancel_formation) {
-    on_formation_cancel();
+    m_placement_view_model->on_formation_cancel();
   }
   switch (prune_effects.cursor_resolution) {
   case App::Core::FrameUiCoordinator::CursorResolution::CancelBarracksRallyPlacement:
@@ -2241,7 +2096,7 @@ void GameEngine::sync_selection_flags() {
 
   emit hold_mode_changed(any_selected_in_hold_mode());
   emit guard_mode_changed(any_selected_in_guard_mode());
-  emit formation_mode_changed(any_selected_in_formation_mode());
+  emit formation_mode_changed(m_placement_view_model->any_selected_in_formation_mode());
   emit run_mode_changed(any_selected_in_run_mode());
   const bool civilian_delivery_available =
       App::Core::FrameUiCoordinator::civilian_delivery_available(
@@ -2461,36 +2316,6 @@ void GameEngine::recruit_near_selected(const QString& unit_type) {
   m_command_controller->recruit_near_selected(unit_type, m_runtime.local_owner_id);
 }
 
-void GameEngine::start_building_placement(const QString& building_type) {
-  ensure_initialized();
-  if (m_production_manager) {
-    m_production_manager->start_building_placement(building_type,
-                                                   m_runtime.local_owner_id);
-    set_cursor_mode(CursorMode::PlaceBuilding);
-  }
-}
-
-void GameEngine::place_building_at_screen(qreal sx, qreal sy) {
-  ensure_initialized();
-  if (m_production_manager) {
-    m_production_manager->place_building_at_screen(
-        sx, sy, m_runtime.local_owner_id, m_viewport);
-    set_cursor_mode(CursorMode::Normal);
-  }
-}
-
-void GameEngine::cancel_building_placement() {
-  if (m_production_manager) {
-    m_production_manager->cancel_building_placement();
-  }
-  set_cursor_mode(CursorMode::Normal);
-}
-
-auto GameEngine::pending_building_type() const -> QString {
-  return m_production_manager ? m_production_manager->pending_building_type()
-                              : QString();
-}
-
 auto GameEngine::get_selected_production_state() const -> QVariantMap {
   return m_production_manager ? m_production_manager->get_selected_production_state(
                                     m_runtime.local_owner_id)
@@ -2509,11 +2334,6 @@ auto GameEngine::get_unit_production_info(
   return m_production_manager
              ? m_production_manager->get_unit_production_info(unit_type, nation_id)
              : QVariantMap();
-}
-
-auto GameEngine::get_construction_info(const QString& item_type) const -> QVariantMap {
-  return m_production_manager ? m_production_manager->get_construction_info(item_type)
-                              : QVariantMap();
 }
 
 auto GameEngine::get_selected_marketplace_state() const -> QVariantMap {
@@ -2649,16 +2469,6 @@ auto GameEngine::rpg_project_world(float x, float y, float z) const -> QVariantM
     result["y"] = screen.y();
   }
   return result;
-}
-
-void GameEngine::start_builder_construction(const QString& item_type) {
-  if (m_production_manager) {
-    m_production_manager->start_builder_construction(item_type);
-    if (m_production_manager->is_placing_construction()) {
-      set_cursor_mode(item_type == QStringLiteral("collect") ? CursorMode::Collect
-                                                             : CursorMode::Build);
-    }
-  }
 }
 
 auto GameEngine::get_selected_units_command_mode() const -> QString {
@@ -3813,4 +3623,20 @@ QString GameEngine::loading_stage_text() const {
 
 auto GameEngine::save_slots_view_model() const -> QObject* {
   return m_save_slots_view_model.get();
+}
+
+auto GameEngine::placement_view_model() const -> QObject* {
+  return m_placement_view_model.get();
+}
+
+auto GameEngine::input_handler() const -> InputCommandHandler* {
+  return m_input_handler.get();
+}
+
+auto GameEngine::command_controller() const -> App::Controllers::CommandController* {
+  return m_command_controller.get();
+}
+
+auto GameEngine::production_manager() const -> ProductionManager* {
+  return m_production_manager.get();
 }

--- a/app/core/game_engine.h
+++ b/app/core/game_engine.h
@@ -25,6 +25,7 @@
 #include "../models/selected_units_model.h"
 #include "../utils/engine_view_helpers.h"
 #include "../utils/movement_utils.h"
+#include "../viewmodels/placement_view_model.h"
 #include "ambient_state_manager.h"
 #include "app_scene_context.h"
 #include "camera_controller.h"
@@ -116,7 +117,7 @@ class AudioSystemProxy;
 class QQuickWindow;
 class LoadingProgressTracker;
 
-class GameEngine : public QObject {
+class GameEngine : public QObject, private App::ViewModels::PlacementHost {
   Q_OBJECT
 public:
   explicit GameEngine(QObject* parent = nullptr);
@@ -166,24 +167,6 @@ public:
       float loading_progress READ loading_progress NOTIFY loading_progress_changed)
   Q_PROPERTY(
       QString loading_stage_text READ loading_stage_text NOTIFY loading_stage_changed)
-  Q_PROPERTY(bool is_placing_formation READ is_placing_formation NOTIFY
-                 placing_formation_changed)
-  Q_PROPERTY(bool is_placing_construction READ is_placing_construction NOTIFY
-                 placing_construction_changed)
-  Q_PROPERTY(QString pending_builder_construction_type READ
-                 pending_builder_construction_type NOTIFY placing_construction_changed)
-  Q_PROPERTY(bool construction_preview_active READ construction_preview_active NOTIFY
-                 construction_preview_active_changed)
-  Q_PROPERTY(bool construction_preview_valid READ construction_preview_valid NOTIFY
-                 construction_preview_valid_changed)
-  Q_PROPERTY(
-      int construction_preview_segment_count READ construction_preview_segment_count
-          NOTIFY construction_preview_summary_changed)
-  Q_PROPERTY(int construction_preview_valid_segment_count READ
-                 construction_preview_valid_segment_count NOTIFY
-                     construction_preview_summary_changed)
-  Q_PROPERTY(int construction_preview_total_cost READ construction_preview_total_cost
-                 NOTIFY construction_preview_summary_changed)
   Q_PROPERTY(
       bool is_campaign_mission READ is_campaign_mission NOTIFY campaign_mission_changed)
 
@@ -205,6 +188,7 @@ public:
       QString save_progress_slot READ save_progress_slot NOTIFY save_progress_changed)
 
   Q_PROPERTY(QObject* saves READ save_slots_view_model CONSTANT)
+  Q_PROPERTY(QObject* placement READ placement_view_model CONSTANT)
 
   Q_INVOKABLE void on_map_clicked(qreal sx, qreal sy);
   Q_INVOKABLE void on_right_click(qreal sx, qreal sy);
@@ -225,7 +209,6 @@ public:
   Q_INVOKABLE void on_hold_command();
   Q_INVOKABLE void on_gate_command();
   Q_INVOKABLE void on_guard_command();
-  Q_INVOKABLE void on_formation_command();
   Q_INVOKABLE void on_run_command();
   Q_INVOKABLE void on_heal_command();
   Q_INVOKABLE void on_build_command();
@@ -234,27 +217,7 @@ public:
 
   [[nodiscard]] bool any_selected_in_hold_mode() const;
   [[nodiscard]] bool any_selected_in_guard_mode() const;
-  [[nodiscard]] bool any_selected_in_formation_mode() const;
   [[nodiscard]] bool any_selected_in_run_mode() const;
-  Q_INVOKABLE [[nodiscard]] bool is_placing_formation() const;
-  Q_INVOKABLE [[nodiscard]] bool is_placing_construction() const;
-  Q_INVOKABLE [[nodiscard]] QString pending_builder_construction_type() const;
-  Q_INVOKABLE [[nodiscard]] bool construction_preview_active() const;
-  Q_INVOKABLE [[nodiscard]] bool construction_preview_valid() const;
-  Q_INVOKABLE [[nodiscard]] bool construction_preview_rotatable() const;
-  Q_INVOKABLE [[nodiscard]] int construction_preview_segment_count() const;
-  Q_INVOKABLE [[nodiscard]] int construction_preview_valid_segment_count() const;
-  Q_INVOKABLE [[nodiscard]] int construction_preview_total_cost() const;
-  Q_INVOKABLE void on_formation_mouse_move(qreal sx, qreal sy);
-  Q_INVOKABLE void on_formation_scroll(float delta);
-  Q_INVOKABLE void on_formation_confirm();
-  Q_INVOKABLE void on_formation_cancel();
-  Q_INVOKABLE void on_construction_mouse_move(qreal sx, qreal sy);
-  Q_INVOKABLE void on_construction_pointer_pressed(qreal sx, qreal sy);
-  Q_INVOKABLE void on_construction_pointer_released(qreal sx, qreal sy);
-  Q_INVOKABLE void on_construction_scroll(float delta);
-  Q_INVOKABLE void on_construction_confirm();
-  Q_INVOKABLE void on_construction_cancel();
   Q_INVOKABLE void on_patrol_click(qreal sx, qreal sy);
   Q_INVOKABLE void toggle_commander_control_mode();
   Q_INVOKABLE void commander_key_down(int key, int modifiers = 0);
@@ -314,7 +277,6 @@ public:
   [[nodiscard]] float time_scale() const { return m_runtime.time_scale; }
   [[nodiscard]] QString victory_state() const { return m_runtime.victory_state; }
   [[nodiscard]] QString cursor_mode() const;
-  void set_cursor_mode(CursorMode mode);
   void set_cursor_mode(const QString& mode);
   [[nodiscard]] qreal global_cursor_x() const;
   [[nodiscard]] qreal global_cursor_y() const;
@@ -340,10 +302,6 @@ public:
 
   Q_INVOKABLE [[nodiscard]] bool has_selected_type(const QString& type) const;
   Q_INVOKABLE void recruit_near_selected(const QString& unit_type);
-  Q_INVOKABLE void start_building_placement(const QString& building_type);
-  Q_INVOKABLE void place_building_at_screen(qreal sx, qreal sy);
-  Q_INVOKABLE void cancel_building_placement();
-  Q_INVOKABLE [[nodiscard]] QString pending_building_type() const;
   Q_INVOKABLE [[nodiscard]] QVariantMap get_selected_production_state() const;
   Q_INVOKABLE [[nodiscard]] QVariantMap get_selected_home_production_state() const;
   Q_INVOKABLE [[nodiscard]] QVariantMap get_selected_builder_production_state() const;
@@ -353,11 +311,8 @@ public:
   Q_INVOKABLE [[nodiscard]] QVariantMap get_controlled_commander_status() const;
   Q_INVOKABLE QVariantList pop_rpg_damage_events();
   Q_INVOKABLE QVariantMap rpg_project_world(float x, float y, float z) const;
-  Q_INVOKABLE void start_builder_construction(const QString& item_type);
   Q_INVOKABLE [[nodiscard]] QVariantMap
   get_unit_production_info(const QString& unit_type, const QString& nation_id) const;
-  Q_INVOKABLE [[nodiscard]] QVariantMap
-  get_construction_info(const QString& item_type) const;
   Q_INVOKABLE [[nodiscard]] QVariantMap get_hud_action_states() const;
   Q_INVOKABLE [[nodiscard]] QString get_selected_units_command_mode() const;
   Q_INVOKABLE [[nodiscard]] QString
@@ -385,6 +340,7 @@ public:
   Q_INVOKABLE void cancel_active_save();
   Q_INVOKABLE void load_game_from_slot(const QString& slot_name);
   [[nodiscard]] QObject* save_slots_view_model() const;
+  [[nodiscard]] QObject* placement_view_model() const;
 
   [[nodiscard]] bool save_in_progress() const { return m_active_save_job != 0; }
   [[nodiscard]] int save_progress_percent() const { return m_save_progress_percent; }
@@ -425,7 +381,7 @@ public:
   [[nodiscard]] bool consume_screenshot_request();
   void submit_frame_image(const QImage& image);
 
-  void ensure_initialized();
+  void ensure_initialized() override;
   [[nodiscard]] bool renderer_initialized() const { return m_runtime.initialized; }
   void update(float dt);
   void render(int pixel_width, int pixel_height);
@@ -503,7 +459,6 @@ private:
   };
   bool screen_to_ground(const QPointF& screen_pt, QVector3D& out_world);
   bool world_to_screen(const QVector3D& world, QPointF& out_screen) const;
-  [[nodiscard]] QPointF map_input_to_viewport(qreal sx, qreal sy) const;
   [[nodiscard]] Engine::Core::Entity* find_local_commander() const;
   void request_enter_commander_control_mode();
   void request_exit_commander_control_mode();
@@ -566,6 +521,16 @@ private:
   void seed_barracks_rally_preview_from_selection();
 
   std::unique_ptr<App::ViewModels::SaveSlotsViewModel> m_save_slots_view_model;
+  std::unique_ptr<App::ViewModels::PlacementViewModel> m_placement_view_model;
+
+  [[nodiscard]] QPointF map_input_to_viewport(qreal sx, qreal sy) const override;
+  [[nodiscard]] const ViewportState& viewport() const override { return m_viewport; }
+  [[nodiscard]] int local_owner_id() const override { return m_runtime.local_owner_id; }
+  void set_cursor_mode(CursorMode mode) override;
+  [[nodiscard]] InputCommandHandler* input_handler() const override;
+  [[nodiscard]] App::Controllers::CommandController*
+  command_controller() const override;
+  [[nodiscard]] ProductionManager* production_manager() const override;
 
   std::unique_ptr<Game::Session::SessionContext> m_session;
   std::unique_ptr<Game::Session::ScopedSession> m_session_scope;
@@ -703,11 +668,6 @@ signals:
   void is_loading_changed();
   void loading_progress_changed(float progress);
   void loading_stage_changed(QString stage_text);
-  void placing_formation_changed();
-  void placing_construction_changed();
-  void construction_preview_active_changed();
-  void construction_preview_valid_changed();
-  void construction_preview_summary_changed();
   void campaign_mission_changed();
   void civilian_delivery_available_changed();
   void control_mode_changed();

--- a/app/viewmodels/placement_view_model.cpp
+++ b/app/viewmodels/placement_view_model.cpp
@@ -1,0 +1,224 @@
+#include "placement_view_model.h"
+
+#include "../controllers/command_controller.h"
+#include "../core/input_command_handler.h"
+#include "../core/production_manager.h"
+
+namespace App::ViewModels {
+
+PlacementViewModel::PlacementViewModel(PlacementHost& host, QObject* parent)
+    : QObject(parent)
+    , m_host(host) {
+}
+
+void PlacementViewModel::on_formation_command() {
+  auto* handler = m_host.input_handler();
+  if (handler == nullptr) {
+    return;
+  }
+  m_host.ensure_initialized();
+  handler->on_formation_command();
+}
+
+auto PlacementViewModel::any_selected_in_formation_mode() const -> bool {
+  auto* handler = m_host.input_handler();
+  return handler != nullptr && handler->any_selected_in_formation_mode();
+}
+
+auto PlacementViewModel::is_placing_formation() const -> bool {
+  auto* commands = m_host.command_controller();
+  return commands != nullptr && commands->is_placing_formation();
+}
+
+void PlacementViewModel::on_formation_mouse_move(qreal sx, qreal sy) {
+  auto* handler = m_host.input_handler();
+  if (handler == nullptr) {
+    return;
+  }
+  m_host.ensure_initialized();
+  handler->on_formation_mouse_move(sx, sy, m_host.viewport());
+}
+
+void PlacementViewModel::on_formation_scroll(float delta) {
+  auto* handler = m_host.input_handler();
+  if (handler == nullptr) {
+    return;
+  }
+  m_host.ensure_initialized();
+  handler->on_formation_scroll(delta);
+}
+
+void PlacementViewModel::on_formation_confirm() {
+  auto* handler = m_host.input_handler();
+  if (handler == nullptr) {
+    return;
+  }
+  m_host.ensure_initialized();
+  handler->on_formation_confirm();
+}
+
+void PlacementViewModel::on_formation_cancel() {
+  auto* handler = m_host.input_handler();
+  if (handler == nullptr) {
+    return;
+  }
+  m_host.ensure_initialized();
+  handler->on_formation_cancel();
+}
+
+auto PlacementViewModel::is_placing_construction() const -> bool {
+  auto* production = m_host.production_manager();
+  return production != nullptr && production->is_placing_construction();
+}
+
+auto PlacementViewModel::pending_builder_construction_type() const -> QString {
+  auto* production = m_host.production_manager();
+  return production != nullptr ? production->pending_builder_construction_type()
+                               : QString();
+}
+
+auto PlacementViewModel::construction_preview_active() const -> bool {
+  auto* production = m_host.production_manager();
+  return production != nullptr && production->construction_preview_active();
+}
+
+auto PlacementViewModel::construction_preview_valid() const -> bool {
+  auto* production = m_host.production_manager();
+  return production != nullptr && production->construction_preview_valid();
+}
+
+auto PlacementViewModel::construction_preview_rotatable() const -> bool {
+  auto* production = m_host.production_manager();
+  return production != nullptr && production->construction_preview_rotatable();
+}
+
+auto PlacementViewModel::construction_preview_segment_count() const -> int {
+  auto* production = m_host.production_manager();
+  return production != nullptr ? production->construction_preview_segment_count() : 0;
+}
+
+auto PlacementViewModel::construction_preview_valid_segment_count() const -> int {
+  auto* production = m_host.production_manager();
+  return production != nullptr ? production->construction_preview_valid_segment_count()
+                               : 0;
+}
+
+auto PlacementViewModel::construction_preview_total_cost() const -> int {
+  auto* production = m_host.production_manager();
+  return production != nullptr ? production->construction_preview_total_cost() : 0;
+}
+
+void PlacementViewModel::on_construction_mouse_move(qreal sx, qreal sy) {
+  m_host.ensure_initialized();
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    const QPointF viewport_point = m_host.map_input_to_viewport(sx, sy);
+    production->on_construction_mouse_move(
+        viewport_point.x(), viewport_point.y(), m_host.viewport());
+  }
+}
+
+void PlacementViewModel::on_construction_pointer_pressed(qreal sx, qreal sy) {
+  m_host.ensure_initialized();
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    const QPointF viewport_point = m_host.map_input_to_viewport(sx, sy);
+    production->on_construction_pointer_pressed(
+        viewport_point.x(), viewport_point.y(), m_host.viewport());
+  }
+}
+
+void PlacementViewModel::on_construction_pointer_released(qreal sx, qreal sy) {
+  m_host.ensure_initialized();
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    const QPointF viewport_point = m_host.map_input_to_viewport(sx, sy);
+    production->on_construction_pointer_released(
+        viewport_point.x(), viewport_point.y(), m_host.viewport());
+  }
+  if (!is_placing_construction()) {
+    m_host.set_cursor_mode(CursorMode::Normal);
+  }
+}
+
+void PlacementViewModel::on_construction_scroll(float delta) {
+  m_host.ensure_initialized();
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    production->on_construction_scroll(delta);
+  }
+}
+
+void PlacementViewModel::on_construction_confirm() {
+  m_host.ensure_initialized();
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    production->on_construction_confirm();
+  }
+  if (!is_placing_construction()) {
+    m_host.set_cursor_mode(CursorMode::Normal);
+  }
+}
+
+void PlacementViewModel::on_construction_cancel() {
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    production->on_construction_cancel();
+  }
+  if (!is_placing_construction()) {
+    m_host.set_cursor_mode(CursorMode::Normal);
+  }
+}
+
+void PlacementViewModel::start_builder_construction(const QString& item_type) {
+  auto* production = m_host.production_manager();
+  if (production == nullptr) {
+    return;
+  }
+  production->start_builder_construction(item_type);
+  if (production->is_placing_construction()) {
+    m_host.set_cursor_mode(item_type == QStringLiteral("collect") ? CursorMode::Collect
+                                                                  : CursorMode::Build);
+  }
+}
+
+auto PlacementViewModel::get_construction_info(const QString& item_type) const
+    -> QVariantMap {
+  auto* production = m_host.production_manager();
+  return production != nullptr ? production->get_construction_info(item_type)
+                               : QVariantMap();
+}
+
+void PlacementViewModel::start_building_placement(const QString& building_type) {
+  m_host.ensure_initialized();
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    production->start_building_placement(building_type, m_host.local_owner_id());
+    m_host.set_cursor_mode(CursorMode::PlaceBuilding);
+  }
+}
+
+void PlacementViewModel::place_building_at_screen(qreal sx, qreal sy) {
+  m_host.ensure_initialized();
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    production->place_building_at_screen(
+        sx, sy, m_host.local_owner_id(), m_host.viewport());
+    m_host.set_cursor_mode(CursorMode::Normal);
+  }
+}
+
+void PlacementViewModel::cancel_building_placement() {
+  auto* production = m_host.production_manager();
+  if (production != nullptr) {
+    production->cancel_building_placement();
+  }
+  m_host.set_cursor_mode(CursorMode::Normal);
+}
+
+auto PlacementViewModel::pending_building_type() const -> QString {
+  auto* production = m_host.production_manager();
+  return production != nullptr ? production->pending_building_type() : QString();
+}
+
+} // namespace App::ViewModels

--- a/app/viewmodels/placement_view_model.h
+++ b/app/viewmodels/placement_view_model.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <QObject>
+#include <QPointF>
+#include <QString>
+#include <QVariantMap>
+
+#include "../models/cursor_mode.h"
+
+struct ViewportState;
+class InputCommandHandler;
+class ProductionManager;
+
+namespace App::Controllers {
+class CommandController;
+}
+
+namespace App::ViewModels {
+
+class PlacementHost {
+public:
+  PlacementHost() = default;
+  PlacementHost(const PlacementHost&) = delete;
+  PlacementHost(PlacementHost&&) = delete;
+  auto operator=(const PlacementHost&) -> PlacementHost& = delete;
+  auto operator=(PlacementHost&&) -> PlacementHost& = delete;
+  virtual ~PlacementHost() = default;
+
+  virtual void ensure_initialized() = 0;
+  [[nodiscard]] virtual auto map_input_to_viewport(qreal sx,
+                                                   qreal sy) const -> QPointF = 0;
+  [[nodiscard]] virtual auto viewport() const -> const ViewportState& = 0;
+  [[nodiscard]] virtual auto local_owner_id() const -> int = 0;
+  virtual void set_cursor_mode(CursorMode mode) = 0;
+
+  [[nodiscard]] virtual auto input_handler() const -> InputCommandHandler* = 0;
+  [[nodiscard]] virtual auto
+  command_controller() const -> App::Controllers::CommandController* = 0;
+  [[nodiscard]] virtual auto production_manager() const -> ProductionManager* = 0;
+};
+
+class PlacementViewModel : public QObject {
+  Q_OBJECT
+
+  Q_PROPERTY(bool is_placing_formation READ is_placing_formation NOTIFY
+                 placing_formation_changed)
+  Q_PROPERTY(bool is_placing_construction READ is_placing_construction NOTIFY
+                 placing_construction_changed)
+  Q_PROPERTY(QString pending_builder_construction_type READ
+                 pending_builder_construction_type NOTIFY placing_construction_changed)
+  Q_PROPERTY(QString pending_building_type READ pending_building_type NOTIFY
+                 placing_construction_changed)
+  Q_PROPERTY(bool construction_preview_active READ construction_preview_active NOTIFY
+                 construction_preview_active_changed)
+  Q_PROPERTY(bool construction_preview_valid READ construction_preview_valid NOTIFY
+                 construction_preview_valid_changed)
+  Q_PROPERTY(
+      int construction_preview_segment_count READ construction_preview_segment_count
+          NOTIFY construction_preview_summary_changed)
+  Q_PROPERTY(int construction_preview_valid_segment_count READ
+                 construction_preview_valid_segment_count NOTIFY
+                     construction_preview_summary_changed)
+  Q_PROPERTY(int construction_preview_total_cost READ construction_preview_total_cost
+                 NOTIFY construction_preview_summary_changed)
+
+public:
+  explicit PlacementViewModel(PlacementHost& host, QObject* parent = nullptr);
+
+  Q_INVOKABLE void on_formation_command();
+  Q_INVOKABLE [[nodiscard]] bool any_selected_in_formation_mode() const;
+  Q_INVOKABLE [[nodiscard]] bool is_placing_formation() const;
+  Q_INVOKABLE void on_formation_mouse_move(qreal sx, qreal sy);
+  Q_INVOKABLE void on_formation_scroll(float delta);
+  Q_INVOKABLE void on_formation_confirm();
+  Q_INVOKABLE void on_formation_cancel();
+
+  Q_INVOKABLE [[nodiscard]] bool is_placing_construction() const;
+  Q_INVOKABLE [[nodiscard]] QString pending_builder_construction_type() const;
+  Q_INVOKABLE [[nodiscard]] bool construction_preview_active() const;
+  Q_INVOKABLE [[nodiscard]] bool construction_preview_valid() const;
+  Q_INVOKABLE [[nodiscard]] bool construction_preview_rotatable() const;
+  Q_INVOKABLE [[nodiscard]] int construction_preview_segment_count() const;
+  Q_INVOKABLE [[nodiscard]] int construction_preview_valid_segment_count() const;
+  Q_INVOKABLE [[nodiscard]] int construction_preview_total_cost() const;
+  Q_INVOKABLE void on_construction_mouse_move(qreal sx, qreal sy);
+  Q_INVOKABLE void on_construction_pointer_pressed(qreal sx, qreal sy);
+  Q_INVOKABLE void on_construction_pointer_released(qreal sx, qreal sy);
+  Q_INVOKABLE void on_construction_scroll(float delta);
+  Q_INVOKABLE void on_construction_confirm();
+  Q_INVOKABLE void on_construction_cancel();
+
+  Q_INVOKABLE void start_builder_construction(const QString& item_type);
+  Q_INVOKABLE [[nodiscard]] QVariantMap
+  get_construction_info(const QString& item_type) const;
+
+  Q_INVOKABLE void start_building_placement(const QString& building_type);
+  Q_INVOKABLE void place_building_at_screen(qreal sx, qreal sy);
+  Q_INVOKABLE void cancel_building_placement();
+  Q_INVOKABLE [[nodiscard]] QString pending_building_type() const;
+
+signals:
+  void placing_formation_changed();
+  void placing_construction_changed();
+  void construction_preview_active_changed();
+  void construction_preview_valid_changed();
+  void construction_preview_summary_changed();
+
+private:
+  PlacementHost& m_host;
+};
+
+} // namespace App::ViewModels

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -430,7 +430,7 @@ Current AI test coverage includes:
 For repo validation, the reliable test binary is:
 
 ```bash
-./build/bin/standard_of_iron_tests --gtest_color=no --gtest_brief=1
+./build/bin/simulation_tests --gtest_color=no --gtest_brief=1
 ```
 
 ## What is already strong

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,8 +39,8 @@ enforced three ways:
 - `tests/architecture/layering_test.cpp` fails on an include of `scene/camera.h`
   from anywhere outside the view layer, and on any include of `app/` from
   `game/`;
-- `bin/headless_simulation_tests` links only `engine_core` and `game_sim`, so a
-  new dependency breaks its link step.
+- `bin/simulation_tests` links only `engine_core` and `game_sim` while covering
+  most of the gameplay suite, so a new dependency breaks its link step.
 
 `Qt::Gui` is present for the value types (`QVector3D`, `QImage`). It brings in no
 windowing or GL usage of our own.
@@ -148,20 +148,40 @@ but unclassified fails the build's test run, an authoritative component the
 serialiser never touches fails, and a derived component the serialiser _does_
 write fails.
 
+## Test binaries and what they enforce
+
+The suite is five binaries, split by link surface rather than by convenience:
+`simulation_tests` and `persistence_tests` link the kernel alone, `render_tests`
+adds `render_gl`, `app_tests` adds `app_core` and `ui_shell`, and `tools_tests`
+links the editor, arena and balance harnesses. `tests/README.md` has the table.
+
+Two rules make the split load-bearing: a test binary links production targets
+rather than re-compiling production `.cpp` files, and no test is excluded from
+the default run. `scripts/run-tests.sh` owns the suite list; the Makefile and
+all four CI workflows call it.
+
 ## The application layer
 
 `GameEngine` is the composition root: it owns the session, the renderer, the
 controllers and the services, and drives the frame.
 
-It is also, historically, the QML API — a surface of roughly 130 invokables and
-45 properties. That is being moved onto view models, one coherent slice at a
-time; `app/viewmodels/save_slots_view_model.h` is the first and shows the shape.
-`tests/architecture/qml_surface_test.cpp` caps the remaining surface so it can
-only shrink.
+It is also, historically, the QML API. That surface is being moved onto view
+models one coherent slice at a time, each exposed from `GameEngine` as a single
+CONSTANT property:
 
-Slices still on `GameEngine` and worth extracting next: placement (formation and
-construction previews), campaign progression, commander/FPV control, and camera
-control.
+- `game.saves` — `app/viewmodels/save_slots_view_model.h`
+- `game.placement` — `app/viewmodels/placement_view_model.h`: formation
+  placement, builder construction and building placement. It reaches back for
+  the few things only the root knows (lazy initialisation, the window mapping,
+  the local owner, the cursor) through `PlacementHost`, which is the shape a
+  further extraction should follow.
+
+`tests/architecture/qml_surface_test.cpp` caps what is left — currently 103
+invokables and 39 properties — so the surface can only shrink, and fails if a
+member is removed without lowering the ceiling.
+
+Slices still on `GameEngine` and worth extracting next: campaign progression,
+commander/FPV control, and camera control.
 
 ## Known limitations
 
@@ -174,3 +194,8 @@ These are real and deliberate, not oversights:
   they still derive from a small polymorphic base with a virtual destructor.
   Access is by dense type-id array index, not by RTTI.
 - `GameEngine` remains large. See above.
+- `game_sim` is still one target. Splitting it further (navigation, combat, AI,
+  economy, missions) is blocked on real cycles between those directories, not on
+  the CMake: `systems/_misc`, combat, movement, AI and units all include each
+  other today. Breaking those cycles is the prerequisite, and it is code work
+  rather than build work.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Runs every C++ test binary the project builds.
+#
+# The Makefile and all four CI workflows call this script, so there is one
+# answer to "what does running the tests mean" instead of five that drift. A
+# binary listed here that is missing from the build directory is an error, not a
+# skip -- silently not running a suite is how a suite stops working.
+#
+# usage: scripts/run-tests.sh [build-dir] [extra gtest args...]
+
+set -uo pipefail
+
+build_dir=${1:-build}
+if [ $# -gt 0 ]; then
+  shift
+fi
+bin_dir="${build_dir}/bin"
+
+# Keep in step with soi_test_binaries in tests/CMakeLists.txt.
+suites=(simulation_tests persistence_tests render_tests app_tests tools_tests)
+
+export QT_QPA_PLATFORM=${QT_QPA_PLATFORM:-offscreen}
+
+resolve() {
+  if [ -x "${bin_dir}/$1" ]; then
+    echo "${bin_dir}/$1"
+  elif [ -x "${bin_dir}/$1.exe" ]; then
+    echo "${bin_dir}/$1.exe"
+  fi
+}
+
+status=0
+failed=()
+
+for suite in "${suites[@]}"; do
+  binary=$(resolve "${suite}")
+  if [ -z "${binary}" ]; then
+    echo "error: ${bin_dir}/${suite} not built. Run 'make test-build' first." >&2
+    status=1
+    failed+=("${suite} (not built)")
+    continue
+  fi
+
+  echo "--- ${suite} ---"
+  if ! "${binary}" "$@"; then
+    status=1
+    failed+=("${suite}")
+  fi
+done
+
+# The QML design-system suite needs Qt QuickTest, which a minimal Qt install may
+# not ship. That one is genuinely optional, and CMake says so by not defining
+# the target at all.
+qml_binary=$(resolve design_system_qml_tests)
+if [ -n "${qml_binary}" ]; then
+  echo "--- design_system_qml_tests ---"
+  if ! "${qml_binary}" -input tests/ui/qml; then
+    status=1
+    failed+=("design_system_qml_tests")
+  fi
+else
+  echo "--- design_system_qml_tests skipped (Qt QuickTest not available) ---"
+fi
+
+if [ ${status} -ne 0 ]; then
+  echo ""
+  echo "failing suites: ${failed[*]}" >&2
+fi
+
+exit ${status}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,61 +1,65 @@
 # Test suite for Standard of Iron
 # Uses Google Test framework
+#
+# The suite is split by the boundary each binary exercises, not by convenience:
+#
+#   simulation_tests   the kernel. Links engine_core + game_sim and nothing
+#                      else, so a gameplay file that starts needing a camera,
+#                      the renderer or the application breaks the link step
+#                      rather than slipping in unnoticed.
+#   persistence_tests  the snapshot contract and the save stack. Kernel-only
+#                      link as well.
+#   render_tests       the renderer and the creature pipeline.
+#   app_tests          the application layer: view models, controllers, the
+#                      widget shell and the gameplay services that need a
+#                      camera or the app layer to be meaningful.
+#   tools_tests        the map editor, the arena and the balance harness.
+#   design_system_qml_tests
+#                      the QML design system, driven by QtQuickTest.
+#
+# Two rules keep this honest:
+#
+#  - a test binary links production targets; it never re-lists a production
+#    `.cpp` in its own source list. A separately compiled copy can pass while
+#    the object the game ships is broken.
+#  - no test is quarantined out of the default path. If a test cannot build or
+#    cannot pass, it is fixed or it is deleted with an issue, not omitted.
 
 set(_soi_optional_test_sources)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/render/creature/combat_visual_state_test.cpp")
     list(APPEND _soi_optional_test_sources render/creature/combat_visual_state_test.cpp)
 endif()
 
-# Test executable
+# Registers a binary with CTest and parks it beside the other executables.
+function(soi_register_test_binary target)
+    set_target_properties(
+        ${target}
+        PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" AUTOMOC ON
+    )
+    target_include_directories(${target} PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/game)
+    gtest_discover_tests(${target} DISCOVERY_MODE PRE_TEST WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endfunction()
+
+include(GoogleTest)
+
+# ---- simulation_tests --------------------------------------------------
+# The kernel under test with nothing on screen. `simulation_main.cpp` gives it a
+# QCoreApplication and the baked animation clips, and no more: a test that
+# reaches for a window fails here.
 add_executable(
-    standard_of_iron_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_assets.qrc
-    ${CMAKE_SOURCE_DIR}/translations.qrc
-    ${CMAKE_SOURCE_DIR}/tools/map_editor/map_data.cpp
-    ${CMAKE_SOURCE_DIR}/tools/map_editor/mission_data.cpp
-    ${CMAKE_SOURCE_DIR}/tools/map_editor/hill_projection_model.cpp
-    ${CMAKE_SOURCE_DIR}/tools/map_editor/commander_preview.cpp
-    ${CMAKE_SOURCE_DIR}/tools/map_editor/element_ops.cpp
-    ${CMAKE_SOURCE_DIR}/tools/map_editor/json_schema.cpp
+    simulation_tests
     session/session_context_test.cpp
     command/command_pipeline_test.cpp
-    save/snapshot_contract_test.cpp
     core/entity_handle_test.cpp
     core/serialization_test.cpp
     core/ground_type_test.cpp
     core/building_spawn_setup_test.cpp
-    core/audio_system_test.cpp
-    core/settings_persistence_test.cpp
-    ui/preferences_test.cpp
-    ui/selection_grouping_test.cpp
-    ui/icon_resources_test.cpp
-    ui/widget_theme_test.cpp
-    core/minimap_manager_test.cpp
-    core/commander_control_regression_test.cpp
-    core/commander_control_controller_test.cpp
-    core/input_command_handler_test.cpp
-    core/mission_commander_setup_test.cpp
-    core/mission_definition_view_test.cpp
-    core/production_manager_test.cpp
-    core/selection_query_service_test.cpp
-    core/rts_action_model_test.cpp
-    controllers/command_controller_test.cpp
-    core/runtime_frame_orchestrator_test.cpp
-    db/save_storage_test.cpp
-    db/save_format_test.cpp
-    db/save_load_service_test.cpp
-    db/save_preview_test.cpp
-    db/mission_progress_test.cpp
     map/terrain_profiles_test.cpp
-    map/terrain_service_test.cpp
-    map/minimap_generator_test.cpp
-    map/minimap_utils_test.cpp
     map/map_loader_test.cpp
     map/explored_mask_codec_test.cpp
     map/visibility_restore_test.cpp
     map/map_catalog_test.cpp
     map/map_weather_coverage_test.cpp
-    map/iron_sepulcher_skirmish_test.cpp
     map/terrain_topology_audit_test.cpp
     map/map_transformer_test.cpp
     map/mission_loader_test.cpp
@@ -75,14 +79,11 @@ add_executable(
     systems/troop_catalog_loader_test.cpp
     systems/stamina_system_test.cpp
     systems/home_manpower_system_test.cpp
-    systems/civilian_delivery_system_test.cpp
     systems/building_collision_test.cpp
-    systems/building_obstruction_lifecycle_test.cpp
     systems/combat_mode_test.cpp
     systems/hold_mode_test.cpp
     systems/defense_formation_test.cpp
     systems/rpg_engagement_system_test.cpp
-    systems/command_service_test.cpp
     systems/commander_system_test.cpp
     systems/pathfinding_test.cpp
     systems/production_system_test.cpp
@@ -97,6 +98,41 @@ add_executable(
     systems/gate_system_test.cpp
     systems/battle_movement_refactor_test.cpp
     systems/battlefield_capture_test.cpp
+    headless/headless_simulation_test.cpp
+    headless/gate_traversal_test.cpp
+    architecture/layering_test.cpp
+    architecture/qml_surface_test.cpp
+    architecture/documentation_accuracy_test.cpp
+    simulation_main.cpp
+)
+target_link_libraries(
+    simulation_tests
+    PRIVATE GTest::gtest GTest::gmock Qt${QT_VERSION_MAJOR}::Core engine_core game_sim
+)
+soi_register_test_binary(simulation_tests)
+
+# ---- persistence_tests -------------------------------------------------
+# What a save is, and whether the thing that writes it agrees. Kernel-only
+# link, because a mission snapshot must be complete without the application.
+add_executable(
+    persistence_tests
+    save/snapshot_contract_test.cpp
+    db/save_storage_test.cpp
+    db/save_format_test.cpp
+    db/save_load_service_test.cpp
+    db/mission_progress_test.cpp
+    headless/headless_main.cpp
+)
+target_link_libraries(
+    persistence_tests
+    PRIVATE GTest::gtest GTest::gmock Qt${QT_VERSION_MAJOR}::Core engine_core game_sim
+)
+soi_register_test_binary(persistence_tests)
+
+# ---- render_tests ------------------------------------------------------
+add_executable(
+    render_tests
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_assets.qrc
     render/pose_controller_test.cpp
     render/pose_controller_compatibility_test.cpp
     render/mounted_pose_controller_test.cpp
@@ -105,6 +141,7 @@ add_executable(
     render/equipment_loadout_catalog_test.cpp
     render/helmet_renderers_test.cpp
     render/armor_renderer_test.cpp
+    render/carthage_armor_bounds_test.cpp
     render/rider_proportions_test.cpp
     render/infantry_proportions_test.cpp
     render/horse_equipment_renderers_test.cpp
@@ -128,9 +165,6 @@ add_executable(
     render/linear_feature_visibility_test.cpp
     render/ground_utils_test.cpp
     render/dead_tree_mesh_test.cpp
-    architecture/layering_test.cpp
-    architecture/qml_surface_test.cpp
-    architecture/documentation_accuracy_test.cpp
     render/local_lighting_test.cpp
     render/contact_shadow_test.cpp
     render/weather_particle_budget_test.cpp
@@ -198,28 +232,61 @@ add_executable(
     render/software/software_backend_integration_test.cpp
     render/software/render_backend_factory_test.cpp
     render/profiling/frame_profile_test.cpp
-    tools/map_editor_map_data_test.cpp
-    tools/map_editor_mission_data_test.cpp
-    tools/map_editor_canvas_transform_test.cpp
-    tools/map_editor_element_ops_test.cpp
-    tools/map_editor_json_schema_test.cpp
-    tools/hill_projection_model_test.cpp
-    tools/map_editor_commander_preview_test.cpp
-    ${CMAKE_SOURCE_DIR}/tools/arena/unit_panel.cpp
-    ${CMAKE_SOURCE_DIR}/tools/arena/building_panel.cpp
-    tools/arena_scenarios_test.cpp
-    tools/arena_scenario_runner_test.cpp
-    tools/arena_frame_continuity_test.cpp
-    tools/arena_panel_population_test.cpp
-    tools/arena_unit_spawn_options_test.cpp
-    tools/arena_terrain_alignment_test.cpp
-    tools/balance_sim_test.cpp
     test_main.cpp
 )
-
-# Link against GTest, project libraries
 target_link_libraries(
-    standard_of_iron_tests
+    render_tests
+    PRIVATE
+        GTest::gtest
+        GTest::gmock
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Gui
+        Qt${QT_VERSION_MAJOR}::Widgets
+        engine_core
+        render_gl
+        game_systems
+)
+set_target_properties(render_tests PROPERTIES AUTORCC ON)
+soi_register_test_binary(render_tests)
+if(TARGET bake_creature_assets)
+    add_dependencies(render_tests bake_creature_assets)
+endif()
+
+# ---- app_tests ---------------------------------------------------------
+# View models, controllers, the widget shell, and the gameplay services that
+# only mean something with a camera or the application around them.
+add_executable(
+    app_tests
+    ${CMAKE_SOURCE_DIR}/translations.qrc
+    core/audio_system_test.cpp
+    db/save_preview_test.cpp
+    core/settings_persistence_test.cpp
+    core/minimap_manager_test.cpp
+    core/commander_control_regression_test.cpp
+    core/commander_control_controller_test.cpp
+    core/input_command_handler_test.cpp
+    core/mission_commander_setup_test.cpp
+    core/mission_definition_view_test.cpp
+    core/production_manager_test.cpp
+    core/selection_query_service_test.cpp
+    core/rts_action_model_test.cpp
+    core/runtime_frame_orchestrator_test.cpp
+    controllers/command_controller_test.cpp
+    ui/preferences_test.cpp
+    ui/selection_grouping_test.cpp
+    ui/icon_resources_test.cpp
+    ui/widget_theme_test.cpp
+    map/minimap_generator_test.cpp
+    map/minimap_utils_test.cpp
+    map/terrain_service_test.cpp
+    map/iron_sepulcher_skirmish_test.cpp
+    systems/civilian_delivery_system_test.cpp
+    systems/building_obstruction_lifecycle_test.cpp
+    systems/command_service_test.cpp
+    test_main.cpp
+)
+target_link_libraries(
+    app_tests
     PRIVATE
         GTest::gtest
         GTest::gmock
@@ -233,66 +300,58 @@ target_link_libraries(
         game_systems
         app_core
         ui_shell
-        arena_scenario_harness
-        balance_sim_harness
         audio_system
 )
-
-# Include directories
-target_include_directories(
-    standard_of_iron_tests
-    PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/game
-)
-
-# Set output directory
-set_target_properties(
-    standard_of_iron_tests
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" AUTORCC ON
-)
-
+set_target_properties(app_tests PROPERTIES AUTORCC ON)
+soi_register_test_binary(app_tests)
 if(TARGET bake_creature_assets)
-    add_dependencies(standard_of_iron_tests bake_creature_assets)
+    add_dependencies(app_tests bake_creature_assets)
 endif()
 
-# Add tests to CTest after target properties are finalized.
-include(GoogleTest)
-gtest_discover_tests(
-    standard_of_iron_tests
-    DISCOVERY_MODE PRE_TEST
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-# ---- Headless simulation binary ----
-# Links the simulation kernel and nothing else. The value is as much in the link
-# step as in the assertions: a gameplay file that starts depending on scene_core
-# or render_gl breaks this target immediately, which is the boundary item 1 of
-# the architecture review asked the build to enforce.
+# ---- tools_tests -------------------------------------------------------
+# The map editor document model, the arena harness and the balance runner --
+# all linked from the libraries those tools ship.
 add_executable(
-    headless_simulation_tests
-    headless/headless_simulation_test.cpp
-    headless/gate_traversal_test.cpp
-    headless/headless_main.cpp
+    tools_tests
+    tools/map_editor_map_data_test.cpp
+    tools/map_editor_mission_data_test.cpp
+    tools/map_editor_canvas_transform_test.cpp
+    tools/map_editor_element_ops_test.cpp
+    tools/map_editor_json_schema_test.cpp
+    tools/hill_projection_model_test.cpp
+    tools/map_editor_commander_preview_test.cpp
+    tools/arena_scenarios_test.cpp
+    tools/arena_scenario_runner_test.cpp
+    tools/arena_frame_continuity_test.cpp
+    tools/arena_panel_population_test.cpp
+    tools/arena_unit_spawn_options_test.cpp
+    tools/arena_terrain_alignment_test.cpp
+    tools/balance_sim_test.cpp
+    test_main.cpp
 )
 target_link_libraries(
-    headless_simulation_tests
-    PRIVATE GTest::gtest Qt${QT_VERSION_MAJOR}::Core engine_core game_sim
+    tools_tests
+    PRIVATE
+        GTest::gtest
+        GTest::gmock
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Gui
+        Qt${QT_VERSION_MAJOR}::Widgets
+        engine_core
+        render_gl
+        game_systems
+        map_editor_core
+        arena_scenario_harness
+        arena_panels
+        balance_sim_harness
 )
-target_include_directories(
-    headless_simulation_tests
-    PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/game
-)
-set_target_properties(
-    headless_simulation_tests
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" AUTOMOC ON
-)
-gtest_discover_tests(
-    headless_simulation_tests
-    DISCOVERY_MODE PRE_TEST
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
+soi_register_test_binary(tools_tests)
+if(TARGET bake_creature_assets)
+    add_dependencies(tools_tests bake_creature_assets)
+endif()
 
-# Focused horse contract binary. It remains runnable when an unrelated test
-# translation unit in the monolithic suite has interface drift.
+# Focused horse contract binary. It stays runnable when an unrelated test
+# translation unit in the render suite has interface drift.
 add_executable(horse_model_tests render/horse/horse_anatomy_test.cpp test_main.cpp)
 target_link_libraries(
     horse_model_tests
@@ -305,19 +364,10 @@ target_link_libraries(
         render_gl
         game_systems
 )
-target_include_directories(horse_model_tests PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/game)
-set_target_properties(
-    horse_model_tests
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" AUTOMOC ON
-)
+soi_register_test_binary(horse_model_tests)
 if(TARGET bake_creature_assets)
     add_dependencies(horse_model_tests bake_creature_assets)
 endif()
-gtest_discover_tests(
-    horse_model_tests
-    DISCOVERY_MODE PRE_TEST
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
 
 add_executable(elephant_model_tests render/elephant/elephant_source_asset_test.cpp test_main.cpp)
 target_link_libraries(
@@ -331,74 +381,9 @@ target_link_libraries(
         render_gl
         game_systems
 )
-target_include_directories(
-    elephant_model_tests
-    PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/game
-)
-set_target_properties(
-    elephant_model_tests
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" AUTOMOC ON
-)
+soi_register_test_binary(elephant_model_tests)
 if(TARGET bake_creature_assets)
     add_dependencies(elephant_model_tests bake_creature_assets)
-endif()
-gtest_discover_tests(
-    elephant_model_tests
-    DISCOVERY_MODE PRE_TEST
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-# --- Subset test binary -------------------------------------------------
-# Three test files have pre-existing compile breakage as of Stage 15.5c
-# (equipment_registry_test.cpp / helmet_renderers_test.cpp /
-# horse_equipment_renderers_test.cpp rely on a MockEquipmentRenderer
-# whose interface drifted from the real registry). Fixing those is
-# out-of-scope for the 15.5x switchover series, so we build a subset
-# binary that skips them and run it as the per-stage verification.
-get_target_property(_soi_tests_sources standard_of_iron_tests SOURCES)
-set(_soi_tests_subset_sources)
-foreach(src IN LISTS _soi_tests_sources)
-    get_filename_component(_name "${src}" NAME)
-    if(
-        NOT _name STREQUAL "equipment_registry_test.cpp"
-        AND NOT _name STREQUAL "helmet_renderers_test.cpp"
-        AND NOT _name STREQUAL "horse_equipment_renderers_test.cpp"
-    )
-        list(APPEND _soi_tests_subset_sources "${src}")
-    endif()
-endforeach()
-
-add_executable(standard_of_iron_tests_subset ${_soi_tests_subset_sources})
-target_link_libraries(
-    standard_of_iron_tests_subset
-    PRIVATE
-        GTest::gtest
-        GTest::gmock
-        Qt${QT_VERSION_MAJOR}::Core
-        Qt${QT_VERSION_MAJOR}::Gui
-        Qt${QT_VERSION_MAJOR}::Quick
-        Qt${QT_VERSION_MAJOR}::Sql
-        Qt${QT_VERSION_MAJOR}::Widgets
-        engine_core
-        render_gl
-        game_systems
-        app_core
-        ui_shell
-        arena_scenario_harness
-        balance_sim_harness
-        audio_system
-)
-target_include_directories(
-    standard_of_iron_tests_subset
-    PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/game
-)
-set_target_properties(
-    standard_of_iron_tests_subset
-    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" AUTOMOC ON AUTOUIC ON AUTORCC ON
-)
-
-if(TARGET bake_creature_assets)
-    add_dependencies(standard_of_iron_tests_subset bake_creature_assets)
 endif()
 
 # ---- QML design system regression tests ----
@@ -434,11 +419,13 @@ if(TARGET Qt${QT_VERSION_MAJOR}::QuickTest)
     )
     # The design system is presentation-only; a real GPU adds nothing to assert.
     set_tests_properties(design_system_qml PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
-else()
-    message(STATUS "Qt QuickTest not found; skipping design_system_qml_tests")
 endif()
 
-add_custom_target(soi_test_binaries DEPENDS standard_of_iron_tests)
+# Everything `make test` runs. Keep this list and scripts/run-tests.sh in step.
+add_custom_target(
+    soi_test_binaries
+    DEPENDS simulation_tests persistence_tests render_tests app_tests tools_tests
+)
 if(TARGET design_system_qml_tests)
     add_dependencies(soi_test_binaries design_system_qml_tests)
 endif()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,222 +1,96 @@
-# Standard of Iron - Test Suite
+# Standard of Iron — test suite
 
-This directory contains unit and integration tests for the Standard of Iron project using Google Test.
+Around 2,700 GoogleTest cases across five binaries, plus a QtQuickTest suite for
+the QML design system. The split is not organisational tidiness: each binary
+links a different slice of the project, so the boundary it sits behind is
+enforced by the link step rather than by review.
 
-## Structure
+## The binaries
 
-```
-tests/
-├── core/              # Core engine tests
-│   └── serialization_test.cpp  # Entity/World serialization tests
-├── db/                # Database tests
-│   └── save_storage_test.cpp   # SQLite save/load tests
-└── CMakeLists.txt     # Test build configuration
-```
+| Binary                    | Links                                                 | Covers                                                                                                                                                                           |
+| ------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `simulation_tests`        | `engine_core`, `game_sim`                             | The simulation kernel: session, command pipeline, ECS, systems (combat, movement, AI, pathfinding, production, formations), map and mission loading, and the architecture guards |
+| `persistence_tests`       | `engine_core`, `game_sim`                             | The snapshot contract, the save format, the save database and mission progress                                                                                                   |
+| `render_tests`            | `+ render_gl`                                         | The renderer, the creature/equipment pipeline, the software rasteriser                                                                                                           |
+| `app_tests`               | `+ app_core`, `ui_shell`                              | View models, controllers, the widget shell, and the gameplay services that need a camera or the application around them                                                          |
+| `tools_tests`             | `+ map_editor_core`, `arena_*`, `balance_sim_harness` | The map editor document model, the arena harness and the balance runner                                                                                                          |
+| `design_system_qml_tests` | `ui_shell`                                            | The QML design system, driven by QtQuickTest. Skipped when Qt QuickTest is not installed                                                                                         |
 
-## Running Tests
+Two rules keep the split meaningful:
 
-### Build and Run All Tests
+- **A test binary links production targets.** It never re-lists a production
+  `.cpp` in its own source list — a separately compiled copy can pass while the
+  object the game ships is broken.
+- **No test is quarantined.** Nothing is excluded from the default run. A test
+  that cannot build or cannot pass is fixed or deleted with an issue.
 
-```bash
-make test
-```
+`simulation_tests` is the one to watch. It links the kernel and nothing else, so
+a gameplay file that starts needing a camera, the renderer or `app/` breaks its
+link step. `tests/architecture/layering_test.cpp` says the same thing about
+includes, and `documentation_accuracy_test.cpp` checks that the README and
+`docs/ARCHITECTURE.md` still describe the code that exists.
 
-### Run Tests Directly
-
-```bash
-cd build
-./bin/standard_of_iron_tests
-```
-
-### Run Specific Tests
-
-```bash
-# Run only serialization tests
-./bin/standard_of_iron_tests --gtest_filter=SerializationTest.*
-
-# Run only database tests
-./bin/standard_of_iron_tests --gtest_filter=SaveStorageTest.*
-
-# Run a specific test case
-./bin/standard_of_iron_tests --gtest_filter=SerializationTest.EntitySerializationBasic
-```
-
-### Verbose Output
+## Running them
 
 ```bash
-./bin/standard_of_iron_tests --gtest_color=yes
+make test              # configure, build the test binaries, run all of them
+make test-only         # run them without rebuilding
 ```
 
-## Test Categories
+`make test` shells out to `scripts/run-tests.sh`, which the CI workflows also
+call — so there is one answer to "what does running the tests mean" rather than
+one per workflow.
 
-### Core Serialization Tests (`core/serialization_test.cpp`)
-
-Tests for JSON serialization and deserialization of game objects:
-
-- **Entity serialization**: Basic entity save/load
-- **Component serialization**: All component types fully tested
-    - TransformComponent (position, rotation, scale)
-    - RenderableComponent (mesh, texture, visibility, color)
-    - UnitComponent (health, speed, vision, nation)
-    - MovementComponent (targets, paths, velocity)
-    - AttackComponent (range, damage, combat modes)
-    - AttackTargetComponent (target tracking, chase behavior)
-    - PatrolComponent (waypoints, patrol state)
-    - ProductionComponent (build queues, rally points)
-    - BuildingComponent (building marker)
-    - AIControlledComponent (AI flag)
-    - CaptureComponent (capture progress, player state)
-- **Round-trip testing**: Serialize→Deserialize→Verify data integrity for all components
-- **Complete entity**: Test entity with all components attached
-- **Edge cases**: Missing fields, malformed JSON, default values
-- **File I/O**: Save to file and load from file
-
-### Database Integration Tests (`db/save_storage_test.cpp`)
-
-Tests for SQLite-based save game storage:
-
-- **Initialization**: In-memory database setup
-- **Save/Load**: Store and retrieve save slots
-- **Schema management**: Database schema creation and validation
-- **Error handling**: Non-existent slots, constraint violations
-- **Complex data**: Large saves, complex metadata, special characters
-- **CRUD operations**: List, delete, and overwrite slots
-
-## Adding New Tests
-
-### 1. Create a New Test File
-
-```cpp
-#include <gtest/gtest.h>
-// Include necessary headers
-
-class MyFeatureTest : public ::testing::Test {
-protected:
-    void SetUp() override {
-        // Setup code
-    }
-
-    void TearDown() override {
-        // Cleanup code
-    }
-};
-
-TEST_F(MyFeatureTest, TestCase) {
-    // Test code
-    EXPECT_EQ(expected, actual);
-}
-```
-
-### 2. Add to CMakeLists.txt
-
-```cmake
-add_executable(standard_of_iron_tests
-    core/serialization_test.cpp
-    db/save_storage_test.cpp
-    your_category/your_test.cpp  # Add your test here
-)
-```
-
-### 3. Rebuild and Run
+Directly:
 
 ```bash
-make test
+./build/bin/simulation_tests
+./build/bin/render_tests --gtest_filter=CarthageArmorBoundsTest.*
+bash scripts/run-tests.sh build --gtest_brief=1
 ```
 
-## Test Conventions
-
-### Naming
-
-- Test suite names should match the class/feature being tested
-- Test case names should describe what is being tested
-- Use descriptive names: `TEST_F(SerializationTest, EntityDeserializationRoundTrip)`
-
-### Assertions
-
-- Use `EXPECT_*` for non-fatal assertions (test continues)
-- Use `ASSERT_*` for fatal assertions (test stops)
-- Common assertions:
-    - `EXPECT_EQ(a, b)` - equality
-    - `EXPECT_TRUE(condition)` - boolean true
-    - `EXPECT_FLOAT_EQ(a, b)` - floating-point equality
-    - `EXPECT_NE(a, b)` - not equal
-
-### Test Organization
-
-- Group related tests in the same test fixture
-- Use descriptive test names
-- Test one thing per test case
-- Keep tests independent
-
-## Dependencies
-
-The test suite uses:
-
-- **Google Test** (v1.14.0) - Testing framework
-- **Qt6/Qt5** - Core, Gui, SQL modules
-- **engine_core** - Core game engine library
-- **game_systems** - Game systems library
-
-## Continuous Integration
-
-Tests are automatically run in CI when:
-
-- Pull requests are created
-- Code is pushed to main branch
-- Release builds are created
-
-## Coverage
-
-Current test coverage focuses on:
-
-- ✅ **Complete entity and component serialization** (all 11 serializable components)
-    - TransformComponent, RenderableComponent, UnitComponent
-    - MovementComponent, AttackComponent, AttackTargetComponent
-    - PatrolComponent, ProductionComponent, BuildingComponent
-    - AIControlledComponent, CaptureComponent
-- ✅ World serialization (multi-entity persistence)
-- ✅ SQLite save/load operations (in-memory testing)
-- ✅ Database CRUD operations (create, read, update, delete)
-- ✅ Error handling and edge cases (missing fields, malformed JSON)
-- ✅ Round-trip testing for data integrity (all components)
-
-Future coverage should include:
-
-- [ ] Terrain serialization
-- [ ] AI system testing
-- [ ] Combat system testing
-- [ ] Pathfinding tests
-- [ ] Production system tests
-
-## Troubleshooting
-
-### Tests Not Found
-
-If tests aren't being discovered:
+Anything that opens a window needs `QT_QPA_PLATFORM=offscreen`;
+`scripts/run-tests.sh` sets it. `TEST_ARGS` forwards GoogleTest flags through
+the Makefile:
 
 ```bash
-rm -rf build
-make configure
-make build
+make test-only TEST_ARGS="--gtest_filter=SaveLoadServiceTest.*"
 ```
 
-### Database Lock Errors
+Two focused binaries exist alongside the five: `horse_model_tests` and
+`elephant_model_tests` build one contract file each, so they stay runnable when
+an unrelated translation unit in the render suite has interface drift.
 
-Tests use in-memory databases (`:memory:`), so file locks shouldn't occur. If they do:
+## Adding a test
 
-- Check for orphaned test processes
-- Restart your terminal
+1. Put the file under the directory matching what it exercises (`systems/`,
+   `render/`, `map/`, `db/`, …).
+2. Add it to the source list of the binary whose link surface it needs, in
+   `tests/CMakeLists.txt`. If a kernel test needs the renderer in order to
+   compile, that dependency is the finding — fix it rather than moving the test
+   up a tier.
+3. `make test`.
 
-### Qt-related Errors
+Fixtures should leave nothing behind. A `SessionContext` plus `ScopedSession`
+gives a test its own world, terrain, ownership, economy and clock; anything
+reached through a registry `instance()` resolves through that session, so tests
+no longer leak into each other through globals. A signal connection made to a
+process-wide singleton must be bound to a context object that dies with the
+test, or it will outlive the stack it captured.
 
-Ensure Qt development packages are installed:
+## Conventions
 
-```bash
-make install  # Installs dependencies
-```
+- `EXPECT_*` continues on failure, `ASSERT_*` stops. Use `ASSERT_*` when the
+  rest of the test would crash or assert nothing.
+- Name the case after the behaviour, not the method:
+  `HeavyArmorHangsBelowTheLightOneButStaysOffTheGround`.
+- Prefer relationships and frame-relative bounds over tuned constants, so a test
+  keeps meaning when the thing it measures is re-authored.
+- One behaviour per case; keep cases independent of ordering.
 
-## References
+## CI
 
-- [Google Test Documentation](https://google.github.io/googletest/)
-- [Google Test Primer](https://google.github.io/googletest/primer.html)
-- [Google Test Advanced Guide](https://google.github.io/googletest/advanced.html)
+`.github/workflows/pr.yml` builds `soi_test_binaries` and runs
+`scripts/run-tests.sh`; the three platform build workflows run the same script
+after their build. A suite missing from the build directory is an error there,
+not a skip.

--- a/tests/architecture/qml_surface_test.cpp
+++ b/tests/architecture/qml_surface_test.cpp
@@ -33,8 +33,8 @@ auto count_occurrences(const fs::path& file, const std::string& needle) -> int {
   return count;
 }
 
-constexpr int k_max_invokables = 129;
-constexpr int k_max_properties = 46;
+constexpr int k_max_invokables = 103;
+constexpr int k_max_properties = 39;
 
 constexpr const char* k_guidance =
     "\nGameEngine is the composition root, not the UI API. New QML-facing "
@@ -73,6 +73,27 @@ TEST(QmlSurface, CeilingsStayTight) {
       << "members were removed; lower k_max_invokables to lock the win in";
   EXPECT_GE(count_occurrences(header, "Q_PROPERTY"), k_max_properties - 10)
       << "members were removed; lower k_max_properties to lock the win in";
+}
+
+TEST(QmlSurface, PlacementLivesOnItsOwnViewModel) {
+  const auto root = find_repo_root();
+  const auto engine = root / "app" / "core" / "game_engine.h";
+  const auto view_model = root / "app" / "viewmodels" / "placement_view_model.h";
+  ASSERT_TRUE(fs::exists(engine));
+  ASSERT_TRUE(fs::exists(view_model));
+
+  for (const char* member : {"on_formation_confirm",
+                             "on_construction_confirm",
+                             "construction_preview_valid",
+                             "pending_builder_construction_type",
+                             "start_builder_construction",
+                             "start_building_placement",
+                             "get_construction_info"}) {
+    EXPECT_EQ(count_occurrences(engine, member), 0)
+        << member << " is still declared on GameEngine";
+    EXPECT_GT(count_occurrences(view_model, member), 0)
+        << member << " is missing from PlacementViewModel";
+  }
 }
 
 TEST(QmlSurface, SaveSlotBrowsingLivesOnItsOwnViewModel) {

--- a/tests/render/carthage_armor_bounds_test.cpp
+++ b/tests/render/carthage_armor_bounds_test.cpp
@@ -1,206 +1,118 @@
 #include <QMatrix4x4>
 #include <QVector3D>
 
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <limits>
 #include <sstream>
-#include <vector>
 
 #include "render/equipment/armor/armor_heavy_carthage.h"
 #include "render/equipment/armor/armor_light_carthage.h"
-#include "render/humanoid/humanoid_renderer_base.h"
-#include "render/humanoid/style_palette.h"
+#include "render/equipment/equipment_submit.h"
+#include "render/gl/humanoid/humanoid_types.h"
 
 using namespace Render::GL;
 
 namespace {
 
-struct MeshBounds {
-  QVector3D min;
-  QVector3D max;
-  int material_id = 0;
+auto reference_frames() -> BodyFrames {
+  BodyFrames frames{};
+  frames.torso.origin = QVector3D(0.0F, 1.10F, 0.0F);
+  frames.torso.right = QVector3D(1.0F, 0.0F, 0.0F);
+  frames.torso.up = QVector3D(0.0F, 1.0F, 0.0F);
+  frames.torso.forward = QVector3D(0.0F, 0.0F, 1.0F);
+  frames.torso.radius = 0.34F;
+  frames.torso.depth = 0.25F;
+  frames.waist.origin = QVector3D(0.0F, 0.72F, 0.0F);
+  frames.waist.right = frames.torso.right;
+  frames.waist.up = frames.torso.up;
+  frames.waist.forward = frames.torso.forward;
+  frames.waist.radius = 0.28F;
+  frames.waist.depth = 0.22F;
+  frames.head.origin = QVector3D(0.0F, 1.78F, 0.0F);
+  frames.head.up = frames.torso.up;
+  frames.head.radius = 0.16F;
+  frames.foot_l.origin = QVector3D(-0.12F, 0.0F, 0.0F);
+  frames.foot_r.origin = QVector3D(0.12F, 0.0F, 0.0F);
+  return frames;
+}
+
+struct BatchBounds {
+  float min_y = std::numeric_limits<float>::max();
+  float max_y = std::numeric_limits<float>::lowest();
+  std::size_t vertex_count = 0;
 };
 
-class BoundsSubmitter : public ISubmitter {
-public:
-  std::vector<MeshBounds> meshes;
+auto bounds_of(const EquipmentBatch& batch) -> BatchBounds {
+  BatchBounds bounds;
 
-  void mesh(Mesh* mesh,
-            const QMatrix4x4& model,
-            const QVector3D&,
-            Texture* = nullptr,
-            float = 1.0F,
-            int material_id = 0) override {
+  const auto include = [&bounds](const QMatrix4x4& world, const Mesh* mesh) {
     if (mesh == nullptr) {
       return;
     }
-
-    MeshBounds b;
-    b.min = QVector3D(std::numeric_limits<float>::max(),
-                      std::numeric_limits<float>::max(),
-                      std::numeric_limits<float>::max());
-    b.max = QVector3D(std::numeric_limits<float>::lowest(),
-                      std::numeric_limits<float>::lowest(),
-                      std::numeric_limits<float>::lowest());
-    b.material_id = material_id;
-
-    for (const auto& v : mesh->getVertices()) {
-      QVector3D p(v.position[0], v.position[1], v.position[2]);
-      QVector3D world = model.map(p);
-      b.min.setX(std::min(b.min.x(), world.x()));
-      b.min.setY(std::min(b.min.y(), world.y()));
-      b.min.setZ(std::min(b.min.z(), world.z()));
-      b.max.setX(std::max(b.max.x(), world.x()));
-      b.max.setY(std::max(b.max.y(), world.y()));
-      b.max.setZ(std::max(b.max.z(), world.z()));
+    for (const auto& vertex : mesh->get_vertices()) {
+      const QVector3D point = world.map(
+          QVector3D(vertex.position[0], vertex.position[1], vertex.position[2]));
+      bounds.min_y = std::min(bounds.min_y, point.y());
+      bounds.max_y = std::max(bounds.max_y, point.y());
+      ++bounds.vertex_count;
     }
+  };
 
-    meshes.push_back(b);
+  for (const auto& submission : batch.meshes) {
+    include(submission.model, submission.mesh);
+  }
+  for (const auto& prim : batch.archetypes) {
+    if (prim.archetype == nullptr) {
+      continue;
+    }
+    for (const auto& draw : prim.archetype->lods[0].draws) {
+      include(prim.world * draw.local_model, draw.mesh);
+    }
   }
 
-  void cylinder(
-      const QVector3D&, const QVector3D&, float, const QVector3D&, float) override {}
-  void selection_ring(const QMatrix4x4&, float, float, const QVector3D&) override {}
-  void grid(const QMatrix4x4&, const QVector3D&, float, float, float) override {}
-  void selection_smoke(const QMatrix4x4&, const QVector3D&, float) override {}
-};
+  return bounds;
+}
 
-class TestCarthageSpearmanBase : public HumanoidRendererBase {
-public:
-  auto get_proportion_scaling() const -> QVector3D override {
-    return {0.94F, 1.04F, 0.92F};
-  }
-
-  void adjust_variation(const DrawContext&,
-                        uint32_t,
-                        VariationParams& variation) const override {
-    variation.bulk_scale *= 0.90F;
-    variation.stance_width *= 0.92F;
-  }
-};
-
-class TestCarthageSwordsmanBase : public HumanoidRendererBase {
-public:
-  auto get_proportion_scaling() const -> QVector3D override {
-    return {0.95F, 1.05F, 0.95F};
-  }
-};
-
-struct PoseResult {
-  HumanoidPose pose;
-  HumanoidVariant variant;
-  DrawContext ctx;
-};
+auto describe(const char* what, const BatchBounds& bounds) -> std::string {
+  std::ostringstream out;
+  out << what << ": y=[" << bounds.min_y << ", " << bounds.max_y << "] over "
+      << bounds.vertex_count << " vertices";
+  return out.str();
+}
 
 template <typename Renderer>
-class PoseBuilder : public Renderer {
-public:
-  auto build(uint32_t seed) -> PoseResult {
-    VariationParams variation = VariationParams::from_seed(seed);
-    this->adjust_variation(DrawContext{}, seed, variation);
+auto armor_bounds() -> BatchBounds {
+  const DrawContext ctx{};
+  const HumanoidPalette palette{};
+  const HumanoidAnimationContext anim{};
+  EquipmentBatch batch;
 
-    const QVector3D prop_scale = this->get_proportion_scaling();
-    const float combined_height_scale = prop_scale.y() * variation.height_scale;
-
-    PoseResult result;
-    result.ctx.model.scale(variation.bulk_scale, combined_height_scale, 1.0F);
-
-    AnimationInputs inputs{};
-    inputs.time = 0.0F;
-    inputs.movement_state = Render::Creature::MovementAnimationState::Idle;
-    inputs.is_attacking = false;
-    inputs.is_melee = false;
-    inputs.is_in_hold_mode = false;
-    inputs.is_exiting_hold = false;
-    inputs.hold_exit_progress = 0.0F;
-
-    HumanoidPose pose;
-    this->computeLocomotionPose(
-        seed,
-        inputs.time,
-        Render::Creature::is_moving_animation(inputs.movement_state),
-        variation,
-        pose);
-
-    HumanoidVariant variant;
-    QVector3D team_tint(0.8F, 0.9F, 1.0F);
-    variant.palette = makeHumanoidPalette(team_tint, seed);
-
-    BoundsSubmitter sink;
-    this->drawCommonBody(result.ctx, variant, pose, sink);
-
-    result.pose = pose;
-    result.variant = variant;
-    return result;
-  }
-};
-
-auto extract_min_y(const std::vector<MeshBounds>& meshes) -> float {
-  float min_y = std::numeric_limits<float>::max();
-  for (const auto& m : meshes) {
-    min_y = std::min(min_y, m.min.y());
-  }
-  return min_y;
+  Renderer armor;
+  armor.render(ctx, reference_frames(), palette, anim, batch);
+  return bounds_of(batch);
 }
 
 } // namespace
 
-TEST(CarthageArmorBoundsTest, LightArmorStaysNearWaist) {
-  PoseBuilder<TestCarthageSpearmanBase> renderer;
-  auto pose_result = renderer.build(1337U);
+TEST(CarthageArmorBoundsTest, LightArmorIsABandAtTheWaist) {
+  const BodyFrames frames = reference_frames();
+  const BatchBounds bounds = armor_bounds<ArmorLightCarthageRenderer>();
+  ASSERT_GT(bounds.vertex_count, 0U) << "the light cuirass emitted no geometry";
+  SCOPED_TRACE(describe("light", bounds));
 
-  ArmorLightCarthageRenderer armor;
-  HumanoidAnimationContext anim_ctx{};
-  BoundsSubmitter submitter;
-  armor.render(pose_result.ctx,
-               pose_result.pose.body_frames,
-               pose_result.variant.palette,
-               anim_ctx,
-               submitter);
-
-  std::ostringstream debug;
-  for (size_t i = 0; i < submitter.meshes.size(); ++i) {
-    const auto& m = submitter.meshes[i];
-    debug << "#" << i << ": [" << m.min.y() << ", " << m.max.y() << "] (mat "
-          << m.material_id << ") ";
-  }
-  debug << "waist_r=" << pose_result.pose.body_frames.waist.radius;
-  SCOPED_TRACE(debug.str());
-
-  float const armor_min_y = extract_min_y(submitter.meshes);
-  float const waist_y =
-      pose_result.ctx.model.map(pose_result.pose.body_frames.waist.origin).y();
-
-  EXPECT_GT(armor_min_y, waist_y - 0.05F)
-      << "min_y=" << armor_min_y << " waist_y=" << waist_y;
+  EXPECT_GT(bounds.min_y, frames.waist.origin.y() - frames.waist.radius);
+  EXPECT_LT(bounds.max_y, frames.head.origin.y());
 }
 
-TEST(CarthageArmorBoundsTest, HeavyArmorStaysNearWaist) {
-  PoseBuilder<TestCarthageSwordsmanBase> renderer;
-  auto pose_result = renderer.build(4242U);
+TEST(CarthageArmorBoundsTest, HeavyArmorHangsBelowTheLightOneButStaysOffTheGround) {
+  const BodyFrames frames = reference_frames();
+  const BatchBounds heavy = armor_bounds<ArmorHeavyCarthageRenderer>();
+  const BatchBounds light = armor_bounds<ArmorLightCarthageRenderer>();
+  ASSERT_GT(heavy.vertex_count, 0U) << "the heavy cuirass emitted no geometry";
+  SCOPED_TRACE(describe("heavy", heavy) + "  " + describe("light", light));
 
-  ArmorHeavyCarthageRenderer armor;
-  HumanoidAnimationContext anim_ctx{};
-  BoundsSubmitter submitter;
-  armor.render(pose_result.ctx,
-               pose_result.pose.body_frames,
-               pose_result.variant.palette,
-               anim_ctx,
-               submitter);
-
-  std::ostringstream debug;
-  for (size_t i = 0; i < submitter.meshes.size(); ++i) {
-    const auto& m = submitter.meshes[i];
-    debug << "#" << i << ": [" << m.min.y() << ", " << m.max.y() << "] (mat "
-          << m.material_id << ") ";
-  }
-  debug << "waist_r=" << pose_result.pose.body_frames.waist.radius;
-  SCOPED_TRACE(debug.str());
-
-  float const armor_min_y = extract_min_y(submitter.meshes);
-  float const waist_y =
-      pose_result.ctx.model.map(pose_result.pose.body_frames.waist.origin).y();
-
-  EXPECT_GT(armor_min_y, waist_y - 0.70F)
-      << "min_y=" << armor_min_y << " waist_y=" << waist_y;
+  EXPECT_LT(heavy.min_y, light.min_y);
+  EXPECT_GT(heavy.min_y, frames.foot_l.origin.y());
+  EXPECT_LT(heavy.max_y, frames.head.origin.y());
 }

--- a/tests/simulation_main.cpp
+++ b/tests/simulation_main.cpp
@@ -1,0 +1,39 @@
+#include <QCoreApplication>
+
+#include <array>
+#include <filesystem>
+#include <gtest/gtest.h>
+
+#include "animation/bpat/bpat_registry.h"
+
+namespace {
+
+void load_baked_clips(const QCoreApplication& app) {
+  namespace fs = std::filesystem;
+  const fs::path app_dir = fs::path(app.applicationDirPath().toStdString());
+  const std::array<fs::path, 8> roots{
+      fs::current_path() / "assets" / "creatures",
+      fs::current_path() / ".." / "assets" / "creatures",
+      fs::current_path() / ".." / ".." / "assets" / "creatures",
+      app_dir / "assets" / "creatures",
+      app_dir / ".." / "assets" / "creatures",
+      app_dir / ".." / ".." / "assets" / "creatures",
+      fs::path("build") / "bin" / "assets" / "creatures",
+      fs::path("assets") / "creatures",
+  };
+  for (const auto& root : roots) {
+    if (fs::exists(root / "humanoid.bpat")) {
+      Render::Creature::Bpat::BpatRegistry::instance().load_all(root.string());
+      return;
+    }
+  }
+}
+
+} // namespace
+
+auto main(int argc, char** argv) -> int {
+  QCoreApplication app(argc, argv);
+  load_baked_clips(app);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/ui/preferences_test.cpp
+++ b/tests/ui/preferences_test.cpp
@@ -108,10 +108,13 @@ TEST_F(UiPreferencesTest, CorruptedStoredValuesFallBackToDefaults) {
 
 TEST_F(UiPreferencesTest, ChangeSignalsFireOnlyOnRealChanges) {
   auto* prefs = UiPreferences::instance();
+
+  QObject context;
   int scale_changes = 0;
-  QObject::connect(prefs, &UiPreferences::ui_scale_changed, prefs, [&scale_changes]() {
-    ++scale_changes;
-  });
+  QObject::connect(prefs,
+                   &UiPreferences::ui_scale_changed,
+                   &context,
+                   [&scale_changes]() { ++scale_changes; });
 
   prefs->set_ui_scale(1.5);
   prefs->set_ui_scale(1.5);

--- a/tools/arena/CMakeLists.txt
+++ b/tools/arena/CMakeLists.txt
@@ -11,14 +11,26 @@ target_link_libraries(
     PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui engine_core render_gl game_systems
 )
 
+# The two panels whose population rules the tests assert. Same reasoning as
+# map_editor_core: the test links the panel the arena ships, not a second copy
+# of its source.
+add_library(arena_panels STATIC unit_panel.cpp building_panel.cpp)
+target_include_directories(arena_panels PUBLIC "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(
+    arena_panels
+    PUBLIC
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Gui
+        Qt${QT_VERSION_MAJOR}::Widgets
+        arena_scenario_harness
+)
+
 if(QT_VERSION_MAJOR EQUAL 6)
     qt6_add_executable(arena_app
         main.cpp
         arena_window.cpp
         arena_viewport.cpp
         terrain_panel.cpp
-        unit_panel.cpp
-        building_panel.cpp
         prop_panel.cpp
         ../../app/core/renderer_bootstrap.cpp
         ../../app/core/commander_control_controller.cpp
@@ -35,8 +47,6 @@ else()
         arena_window.cpp
         arena_viewport.cpp
         terrain_panel.cpp
-        unit_panel.cpp
-        building_panel.cpp
         prop_panel.cpp
         ../../app/core/renderer_bootstrap.cpp
         ../../app/core/commander_control_controller.cpp
@@ -65,6 +75,7 @@ target_link_libraries(
         render_gl
         game_systems
         arena_scenario_harness
+        arena_panels
 )
 
 set_target_properties(

--- a/tools/arena/README.md
+++ b/tools/arena/README.md
@@ -127,7 +127,7 @@ the same `TerrainService` and renderer passes used by the game.
 
 ```bash
 QT_QPA_PLATFORM=offscreen \
-  build/bin/standard_of_iron_tests \
+  build/bin/tools_tests \
   --gtest_filter='ArenaScenario*'
 ```
 

--- a/tools/map_editor/CMakeLists.txt
+++ b/tools/map_editor/CMakeLists.txt
@@ -1,18 +1,36 @@
+# The editor's document model, with no widget in it: the map and mission
+# documents, element operations, the JSON schema, the derived-commander rules
+# and the hill projection maths.
+#
+# It is a library rather than a list of sources on the executable so the tests
+# can link the objects the editor actually ships. Recompiling these `.cpp` files
+# a second time inside a test binary is how a test ends up passing against a
+# translation unit nobody runs.
+add_library(
+    map_editor_core
+    STATIC
+    map_data.cpp
+    mission_data.cpp
+    commander_preview.cpp
+    element_ops.cpp
+    json_schema.cpp
+    hill_projection_model.cpp
+)
+target_include_directories(
+    map_editor_core
+    PUBLIC "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+target_link_libraries(map_editor_core PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui)
+
 if(QT_VERSION_MAJOR EQUAL 6)
     qt6_add_executable(map_editor
         main.cpp
         ${CMAKE_SOURCE_DIR}/game/map/environment_lighting.cpp
         editor_window.cpp
-        map_data.cpp
-        mission_data.cpp
         mission_panel.cpp
         map_canvas.cpp
-        commander_preview.cpp
-        element_ops.cpp
-        json_schema.cpp
         spawn_icon_library.cpp
         tool_panel.cpp
-        hill_projection_model.cpp
         terrain_projection_widget.cpp
         hill_projection_widget.cpp
         mountain_projection_widget.cpp
@@ -28,16 +46,10 @@ else()
         main.cpp
         ${CMAKE_SOURCE_DIR}/game/map/environment_lighting.cpp
         editor_window.cpp
-        map_data.cpp
-        mission_data.cpp
         mission_panel.cpp
         map_canvas.cpp
-        commander_preview.cpp
-        element_ops.cpp
-        json_schema.cpp
         spawn_icon_library.cpp
         tool_panel.cpp
-        hill_projection_model.cpp
         terrain_projection_widget.cpp
         hill_projection_widget.cpp
         mountain_projection_widget.cpp
@@ -51,7 +63,11 @@ endif()
 
 target_link_libraries(
     map_editor
-    PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Qml
+    PRIVATE
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Widgets
+        Qt${QT_VERSION_MAJOR}::Qml
+        map_editor_core
 )
 
 # Keep tool binaries alongside the main game binary for consistent dev runs

--- a/ui/qml/GameView.qml
+++ b/ui/qml/GameView.qml
@@ -10,8 +10,8 @@ Item {
     property string cursor_mode: "normal"
     property bool is_placing_formation: false
     property bool is_placing_construction: false
-    property bool construction_preview_active: typeof game !== 'undefined' && game.construction_preview_active
-    property bool construction_preview_valid: typeof game !== 'undefined' && game.construction_preview_valid
+    property bool construction_preview_active: typeof game !== 'undefined' && game.placement.construction_preview_active
+    property bool construction_preview_valid: typeof game !== 'undefined' && game.placement.construction_preview_valid
     property var pressed_keys: ({})
 
     onConstruction_preview_activeChanged: {
@@ -224,11 +224,11 @@ Item {
         var shiftHeld = (event.modifiers & Qt.ShiftModifier) !== 0;
         switch (event.key) {
         case Qt.Key_Escape:
-            if (typeof game !== 'undefined' && game.is_placing_construction && game.on_construction_cancel) {
-                game.on_construction_cancel();
+            if (typeof game !== 'undefined' && game.placement.is_placing_construction && game.placement.on_construction_cancel) {
+                game.placement.on_construction_cancel();
                 event.accepted = true;
-            } else if (typeof game !== 'undefined' && game.is_placing_formation && game.on_formation_cancel) {
-                game.on_formation_cancel();
+            } else if (typeof game !== 'undefined' && game.placement.is_placing_formation && game.placement.on_formation_cancel) {
+                game.placement.on_formation_cancel();
                 event.accepted = true;
             } else if (game_view.is_rally_placement()) {
                 game_view.cancel_rally_placement();
@@ -389,19 +389,6 @@ Item {
                     game_view.cursor_mode = game.cursor_mode;
             }
 
-            function onPlacing_formation_changed() {
-                if (typeof game !== 'undefined') {
-                    game_view.is_placing_formation = game.is_placing_formation;
-                    if (!game.is_placing_formation)
-                        mouseArea.is_selecting = false;
-                }
-            }
-
-            function onPlacing_construction_changed() {
-                if (typeof game !== 'undefined')
-                    game_view.is_placing_construction = game.is_placing_construction;
-            }
-
             function onControl_mode_changed() {
                 if (typeof game === 'undefined')
                     return;
@@ -420,6 +407,23 @@ Item {
             }
 
             target: game
+        }
+
+        Connections {
+            function onPlacing_formation_changed() {
+                if (typeof game !== 'undefined') {
+                    game_view.is_placing_formation = game.placement.is_placing_formation;
+                    if (!game.placement.is_placing_formation)
+                        mouseArea.is_selecting = false;
+                }
+            }
+
+            function onPlacing_construction_changed() {
+                if (typeof game !== 'undefined')
+                    game_view.is_placing_construction = game.placement.is_placing_construction;
+            }
+
+            target: typeof game !== 'undefined' ? game.placement : null
         }
 
         MouseArea {
@@ -458,26 +462,26 @@ Item {
                         if (!game_view.is_rally_placement())
                             game.on_right_move(mouse.x, mouse.y);
                     } else if (game_view.is_placing_formation) {
-                        if (typeof game !== 'undefined' && game.on_formation_mouse_move)
-                            game.on_formation_mouse_move(mouse.x, mouse.y);
+                        if (typeof game !== 'undefined' && game.placement.on_formation_mouse_move)
+                            game.placement.on_formation_mouse_move(mouse.x, mouse.y);
                     }
                     if (game_view.is_placing_construction) {
-                        if (typeof game !== 'undefined' && game.on_construction_mouse_move)
-                            game.on_construction_mouse_move(mouse.x, mouse.y);
+                        if (typeof game !== 'undefined' && game.placement.on_construction_mouse_move)
+                            game.placement.on_construction_mouse_move(mouse.x, mouse.y);
                     }
                 }
             }
             onWheel: function (w) {
                 var dy = (w.angleDelta ? w.angleDelta.y / 120 : w.delta / 120);
-                if (typeof game !== 'undefined' && game.construction_preview_rotatable && game.construction_preview_rotatable()) {
-                    if (game.on_construction_scroll)
-                        game.on_construction_scroll(dy);
+                if (typeof game !== 'undefined' && game.placement.construction_preview_rotatable && game.placement.construction_preview_rotatable()) {
+                    if (game.placement.on_construction_scroll)
+                        game.placement.on_construction_scroll(dy);
                     w.accepted = true;
                     return;
                 }
-                if (typeof game !== 'undefined' && game.is_placing_formation) {
-                    if (game.on_formation_scroll)
-                        game.on_formation_scroll(dy);
+                if (typeof game !== 'undefined' && game.placement.is_placing_formation) {
+                    if (game.placement.on_formation_scroll)
+                        game.placement.on_formation_scroll(dy);
                     w.accepted = true;
                     return;
                 }
@@ -509,10 +513,10 @@ Item {
                         return;
                     }
                     if (game_view.cursor_mode === "place_building") {
-                        if (typeof game !== 'undefined' && game.is_placing_construction && game.on_construction_pointer_pressed)
-                            game.on_construction_pointer_pressed(mouse.x, mouse.y);
-                        else if (typeof game !== 'undefined' && game.place_building_at_screen)
-                            game.place_building_at_screen(mouse.x, mouse.y);
+                        if (typeof game !== 'undefined' && game.placement.is_placing_construction && game.placement.on_construction_pointer_pressed)
+                            game.placement.on_construction_pointer_pressed(mouse.x, mouse.y);
+                        else if (typeof game !== 'undefined' && game.placement.place_building_at_screen)
+                            game.placement.place_building_at_screen(mouse.x, mouse.y);
                         return;
                     }
                     if (game_view.cursor_mode === "place_commander_rally") {
@@ -525,14 +529,14 @@ Item {
                             game.confirm_barracks_rally_placement(mouse.x, mouse.y);
                         return;
                     }
-                    if (typeof game !== 'undefined' && game.is_placing_formation) {
-                        if (game.on_formation_confirm)
-                            game.on_formation_confirm();
+                    if (typeof game !== 'undefined' && game.placement.is_placing_formation) {
+                        if (game.placement.on_formation_confirm)
+                            game.placement.on_formation_confirm();
                         return;
                     }
-                    if (typeof game !== 'undefined' && game.is_placing_construction) {
-                        if (game.on_construction_pointer_pressed)
-                            game.on_construction_pointer_pressed(mouse.x, mouse.y);
+                    if (typeof game !== 'undefined' && game.placement.is_placing_construction) {
+                        if (game.placement.on_construction_pointer_pressed)
+                            game.placement.on_construction_pointer_pressed(mouse.x, mouse.y);
                         return;
                     }
                     is_selecting = true;
@@ -573,9 +577,9 @@ Item {
                         if (typeof game !== 'undefined' && game.on_click_select)
                             game.on_click_select(mouse.x, mouse.y, false);
                     }
-                } else if (mouse.button === Qt.LeftButton && typeof game !== 'undefined' && game.is_placing_construction) {
-                    if (game.on_construction_pointer_released)
-                        game.on_construction_pointer_released(mouse.x, mouse.y);
+                } else if (mouse.button === Qt.LeftButton && typeof game !== 'undefined' && game.placement.is_placing_construction) {
+                    if (game.placement.on_construction_pointer_released)
+                        game.placement.on_construction_pointer_released(mouse.x, mouse.y);
                 }
                 if (mouse.button === Qt.RightButton) {
                     if (typeof game !== 'undefined' && game.on_right_release)
@@ -1005,7 +1009,7 @@ Item {
     }
 
     Rectangle {
-        visible: game_view.is_placing_construction && typeof game !== 'undefined' && game.construction_preview_segment_count > 0
+        visible: game_view.is_placing_construction && typeof game !== 'undefined' && game.placement.construction_preview_segment_count > 0
         z: 999999
         radius: 6
         color: "#B8141414"
@@ -1023,7 +1027,7 @@ Item {
 
             anchors.centerIn: parent
             color: Theme.textMain
-            text: game.construction_preview_valid_segment_count + "/" + game.construction_preview_segment_count + " walls  •  " + game.construction_preview_total_cost + " wood"
+            text: game.placement.construction_preview_valid_segment_count + "/" + game.placement.construction_preview_segment_count + " walls  •  " + game.placement.construction_preview_total_cost + " wood"
             font.pixelSize: 14
         }
     }

--- a/ui/qml/HUDBottom.qml
+++ b/ui/qml/HUDBottom.qml
@@ -150,8 +150,8 @@ RowLayout {
             "hint": qsTr("Arrange the selection in a tactical formation."),
             "unavailable": qsTr("Select multiple units to use formation"),
             "invoke": function () {
-                if (bottomRoot.game_ready() && game.on_formation_command)
-                    game.on_formation_command();
+                if (bottomRoot.game_ready() && game.placement.on_formation_command)
+                    game.placement.on_formation_command();
             }
         }, {
             "id": "build",
@@ -164,8 +164,8 @@ RowLayout {
             "invoke": function () {
                 if (!bottomRoot.game_ready())
                     return;
-                if (game.is_placing_construction && game.on_construction_cancel) {
-                    game.on_construction_cancel();
+                if (game.placement.is_placing_construction && game.placement.on_construction_cancel) {
+                    game.placement.on_construction_cancel();
                     return;
                 }
                 if (bottomRoot.current_command_mode === "build") {
@@ -186,13 +186,13 @@ RowLayout {
                 if (!bottomRoot.game_ready())
                     return;
                 if (bottomRoot.action_state("collect").placing) {
-                    if (game.on_construction_cancel)
-                        game.on_construction_cancel();
+                    if (game.placement.on_construction_cancel)
+                        game.placement.on_construction_cancel();
                     bottomRoot.command_mode_changed("normal");
                     return;
                 }
-                if (game.start_builder_construction)
-                    game.start_builder_construction("collect");
+                if (game.placement.start_builder_construction)
+                    game.placement.start_builder_construction("collect");
             }
         }, {
             "id": "deliver",
@@ -266,6 +266,14 @@ RowLayout {
             bottomRoot.update_action_states();
         }
 
+        function onSelected_units_changed() {
+            bottomRoot.refresh_selection();
+        }
+
+        target: bottomRoot.game_ready() ? game : null
+    }
+
+    Connections {
         function onPlacing_construction_changed() {
             bottomRoot.update_action_states();
         }
@@ -274,11 +282,7 @@ RowLayout {
             bottomRoot.update_action_states();
         }
 
-        function onSelected_units_changed() {
-            bottomRoot.refresh_selection();
-        }
-
-        target: bottomRoot.game_ready() ? game : null
+        target: bottomRoot.game_ready() ? game.placement : null
     }
 
     Design.IronSelectionSummary {
@@ -386,12 +390,12 @@ RowLayout {
             }
         }
         onBuild_tower: {
-            if (bottomRoot.game_ready() && game.start_building_placement)
-                game.start_building_placement("defense_tower");
+            if (bottomRoot.game_ready() && game.placement.start_building_placement)
+                game.placement.start_building_placement("defense_tower");
         }
         onBuilder_construction: function (item_type) {
-            if (bottomRoot.game_ready() && game.start_builder_construction)
-                game.start_builder_construction(item_type);
+            if (bottomRoot.game_ready() && game.placement.start_builder_construction)
+                game.placement.start_builder_construction(item_type);
         }
     }
 }

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -468,27 +468,27 @@ ApplicationWindow {
                     else
                         game.set_hover_at_screen(-1, -1);
                 }
-                if (typeof game !== 'undefined' && game.is_placing_formation && game.on_formation_mouse_move) {
+                if (typeof game !== 'undefined' && game.placement.is_placing_formation && game.placement.on_formation_mouse_move) {
                     if (!edge_scroll_overlay.in_hud_zone(mouse.x, mouse.y))
-                        game.on_formation_mouse_move(mouse.x, mouse.y);
+                        game.placement.on_formation_mouse_move(mouse.x, mouse.y);
                 }
-                if (typeof game !== 'undefined' && game.is_placing_construction && game.on_construction_mouse_move) {
+                if (typeof game !== 'undefined' && game.placement.is_placing_construction && game.placement.on_construction_mouse_move) {
                     if (!edge_scroll_overlay.in_hud_zone(mouse.x, mouse.y))
-                        game.on_construction_mouse_move(mouse.x, mouse.y);
+                        game.placement.on_construction_mouse_move(mouse.x, mouse.y);
                 }
             }
             onWheel: function (w) {
-                if (typeof game !== 'undefined' && game.construction_preview_rotatable && game.construction_preview_rotatable()) {
+                if (typeof game !== 'undefined' && game.placement.construction_preview_rotatable && game.placement.construction_preview_rotatable()) {
                     var constructionDy = (w.angleDelta ? w.angleDelta.y / 120 : w.delta / 120);
-                    if (constructionDy !== 0 && game.on_construction_scroll)
-                        game.on_construction_scroll(constructionDy);
+                    if (constructionDy !== 0 && game.placement.on_construction_scroll)
+                        game.placement.on_construction_scroll(constructionDy);
                     w.accepted = true;
                     return;
                 }
-                if (typeof game !== 'undefined' && game.is_placing_formation && game.on_formation_scroll) {
+                if (typeof game !== 'undefined' && game.placement.is_placing_formation && game.placement.on_formation_scroll) {
                     var dy = (w.angleDelta ? w.angleDelta.y / 120 : w.delta / 120);
                     if (dy !== 0)
-                        game.on_formation_scroll(dy);
+                        game.placement.on_formation_scroll(dy);
                     w.accepted = true;
                     return;
                 }

--- a/ui/qml/ProductionPanel.qml
+++ b/ui/qml/ProductionPanel.qml
@@ -122,8 +122,8 @@ Rectangle {
     }
 
     function get_construction_info(item_type) {
-        if (productionPanel.game_instance && productionPanel.game_instance.get_construction_info)
-            return productionPanel.game_instance.get_construction_info(item_type || "");
+        if (productionPanel.game_instance && productionPanel.game_instance.placement)
+            return productionPanel.game_instance.placement.get_construction_info(item_type || "");
         return {
             "build_time": 10,
             "resource_costs": {},


### PR DESCRIPTION
…surface

Placement (formation placement, builder construction, building placement) moves out of GameEngine into app/viewmodels/placement_view_model, exposed to QML as game.placement. GameEngine now implements a PlacementHost interface through which the view model reaches the few things only the root knows (lazy init, window mapping, local owner, cursor mode). All QML call sites switch to game.placement; the QML surface ceiling drops from 129/46 to 103/39 invokables/properties and a new architecture test locks placement off GameEngine for good.

The monolithic standard_of_iron_tests binary is split into five by link surface: simulation_tests and persistence_tests (kernel only), render_tests (+render_gl), app_tests (+app_core, ui_shell) and tools_tests (+map_editor_core, arena_*, balance_sim_harness). map_editor and the arena now ship their document/panel sources as libraries so tests link the same objects the tools build, per the new rule that a test never re-compiles a production .cpp. scripts/run-tests.sh owns the suite list and is called by the Makefile and all four CI workflows (Windows now runs Git bash); a missing suite is an error, not a skip.

Test fixes along the way: carthage_armor_bounds_test is rewritten against the EquipmentBatch submitter API, and preferences_test binds its signal connection to a scoped context so it cannot outlive the test.