### PR TITLE
Prioritize troop targets over enemy structures

### DIFF
--- a/game/systems/ai_system/ai_snapshot_builder.cpp
+++ b/game/systems/ai_system/ai_snapshot_builder.cpp
@@ -263,6 +263,9 @@ auto AISnapshotBuilder::build(const Engine::Core::World& world,
     friendly.engagement_resolved = true;
     friendly.engaged = false;
     for (const auto& enemy : snapshot.visible_enemies) {
+      if (enemy.is_building) {
+        continue;
+      }
       const float dx = enemy.pos_x - friendly.pos_x;
       const float dy = enemy.pos_y - friendly.pos_y;
       const float dz = enemy.pos_z - friendly.pos_z;

--- a/game/systems/ai_system/ai_tactical.cpp
+++ b/game/systems/ai_system/ai_tactical.cpp
@@ -89,7 +89,14 @@ auto TacticalUtils::select_focus_fire_target(
     return best_target;
   }
 
+  const bool troops_in_sight = has_troop_contact(enemies);
+
   for (const auto* enemy : enemies) {
+
+    if (troops_in_sight && enemy->is_building) {
+      continue;
+    }
+
     float score = 0.0F;
 
     float const dist = distance(enemy->pos_x,
@@ -117,10 +124,6 @@ auto TacticalUtils::select_focus_fire_target(
         Game::Units::spawn_typeToString(enemy->spawn_type), context.nation);
     score += type_priority * 3.0F;
 
-    if (!enemy->is_building) {
-      score += 5.0F;
-    }
-
     if (current_target != 0 && enemy->id == current_target) {
       score += 10.0F;
     }
@@ -141,10 +144,6 @@ auto TacticalUtils::select_focus_fire_target(
       if (dist_to_base < 16.0F) {
         score += (16.0F - dist_to_base) * 0.8F;
       }
-    }
-
-    if (context.state == AIState::Attacking && !enemy->is_building) {
-      score += 3.0F;
     }
 
     if (score > best_target.score) {

--- a/game/systems/ai_system/ai_utils.h
+++ b/game/systems/ai_system/ai_utils.h
@@ -56,6 +56,9 @@ inline auto is_entity_engaged(const EntitySnapshot& entity,
   const float engaged_sq = ENGAGED_RADIUS * ENGAGED_RADIUS;
 
   for (const auto& enemy : enemies) {
+    if (enemy.is_building) {
+      continue;
+    }
     float const dx = enemy.pos_x - entity.pos_x;
     float const dy = enemy.pos_y - entity.pos_y;
     float const dz = enemy.pos_z - entity.pos_z;
@@ -71,6 +74,21 @@ inline auto is_entity_engaged(const EntitySnapshot& entity,
 
 inline auto is_combat_role_unit(const EntitySnapshot& entity) -> bool {
   return !entity.is_building && entity.spawn_type != Game::Units::SpawnType::Builder;
+}
+
+inline auto has_troop_contact(const std::vector<ContactSnapshot>& contacts) -> bool {
+  return std::any_of(
+      contacts.begin(), contacts.end(), [](const ContactSnapshot& contact) {
+        return !contact.is_building;
+      });
+}
+
+inline auto
+has_troop_contact(const std::vector<const ContactSnapshot*>& contacts) -> bool {
+  return std::any_of(
+      contacts.begin(), contacts.end(), [](const ContactSnapshot* contact) {
+        return contact != nullptr && !contact->is_building;
+      });
 }
 
 inline auto is_reserved_unit(Engine::Core::EntityID unit_id,

--- a/game/systems/ai_system/behaviors/assault_behavior.cpp
+++ b/game/systems/ai_system/behaviors/assault_behavior.cpp
@@ -24,12 +24,14 @@ auto select_assault_target(const AISnapshot& snapshot,
   const ContactSnapshot* best = nullptr;
   float best_score = std::numeric_limits<float>::infinity();
 
+  const bool troops_in_sight = has_troop_contact(snapshot.visible_enemies);
+
   for (const auto& candidate : snapshot.visible_enemies) {
-    float score = distance_squared(
-        candidate.pos_x, 0.0F, candidate.pos_z, reference_x, 0.0F, reference_z);
-    if (candidate.is_building) {
-      score += 400.0F;
+    if (troops_in_sight && candidate.is_building) {
+      continue;
     }
+    const float score = distance_squared(
+        candidate.pos_x, 0.0F, candidate.pos_z, reference_x, 0.0F, reference_z);
     if (score < best_score) {
       best_score = score;
       best = &candidate;

--- a/game/systems/ai_system/behaviors/harass_behavior.cpp
+++ b/game/systems/ai_system/behaviors/harass_behavior.cpp
@@ -2,6 +2,7 @@
 
 #include <QVector3D>
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <utility>
@@ -24,6 +25,26 @@ auto select_visible_harass_target(const AISnapshot& snapshot,
   const ContactSnapshot* best_target = nullptr;
   float best_score = std::numeric_limits<float>::infinity();
 
+  const float harassment_range_sq = harassment_range * harassment_range;
+  const auto in_harassment_range = [&](const ContactSnapshot& contact) {
+    if (harassment_range <= 0.0F) {
+      return true;
+    }
+    return distance_squared(contact.pos_x,
+                            contact.pos_y,
+                            contact.pos_z,
+                            reference_x,
+                            reference_y,
+                            reference_z) <= harassment_range_sq;
+  };
+
+  const bool troops_in_sight =
+      std::any_of(snapshot.visible_enemies.begin(),
+                  snapshot.visible_enemies.end(),
+                  [&](const ContactSnapshot& contact) {
+                    return !contact.is_building && in_harassment_range(contact);
+                  });
+
   for (const auto& candidate : snapshot.visible_enemies) {
     const float dist_sq = distance_squared(candidate.pos_x,
                                            candidate.pos_y,
@@ -31,14 +52,15 @@ auto select_visible_harass_target(const AISnapshot& snapshot,
                                            reference_x,
                                            reference_y,
                                            reference_z);
-    if (harassment_range > 0.0F && dist_sq > harassment_range * harassment_range) {
+    if (harassment_range > 0.0F && dist_sq > harassment_range_sq) {
+      continue;
+    }
+
+    if (troops_in_sight && candidate.is_building) {
       continue;
     }
 
     float score = dist_sq;
-    if (!candidate.is_building) {
-      score += 120.0F;
-    }
     if (candidate.spawn_type == Game::Units::SpawnType::DefenseTower) {
       score += 800.0F;
     }

--- a/game/systems/combat_system/attack_processor.cpp
+++ b/game/systems/combat_system/attack_processor.cpp
@@ -452,6 +452,37 @@ auto is_high_ground_advantage(const Engine::Core::TransformComponent* high_trans
   return height_diff > Constants::k_high_ground_height_threshold;
 }
 
+void release_structure_lock_for_troop_target(Engine::Core::Entity* attacker,
+                                             Engine::Core::AttackComponent* attack_comp,
+                                             Engine::Core::World* world) {
+  if ((attack_comp == nullptr) || (world == nullptr) || !attack_comp->in_melee_lock ||
+      attack_comp->melee_lock_target_id == 0) {
+    return;
+  }
+
+  auto* lock_target = world->get_entity(attack_comp->melee_lock_target_id);
+  if ((lock_target == nullptr) || !is_building(lock_target)) {
+    return;
+  }
+
+  auto const* attack_target =
+      attacker->get_component<Engine::Core::AttackTargetComponent>();
+  if ((attack_target == nullptr) ||
+      attack_target->target_id == attack_comp->melee_lock_target_id) {
+    return;
+  }
+
+  auto* ordered_target = world->get_entity(attack_target->target_id);
+  auto const* attacker_unit = attacker->get_component<Engine::Core::UnitComponent>();
+  if (!is_valid_enemy_unit(attacker_unit, ordered_target, false)) {
+    return;
+  }
+
+  attack_comp->in_melee_lock = false;
+  attack_comp->melee_lock_target_id = 0;
+  attack_comp->melee_lock_separation_time = 0.0F;
+}
+
 void process_melee_lock(Engine::Core::Entity* attacker,
                         Engine::Core::AttackComponent* attack_comp,
                         Engine::Core::World* world,
@@ -1151,6 +1182,8 @@ void process_attacks(Engine::Core::World* world,
         pending_charge != nullptr &&
         (pending_charge->state == Engine::Core::MountedChargeState::Charging ||
          pending_charge->state == Engine::Core::MountedChargeState::ImpactActive);
+    release_structure_lock_for_troop_target(attacker, attacker_atk, world);
+
     if (!resolving_charge_impact) {
       process_melee_lock(attacker, attacker_atk, world, delta_time);
     }

--- a/game/systems/combat_system/auto_engagement.cpp
+++ b/game/systems/combat_system/auto_engagement.cpp
@@ -9,6 +9,29 @@
 
 namespace Game::Systems::Combat {
 
+namespace {
+
+auto besieging_structure(Engine::Core::Entity* unit,
+                         const CombatQueryContext& query_context) -> bool {
+  if (!unit->has_component<Engine::Core::AIControlledComponent>()) {
+    return false;
+  }
+
+  auto* attack_target = unit->get_component<Engine::Core::AttackTargetComponent>();
+  if (attack_target == nullptr || attack_target->target_id == 0) {
+    return false;
+  }
+
+  auto it = query_context.entities_by_id.find(attack_target->target_id);
+  if (it == query_context.entities_by_id.end()) {
+    return false;
+  }
+
+  return is_building(it->second);
+}
+
+} // namespace
+
 void AutoEngagement::process(Engine::Core::World*,
                              const CombatQueryContext& query_context,
                              float delta_time) {
@@ -61,7 +84,9 @@ void AutoEngagement::process(Engine::Core::World*,
     auto* guard_mode = unit->get_component<Engine::Core::GuardModeComponent>();
     bool const in_guard_mode = (guard_mode != nullptr) && guard_mode->active;
 
-    if (!in_guard_mode && !is_unit_idle(unit)) {
+    bool const siege_retarget = besieging_structure(unit, query_context);
+
+    if (!in_guard_mode && !siege_retarget && !is_unit_idle(unit)) {
       continue;
     }
 

--- a/game/systems/command_service.cpp
+++ b/game/systems/command_service.cpp
@@ -400,7 +400,15 @@ void CommandService::attack_target(Engine::Core::World& world,
       bool const locked_opponent_alive =
           locked_unit != nullptr && locked_unit->health > 0 &&
           !locked_target->has_component<Engine::Core::PendingRemovalComponent>();
-      if (locked_opponent_alive) {
+
+      auto* new_target = world.get_entity(target_id);
+      bool const leaves_structure_for_troop =
+          locked_target != nullptr &&
+          locked_target->has_component<Engine::Core::BuildingComponent>() &&
+          new_target != nullptr &&
+          !new_target->has_component<Engine::Core::BuildingComponent>();
+
+      if (locked_opponent_alive && !leaves_structure_for_troop) {
         continue;
       }
       CombatRules::clear_rts_melee_lock(e);

--- a/tests/systems/ai_system_test.cpp
+++ b/tests/systems/ai_system_test.cpp
@@ -73,6 +73,15 @@ protected:
     return enemy;
   }
 
+  static auto make_enemy_building(Engine::Core::EntityID id,
+                                  float x,
+                                  float z) -> Game::Systems::AI::ContactSnapshot {
+    auto building = make_enemy(id, x, z);
+    building.is_building = true;
+    building.spawn_type = Game::Units::SpawnType::Barracks;
+    return building;
+  }
+
   static auto make_builder(Engine::Core::EntityID id,
                            float x,
                            float z) -> Game::Systems::AI::EntitySnapshot {
@@ -1413,6 +1422,101 @@ TEST_F(AISystemTest, HarassBehaviorUsesDedicatedRaidersTowardStrategicObjective)
   ASSERT_EQ(commands.size(), 1U);
   EXPECT_EQ(commands.front().type, Game::Systems::AI::AICommandType::MoveUnits);
   EXPECT_EQ(commands.front().units, (std::vector<Engine::Core::EntityID>{2U, 3U}));
+}
+
+TEST_F(AISystemTest, AttackBehaviorPicksSoldierOverCloserBuilding) {
+  Game::Systems::AI::AttackBehavior behavior;
+
+  Game::Systems::AI::AISnapshot snapshot;
+  snapshot.friendly_units = {
+      make_unit(1, 30.0F, 20.0F),
+      make_unit(2, 32.0F, 22.0F),
+  };
+  auto damaged_building = make_enemy_building(101, 33.0F, 23.0F);
+  damaged_building.health = 10;
+  snapshot.visible_enemies = {
+      damaged_building,
+      make_enemy(102, 38.0F, 28.0F),
+  };
+
+  Game::Systems::AI::AIContext context;
+  context.player_id = 3;
+  context.state = Game::Systems::AI::AIState::Attacking;
+  context.total_units = 2;
+
+  std::vector<Game::Systems::AI::AICommand> commands;
+  behavior.execute(snapshot, context, 1.6F, commands);
+
+  ASSERT_EQ(commands.size(), 1U);
+  EXPECT_EQ(commands.front().type, Game::Systems::AI::AICommandType::AttackTarget);
+  EXPECT_EQ(commands.front().target_id, 102U);
+  EXPECT_TRUE(commands.front().should_chase);
+}
+
+TEST_F(AISystemTest, AssaultBehaviorPicksSoldierOverCloserBuilding) {
+  Game::Systems::AI::AssaultBehavior behavior;
+
+  Game::Systems::AI::AISnapshot snapshot;
+  auto assault_unit = make_unit(1, 30.0F, 20.0F);
+  assault_unit.is_assault = true;
+  snapshot.friendly_units = {assault_unit};
+  snapshot.visible_enemies = {
+      make_enemy_building(101, 31.0F, 21.0F),
+      make_enemy(102, 45.0F, 35.0F),
+  };
+
+  Game::Systems::AI::AIContext context;
+  context.player_id = 3;
+  context.assault_unit_ids = {1U};
+  context.assault_unit_count = 1;
+
+  std::vector<Game::Systems::AI::AICommand> commands;
+  behavior.execute(snapshot, context, 1.1F, commands);
+
+  ASSERT_EQ(commands.size(), 1U);
+  EXPECT_EQ(commands.front().type, Game::Systems::AI::AICommandType::MoveUnits);
+  ASSERT_EQ(commands.front().move_target_x.size(), 1U);
+  EXPECT_NEAR(commands.front().move_target_x.front(), 45.0F, 8.0F);
+  EXPECT_NEAR(commands.front().move_target_z.front(), 35.0F, 8.0F);
+}
+
+TEST_F(AISystemTest, HarassBehaviorPicksSoldierOverCloserBuilding) {
+  Game::Systems::AI::HarassBehavior behavior;
+
+  Game::Systems::AI::AISnapshot snapshot;
+  snapshot.game_time = 5.0F;
+  snapshot.friendly_units = {make_unit(1, 45.0F, 20.0F)};
+  snapshot.visible_enemies = {
+      make_enemy_building(101, 47.0F, 22.0F),
+      make_enemy(102, 55.0F, 30.0F),
+  };
+
+  Game::Systems::AI::AIContext context;
+  context.player_id = 3;
+  context.state = Game::Systems::AI::AIState::Gathering;
+  context.strategy_config = Game::Systems::AI::AIStrategyFactory::create_config(
+      Game::Systems::AI::AIStrategy::Harasser);
+  context.strategy_config.harassment_range = 50.0F;
+  context.harass_unit_ids = {1U};
+  context.effective_harass_units = 1;
+
+  ASSERT_TRUE(behavior.should_execute(snapshot, context));
+
+  std::vector<Game::Systems::AI::AICommand> commands;
+  behavior.execute(snapshot, context, 2.1F, commands);
+
+  ASSERT_EQ(commands.size(), 1U);
+  EXPECT_EQ(commands.front().type, Game::Systems::AI::AICommandType::AttackTarget);
+  EXPECT_EQ(commands.front().target_id, 102U);
+}
+
+TEST_F(AISystemTest, StandingNextToEnemyBuildingDoesNotCountAsEngaged) {
+  auto unit = make_unit(7, 10.0F, 10.0F);
+
+  EXPECT_FALSE(Game::Systems::AI::is_entity_engaged(
+      unit, {make_enemy_building(9, 11.0F, 10.0F)}));
+  EXPECT_TRUE(
+      Game::Systems::AI::is_entity_engaged(unit, {make_enemy(9, 11.0F, 10.0F)}));
 }
 
 TEST_F(AISystemTest, HarassBehaviorStopsWhenBaseIsUnderThreat) {

--- a/tests/systems/melee_engagement_test.cpp
+++ b/tests/systems/melee_engagement_test.cpp
@@ -271,3 +271,57 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<BareHandedCase>& info) {
       return sanitized_case_name(info.param.name);
     });
+
+TEST_F(MeleeEngagementTest, SiegingUnitDropsTheWallForAnEnemySoldierInReach) {
+  Engine::Core::World world;
+  Game::Systems::register_runtime_systems(world);
+
+  auto* besieger = spawn(world,
+                         Game::Units::SpawnType::Spearman,
+                         2,
+                         QVector3D(0.0F, 0.0F, 0.0F),
+                         Game::Systems::NationID::Carthage);
+  ASSERT_NE(besieger, nullptr);
+  (void)besieger->add_component<Engine::Core::AIControlledComponent>();
+
+  auto* structure = world.create_entity();
+  (void)structure->add_component<TransformComponent>(3.0F, 0.0F, 0.0F);
+  auto* structure_unit =
+      structure->add_component<UnitComponent>(100000, 100000, 0.0F, 12.0F);
+  structure_unit->owner_id = 1;
+  structure_unit->spawn_type = Game::Units::SpawnType::Barracks;
+  (void)structure->add_component<Engine::Core::BuildingComponent>();
+
+  order_attack(*besieger, *structure);
+
+  bool locked_onto_structure = false;
+  for (int tick = 0; tick < 200 && !locked_onto_structure; ++tick) {
+    world.update(0.05F);
+    const auto* attack = besieger->get_component<AttackComponent>();
+    locked_onto_structure = attack != nullptr && attack->in_melee_lock &&
+                            attack->melee_lock_target_id == structure->get_id();
+  }
+  ASSERT_TRUE(locked_onto_structure) << "besieger never engaged the structure";
+
+  auto* soldier = spawn(world,
+                        Game::Units::SpawnType::Knight,
+                        1,
+                        QVector3D(-1.2F, 0.0F, 0.0F),
+                        Game::Systems::NationID::RomanRepublic);
+  ASSERT_NE(soldier, nullptr);
+  auto* soldier_unit = soldier->get_component<UnitComponent>();
+  ASSERT_NE(soldier_unit, nullptr);
+  soldier_unit->health = soldier_unit->max_health = 100000;
+
+  bool switched_to_soldier = false;
+  for (int tick = 0; tick < 120 && !switched_to_soldier; ++tick) {
+    world.update(0.05F);
+    const auto* attack_target =
+        besieger->get_component<Engine::Core::AttackTargetComponent>();
+    switched_to_soldier =
+        attack_target != nullptr && attack_target->target_id == soldier->get_id();
+  }
+
+  EXPECT_TRUE(switched_to_soldier)
+      << "besieger kept hitting the barracks with an enemy soldier on top of it";
+}


### PR DESCRIPTION
Update AI targeting, engagement checks, and combat retargeting so visible enemy troops take precedence over buildings. Add regression coverage for AI selection, siege retargeting, and structure engagement handling.