### PR TITLE
Record formation showcase reels from the arena

### DIFF
--- a/docs/FORMATION_ARCHITECTURE.md
+++ b/docs/FORMATION_ARCHITECTURE.md
@@ -357,3 +357,13 @@ visual side and need a real GPU context; `tests/tools/arena_scenarios_test.cpp`
 asserts headlessly that each one exists, spawns groups, carries expectations,
 issues a `FormationMove`, and — for the terrain fixtures — actually declares the
 rivers, bridges, elevation patches, walls and buildings it claims to test.
+
+## Showing it off
+
+The three `promo_` formation scenarios are army-scale versions of the same
+material, authored for video rather than for acceptance: one faction, several
+hundred soldiers, and a scripted cycle through the intents. They drive the
+planner through `ScenarioCommandKind::FormArmy` — `FormationMove` only
+translates a shape that already exists — and the same test file asserts that
+they field an army, name real groups, and show at least three intents. See
+[PROMO_CAPTURE.md](PROMO_CAPTURE.md).

--- a/docs/PROMO_CAPTURE.md
+++ b/docs/PROMO_CAPTURE.md
@@ -1,0 +1,106 @@
+# Promo capture
+
+Two programs make a promo video. The arena renders authored camera moves over a
+scenario and writes one clip per shot; `scripts/promo-edit.py` joins, grades,
+captions and scores those clips into a finished cut. Both read the **same spec
+file**, so the camera work and the edit that presents it live next to each
+other:
+
+```sh
+build/bin/arena_app --promo-spec tools/arena/promos/rome_iron_line.json \
+  --promo-out artifacts/promo
+scripts/promo-edit.py --spec tools/arena/promos/rome_iron_line.json \
+  --clips artifacts/promo/rome_iron_line
+```
+
+`scripts/capture-formation-promos.sh` runs both steps over all three formation
+reels; `--edit-only` re-cuts the footage already on disk without re-rendering
+it, which is the loop to use while tuning captions, grade or transitions.
+
+The arena needs a real display — it renders through OpenGL and `offscreen` has
+no framebuffer. The edit needs `ffmpeg` on `PATH`.
+
+## The spec
+
+`tools/arena/promo_spec.h` defines what the arena reads; the arena ignores keys
+it does not know, which is why the editorial fields (`title`, `grade`,
+`caption`, `transition`, `music`) sit in the same file without the recorder
+caring about them.
+
+A shot names a scenario, a window into it (`start`, `duration`), what the camera
+looks at (`focus`), and how it moves (`camera` keyframes). Each shot **reloads
+and re-simulates its scenario from zero**, so shots may be authored in any order
+and two shots may cover overlapping windows of the same battle from different
+angles. `slow_motion` shrinks the simulation step rather than duplicating
+frames, so a half-speed shot keeps full temporal detail.
+
+Camera `yaw` blends along the shorter arc between keys: `8` followed by `352` is
+sixteen degrees back, not a full orbit the other way. Author a middle key when
+you really want the long way round.
+
+## Transitions
+
+`promo-edit.py` joins the clips. Each shot's `transition` describes the cut
+*into* it, so the first shot's is ignored; the spec-level `transition` is the
+default for every join.
+
+```json
+{
+  "transition": {"type": "dissolve", "duration": 0.35},
+  "shots": [
+    {"name": "deploy", "transition": {"type": "dip", "duration": 0.5}}
+  ]
+}
+```
+
+`{"type": "cut"}` restores a hard cut for one join. The vocabulary is in
+`TRANSITIONS` in the script — `dissolve`, `dip`, `flash`, `whip`, `smear`,
+`push`, `zoom`, `radial`, `grain`, `iris`, `wipe`, `bleach`, `cut`. Runs of hard
+cuts are concatenated and only the blended joins become `xfade` filters, because
+`xfade` has no zero-length form.
+
+Blended joins **overlap** their two shots, so the finished cut is shorter than
+the sum of its clips. Caption timing is measured on the blended timeline and
+held clear of the blend either side of it. `--transition` and
+`--transition-duration` override the whole reel from the command line, which is
+the quick way to compare an edit against hard cuts.
+
+## Scenarios built for capture
+
+Capture scenarios differ from acceptance scenarios in scale and dressing, not in
+kind. `add_formation_promo_scenarios` in
+`tools/arena/arena_formation_scenarios.cpp` holds the three formation reels;
+`dress_for_capture` is the shared dressing pass.
+
+Two settings matter more than they look:
+
+- **`arena_floor_half_extent`** — the arena levels a flat square out of its
+  mountain noise, 18 units either side by default. That is a duelling floor; an
+  army deploying from column into line needs far more, and outside the square
+  the ground is rough enough to break the shapes up. The floor eases into the
+  surrounding noise over a taper rather than stepping out of it, so the
+  mountains do not stand as a wall on the touchline.
+- **the environment overrides** — leave `exposure_override` and
+  `fog_density_override` alone unless the scene really needs them. Setting them
+  is what turned the first generation of capture scenarios into murk. Locking
+  `time_mode` is worth it though: a promo records the same scenario once per
+  shot, and the light has to match across the cut. While you are still choosing
+  the hour, `--time <hour>` overrides a locked scenario, so a lighting sweep is
+  four batch captures rather than four rebuilds.
+
+## Driving the formation system
+
+`ScenarioCommandKind::FormArmy` is the step that shows the army formation layer
+off. `FormationMove` only translates whatever shape a group already stands in;
+`FormArmy` folds any number of groups into one army, asks the doctrine planner
+where every unit belongs, writes the chosen slots back onto each unit's
+formation mode so the runtime can measure cohesion against them, and walks
+everyone there — the same path a player's formation drag takes.
+
+```cpp
+auto advance = form_step(36.0F, legion, Intent::Assault, {0, 0, 18}, 0.0F, 54.0F);
+advance.formation.options.movement_policy = MovementPolicy::MaintainFormation;
+```
+
+Cycling one army through `Column`, `Line`, `Defensive` and `Assault` is what
+makes a formation reel read as a system rather than as a battle.

--- a/render/creature/compiled_creature_assets.cpp
+++ b/render/creature/compiled_creature_assets.cpp
@@ -870,10 +870,27 @@ void rotate_elephant_subtree(std::span<QMatrix4x4> palette,
   }
 }
 
-auto sample_elephant_locomotion(SourceAsset const& asset,
-                                float phase,
-                                bool fast,
-                                std::span<QMatrix4x4> out) noexcept -> bool {
+// Synthesise a walk from the bind pose by swinging the leg subtrees.
+//
+// The production rig ships no locomotion clip, so the gait is built here.
+// Two things keep it from tearing the animal apart, and both were learned the
+// hard way:
+//
+//   * The hip sits inside the barrel, so a big swing carries the top of the
+//     thigh out through the flank and leaves a hole. Opposite legs are half a
+//     cycle apart, so whatever the amplitude is, the two front legs end up
+//     twice that far apart -- which is how a 25 degree swing put the elephant
+//     into the splits. An elephant's real walk is stiff and shallow; keep it
+//     that way.
+//   * The shin has to counter-rotate against the thigh. Rotating both the same
+//     way compounds at the foot and turns the leg into a straight stilt raking
+//     out from under the body.
+constexpr float k_elephant_shin_counter_rotation = 0.55F;
+
+auto synthesise_elephant_locomotion(SourceAsset const& asset,
+                                    float phase,
+                                    bool fast,
+                                    std::span<QMatrix4x4> out) noexcept -> bool {
   if (!asset.status.loaded || out.size() < asset.bind_palette.size()) {
     return false;
   }
@@ -881,15 +898,21 @@ auto sample_elephant_locomotion(SourceAsset const& asset,
   constexpr std::array<std::size_t, 4> upper{{9U, 12U, 15U, 18U}};
   constexpr std::array<std::size_t, 4> lower{{10U, 13U, 16U, 19U}};
 
+  // Lateral-sequence walk: rear left, front left, rear right, front right.
   constexpr std::array<float, 4> offset{{0.25F, 0.75F, 0.0F, 0.50F}};
-  float const stride_degrees = fast ? 25.0F : 16.0F;
-  float const knee_degrees = fast ? 24.0F : 15.0F;
+  float const stride_degrees = fast ? 13.0F : 10.5F;
+  float const knee_degrees = fast ? 10.0F : 8.0F;
   float const two_pi = 6.2831853071795864769F;
   for (std::size_t leg = 0U; leg < upper.size(); ++leg) {
     float const wave = std::sin((phase + offset[leg]) * two_pi);
-    rotate_elephant_subtree(out, asset.bone_defs, upper[leg], wave * stride_degrees);
-    rotate_elephant_subtree(
-        out, asset.bone_defs, lower[leg], std::max(wave, 0.0F) * knee_degrees);
+    float const thigh = wave * stride_degrees;
+    // Fold the shin back under the body by most of the thigh's swing, then add
+    // the lift that carries the foot forward through the swing half of the
+    // cycle.
+    float const shin = (-thigh * k_elephant_shin_counter_rotation) +
+                       (std::max(wave, 0.0F) * knee_degrees);
+    rotate_elephant_subtree(out, asset.bone_defs, upper[leg], thigh);
+    rotate_elephant_subtree(out, asset.bone_defs, lower[leg], shin);
   }
   float const bob = std::sin(phase * two_pi * 2.0F) * (fast ? 0.0225F : 0.0125F);
   float const sway = std::sin(phase * two_pi) * (fast ? 1.8F : 1.0F);
@@ -905,6 +928,20 @@ auto sample_elephant_locomotion(SourceAsset const& asset,
   rotate_elephant_subtree(
       out, asset.bone_defs, 4U, std::sin((phase + 0.18F) * two_pi) * 7.0F);
   return true;
+}
+
+// The elephant asset carries Angry, Eating, GettingUp, Idle and Sitting, and
+// no locomotion. Take an authored clip the moment one is added; synthesise
+// until then.
+auto sample_elephant_locomotion(SourceAsset const& asset,
+                                float phase,
+                                bool fast,
+                                std::span<QMatrix4x4> out) noexcept -> bool {
+  const std::string_view authored = fast ? "Run" : "Walk";
+  if (sample_source_clip(asset, k_elephant_config, authored, phase, out)) {
+    return true;
+  }
+  return synthesise_elephant_locomotion(asset, phase, fast, out);
 }
 
 } // namespace

--- a/scripts/capture-formation-promos.sh
+++ b/scripts/capture-formation-promos.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Record and cut the three formation showcase reels.
+#
+#   scripts/capture-formation-promos.sh [output-dir] [--edit-only]
+#
+# Each reel is one faction's army put through the army formation layer's own
+# vocabulary -- column, line, defensive, assault, encirclement -- rather than a
+# battle. See docs/PROMO_CAPTURE.md.
+#
+# Needs a working display (the Arena renders through OpenGL, not offscreen) and
+# ffmpeg. Raw clips are kept under <output-dir>/clips so the edit can be redone
+# without re-rendering; pass --edit-only to skip the capture entirely.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly ROOT
+readonly ARENA="${ROOT}/build/bin/arena_app"
+
+OUT_DIR="${ROOT}/artifacts/promo-formations"
+EDIT_ONLY=0
+for arg in "$@"; do
+  case "${arg}" in
+    --edit-only) EDIT_ONLY=1 ;;
+    *) OUT_DIR="${arg}" ;;
+  esac
+done
+readonly CLIP_DIR="${OUT_DIR}/clips"
+
+readonly REELS=(
+  rome_iron_line
+  carthage_crescent
+  rome_hill_drill
+)
+
+if [[ ${EDIT_ONLY} -eq 0 && ! -x "${ARENA}" ]]; then
+  echo "capture-formation-promos: build arena_app first (cmake --build build --target arena_app)" >&2
+  exit 1
+fi
+
+mkdir -p "${CLIP_DIR}"
+for reel in "${REELS[@]}"; do
+  spec="${ROOT}/tools/arena/promos/${reel}.json"
+  if [[ ${EDIT_ONLY} -eq 0 ]]; then
+    echo "== recording ${reel}"
+    DISPLAY="${DISPLAY:-:0}" "${ARENA}" --promo-spec "${spec}" --promo-out "${CLIP_DIR}"
+  fi
+  echo "== cutting ${reel}"
+  # Invoked through python3 rather than the shebang: promo-edit.py is tracked
+  # without its executable bit.
+  python3 "${ROOT}/scripts/promo-edit.py" \
+    --spec "${spec}" \
+    --clips "${CLIP_DIR}/${reel}" \
+    --out "${OUT_DIR}/${reel}.mp4"
+done
+
+echo "capture-formation-promos: wrote ${#REELS[@]} reel(s) to ${OUT_DIR}"

--- a/scripts/promo-edit.py
+++ b/scripts/promo-edit.py
@@ -2,9 +2,10 @@
 """Cut, grade and caption the clips ``arena_app --promo-spec`` recorded.
 
 The arena records one clip per authored shot plus a ``shots.json`` manifest.
-This script turns that raw footage into a finished vertical short in a single
-ffmpeg pass -- concatenate, grade, caption, title card, fade -- so the footage
-is only re-encoded once.
+This script turns that raw footage into a finished short in a single ffmpeg
+pass -- join, grade, caption, title card, fade -- so the footage is only
+re-encoded once. The frame is whatever the spec asked the arena to record;
+vertical suits a battle, landscape suits a battle line.
 
 Everything the edit needs lives in the same promo spec the arena consumed. The
 arena ignores keys it does not know, so the editorial fields sit next to the
@@ -14,10 +15,19 @@ camera work they belong to::
       "title": "THE LAST STAND",
       "subtitle": "STANDARD OF IRON",
       "grade": {"contrast": 1.12, "saturation": 1.14},
+      "transition": {"type": "dissolve", "duration": 0.35},
       "shots": [
-        {"name": "collision", "caption": "HOLD THE LINE", ...}
+        {"name": "collision", "caption": "HOLD THE LINE",
+         "transition": {"type": "dip", "duration": 0.5}, ...}
       ]
     }
+
+A shot's ``transition`` describes how the cut *into* it is played, so the first
+shot's is ignored. The spec-level ``transition`` is the default for every join;
+``{"type": "cut"}`` on a shot restores a hard cut for that one join. See
+``TRANSITIONS`` for the vocabulary. Joined shots overlap, so the finished cut is
+shorter than the sum of its clips and caption timing is measured on the blended
+timeline rather than on raw clip lengths.
 
 Typical use::
 
@@ -43,6 +53,31 @@ CAPTION_Y_FRACTION = 0.70
 TITLE_Y_FRACTION = 0.42
 CAPTION_FADE = 0.25
 END_CARD_SECONDS = 2.2
+OPENING_FADE = 0.6
+
+# Editorial names for the xfade transitions worth reaching for in a battle reel.
+# The value is the ffmpeg transition; ``None`` means a hard cut, which xfade
+# cannot express and which is therefore handled by concatenation instead.
+TRANSITIONS = {
+    "cut": None,
+    "dissolve": "fade",
+    "dip": "fadeblack",
+    "flash": "fadewhite",
+    "whip": "hblur",
+    "smear": "smoothleft",
+    "smear_right": "smoothright",
+    "push": "slideleft",
+    "push_right": "slideright",
+    "zoom": "zoomin",
+    "radial": "radial",
+    "grain": "pixelize",
+    "iris": "circleopen",
+    "wipe": "wipeleft",
+    "bleach": "fadegrays",
+}
+
+DEFAULT_TRANSITION = "dissolve"
+DEFAULT_TRANSITION_SECONDS = 0.35
 
 FONT_CANDIDATES = (
     "/usr/share/fonts/truetype/dejavu/DejaVuSerif-Bold.ttf",
@@ -138,6 +173,125 @@ def build_grade(grade: dict) -> str:
     return ",".join(stages)
 
 
+class Join:
+    """How one shot is played into the next."""
+
+    __slots__ = ("kind", "transition", "seconds")
+
+    def __init__(self, kind: str, transition: str | None, seconds: float) -> None:
+        self.kind = kind
+        self.transition = transition
+        self.seconds = seconds if transition else 0.0
+
+    @property
+    def blended(self) -> bool:
+        return self.transition is not None and self.seconds > 0.0
+
+
+HARD_CUT = Join("cut", None, 0.0)
+
+
+def read_transition(config, kind: str, seconds: float) -> tuple[str, float]:
+    """Read a spec's ``transition`` value over a kind/duration pair.
+
+    Accepts a bare name (``"dip"``), a full object, or nothing at all, so a reel
+    that wants one dissolve everywhere only writes the spec-level default. Kind
+    and duration stay separate all the way down: a spec whose default is a hard
+    cut must still hand its authored duration to the one shot that asks for a
+    dissolve.
+    """
+    if isinstance(config, str):
+        kind = config
+    elif isinstance(config, dict):
+        kind = str(config.get("type", kind))
+        seconds = float(config.get("duration", seconds))
+    elif config is not None:
+        fail(f"a transition must be a name or an object, not {type(config).__name__}")
+
+    kind = kind.strip().lower()
+    if kind not in TRANSITIONS:
+        known = ", ".join(sorted(TRANSITIONS))
+        fail(f"unknown transition '{kind}'; known transitions are {known}")
+    if seconds < 0:
+        fail(f"transition '{kind}' has a negative duration")
+    return kind, seconds
+
+
+def resolve_join(config, default_kind: str, default_seconds: float) -> Join:
+    kind, seconds = read_transition(config, default_kind, default_seconds)
+    return Join(kind, TRANSITIONS[kind], seconds)
+
+
+def plan_timeline(
+    lengths: list[float], joins: list[Join]
+) -> tuple[list[tuple[float, float]], float]:
+    """Place every shot on the finished timeline.
+
+    A blended join overlaps its two shots, so each transition pulls the rest of
+    the reel earlier by its own duration. An overlap is clamped against both
+    neighbours' *unshared* footage: two dissolves either side of a short shot
+    must not consume the same frames twice, or the second xfade would be asked
+    for an offset that lies before the first one finished.
+    """
+    spans: list[tuple[float, float]] = []
+    cursor = 0.0
+    previous_overlap = 0.0
+    for index, length in enumerate(lengths):
+        join = joins[index]
+        overlap = 0.0
+        if index > 0 and join.blended:
+            headroom = min(lengths[index - 1] - previous_overlap, length)
+            overlap = min(join.seconds, max(0.0, headroom * 0.9))
+            if overlap <= 0.0:
+                join.seconds = 0.0
+                join.transition = None
+            else:
+                join.seconds = overlap
+        cursor = max(0.0, cursor - overlap)
+        spans.append((cursor, cursor + length))
+        cursor += length
+        previous_overlap = overlap
+    return spans, cursor
+
+
+def build_join_graph(
+    lengths: list[float], joins: list[Join], spans: list[tuple[float, float]]
+) -> tuple[list[str], str]:
+    """Join the clips into one stream, blending where a transition asks for it.
+
+    xfade has no zero-length form, so runs of hard cuts are concatenated into a
+    single segment first and only the blended joins become xfades.
+    """
+    segments: list[list[int]] = [[0]]
+    for index in range(1, len(lengths)):
+        if joins[index].blended:
+            segments.append([index])
+        else:
+            segments[-1].append(index)
+
+    chain: list[str] = []
+    labels: list[str] = []
+    for position, members in enumerate(segments):
+        if len(members) == 1:
+            labels.append(f"{members[0]}:v")
+            continue
+        sources = "".join(f"[{index}:v]" for index in members)
+        chain.append(f"{sources}concat=n={len(members)}:v=1:a=0[seg{position}]")
+        labels.append(f"seg{position}")
+
+    stage = labels[0]
+    for position in range(1, len(segments)):
+        join = joins[segments[position][0]]
+        offset = spans[segments[position][0]][0]
+        chain.append(
+            f"[{stage}][{labels[position]}]"
+            f"xfade=transition={join.transition}:duration={join.seconds:.3f}"
+            f":offset={offset:.3f}[join{position}]"
+        )
+        stage = f"join{position}"
+    return chain, stage
+
+
 def build_drum_bed(seconds: float, tempo: float) -> str:
     """A procedural war-drum bed.
 
@@ -185,6 +339,16 @@ def main() -> int:
         help="seconds into the track to start (default: the spec's value)",
     )
     parser.add_argument("--tempo", type=float, default=104.0, help="drum bed tempo")
+    parser.add_argument(
+        "--transition",
+        choices=tuple(sorted(TRANSITIONS)),
+        help="override every join the spec asks for (use 'cut' for hard cuts)",
+    )
+    parser.add_argument(
+        "--transition-duration",
+        type=float,
+        help="override every transition's length in seconds",
+    )
     args = parser.parse_args()
 
     if shutil.which("ffmpeg") is None:
@@ -204,50 +368,83 @@ def main() -> int:
         fail("the capture manifest contains no shots")
 
     captions = {shot.get("name"): shot.get("caption") for shot in spec.get("shots", [])}
+    authored = {shot.get("name"): shot for shot in spec.get("shots", [])}
     font = resolve_font(args.font)
     output = args.out or args.clips.with_suffix(".mp4")
     output.parent.mkdir(parents=True, exist_ok=True)
 
+    default_kind, default_seconds = read_transition(
+        spec.get("transition"), DEFAULT_TRANSITION, DEFAULT_TRANSITION_SECONDS
+    )
+
     inputs: list[str] = []
-    concat_labels = ""
-    timeline: list[tuple[str, float, float]] = []
-    cursor = 0.0
+    names: list[str] = []
+    lengths: list[float] = []
+    joins: list[Join] = []
     for index, shot in enumerate(shots):
         clip = args.clips / shot["clip"]
         if not clip.is_file():
             fail(f"missing clip {clip}")
         inputs += ["-i", str(clip)]
-        concat_labels += f"[{index}:v]"
         length = float(shot.get("clip_seconds") or 0.0)
         if length <= 0:
             fail(f"clip {clip.name} reports no duration")
-        timeline.append((shot.get("name", ""), cursor, cursor + length))
-        cursor += length
+        name = shot.get("name", "")
+        names.append(name)
+        lengths.append(length)
+        if index == 0:
+            joins.append(HARD_CUT)
+            continue
+        authored_join = (
+            args.transition
+            if args.transition
+            else authored.get(name, {}).get("transition")
+        )
+        join = resolve_join(authored_join, default_kind, default_seconds)
+        if args.transition_duration is not None:
+            join.seconds = args.transition_duration
+        joins.append(join)
 
-    total = cursor
+    spans, total = plan_timeline(lengths, joins)
     width = int(manifest.get("width", 1080))
     height = int(manifest.get("height", 1920))
 
-    chain = [
-        f"{concat_labels}concat=n={len(shots)}:v=1:a=0[cat]",
-        f"[cat]{build_grade(spec.get('grade', {}))}[graded]",
-    ]
+    chain, joined = build_join_graph(lengths, joins, spans)
+    chain.append(f"[{joined}]{build_grade(spec.get('grade', {}))}[graded]")
 
+    timeline = [
+        (names[index], spans[index][0], spans[index][1]) for index in range(len(names))
+    ]
     stage = "graded"
     if not args.no_captions:
-        caption_size = max(46, int(width * 0.075))
-        title_size = max(60, int(width * 0.105))
-        subtitle_size = max(30, int(width * 0.040))
+        # Type is sized off the shorter edge. Scaling it by width makes a
+        # landscape title so tall that it lands on top of the last caption.
+        type_base = min(width, height)
+        caption_size = max(46, int(type_base * 0.075))
+        title_size = max(60, int(type_base * 0.105))
+        subtitle_size = max(30, int(type_base * 0.040))
         caption_y = f"h*{CAPTION_Y_FRACTION}"
         safe_width = int(width * 0.88)
+        card_start = max(0.0, total - END_CARD_SECONDS)
+        has_card = bool(spec.get("title") or spec.get("subtitle"))
         step = 0
-        for name, start, end in timeline:
+        for index, (name, start, end) in enumerate(timeline):
             caption = captions.get(name)
             if not caption:
                 continue
 
-            visible_start = start + 0.15
-            visible_end = max(visible_start + 0.6, end - 0.15)
+            # Hold the caption clear of the blend either side of it, so it is
+            # never half-dissolved into the neighbouring shot.
+            leading = max(0.15, joins[index].seconds)
+            trailing = 0.15
+            if index + 1 < len(joins):
+                trailing = max(trailing, joins[index + 1].seconds)
+            visible_start = start + leading
+            visible_end = max(visible_start + 0.6, end - trailing)
+            # The end card owns the frame once it starts; a caption still up
+            # underneath it reads as two overlapping titles.
+            if has_card and visible_start < card_start:
+                visible_end = min(visible_end, card_start - CAPTION_FADE)
             chain.append(
                 f"[{stage}]"
                 + drawtext(
@@ -263,7 +460,6 @@ def main() -> int:
             stage = f"cap{step}"
             step += 1
 
-        card_start = max(0.0, total - END_CARD_SECONDS)
         title = spec.get("title")
         if title:
             chain.append(
@@ -296,7 +492,10 @@ def main() -> int:
             )
             stage = "sub"
 
-    chain.append(f"[{stage}]fade=t=out:st={max(0.0, total - 0.55):.3f}:d=0.55[vout]")
+    chain.append(
+        f"[{stage}]fade=t=in:st=0:d={OPENING_FADE:.2f},"
+        f"fade=t=out:st={max(0.0, total - 0.55):.3f}:d=0.55[vout]"
+    )
 
     command = ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", *inputs]
     filter_complex = ";".join(chain)
@@ -355,9 +554,16 @@ def main() -> int:
         str(output),
     ]
 
+    blended = [join for join in joins[1:] if join.blended]
+    joined_note = (
+        f"{len(blended)} blended join(s): "
+        + ", ".join(f"{join.kind} {join.seconds:.2f}s" for join in blended)
+        if blended
+        else "hard cuts throughout"
+    )
     print(
         f"promo-edit: cutting {len(shots)} shot(s), {total:.2f}s, "
-        f"{width}x{height} -> {output}"
+        f"{width}x{height} -> {output}\npromo-edit: {joined_note}"
     )
     result = subprocess.run(command, check=False)
     if result.returncode != 0:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -336,6 +336,11 @@ add_executable(
     tools/hill_projection_model_test.cpp
     tools/map_editor_commander_preview_test.cpp
     tools/arena_scenarios_test.cpp
+    tools/arena_promo_spec_test.cpp
+    # The promo spec ships only inside arena_app, which needs a GL context to
+    # link. Compiling the translation unit here keeps the camera and capture
+    # scheduling rules under test without one.
+    ${CMAKE_SOURCE_DIR}/tools/arena/promo_spec.cpp
     tools/arena_scenario_runner_test.cpp
     tools/arena_frame_continuity_test.cpp
     tools/arena_panel_population_test.cpp

--- a/tests/render/elephant/elephant_source_asset_test.cpp
+++ b/tests/render/elephant/elephant_source_asset_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <limits>
 #include <string_view>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -199,6 +200,60 @@ TEST(ElephantSourceAssetTest, HowdahSocketFollowsAuthoredBackBone) {
     ASSERT_TRUE(Render::Elephant::elephant_source_sample_clip("Run", phase, pose));
     EXPECT_LT((howdah.seat_position - pose[k_back].map(local)).length(), 1.0e-5F);
     EXPECT_NEAR(howdah.seat_up.length(), 1.0F, 1.0e-5F);
+  }
+}
+
+// The rig ships no locomotion clip, so the walk and run are synthesised by
+// swinging the leg subtrees. Swinging them too far is what broke the animal on
+// screen: opposite legs are half a cycle apart, so the pair ends up twice the
+// amplitude apart, the elephant does the splits, and the tops of the thighs
+// swing out through the flank. These bounds are what "still looks like an
+// elephant" means in numbers.
+TEST(ElephantSourceAssetTest, SynthesisedGaitKeepsTheLegsUnderTheBody) {
+  auto const bind = Render::Elephant::elephant_source_bind_palette();
+  ASSERT_EQ(bind.size(), 32U);
+
+  constexpr std::size_t k_foot_front_left = 11U;
+  constexpr std::size_t k_foot_front_right = 14U;
+  constexpr std::size_t k_foot_rear_left = 17U;
+  constexpr std::size_t k_foot_rear_right = 20U;
+  constexpr std::size_t k_hip_front_left = 9U;
+
+  float const leg_length = (bind[k_hip_front_left].column(3).toVector3D().y() -
+                            bind[k_foot_front_left].column(3).toVector3D().y());
+  ASSERT_GT(leg_length, 0.1F);
+
+  for (auto const* clip : {"Walk", "Run"}) {
+    float widest_pair = 0.0F;
+    float furthest_foot = 0.0F;
+    for (int frame = 0; frame < 64; ++frame) {
+      float const phase = static_cast<float>(frame) / 64.0F;
+      Render::Elephant::BonePalette pose{};
+      ASSERT_TRUE(Render::Elephant::elephant_source_sample_clip(clip, phase, pose))
+          << clip;
+
+      for (auto const pair : {std::pair{k_foot_front_left, k_foot_front_right},
+                              std::pair{k_foot_rear_left, k_foot_rear_right}}) {
+        float const spread = std::abs(pose[pair.first].column(3).toVector3D().z() -
+                                      pose[pair.second].column(3).toVector3D().z());
+        widest_pair = std::max(widest_pair, spread);
+      }
+      for (auto const foot : {k_foot_front_left,
+                              k_foot_front_right,
+                              k_foot_rear_left,
+                              k_foot_rear_right}) {
+        float const travel = std::abs(pose[foot].column(3).toVector3D().z() -
+                                      bind[foot].column(3).toVector3D().z());
+        furthest_foot = std::max(furthest_foot, travel);
+      }
+    }
+
+    // A pair of legs never opens wider than half a leg, and no foot strays more
+    // than a third of one from where it stands at rest.
+    EXPECT_LT(widest_pair, leg_length * 0.5F) << clip << " is doing the splits";
+    EXPECT_LT(furthest_foot, leg_length * 0.34F) << clip << " over-strides";
+    // ...and it does move. A gait clamped to nothing would pass the bounds above.
+    EXPECT_GT(furthest_foot, leg_length * 0.04F) << clip << " does not animate";
   }
 }
 

--- a/tests/tools/arena_promo_spec_test.cpp
+++ b/tests/tools/arena_promo_spec_test.cpp
@@ -1,0 +1,98 @@
+#include <cmath>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "tools/arena/promo_spec.h"
+
+namespace {
+
+using Arena::Promo::CameraKey;
+using Arena::Promo::Ease;
+using Arena::Promo::Shot;
+using Arena::Promo::Spec;
+
+auto key(float time, float yaw, Ease ease = Ease::Linear) -> CameraKey {
+  CameraKey result;
+  result.time = time;
+  result.yaw = yaw;
+  result.ease = ease;
+  return result;
+}
+
+auto shot(const char* name,
+          const char* scenario,
+          float start,
+          float duration,
+          int seed = 1337) -> Shot {
+  Shot result;
+  result.name = QString::fromLatin1(name);
+  result.scenario = QString::fromLatin1(scenario);
+  result.start_seconds = start;
+  result.duration_seconds = duration;
+  result.seed = seed;
+  return result;
+}
+
+} // namespace
+
+// A promo author writes yaw as a compass bearing, so keys either side of north
+// wrap. Blending them numerically sweeps the camera the long way around the
+// battle -- three hundred degrees of orbit where sixteen were meant.
+TEST(ArenaPromoSpecTest, YawBlendsAlongTheShorterArc) {
+  const std::vector<CameraKey> keys{key(0.0F, 8.0F), key(1.0F, 352.0F)};
+
+  const float midpoint = Arena::Promo::evaluate(keys, 0.5F).yaw;
+  EXPECT_NEAR(std::fmod(midpoint + 360.0F, 360.0F), 0.0F, 0.01F);
+
+  // A quarter of the way in, the camera has moved a quarter of sixteen
+  // degrees, not a quarter of the way round the compass.
+  EXPECT_NEAR(Arena::Promo::evaluate(keys, 0.25F).yaw, 4.0F, 0.01F);
+}
+
+TEST(ArenaPromoSpecTest, YawStillTakesAuthoredMiddleKeysTheLongWay) {
+  const std::vector<CameraKey> keys{
+      key(0.0F, 0.0F), key(1.0F, 170.0F), key(2.0F, 340.0F)};
+  EXPECT_NEAR(Arena::Promo::evaluate(keys, 1.0F).yaw, 170.0F, 0.01F);
+  EXPECT_NEAR(Arena::Promo::evaluate(keys, 2.0F).yaw, 340.0F, 0.01F);
+}
+
+TEST(ArenaPromoSpecTest, ShotsOverOneScenarioRecordInASinglePass) {
+  Spec spec;
+  spec.shots = {shot("late", "battle", 30.0F, 3.0F),
+                shot("early", "battle", 4.0F, 2.0F),
+                shot("middle", "battle", 12.0F, 2.0F)};
+
+  const auto passes = Arena::Promo::plan_passes(spec);
+  ASSERT_EQ(passes.size(), 1U);
+  EXPECT_EQ(passes[0].scenario, QStringLiteral("battle"));
+  // Ordered by start time, whatever order they were authored in: the recorder
+  // plays a pass forwards through one continuous simulation.
+  EXPECT_EQ(passes[0].shots, (std::vector<std::size_t>{1, 2, 0}));
+}
+
+TEST(ArenaPromoSpecTest, DifferentScenariosOrSeedsNeedTheirOwnPass) {
+  Spec spec;
+  spec.shots = {shot("a", "battle", 4.0F, 2.0F),
+                shot("b", "siege", 4.0F, 2.0F),
+                shot("c", "battle", 20.0F, 2.0F, 99)};
+
+  const auto passes = Arena::Promo::plan_passes(spec);
+  ASSERT_EQ(passes.size(), 3U);
+  EXPECT_EQ(passes[0].shots, (std::vector<std::size_t>{0}));
+  EXPECT_EQ(passes[1].shots, (std::vector<std::size_t>{1}));
+  EXPECT_EQ(passes[2].seed, 99);
+}
+
+// Two angles on the same moment are a normal thing to author, and one run
+// cannot record both: the second has to get a run of its own.
+TEST(ArenaPromoSpecTest, OverlappingWindowsSplitIntoSeparatePasses) {
+  Spec spec;
+  spec.shots = {shot("wide", "battle", 10.0F, 4.0F),
+                shot("close", "battle", 12.0F, 4.0F),
+                shot("after", "battle", 20.0F, 2.0F)};
+
+  const auto passes = Arena::Promo::plan_passes(spec);
+  ASSERT_EQ(passes.size(), 2U);
+  EXPECT_EQ(passes[0].shots, (std::vector<std::size_t>{0, 2}));
+  EXPECT_EQ(passes[1].shots, (std::vector<std::size_t>{1}));
+}

--- a/tests/tools/arena_scenarios_test.cpp
+++ b/tests/tools/arena_scenarios_test.cpp
@@ -784,3 +784,45 @@ TEST(ArenaScenariosTest, RampartsCloseWithGatesAndCornerTowers) {
     }
   }
 }
+
+// The formation promo scenarios are the footage source for the formation
+// showcase reels. What makes them different from the acceptance scenarios is
+// exactly what a careless edit would undo: they drive the army formation layer
+// rather than translating an existing block, they field a whole army, and they
+// need flat ground wide enough for that army to manoeuvre on.
+TEST(ArenaScenariosTest, FormationPromoScenariosDriveTheArmyFormationLayer) {
+  using Intent = Game::Formation::ArmyFormationIntent;
+  for (auto const* id :
+       {"promo_rome_iron_line", "promo_carthage_crescent", "promo_rome_hill_drill"}) {
+    auto const* scenario = Arena::Scenarios::find_definition(QString::fromLatin1(id));
+    ASSERT_NE(scenario, nullptr) << id;
+    EXPECT_TRUE(Arena::validate_scenario(*scenario).empty()) << id;
+
+    EXPECT_GT(scenario->arena_floor_half_extent, 30.0F)
+        << id << " manoeuvres an army and needs more than a duelling floor";
+
+    std::set<QString> group_names;
+    int soldiers = 0;
+    for (auto const& group : scenario->groups) {
+      group_names.insert(group.name);
+      soldiers += group.count * std::max(1, group.individuals_per_unit);
+    }
+    EXPECT_GE(soldiers, 300) << id << " does not field an army";
+
+    std::set<Intent> intents;
+    for (auto const& step : scenario->steps) {
+      if (step.command != Arena::ScenarioCommandKind::FormArmy) {
+        continue;
+      }
+      intents.insert(step.formation.intent);
+      EXPECT_FALSE(step.formation.groups.isEmpty())
+          << id << " step " << step.name.toStdString() << " forms nobody";
+      for (auto const& member : step.formation.groups) {
+        EXPECT_TRUE(group_names.contains(member))
+            << id << " forms unknown group " << member.toStdString();
+      }
+    }
+    EXPECT_GE(intents.size(), 3U)
+        << id << " shows too little of the formation vocabulary";
+  }
+}

--- a/tools/arena/arena_formation_scenarios.cpp
+++ b/tools/arena/arena_formation_scenarios.cpp
@@ -1156,14 +1156,333 @@ void add_terrain_formation_scenarios(std::vector<ArenaScenarioDefinition>& out) 
   }
 }
 
+// The capture scenarios behind the formation promo reels. They differ from the
+// acceptance scenarios above in scale and dressing rather than in kind: each is
+// one faction's army large enough to read as an army, put through the army
+// formation layer's own vocabulary -- column, line, defensive, assault,
+// encirclement -- so the finished video shows the system working rather than a
+// battle happening.
+using Intent = Game::Formation::ArmyFormationIntent;
+
+auto form_step(float time,
+               QStringList groups,
+               Intent intent,
+               QVector3D anchor,
+               float facing_degrees,
+               float frontage = 0.0F) -> ArenaScenarioStep {
+  ArenaScenarioStep result;
+  result.name =
+      QStringLiteral("%1_%2").arg(QString::number(time, 'f', 2), groups.value(0));
+  result.trigger = {Trigger::AtTime, time, {}, {}, 0.0F};
+  result.command = Command::FormArmy;
+  result.group = groups.value(0);
+  result.formation.groups = std::move(groups);
+  result.formation.intent = intent;
+  result.formation.anchor = anchor;
+  result.formation.facing_degrees = facing_degrees;
+  result.formation.frontage = frontage;
+  return result;
+}
+
+void dress_for_capture(ArenaScenarioDefinition& scenario, float hour) {
+  scenario.suppress_terrain_scatter = false;
+  scenario.select_spawned_units = false;
+  scenario.suppress_spawn_anchor = true;
+  scenario.suppress_ui_overlays = true;
+  scenario.force_full_creature_lod = true;
+  scenario.collect_animation_diagnostics = false;
+  scenario.graphics_quality = Render::GraphicsQuality::Ultra;
+  scenario.arena_floor_half_extent = 40.0F;
+  scenario.environment.start_time = hour;
+  // Locked, because a promo records the same scenario once per shot and the
+  // light has to match across the cut. The exposure and fog the profile picks
+  // for the hour are left alone: overriding them is what turned the earlier
+  // capture scenes into murk.
+  scenario.environment.time_mode = Game::Map::TimeMode::Locked;
+}
+
+void add_formation_promo_scenarios(std::vector<ArenaScenarioDefinition>& out) {
+  {
+    auto s = formation_definition(
+        QStringLiteral("promo_rome_iron_line"),
+        QStringLiteral("Promo: Rome, The Iron Line"),
+        QStringLiteral("A full Roman army marches up in column, deploys into the "
+                       "doctrine battle line, closes into a shield wall, and then "
+                       "advances holding the shape."),
+        46.0F,
+        three_quarter_camera(72.0F));
+    dress_for_capture(s, 10.5F);
+    s.groups = {
+        troop_group(QStringLiteral("first_line"),
+                    Troop::Swordsman,
+                    Nation::RomanRepublic,
+                    1,
+                    9,
+                    {-24.0F, 0.0F, -26.0F},
+                    18,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("second_line"),
+                    Troop::Swordsman,
+                    Nation::RomanRepublic,
+                    1,
+                    9,
+                    {-24.0F, 0.0F, -31.0F},
+                    18,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("spear_screen"),
+                    Troop::Spearman,
+                    Nation::RomanRepublic,
+                    1,
+                    7,
+                    {-18.0F, 0.0F, -36.0F},
+                    18,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("velites"),
+                    Troop::Archer,
+                    Nation::RomanRepublic,
+                    1,
+                    5,
+                    {-12.0F, 0.0F, -30.0F},
+                    12,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("equites"),
+                    Troop::MountedKnight,
+                    Nation::RomanRepublic,
+                    1,
+                    5,
+                    {12.0F, 0.0F, -30.0F},
+                    8,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("consul"),
+                    Troop::RomanVeteranConsul,
+                    Nation::RomanRepublic,
+                    1,
+                    1,
+                    {0.0F, 0.0F, -36.0F},
+                    1),
+    };
+    const QStringList legion{QStringLiteral("first_line"),
+                             QStringLiteral("second_line"),
+                             QStringLiteral("spear_screen"),
+                             QStringLiteral("velites"),
+                             QStringLiteral("equites"),
+                             QStringLiteral("consul")};
+    s.steps = {
+        form_step(1.0F, legion, Intent::Column, {0.0F, 0.0F, -24.0F}, 0.0F, 22.0F),
+        form_step(14.0F, legion, Intent::Line, {0.0F, 0.0F, -6.0F}, 0.0F, 58.0F),
+        form_step(27.0F, legion, Intent::Defensive, {0.0F, 0.0F, -4.0F}, 0.0F, 48.0F),
+    };
+    auto advance =
+        form_step(36.0F, legion, Intent::Assault, {0.0F, 0.0F, 18.0F}, 0.0F, 54.0F);
+    advance.formation.options.movement_policy =
+        Game::Formation::MovementPolicy::MaintainFormation;
+    s.steps.push_back(std::move(advance));
+    s.expectations = {
+        expect(Expect::GroupIsRendered, QStringLiteral("first_line")),
+        expect(Expect::GroupIsRendered, QStringLiteral("equites")),
+        expect(Expect::MovementIsContinuous, QStringLiteral("second_line")),
+        expect(Expect::NoRootTeleport, QStringLiteral("spear_screen")),
+        expect(Expect::NoUnexpectedFallPose, QStringLiteral("first_line")),
+    };
+    out.push_back(std::move(s));
+  }
+
+  {
+    auto s = formation_definition(
+        QStringLiteral("promo_carthage_crescent"),
+        QStringLiteral("Promo: Carthage, The Crescent"),
+        QStringLiteral("A Carthaginian host forms its wide bow, throws the "
+                       "Numidian wings out to either flank, and then closes the "
+                       "horns into an encirclement."),
+        56.0F,
+        three_quarter_camera(78.0F));
+    dress_for_capture(s, 10.2F);
+    s.groups = {
+        troop_group(QStringLiteral("libyan_spears"),
+                    Troop::Spearman,
+                    Nation::Carthage,
+                    1,
+                    9,
+                    {-24.0F, 0.0F, -24.0F},
+                    18,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("iberian_swords"),
+                    Troop::Swordsman,
+                    Nation::Carthage,
+                    1,
+                    7,
+                    {-18.0F, 0.0F, -30.0F},
+                    16,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("balearic_slingers"),
+                    Troop::Archer,
+                    Nation::Carthage,
+                    1,
+                    6,
+                    {-15.0F, 0.0F, -36.0F},
+                    12,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("numidian_left"),
+                    Troop::HorseArcher,
+                    Nation::Carthage,
+                    1,
+                    8,
+                    {-32.0F, 0.0F, -30.0F},
+                    8,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("numidian_right"),
+                    Troop::HorseSpearman,
+                    Nation::Carthage,
+                    1,
+                    8,
+                    {16.0F, 0.0F, -30.0F},
+                    8,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("war_elephants"),
+                    Troop::Elephant,
+                    Nation::Carthage,
+                    1,
+                    6,
+                    {-15.0F, 0.0F, -18.0F},
+                    1,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("elephant_master"),
+                    Troop::CarthageElephantMaster,
+                    Nation::Carthage,
+                    1,
+                    1,
+                    {0.0F, 0.0F, -38.0F},
+                    1),
+    };
+    const QStringList host{QStringLiteral("libyan_spears"),
+                           QStringLiteral("iberian_swords"),
+                           QStringLiteral("balearic_slingers"),
+                           QStringLiteral("war_elephants"),
+                           QStringLiteral("elephant_master")};
+    const QStringList wings{QStringLiteral("numidian_left"),
+                            QStringLiteral("numidian_right")};
+
+    auto bow = form_step(1.0F, host, Intent::Line, {0.0F, 0.0F, -12.0F}, 0.0F, 62.0F);
+    bow.formation.options.ranged_placement = Game::Formation::RangedPlacement::Skirmish;
+    s.steps.push_back(std::move(bow));
+
+    auto left_wing = form_step(4.0F,
+                               {QStringLiteral("numidian_left")},
+                               Intent::Assault,
+                               {-33.0F, 0.0F, -2.0F},
+                               35.0F,
+                               18.0F);
+    left_wing.formation.options.flank_preference =
+        Game::Formation::FlankPreference::StrongLeft;
+    s.steps.push_back(std::move(left_wing));
+
+    auto right_wing = form_step(4.0F,
+                                {QStringLiteral("numidian_right")},
+                                Intent::Assault,
+                                {33.0F, 0.0F, -2.0F},
+                                -35.0F,
+                                18.0F);
+    right_wing.formation.options.flank_preference =
+        Game::Formation::FlankPreference::StrongRight;
+    s.steps.push_back(std::move(right_wing));
+
+    auto centre_holds =
+        form_step(18.0F, host, Intent::Line, {0.0F, 0.0F, 2.0F}, 0.0F, 66.0F);
+    centre_holds.formation.options.frontage_scale = 1.2F;
+    s.steps.push_back(std::move(centre_holds));
+
+    s.steps.push_back(form_step(
+        26.0F, host + wings, Intent::Encirclement, {0.0F, 0.0F, 11.0F}, 0.0F, 58.0F));
+
+    s.expectations = {
+        expect(Expect::GroupIsRendered, QStringLiteral("libyan_spears")),
+        expect(Expect::GroupIsRendered, QStringLiteral("war_elephants")),
+        expect(Expect::GroupIsRendered, QStringLiteral("numidian_left")),
+        expect(Expect::MovementIsContinuous, QStringLiteral("iberian_swords")),
+        expect(Expect::NoRootTeleport, QStringLiteral("libyan_spears")),
+    };
+    out.push_back(std::move(s));
+  }
+
+  {
+    auto s = formation_definition(
+        QStringLiteral("promo_rome_hill_drill"),
+        QStringLiteral("Promo: Rome, Drill On The Ridge"),
+        QStringLiteral("The same legion cycles column, line, defensive and "
+                       "assault across a ridge, so the doctrine shapes and the "
+                       "terrain fitting read from overhead."),
+        52.0F,
+        overhead_camera(92.0F));
+    dress_for_capture(s, 13.0F);
+    ArenaScenarioElevationPatch ridge;
+    ridge.center = QVector3D(0.0F, 0.0F, 4.0F);
+    ridge.radius = 30.0F;
+    ridge.height = 6.0F;
+    s.elevation_patches = {ridge};
+    s.groups = {
+        troop_group(QStringLiteral("cohorts"),
+                    Troop::Swordsman,
+                    Nation::RomanRepublic,
+                    1,
+                    10,
+                    {-27.0F, 0.0F, -26.0F},
+                    18,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("pikes"),
+                    Troop::Spearman,
+                    Nation::RomanRepublic,
+                    1,
+                    7,
+                    {-18.0F, 0.0F, -32.0F},
+                    18,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("bows"),
+                    Troop::Archer,
+                    Nation::RomanRepublic,
+                    1,
+                    6,
+                    {-15.0F, 0.0F, -38.0F},
+                    12,
+                    {6.0F, 0.0F, 0.0F}),
+        troop_group(QStringLiteral("wings"),
+                    Troop::MountedKnight,
+                    Nation::RomanRepublic,
+                    1,
+                    6,
+                    {12.0F, 0.0F, -34.0F},
+                    8,
+                    {6.0F, 0.0F, 0.0F}),
+    };
+    const QStringList legion{QStringLiteral("cohorts"),
+                             QStringLiteral("pikes"),
+                             QStringLiteral("bows"),
+                             QStringLiteral("wings")};
+    s.steps = {
+        form_step(1.0F, legion, Intent::Column, {0.0F, 0.0F, -26.0F}, 0.0F, 16.0F),
+        form_step(13.0F, legion, Intent::Line, {0.0F, 0.0F, 2.0F}, 0.0F, 44.0F),
+        form_step(25.0F, legion, Intent::Defensive, {0.0F, 0.0F, 4.0F}, 0.0F, 32.0F),
+        form_step(35.0F, legion, Intent::Assault, {0.0F, 0.0F, 6.0F}, 0.0F, 40.0F),
+        form_step(45.0F, legion, Intent::Column, {0.0F, 0.0F, 26.0F}, 0.0F, 16.0F),
+    };
+    s.expectations = {
+        expect(Expect::GroupIsRendered, QStringLiteral("cohorts")),
+        expect(Expect::MovementIsContinuous, QStringLiteral("cohorts")),
+        expect(Expect::NoUnexpectedFallPose, QStringLiteral("pikes")),
+        expect(Expect::NoRootTeleport, QStringLiteral("bows")),
+    };
+    out.push_back(std::move(s));
+  }
+}
+
 } // namespace
 
 auto build_formation_definitions() -> std::vector<ArenaScenarioDefinition> {
   std::vector<ArenaScenarioDefinition> result;
-  result.reserve(24);
+  result.reserve(28);
   add_unit_layout_scenarios(result);
   add_army_formation_scenarios(result);
   add_terrain_formation_scenarios(result);
+  add_formation_promo_scenarios(result);
   return result;
 }
 

--- a/tools/arena/arena_scenario.cpp
+++ b/tools/arena/arena_scenario.cpp
@@ -18,6 +18,7 @@
 #include "game/command/command_dispatcher.h"
 #include "game/core/component.h"
 #include "game/core/world.h"
+#include "game/formation/army_formation_service.h"
 #include "game/map/terrain_service.h"
 #include "game/systems/combat_actions/combat_action_definition.h"
 #include "game/systems/combat_system/damage_application.h"
@@ -84,6 +85,8 @@ auto command_name(ScenarioCommandKind kind) -> QString {
     return QStringLiteral("Move");
   case ScenarioCommandKind::FormationMove:
     return QStringLiteral("FormationMove");
+  case ScenarioCommandKind::FormArmy:
+    return QStringLiteral("FormArmy");
   case ScenarioCommandKind::Charge:
     return QStringLiteral("Charge");
   case ScenarioCommandKind::Attack:
@@ -423,6 +426,18 @@ auto validate_scenario(const ArenaScenarioDefinition& definition)
       check_group(step.trigger.target_group,
                   field + QStringLiteral(".trigger.target_group"),
                   true);
+    }
+    // A FormArmy step folds several groups into one army; a typo in that list
+    // would silently deploy a smaller army rather than fail.
+    for (int member = 0; member < step.formation.groups.size(); ++member) {
+      check_group(step.formation.groups.at(member),
+                  field + QStringLiteral(".formation.groups[%1]").arg(member),
+                  true);
+    }
+    if (step.command == ScenarioCommandKind::FormArmy &&
+        step.formation.frontage < 0.0F) {
+      errors.push_back(
+          {field, QStringLiteral("formation frontage cannot be negative")});
     }
   }
 
@@ -959,6 +974,98 @@ struct ArenaScenarioRunner::Impl {
     }
   }
 
+  // Deploy one or more groups as a single doctrine-planned army, the same way
+  // `CommandController::confirm_formation_placement` does for a player drag:
+  // commit the plan so the registry owns the group, write each unit's slot back
+  // onto its formation mode so the runtime can measure cohesion against it, and
+  // then move everyone to the slot the planner chose.
+  void form_army(const ArenaScenarioStep& step) {
+    std::vector<Engine::Core::EntityID> members;
+    QStringList sources = step.formation.groups;
+    if (sources.isEmpty()) {
+      sources.append(step.group);
+    }
+    for (auto const& name : sources) {
+      auto const& group_ids = ids(name);
+      members.insert(members.end(), group_ids.begin(), group_ids.end());
+    }
+    members.erase(
+        std::remove_if(members.begin(),
+                       members.end(),
+                       [&](auto entity_id) { return !entity_alive(entity_id); }),
+        members.end());
+    if (members.empty()) {
+      add_issue(
+          QStringLiteral("formation_members_missing"),
+          QStringLiteral("FormArmy step '%1' resolved no living units").arg(step.name));
+      return;
+    }
+
+    Game::Formation::ArmyFormationRequest request;
+    request.members = members;
+    request.anchor = world_origin + step.formation.anchor;
+    request.facing = step.formation.facing_degrees;
+    request.frontage = step.formation.frontage;
+    request.intent = step.formation.intent;
+    request.options = step.formation.options;
+    if (!step.formation.doctrine.isEmpty()) {
+      request.doctrine = step.formation.doctrine.toStdString();
+      request.options.doctrine_locked = true;
+    }
+    if (step.formation.spacing > 0.0F) {
+      request.spacing = step.formation.spacing;
+    }
+
+    auto const result = Game::Formation::ArmyFormationService::commit(world, request);
+    if (!result.valid) {
+      add_issue(QStringLiteral("formation_rejected"),
+                QStringLiteral("FormArmy step '%1' was rejected: %2")
+                    .arg(step.name, QString::fromStdString(result.rejection_reason)));
+      return;
+    }
+    if (result.positions.size() != members.size()) {
+      add_issue(QStringLiteral("formation_plan_mismatch"),
+                QStringLiteral("FormArmy step '%1' planned %2 slots for %3 units")
+                    .arg(step.name)
+                    .arg(result.positions.size())
+                    .arg(members.size()));
+      return;
+    }
+
+    for (std::size_t i = 0; i < members.size(); ++i) {
+      auto* entity = world.get_entity(members[i]);
+      if (entity == nullptr) {
+        continue;
+      }
+      if (auto* transform = entity->get_component<Engine::Core::TransformComponent>()) {
+        if (i < result.facing_angles.size()) {
+          transform->desired_yaw = result.facing_angles[i];
+          transform->has_desired_yaw = true;
+        }
+      }
+      auto* formation_mode =
+          entity->get_component<Engine::Core::FormationModeComponent>();
+      if (formation_mode != nullptr && i < result.stable_slot_ids.size()) {
+        formation_mode->formation_id = result.group_id;
+        formation_mode->stable_slot_id = result.stable_slot_ids[i];
+        formation_mode->stable_rank = result.stable_ranks[i];
+        formation_mode->stable_file = result.stable_files[i];
+        formation_mode->stable_slot_x = result.positions[i].x();
+        formation_mode->stable_slot_z = result.positions[i].z();
+      }
+    }
+
+    Game::Systems::CommandService::MoveOptions options;
+    options.kind = Game::Systems::MoveOrderKind::FormationMove;
+    options.preserve_formation_mode = result.used_army_formation;
+    Game::Systems::CommandService::move_units(
+        world, members, result.positions, options);
+
+    for (auto const& name : sources) {
+      arm_response(name, command_name(step.command));
+    }
+  }
+
   void execute_step(std::size_t index, const ArenaScenarioStep& step) {
     auto& runtime = steps[index];
     runtime.executed = true;
@@ -985,6 +1092,9 @@ struct ArenaScenarioRunner::Impl {
       arm_response(step.group, command_name(step.command));
       break;
     }
+    case ScenarioCommandKind::FormArmy:
+      form_army(step);
+      break;
     case ScenarioCommandKind::Charge:
       for (auto entity_id : ids(step.group)) {
         if (auto* entity = world.get_entity(entity_id)) {

--- a/tools/arena/arena_scenario.h
+++ b/tools/arena/arena_scenario.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+#include <QStringList>
 #include <QVector3D>
 
 #include <cstdint>
@@ -10,6 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "game/formation/army_formation_types.h"
 #include "game/map/map_definition.h"
 #include "game/map/terrain.h"
 #include "game/systems/nation_id.h"
@@ -50,6 +52,7 @@ enum class ScenarioCommandKind : std::uint8_t {
   Stand,
   Move,
   FormationMove,
+  FormArmy,
   Charge,
   Attack,
   AttackMove,
@@ -111,6 +114,28 @@ struct ArenaScenarioElevationPatch {
   float height{3.0F};
 };
 
+// A `FormArmy` step's payload: the army-formation layer's own request, told in
+// scenario terms. `FormationMove` only translates whatever shape a group is
+// already standing in; this asks the doctrine planner where every unit belongs
+// and walks them there, which is the behaviour a formation showcase is about.
+struct ArenaScenarioFormationOrder {
+  // Every named group is folded into one army, so a scenario can deploy its
+  // infantry, cavalry and ranged as a single doctrine plan rather than three
+  // unrelated blocks. Empty means "the step's own group".
+  QStringList groups;
+  Game::Formation::ArmyFormationIntent intent{
+      Game::Formation::ArmyFormationIntent::FactionDefault};
+
+  // Empty derives the doctrine from the members' nations.
+  QString doctrine;
+  Game::Formation::ArmyFormationOptions options;
+
+  QVector3D anchor;
+  float facing_degrees{0.0F};
+  float frontage{0.0F};
+  float spacing{0.0F};
+};
+
 struct ArenaScenarioStep {
   QString name;
   ScenarioTrigger trigger;
@@ -126,6 +151,7 @@ struct ArenaScenarioStep {
   float camera_yaw{30.0F};
 
   std::optional<float> rpg_view_yaw_degrees;
+  ArenaScenarioFormationOrder formation;
 };
 
 enum class ArenaExpectationKind : std::uint8_t {
@@ -226,6 +252,12 @@ struct ArenaScenarioDefinition {
   QString label;
   QString description;
   float duration_seconds{12.0F};
+
+  // Half-width of the flat field the arena levels out of its mountain noise.
+  // The default is sized for a duel; an army manoeuvring in formation needs
+  // ground that a whole battle line can march across, and outside this square
+  // the terrain is rough enough to break the shapes up.
+  float arena_floor_half_extent{18.0F};
   ArenaCameraView camera;
   std::optional<QVector3D> camera_focus;
   bool suppress_terrain_scatter{false};

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -98,6 +98,7 @@ constexpr int k_all_owners_filter = 0;
 constexpr int k_terrain_width = 96;
 constexpr int k_terrain_height = 96;
 constexpr float k_terrain_tile_size = 1.0F;
+constexpr float k_default_floor_extent = 18.0F;
 constexpr int k_selection_drag_threshold = 6;
 constexpr int k_interactive_frame_interval_ms = 8;
 
@@ -1463,20 +1464,31 @@ void ArenaViewport::regenerate_terrain() {
 
   float const arena_floor_height =
       std::min(safe_scale * 0.18F, std::max(0.0F, max_height * 0.25F));
-  constexpr float k_arena_half_width = 18.0F;
-  constexpr float k_arena_half_depth = 18.0F;
+  float const arena_half_extent =
+      std::clamp(m_arena_floor_half_extent, 4.0F, half_width - 2.0F);
+  // Ease the flat floor into the surrounding noise instead of stepping out of
+  // it. A hard edge turns the mountains into a wall standing right on the
+  // touchline, which a camera at eye level inside the field cannot avoid.
+  float const taper = std::min(12.0F, half_width - arena_half_extent);
   for (int z = 0; z < k_terrain_height; ++z) {
     for (int x = 0; x < k_terrain_width; ++x) {
       float const world_x = (static_cast<float>(x) - half_width) * k_terrain_tile_size;
       float const world_z = (static_cast<float>(z) - half_height) * k_terrain_tile_size;
-      if (std::abs(world_x) > k_arena_half_width ||
-          std::abs(world_z) > k_arena_half_depth) {
+      float const edge = std::max(std::abs(world_x), std::abs(world_z));
+      if (edge > arena_half_extent + taper) {
         continue;
       }
 
+      float blend = 0.0F;
+      if (taper > 0.0F && edge > arena_half_extent) {
+        blend = std::clamp((edge - arena_half_extent) / taper, 0.0F, 1.0F);
+        blend = blend * blend * (3.0F - (2.0F * blend));
+      }
       auto const index = static_cast<size_t>(z * k_terrain_width + x);
-      heights[index] = arena_floor_height;
-      terrain_types[index] = Game::Map::TerrainType::Flat;
+      heights[index] = std::lerp(arena_floor_height, heights[index], blend);
+      if (blend < 0.5F) {
+        terrain_types[index] = Game::Map::TerrainType::Flat;
+      }
     }
   }
 
@@ -1612,6 +1624,11 @@ void ArenaViewport::set_environment_time(float hour) {
   }
   emit lighting_changed(lighting_summary());
   update();
+}
+
+void ArenaViewport::set_environment_hour_override(float hour) {
+  m_environment_hour_override = Game::Map::normalize_hour(hour);
+  set_environment_time(*m_environment_hour_override);
 }
 
 void ArenaViewport::set_lighting_profile(const QString& profile) {
@@ -2346,12 +2363,14 @@ void ArenaViewport::reset_arena() {
   clear_units();
   const bool had_custom_terrain = !m_arena_rivers.empty() || !m_arena_lakes.empty() ||
                                   !m_arena_bridges.empty() || !m_arena_roads.empty() ||
-                                  !m_arena_elevation_patches.empty();
+                                  !m_arena_elevation_patches.empty() ||
+                                  m_arena_floor_half_extent != k_default_floor_extent;
   m_arena_rivers.clear();
   m_arena_lakes.clear();
   m_arena_bridges.clear();
   m_arena_roads.clear();
   m_arena_elevation_patches.clear();
+  m_arena_floor_half_extent = k_default_floor_extent;
   clear_world_props();
   if (had_custom_terrain && m_world_props.empty()) {
     reconfigure_terrain_from_state();
@@ -3016,8 +3035,12 @@ void ArenaViewport::load_scenario(const QString& scenario_id) {
   Render::GraphicsSettings::instance().set_quality(definition->graphics_quality);
   m_environment_definition = definition->environment;
   m_environment_hour = definition->environment.start_time;
+  if (m_environment_hour_override.has_value()) {
+    m_environment_hour = *m_environment_hour_override;
+    m_environment_definition.start_time = m_environment_hour;
+  }
   m_lighting_profile = definition->environment.lighting_profile;
-  m_environment_clock.reset(definition->environment);
+  m_environment_clock.reset(m_environment_definition);
   m_rain_enabled = definition->weather.rain > 0.0F ||
                    definition->weather.storm > 0.0F || definition->weather.snow > 0.0F;
   m_rain_intensity = std::max(
@@ -3038,8 +3061,10 @@ void ArenaViewport::load_scenario(const QString& scenario_id) {
   m_arena_bridges = definition->bridges;
   m_arena_roads = definition->roads;
   m_arena_elevation_patches = definition->elevation_patches;
+  m_arena_floor_half_extent = definition->arena_floor_half_extent;
   if (!m_arena_rivers.empty() || !m_arena_lakes.empty() || !m_arena_bridges.empty() ||
-      !m_arena_roads.empty() || !m_arena_elevation_patches.empty()) {
+      !m_arena_roads.empty() || !m_arena_elevation_patches.empty() ||
+      m_arena_floor_half_extent != k_default_floor_extent) {
     reconfigure_terrain_from_state();
   }
   auto& owners = Game::Systems::OwnerRegistry::instance();

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -92,6 +92,11 @@ public slots:
   void set_rain_intensity(float intensity);
   void set_time_of_day(Game::Map::TimeOfDay time_of_day);
   void set_environment_time(float hour);
+
+  // Hold this hour against a scenario that locks its own. Capture scenarios
+  // pin the light so it matches across a promo's shots, which is right for a
+  // recording and wrong while you are still deciding what hour to record at.
+  void set_environment_hour_override(float hour);
   void set_lighting_profile(const QString& profile);
   void set_time_mode(const QString& mode);
   void set_day_length(float seconds);
@@ -327,6 +332,7 @@ private:
   Game::Map::GroundType m_ground_type = Game::Map::GroundType::ForestMud;
   Game::Map::TimeOfDay m_time_of_day = Game::Map::TimeOfDay::Day;
   float m_environment_hour = 13.0F;
+  std::optional<float> m_environment_hour_override;
   QString m_lighting_profile = QStringLiteral("mediterranean_summer");
   Game::Map::EnvironmentDefinition m_environment_definition;
   Game::Map::EnvironmentClock m_environment_clock;
@@ -373,6 +379,7 @@ private:
   std::vector<Game::Map::Bridge> m_arena_bridges;
   std::vector<Game::Map::RoadSegment> m_arena_roads;
   std::vector<Arena::ArenaScenarioElevationPatch> m_arena_elevation_patches;
+  float m_arena_floor_half_extent = 18.0F;
   std::vector<Game::Map::UndeadZone> m_arena_undead_zones;
   Game::Map::WorldProp::Type m_spawn_world_prop_type =
       Game::Map::WorldProp::Type::FireCamp;

--- a/tools/arena/main.cpp
+++ b/tools/arena/main.cpp
@@ -251,7 +251,7 @@ auto main(int argc, char** argv) -> int {
   QCommandLineOption const environment_time_option(
       QStringList{QStringLiteral("time")},
       QStringLiteral("Exact decimal environment hour (0-24); overrides "
-                     "--time-of-day."),
+                     "--time-of-day and any hour a scenario locks."),
       QStringLiteral("hour"));
   QCommandLineOption const lighting_profile_option(
       QStringList{QStringLiteral("lighting-profile")},
@@ -341,6 +341,7 @@ auto main(int argc, char** argv) -> int {
   }
 
   const bool time_of_day_forced = parser.isSet(time_of_day_option);
+  const bool environment_hour_forced = parser.isSet(environment_time_option);
   const auto forced_time_of_day = *parsed_time_of_day;
   float environment_hour = Game::Map::hour_for_time_of_day(*parsed_time_of_day);
   if (parser.isSet(environment_time_option)) {
@@ -367,7 +368,13 @@ auto main(int argc, char** argv) -> int {
   window.show();
   window.viewport()->set_time_of_day(*parsed_time_of_day);
   window.viewport()->set_lighting_profile(lighting_profile);
-  window.viewport()->set_environment_time(environment_hour);
+  // An explicit --time is a deliberate instruction and outranks a scenario
+  // that pins its own hour; --time-of-day stays a default the scenario wins.
+  if (environment_hour_forced) {
+    window.viewport()->set_environment_hour_override(environment_hour);
+  } else {
+    window.viewport()->set_environment_time(environment_hour);
+  }
   window.viewport()->set_terrain_review_content_enabled(include_map_preview_content);
   window.viewport()->set_clean_capture(parser.isSet(clean_capture_option));
   window.viewport()->set_prewarm_unit_templates(parser.isSet(prewarm_option));
@@ -695,6 +702,7 @@ auto main(int argc, char** argv) -> int {
                  duration,
                  capture_interval,
                  environment_hour,
+                 environment_hour_forced,
                  lighting_profile]() {
     if (state->next_index >= state->scenarios.size()) {
       qInfo().noquote()
@@ -734,8 +742,9 @@ auto main(int argc, char** argv) -> int {
         QDir(state->current_directory).filePath(QStringLiteral("run_config.json")));
     if (config_file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
       auto const* scenario = Arena::Scenarios::find_definition(id);
-      const float effective_hour =
-          scenario != nullptr ? scenario->environment.start_time : environment_hour;
+      const float effective_hour = (scenario != nullptr && !environment_hour_forced)
+                                       ? scenario->environment.start_time
+                                       : environment_hour;
       const QString effective_profile = scenario != nullptr
                                             ? scenario->environment.lighting_profile
                                             : lighting_profile;

--- a/tools/arena/promo_runner.cpp
+++ b/tools/arena/promo_runner.cpp
@@ -29,7 +29,7 @@ namespace Arena::Promo {
 namespace {
 
 constexpr float k_scenario_tail_seconds = 2.0F;
-constexpr int k_shot_watchdog_ms = 900'000;
+constexpr int k_pass_watchdog_ms = 1'800'000;
 
 struct ShotResult {
   QString name;
@@ -46,7 +46,9 @@ public:
   Recorder(ArenaViewport& viewport, const Spec& spec, RunOptions options)
       : m_viewport(viewport)
       , m_spec(spec)
-      , m_options(std::move(options)) {}
+      , m_options(std::move(options))
+      , m_passes(plan_passes(spec))
+      , m_results(spec.shots.size()) {}
 
   auto start(QString* error) -> bool {
     if (!VideoEncoder::ffmpeg_available()) {
@@ -69,34 +71,91 @@ public:
                                       m_spec.height * m_spec.supersample);
     m_viewport.set_capture_sink([this](const QImage& frame) { on_frame(frame); });
     m_viewport.set_frame_hook([this](float scenario_time) { on_tick(scenario_time); });
-    QTimer::singleShot(250, [this]() { begin_next_shot(); });
+    QTimer::singleShot(250, [this]() { begin_next_pass(); });
     return true;
   }
 
   [[nodiscard]] auto failed() const noexcept -> bool { return m_failed; }
 
 private:
-  void begin_next_shot() {
-    if (m_shot_index >= m_spec.shots.size()) {
+  [[nodiscard]] auto current_shot() const -> const Shot& {
+    return m_spec.shots[m_passes[m_pass_index].shots[m_slot_index]];
+  }
+
+  [[nodiscard]] auto current_shot_index() const -> std::size_t {
+    return m_passes[m_pass_index].shots[m_slot_index];
+  }
+
+  void begin_next_pass() {
+    if (m_pass_index >= m_passes.size()) {
       finish_run();
       return;
     }
-
-    const Shot& shot = m_spec.shots[m_shot_index];
-    if (Arena::Scenarios::find_definition(shot.scenario) == nullptr) {
-      qCritical().noquote() << QStringLiteral("Promo shot '%1' names unknown scenario "
-                                              "'%2'")
-                                   .arg(shot.name, shot.scenario);
+    const CapturePass& pass = m_passes[m_pass_index];
+    if (Arena::Scenarios::find_definition(pass.scenario) == nullptr) {
+      qCritical().noquote() << QStringLiteral("Promo pass names unknown scenario '%1'")
+                                   .arg(pass.scenario);
       m_failed = true;
-      ++m_shot_index;
-      QTimer::singleShot(0, [this]() { begin_next_shot(); });
+      ++m_pass_index;
+      QTimer::singleShot(0, [this]() { begin_next_pass(); });
       return;
     }
 
-    m_clip_path = QDir(m_options.output_directory)
-                      .filePath(QStringLiteral("%1_%2.mp4")
-                                    .arg(m_shot_index + 1U, 2, 10, QLatin1Char('0'))
-                                    .arg(shot.name));
+    float last_end = 0.0F;
+    for (std::size_t index : pass.shots) {
+      const Shot& shot = m_spec.shots[index];
+      last_end = std::max(last_end, shot.start_seconds + shot.duration_seconds);
+    }
+
+    m_slot_index = 0;
+    m_pass_active = true;
+    m_viewport.set_terrain_seed(pass.seed);
+    m_viewport.set_batch_fixed_step(idle_step());
+    m_viewport.set_scenario_duration_override(last_end + k_scenario_tail_seconds);
+    m_viewport.set_capture_active(false);
+    m_viewport.clear_cinematic_view();
+    m_viewport.load_scenario(pass.scenario);
+
+    qInfo().noquote() << QStringLiteral("Promo pass %1/%2: %3, %4 shot(s) across "
+                                        "%5 s of scenario")
+                             .arg(m_pass_index + 1U)
+                             .arg(m_passes.size())
+                             .arg(pass.scenario)
+                             .arg(pass.shots.size())
+                             .arg(QString::number(last_end, 'f', 1));
+
+    const std::size_t guarded_pass = m_pass_index;
+    QTimer::singleShot(k_pass_watchdog_ms, [this, guarded_pass]() {
+      if (m_pass_active && m_pass_index == guarded_pass) {
+        qCritical().noquote() << QStringLiteral("Promo pass over scenario '%1' "
+                                                "exceeded its watchdog")
+                                     .arg(m_passes[guarded_pass].scenario);
+        m_failed = true;
+        end_shot();
+        end_pass();
+      }
+    });
+    begin_shot();
+  }
+
+  [[nodiscard]] auto idle_step() const -> float {
+    return 1.0F / static_cast<float>(m_spec.fps);
+  }
+
+  void begin_shot() {
+    if (!m_pass_active) {
+      return;
+    }
+    if (m_slot_index >= m_passes[m_pass_index].shots.size()) {
+      end_pass();
+      return;
+    }
+    const Shot& shot = current_shot();
+    m_clip_path =
+        QDir(m_options.output_directory)
+            .filePath(QStringLiteral("%1_%2.mp4")
+                          .arg(current_shot_index() + 1U, 2, 10, QLatin1Char('0'))
+                          .arg(shot.name));
     QString encoder_error;
     m_encoder = std::make_unique<VideoEncoder>();
     if (!m_encoder->open(
@@ -105,8 +164,8 @@ private:
           << QStringLiteral("Promo shot '%1': %2").arg(shot.name, encoder_error);
       m_failed = true;
       m_encoder.reset();
-      ++m_shot_index;
-      QTimer::singleShot(0, [this]() { begin_next_shot(); });
+      ++m_slot_index;
+      begin_shot();
       return;
     }
 
@@ -120,42 +179,25 @@ private:
     m_logged_framing = false;
     m_shot_active = true;
     m_last_frame.reset();
+    m_viewport.set_batch_fixed_step(idle_step());
 
-    m_viewport.set_terrain_seed(shot.seed);
-    m_viewport.set_batch_fixed_step(m_step_seconds);
-    m_viewport.set_scenario_duration_override(
-        shot.start_seconds + shot.duration_seconds + k_scenario_tail_seconds);
-    m_viewport.set_capture_active(false);
-    m_viewport.clear_cinematic_view();
-    m_viewport.load_scenario(shot.scenario);
-
-    qInfo().noquote() << QStringLiteral("Recording promo shot %1/%2: %3 (%4, %5 "
-                                        "frames at %6x%7)")
-                             .arg(m_shot_index + 1U)
-                             .arg(m_spec.shots.size())
-                             .arg(shot.name, shot.scenario)
+    qInfo().noquote() << QStringLiteral("  shot %1: %2 (%3 frames at %4x%5, from "
+                                        "%6 s)")
+                             .arg(current_shot_index() + 1U)
+                             .arg(shot.name)
                              .arg(m_target_frames)
                              .arg(m_spec.width)
-                             .arg(m_spec.height);
-
-    const std::size_t guarded_shot = m_shot_index;
-    QTimer::singleShot(k_shot_watchdog_ms, [this, guarded_shot]() {
-      if (m_shot_active && m_shot_index == guarded_shot) {
-        qCritical().noquote() << QStringLiteral("Promo shot '%1' exceeded its watchdog")
-                                     .arg(m_spec.shots[guarded_shot].name);
-        m_failed = true;
-        end_shot();
-      }
-    });
+                             .arg(m_spec.height)
+                             .arg(QString::number(shot.start_seconds, 'f', 1));
   }
 
   // Runs once per rendered frame, before the frame is drawn: this is where the
   // authored camera is resolved against the live battle.
   void on_tick(float scenario_time) {
-    if (!m_shot_active || m_shot_index >= m_spec.shots.size()) {
+    if (!m_shot_active) {
       return;
     }
-    const Shot& shot = m_spec.shots[m_shot_index];
+    const Shot& shot = current_shot();
     const float shot_time = std::max(0.0F, scenario_time - shot.start_seconds);
 
     const QVector3D focus = resolve_focus(shot);
@@ -169,6 +211,11 @@ private:
 
     const bool recording =
         scenario_time >= shot.start_seconds && m_frames_written < m_target_frames;
+    if (recording && m_frames_written == 0) {
+      // Only slow the simulation down once the shot is actually running, so
+      // the run-up to a slow-motion shot costs the same as any other.
+      m_viewport.set_batch_fixed_step(m_step_seconds);
+    }
     m_viewport.set_capture_active(recording);
 
     // Report the framing that the first recorded frame actually used. Authoring
@@ -195,6 +242,7 @@ private:
 
     if (!recording && m_frames_written >= m_target_frames) {
       end_shot();
+      advance_within_pass();
       return;
     }
     // A scenario that resolves early (everyone dead) can never deliver the rest
@@ -206,6 +254,7 @@ private:
                                   .arg(m_frames_written)
                                   .arg(m_target_frames);
       end_shot();
+      end_pass();
     }
   }
 
@@ -223,6 +272,7 @@ private:
       qCritical().noquote() << QStringLiteral("Promo encode failed: %1").arg(error);
       m_failed = true;
       end_shot();
+      end_pass();
       return;
     }
     ++m_frames_written;
@@ -277,8 +327,10 @@ private:
     }
     m_shot_active = false;
     m_viewport.set_capture_active(false);
+    m_viewport.set_batch_fixed_step(idle_step());
 
-    const Shot& shot = m_spec.shots[m_shot_index];
+    const std::size_t shot_index = current_shot_index();
+    const Shot& shot = m_spec.shots[shot_index];
     QString error;
     if (m_encoder != nullptr && !m_encoder->close(&error)) {
       qCritical().noquote()
@@ -299,19 +351,30 @@ private:
       result.poster_path =
           QDir(m_options.output_directory)
               .filePath(QStringLiteral("%1_%2.png")
-                            .arg(m_shot_index + 1U, 2, 10, QLatin1Char('0'))
+                            .arg(shot_index + 1U, 2, 10, QLatin1Char('0'))
                             .arg(shot.name));
       m_last_frame->save(result.poster_path);
     }
-    m_results.push_back(result);
+    m_results[shot_index] = result;
 
     qInfo().noquote() << QStringLiteral("  wrote %1 (%2 frames, %3 s)")
                              .arg(QFileInfo(m_clip_path).fileName())
                              .arg(m_frames_written)
                              .arg(QString::number(result.clip_duration, 'f', 2));
+  }
 
-    ++m_shot_index;
-    QTimer::singleShot(0, [this]() { begin_next_shot(); });
+  void advance_within_pass() {
+    ++m_slot_index;
+    begin_shot();
+  }
+
+  void end_pass() {
+    if (!m_pass_active) {
+      return;
+    }
+    m_pass_active = false;
+    ++m_pass_index;
+    QTimer::singleShot(0, [this]() { begin_next_pass(); });
   }
 
   void finish_run() {
@@ -319,14 +382,24 @@ private:
     m_viewport.set_frame_hook(nullptr);
     write_manifest();
     qInfo().noquote() << QStringLiteral("Promo capture complete: %1 shot(s) in %2")
-                             .arg(m_results.size())
+                             .arg(recorded_count())
                              .arg(QDir(m_options.output_directory).absolutePath());
     QApplication::exit(m_failed ? 1 : 0);
+  }
+
+  [[nodiscard]] auto recorded_count() const -> std::size_t {
+    return static_cast<std::size_t>(
+        std::count_if(m_results.begin(), m_results.end(), [](const ShotResult& result) {
+          return result.frames > 0;
+        }));
   }
 
   void write_manifest() {
     QJsonArray shots;
     for (const ShotResult& result : m_results) {
+      if (result.frames <= 0) {
+        continue;
+      }
       shots.append(QJsonObject{
           {QStringLiteral("name"), result.name},
           {QStringLiteral("scenario"), result.scenario},
@@ -353,15 +426,18 @@ private:
   ArenaViewport& m_viewport;
   const Spec& m_spec;
   RunOptions m_options;
+  std::vector<CapturePass> m_passes;
   std::unique_ptr<VideoEncoder> m_encoder;
   std::vector<ShotResult> m_results;
   std::optional<QImage> m_last_frame;
   QString m_clip_path;
   QVector3D m_smoothed_focus;
-  std::size_t m_shot_index{0};
+  std::size_t m_pass_index{0};
+  std::size_t m_slot_index{0};
   int m_target_frames{0};
   int m_frames_written{0};
   float m_step_seconds{1.0F / 60.0F};
+  bool m_pass_active{false};
   bool m_shot_active{false};
   bool m_focus_valid{false};
   bool m_logged_framing{false};

--- a/tools/arena/promo_spec.cpp
+++ b/tools/arena/promo_spec.cpp
@@ -99,6 +99,20 @@ auto ease_value(Ease ease, float t) -> float {
   return clamped * clamped * (3.0F - (2.0F * clamped));
 }
 
+// Yaw is an angle, so a key at 352 sitting after one at 8 means "sixteen
+// degrees back", not "344 degrees the other way around the battle". Blend along
+// the shorter arc; an author who really wants the long orbit says so by putting
+// a key in the middle of it.
+auto lerp_yaw(float from, float to, float blend) -> float {
+  float delta = std::fmod(to - from, 360.0F);
+  if (delta > 180.0F) {
+    delta -= 360.0F;
+  } else if (delta < -180.0F) {
+    delta += 360.0F;
+  }
+  return from + (delta * blend);
+}
+
 auto hash_noise(int seed) -> float {
   auto value = static_cast<std::uint32_t>(seed) * 747796405U + 2891336453U;
   value = ((value >> ((value >> 28U) + 4U)) ^ value) * 277803737U;
@@ -144,7 +158,7 @@ auto evaluate(const std::vector<CameraKey>& keys, float shot_time) -> Pose {
     Pose result;
     result.distance = std::lerp(previous.distance, next.distance, blend);
     result.pitch = std::lerp(previous.pitch, next.pitch, blend);
-    result.yaw = std::lerp(previous.yaw, next.yaw, blend);
+    result.yaw = lerp_yaw(previous.yaw, next.yaw, blend);
     result.fov = std::lerp(previous.fov, next.fov, blend);
     result.roll = std::lerp(previous.roll, next.roll, blend);
     result.height = std::lerp(previous.height, next.height, blend);
@@ -160,6 +174,49 @@ auto shake_offset(int frame_index, float amount) -> QVector3D {
   return {hash_noise(frame_index * 3) * amount,
           hash_noise((frame_index * 3) + 1) * amount * 0.5F,
           hash_noise((frame_index * 3) + 2) * amount};
+}
+
+namespace {
+
+[[nodiscard]] auto windows_overlap(const Shot& lhs, const Shot& rhs) -> bool {
+  const float lhs_end = lhs.start_seconds + lhs.duration_seconds;
+  const float rhs_end = rhs.start_seconds + rhs.duration_seconds;
+  return lhs.start_seconds < rhs_end && rhs.start_seconds < lhs_end;
+}
+
+} // namespace
+
+auto plan_passes(const Spec& spec) -> std::vector<CapturePass> {
+  std::vector<CapturePass> passes;
+  for (std::size_t index = 0; index < spec.shots.size(); ++index) {
+    const Shot& shot = spec.shots[index];
+    CapturePass* home = nullptr;
+    for (CapturePass& pass : passes) {
+      if (pass.scenario != shot.scenario || pass.seed != shot.seed) {
+        continue;
+      }
+      const bool clashes =
+          std::any_of(pass.shots.begin(), pass.shots.end(), [&](std::size_t other) {
+            return windows_overlap(spec.shots[other], shot);
+          });
+      if (!clashes) {
+        home = &pass;
+        break;
+      }
+    }
+    if (home == nullptr) {
+      passes.push_back(CapturePass{shot.scenario, shot.seed, {}});
+      home = &passes.back();
+    }
+    home->shots.push_back(index);
+  }
+  for (CapturePass& pass : passes) {
+    std::stable_sort(
+        pass.shots.begin(), pass.shots.end(), [&](std::size_t lhs, std::size_t rhs) {
+          return spec.shots[lhs].start_seconds < spec.shots[rhs].start_seconds;
+        });
+  }
+  return passes;
 }
 
 auto load(const QString& path, QString* error) -> std::optional<Spec> {

--- a/tools/arena/promo_spec.h
+++ b/tools/arena/promo_spec.h
@@ -77,6 +77,22 @@ struct Pose {
   float height{0.0F};
 };
 
+// One load of one scenario, covering every shot whose window fits inside it.
+struct CapturePass {
+  QString scenario;
+  int seed{0};
+  std::vector<std::size_t> shots;
+};
+
+// Reloading per shot means re-simulating the whole battle up to that shot's
+// start, and a reel whose shots march through a long scenario pays that bill
+// once per shot; recording them in one continuous take pays it once. Shots go
+// in authored order into the first pass that can still take them -- same
+// scenario, same seed, no window already claimed -- so two angles on the same
+// moment still work, each in its own pass. Within a pass the shots come out
+// ordered by start time, which is the order the recorder has to play them in.
+[[nodiscard]] auto plan_passes(const Spec& spec) -> std::vector<CapturePass>;
+
 [[nodiscard]] auto load(const QString& path, QString* error) -> std::optional<Spec>;
 
 [[nodiscard]] auto evaluate(const std::vector<CameraKey>& keys,

--- a/tools/arena/promos/carthage_crescent.json
+++ b/tools/arena/promos/carthage_crescent.json
@@ -1,0 +1,195 @@
+{
+  "id": "carthage_crescent",
+  "title": "THE CRESCENT",
+  "subtitle": "STANDARD OF IRON",
+  "width": 1920,
+  "height": 1080,
+  "fps": 60,
+  "supersample": 1,
+  "transition": {
+    "type": "dissolve",
+    "duration": 0.4
+  },
+  "shots": [
+    {
+      "name": "host",
+      "scenario": "promo_carthage_crescent",
+      "start": 11.0,
+      "duration": 3.6,
+      "focus": {
+        "mode": "all",
+        "smoothing": 0.8
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 40,
+          "pitch": 22,
+          "yaw": 8,
+          "fov": 40,
+          "height": 1.0
+        },
+        {
+          "time": 3.6,
+          "distance": 34,
+          "pitch": 18,
+          "yaw": 350,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "CARTHAGE FORMS ITS BOW"
+    },
+    {
+      "name": "bow",
+      "scenario": "promo_carthage_crescent",
+      "start": 15.2,
+      "duration": 3.4,
+      "focus": {
+        "mode": "group",
+        "group": "libyan_spears",
+        "smoothing": 0.4
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 30,
+          "pitch": 8,
+          "yaw": 100,
+          "fov": 46,
+          "height": 1.9
+        },
+        {
+          "time": 3.4,
+          "distance": 25,
+          "pitch": 10,
+          "yaw": 78,
+          "fov": 46,
+          "height": 1.8,
+          "ease": "linear"
+        }
+      ],
+      "caption": "ELEPHANTS ANCHOR THE CENTRE",
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      }
+    },
+    {
+      "name": "wing",
+      "scenario": "promo_carthage_crescent",
+      "start": 10.0,
+      "duration": 3.0,
+      "focus": {
+        "mode": "group",
+        "group": "numidian_left",
+        "smoothing": 0.3
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 30,
+          "pitch": 12,
+          "yaw": 100,
+          "fov": 48,
+          "height": 1.6
+        },
+        {
+          "time": 3.0,
+          "distance": 24,
+          "pitch": 14,
+          "yaw": 84,
+          "fov": 48,
+          "height": 1.6,
+          "ease": "linear"
+        }
+      ],
+      "caption": "THE WINGS RIDE WIDE",
+      "transition": {
+        "type": "whip",
+        "duration": 0.2
+      }
+    },
+    {
+      "name": "elephants",
+      "scenario": "promo_carthage_crescent",
+      "start": 22.0,
+      "duration": 3.0,
+      "slow_motion": 1.5,
+      "focus": {
+        "mode": "group",
+        "group": "war_elephants",
+        "smoothing": 0.3
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 22,
+          "pitch": 7,
+          "yaw": 200,
+          "fov": 48,
+          "height": 2.4
+        },
+        {
+          "time": 3.0,
+          "distance": 16,
+          "pitch": 10,
+          "yaw": 214,
+          "fov": 48,
+          "height": 2.4,
+          "ease": "out"
+        }
+      ],
+      "transition": {
+        "type": "dissolve",
+        "duration": 0.45
+      }
+    },
+    {
+      "name": "encircle",
+      "scenario": "promo_carthage_crescent",
+      "start": 38.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "all",
+        "smoothing": 0.9
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 32,
+          "pitch": 20,
+          "yaw": 6,
+          "fov": 40,
+          "height": 1.2
+        },
+        {
+          "time": 7.0,
+          "distance": 46,
+          "pitch": 38,
+          "yaw": 0,
+          "fov": 40,
+          "height": 1.0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "AND THE HORNS CLOSE",
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      }
+    }
+  ],
+  "grade": {
+    "contrast": 1.13,
+    "saturation": 1.18,
+    "brightness": 0.07,
+    "gamma": 1.1,
+    "grain": 3,
+    "vignette": 0.09,
+    "sharpen": 0.7
+  },
+  "music": "assets/audio/music/combat/combat_attack_order_carthage_cavalry.ogg",
+  "music_start": 8.0
+}

--- a/tools/arena/promos/rome_hill_drill.json
+++ b/tools/arena/promos/rome_hill_drill.json
@@ -1,0 +1,185 @@
+{
+  "id": "rome_hill_drill",
+  "title": "DRILL ON THE RIDGE",
+  "subtitle": "STANDARD OF IRON",
+  "width": 1920,
+  "height": 1080,
+  "fps": 60,
+  "supersample": 1,
+  "transition": {
+    "type": "dip",
+    "duration": 0.45
+  },
+  "shots": [
+    {
+      "name": "column",
+      "scenario": "promo_rome_hill_drill",
+      "start": 8.0,
+      "duration": 3.4,
+      "focus": {
+        "mode": "all",
+        "smoothing": 0.8
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 44,
+          "pitch": 56,
+          "yaw": 2,
+          "fov": 40,
+          "height": 1.0
+        },
+        {
+          "time": 3.4,
+          "distance": 38,
+          "pitch": 64,
+          "yaw": 8,
+          "fov": 40,
+          "height": 1.0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "COLUMN"
+    },
+    {
+      "name": "line",
+      "scenario": "promo_rome_hill_drill",
+      "start": 20.0,
+      "duration": 3.6,
+      "focus": {
+        "mode": "all",
+        "smoothing": 0.9
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 40,
+          "pitch": 54,
+          "yaw": 6,
+          "fov": 40,
+          "height": 1.0
+        },
+        {
+          "time": 3.6,
+          "distance": 48,
+          "pitch": 62,
+          "yaw": 354,
+          "fov": 40,
+          "height": 1.0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "LINE"
+    },
+    {
+      "name": "defensive",
+      "scenario": "promo_rome_hill_drill",
+      "start": 31.0,
+      "duration": 3.2,
+      "focus": {
+        "mode": "group",
+        "group": "cohorts",
+        "smoothing": 0.5
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 40,
+          "pitch": 62,
+          "yaw": 0,
+          "fov": 40,
+          "height": 1.0
+        },
+        {
+          "time": 3.2,
+          "distance": 30,
+          "pitch": 72,
+          "yaw": 6,
+          "fov": 40,
+          "height": 1.0,
+          "ease": "out"
+        }
+      ],
+      "caption": "DEFENSIVE"
+    },
+    {
+      "name": "assault",
+      "scenario": "promo_rome_hill_drill",
+      "start": 40.0,
+      "duration": 3.4,
+      "focus": {
+        "mode": "all",
+        "smoothing": 0.8
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 36,
+          "pitch": 28,
+          "yaw": 22,
+          "fov": 42,
+          "height": 1.4
+        },
+        {
+          "time": 3.4,
+          "distance": 30,
+          "pitch": 20,
+          "yaw": 40,
+          "fov": 42,
+          "height": 1.6,
+          "ease": "linear"
+        }
+      ],
+      "caption": "ASSAULT",
+      "transition": {
+        "type": "whip",
+        "duration": 0.2
+      }
+    },
+    {
+      "name": "march_off",
+      "scenario": "promo_rome_hill_drill",
+      "start": 48.0,
+      "duration": 4.2,
+      "focus": {
+        "mode": "all",
+        "smoothing": 0.9
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 36,
+          "pitch": 30,
+          "yaw": 16,
+          "fov": 40,
+          "height": 1.2
+        },
+        {
+          "time": 4.2,
+          "distance": 52,
+          "pitch": 48,
+          "yaw": 0,
+          "fov": 40,
+          "height": 1.0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "ONE ORDER, ONE SHAPE",
+      "transition": {
+        "type": "dissolve",
+        "duration": 0.5
+      }
+    }
+  ],
+  "grade": {
+    "contrast": 1.14,
+    "saturation": 1.2,
+    "brightness": 0.09,
+    "gamma": 1.16,
+    "grain": 3,
+    "vignette": 0.08,
+    "sharpen": 0.75
+  },
+  "music": "assets/audio/music/base/base_pre_battle_deployment.ogg",
+  "music_start": 6.0
+}

--- a/tools/arena/promos/rome_iron_line.json
+++ b/tools/arena/promos/rome_iron_line.json
@@ -1,0 +1,191 @@
+{
+  "id": "rome_iron_line",
+  "title": "THE IRON LINE",
+  "subtitle": "STANDARD OF IRON",
+  "width": 1920,
+  "height": 1080,
+  "fps": 60,
+  "supersample": 1,
+  "transition": {
+    "type": "dissolve",
+    "duration": 0.4
+  },
+  "shots": [
+    {
+      "name": "column",
+      "scenario": "promo_rome_iron_line",
+      "start": 6.0,
+      "duration": 3.2,
+      "focus": {
+        "mode": "group",
+        "group": "first_line",
+        "smoothing": 0.6
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 30,
+          "pitch": 11,
+          "yaw": 252,
+          "fov": 42,
+          "height": 2.2
+        },
+        {
+          "time": 3.2,
+          "distance": 25,
+          "pitch": 9,
+          "yaw": 268,
+          "fov": 42,
+          "height": 2.0,
+          "ease": "linear"
+        }
+      ],
+      "caption": "ONE ARMY, ONE COLUMN"
+    },
+    {
+      "name": "deploy",
+      "scenario": "promo_rome_iron_line",
+      "start": 15.5,
+      "duration": 4.0,
+      "focus": {
+        "mode": "all",
+        "smoothing": 0.8
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 38,
+          "pitch": 28,
+          "yaw": 4,
+          "fov": 40,
+          "height": 1.0
+        },
+        {
+          "time": 4.0,
+          "distance": 44,
+          "pitch": 40,
+          "yaw": 352,
+          "fov": 40,
+          "height": 1.0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE LINE FORMS ITSELF",
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      }
+    },
+    {
+      "name": "front_rank",
+      "scenario": "promo_rome_iron_line",
+      "start": 24.0,
+      "duration": 3.4,
+      "focus": {
+        "mode": "group",
+        "group": "first_line",
+        "smoothing": 0.4
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 26,
+          "pitch": 7,
+          "yaw": 96,
+          "fov": 46,
+          "height": 1.8
+        },
+        {
+          "time": 3.4,
+          "distance": 22,
+          "pitch": 9,
+          "yaw": 74,
+          "fov": 46,
+          "height": 1.8,
+          "ease": "linear"
+        }
+      ]
+    },
+    {
+      "name": "shield_wall",
+      "scenario": "promo_rome_iron_line",
+      "start": 31.0,
+      "duration": 3.0,
+      "slow_motion": 1.4,
+      "focus": {
+        "mode": "group",
+        "group": "spear_screen",
+        "smoothing": 0.3
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 20,
+          "pitch": 12,
+          "yaw": 186,
+          "fov": 48,
+          "height": 1.6
+        },
+        {
+          "time": 3.0,
+          "distance": 14,
+          "pitch": 15,
+          "yaw": 196,
+          "fov": 48,
+          "height": 1.5,
+          "ease": "out"
+        }
+      ],
+      "caption": "SHIELDS CLOSE",
+      "transition": {
+        "type": "whip",
+        "duration": 0.2
+      }
+    },
+    {
+      "name": "advance",
+      "scenario": "promo_rome_iron_line",
+      "start": 39.0,
+      "duration": 4.6,
+      "focus": {
+        "mode": "all",
+        "smoothing": 0.9
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 32,
+          "pitch": 22,
+          "yaw": 10,
+          "fov": 40,
+          "height": 1.2
+        },
+        {
+          "time": 4.6,
+          "distance": 50,
+          "pitch": 36,
+          "yaw": 24,
+          "fov": 40,
+          "height": 1.0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "AND ADVANCES IN SHAPE",
+      "transition": {
+        "type": "dissolve",
+        "duration": 0.5
+      }
+    }
+  ],
+  "grade": {
+    "contrast": 1.13,
+    "saturation": 1.16,
+    "brightness": 0.07,
+    "gamma": 1.1,
+    "grain": 3,
+    "vignette": 0.09,
+    "sharpen": 0.7
+  },
+  "music": "assets/audio/music/combat/combat_defensive_hold_roman.ogg",
+  "music_start": 12.0
+}


### PR DESCRIPTION
Three video reels, one faction each, showing the army formation layer rather than a battle: Rome marching from column into the doctrine line and closing to a shield wall, Carthage forming its wide bow and closing the horns, and the same legion cycling every intent across a ridge.

Getting them out of the arena needed work on both sides.

Formation:
  ScenarioCommandKind::FormArmy drives the army formation layer itself.
  FormationMove only translates a shape a group already stands in, so it
  cannot show a doctrine deploying; FormArmy folds any number of groups
  into one army, asks the planner where every unit belongs, writes the
  chosen slots back onto each unit's formation mode so the runtime can
  measure cohesion against them, and walks everyone there -- the path a
  player's formation drag takes. validate_scenario now checks the group
  list a FormArmy step names, since a typo would silently deploy a
  smaller army instead of failing.

Arena capture:
  - Shots over one scenario record in a single continuous take. Each shot used to reload and re-simulate the battle from zero, so a reel marching through a long scenario paid that bill once per shot; the Rome reel went from about twelve minutes to two. Overlapping windows still split into separate passes.
  - promo-edit.py joins shots with transitions instead of hard cuts. Blends overlap, so the finished cut is shorter than the sum of its clips, caption timing is measured on the blended timeline and held clear of each blend, and the end card no longer lands on top of the last caption. Type is sized off the shorter edge so a landscape title does not overrun.
  - Camera yaw blends along the shorter arc. A key at 352 after one at 8 meant sixteen degrees back, not an orbit the other way round.
  - arena_floor_half_extent: the flat field was eighteen units either side, which is a duelling floor. An army deploying from column into line needs far more, and the floor now eases into the surrounding noise rather than stepping out of it, so the mountains stop standing as a wall on the touchline.
  - --time overrides an hour a scenario locks, so choosing the light for a capture is a few batch runs instead of a rebuild each.

Elephants:
  The production rig ships no locomotion clip, so the walk is synthesised
  by swinging the leg subtrees. It swung them up to 25 degrees; opposite
  legs are half a cycle apart, so the pair opened fifty and the animal
  did the splits with the tops of its thighs coming out through the
  flank, and the shin rotated with the thigh instead of against it, which
  compounded at the foot and raked the legs out from under the body. The
  shin now counter-rotates and the amplitudes are close to an elephant's
  real stiff, shallow walk.

Tests cover the gait bounds, the promo scenarios' contract, and the yaw blending and pass planning. docs/PROMO_CAPTURE.md describes the pipeline; scripts/capture-formation-promos.sh rebuilds all three reels.