### PR TITLE
polish: improve barracks stockpile yard visuals

### DIFF
--- a/render/entity/barracks_stockpile.cpp
+++ b/render/entity/barracks_stockpile.cpp
@@ -25,15 +25,23 @@ using Game::Systems::k_stockpile_deposit_flash_seconds;
 using Game::Systems::k_stockpile_half_depth;
 using Game::Systems::k_stockpile_half_width;
 
-constexpr float k_pile_center_x = k_stockpile_center_x - 0.55F;
 constexpr float k_bed_height = 0.035F;
-constexpr int k_kerb_long_steps = 11;
-constexpr int k_kerb_short_steps = 6;
+constexpr float k_ground = k_bed_height * 2.0F;
 constexpr float k_detail_distance_sq = 5200.0F;
 
-constexpr float k_wood_pile_z = k_stockpile_center_z - 1.20F;
+constexpr float k_yard_back_x = k_stockpile_center_x - k_stockpile_half_width + 0.09F;
+constexpr float k_yard_near_z = k_stockpile_center_z - k_stockpile_half_depth + 0.09F;
+constexpr float k_yard_far_z = k_stockpile_center_z + k_stockpile_half_depth - 0.09F;
+constexpr float k_gate_x = k_stockpile_center_x + 0.55F;
+constexpr float k_stall_edge_x = k_stockpile_center_x + 0.10F;
+
+constexpr float k_pile_center_x = k_stockpile_center_x - 0.55F;
+constexpr float k_wood_pile_z = k_stockpile_center_z - 1.35F;
 constexpr float k_stone_pile_z = k_stockpile_center_z;
-constexpr float k_iron_pile_z = k_stockpile_center_z + 1.25F;
+constexpr float k_iron_pile_z = k_stockpile_center_z + 1.35F;
+
+constexpr float k_rail_low_y = 0.17F;
+constexpr float k_rail_high_y = 0.34F;
 
 auto rand01(std::uint32_t seed) -> float {
   std::uint32_t value = seed + 0x9E3779B9U;
@@ -108,6 +116,58 @@ void rock(ISubmitter& out,
   out.mesh(mesh, model, color, yard.white, 1.0F);
 }
 
+void rail_along_z(ISubmitter& out,
+                  const Yard& yard,
+                  float x,
+                  float z_from,
+                  float z_to,
+                  float y,
+                  const QVector3D& color) {
+  box(out,
+      yard,
+      QVector3D(x, y, (z_from + z_to) * 0.5F),
+      QVector3D(0.035F, 0.045F, std::abs(z_to - z_from) * 0.5F),
+      0.0F,
+      color);
+}
+
+void rail_along_x(ISubmitter& out,
+                  const Yard& yard,
+                  float z,
+                  float x_from,
+                  float x_to,
+                  float y,
+                  const QVector3D& color) {
+  box(out,
+      yard,
+      QVector3D((x_from + x_to) * 0.5F, y, z),
+      QVector3D(std::abs(x_to - x_from) * 0.5F, 0.045F, 0.035F),
+      0.0F,
+      color);
+}
+
+void fence_post(ISubmitter& out,
+                const Yard& yard,
+                float x,
+                float z,
+                float height,
+                const StockpileYardStyle& style) {
+  auto const seed = static_cast<std::uint32_t>((x * 97.0F) + (z * 31.0F) + 400.0F);
+  float const lean = jitter(seed, 1.6F);
+  box(out,
+      yard,
+      QVector3D(x, height * 0.5F, z),
+      QVector3D(0.072F, height * 0.5F, 0.072F),
+      lean,
+      tint(style.timber_dark, 0.92F + (rand01(seed * 3U) * 0.22F)));
+  box(out,
+      yard,
+      QVector3D(x, height + 0.025F, z),
+      QVector3D(0.088F, 0.028F, 0.088F),
+      lean,
+      style.timber);
+}
+
 void draw_bed(ISubmitter& out, const Yard& yard, const StockpileYardStyle& style) {
   box(out,
       yard,
@@ -115,73 +175,107 @@ void draw_bed(ISubmitter& out, const Yard& yard, const StockpileYardStyle& style
       QVector3D(k_stockpile_half_width, k_bed_height, k_stockpile_half_depth),
       0.0F,
       style.gravel);
-}
 
-void draw_kerb(ISubmitter& out, const Yard& yard, const StockpileYardStyle& style) {
-  std::uint32_t seed = 17U;
+  box(out,
+      yard,
+      QVector3D(
+          (k_yard_back_x + k_stall_edge_x) * 0.5F, k_ground, k_stockpile_center_z),
+      QVector3D((k_stall_edge_x - k_yard_back_x) * 0.5F,
+                0.004F,
+                k_stockpile_half_depth - 0.06F),
+      0.0F,
+      tint(style.gravel, 0.86F));
 
-  for (int side = 0; side < 2; ++side) {
-    float const edge_x = k_stockpile_center_x + ((side == 0) ? -k_stockpile_half_width
-                                                             : k_stockpile_half_width);
-    for (int i = 0; i < k_kerb_long_steps; ++i) {
-      float const t = static_cast<float>(i) / static_cast<float>(k_kerb_long_steps - 1);
-      float const z = k_stockpile_center_z +
-                      (((t * 2.0F) - 1.0F) * (k_stockpile_half_depth - 0.16F));
-      ++seed;
-      float const radius = 0.24F + (rand01(seed) * 0.13F);
-      rock(out,
-           yard,
-           QVector3D(edge_x + jitter(seed * 3U, 0.09F),
-                     0.05F + (rand01(seed * 5U) * 0.02F),
-                     z + jitter(seed * 7U, 0.10F)),
-           QVector3D(radius, 0.055F + (rand01(seed * 11U) * 0.03F), radius * 0.82F),
-           rand01(seed * 13U) * 360.0F,
-           jitter(seed * 17U, 5.0F),
-           brighten(tint(style.stone_mid, 0.9F + (rand01(seed * 19U) * 0.26F)), 0.1F));
-    }
+  if (!yard.detailed) {
+    return;
   }
 
-  for (int side = 0; side < 2; ++side) {
-    float const edge_z = k_stockpile_center_z + ((side == 0) ? -k_stockpile_half_depth
-                                                             : k_stockpile_half_depth);
-    for (int i = 0; i < k_kerb_short_steps; ++i) {
-      float const t =
-          static_cast<float>(i) / static_cast<float>(k_kerb_short_steps - 1);
-      float const x = k_stockpile_center_x +
-                      (((t * 2.0F) - 1.0F) * (k_stockpile_half_width - 0.16F));
-      ++seed;
-      float const radius = 0.23F + (rand01(seed) * 0.14F);
-      rock(out,
-           yard,
-           QVector3D(x + jitter(seed * 3U, 0.10F),
-                     0.05F + (rand01(seed * 5U) * 0.02F),
-                     edge_z + jitter(seed * 7U, 0.09F)),
-           QVector3D(radius, 0.05F + (rand01(seed * 11U) * 0.03F), radius * 0.86F),
-           rand01(seed * 13U) * 360.0F,
-           jitter(seed * 17U, 5.0F),
-           brighten(tint(style.stone_light, 0.88F + (rand01(seed * 19U) * 0.28F)),
-                    0.12F));
-    }
-  }
-}
-
-void draw_flagstones(ISubmitter& out,
-                     const Yard& yard,
-                     const StockpileYardStyle& style) {
-  constexpr int k_flagstone_count = 7;
-  for (int i = 0; i < k_flagstone_count; ++i) {
-    auto const seed = static_cast<std::uint32_t>(101 + (i * 37));
-    float const x = k_stockpile_center_x + jitter(seed, k_stockpile_half_width - 0.35F);
-    float const z =
-        k_stockpile_center_z + jitter(seed * 3U, k_stockpile_half_depth - 0.40F);
-    float const radius = 0.26F + (rand01(seed * 5U) * 0.16F);
+  QVector3D const scuff = (style.gravel + style.earth_light) * 0.5F;
+  constexpr std::array<std::array<float, 3>, 3> k_scuffs{
+      {{0.78F, 0.0F, 0.68F}, {0.52F, -1.15F, 0.40F}, {0.95F, 1.05F, 0.34F}}};
+  for (std::size_t i = 0; i < k_scuffs.size(); ++i) {
+    auto const seed = static_cast<std::uint32_t>(131 + (i * 41));
     rock(out,
          yard,
-         QVector3D(x, 0.045F, z),
-         QVector3D(radius, 0.03F, radius * 0.74F),
-         rand01(seed * 7U) * 360.0F,
+         QVector3D(k_stockpile_center_x + k_scuffs.at(i).at(0),
+                   k_ground,
+                   k_stockpile_center_z + k_scuffs.at(i).at(1)),
+         QVector3D(k_scuffs.at(i).at(2), 0.006F, k_scuffs.at(i).at(2) * 0.78F),
+         rand01(seed) * 180.0F,
          0.0F,
-         brighten(tint(style.stone_dark, 0.92F + (rand01(seed * 11U) * 0.26F)), 0.08F));
+         tint(scuff, 0.97F + (rand01(seed * 7U) * 0.07F)));
+  }
+}
+
+void draw_yard_clutter(ISubmitter& out,
+                       const Yard& yard,
+                       const StockpileYardStyle& style) {
+  constexpr float k_stack_x = k_stockpile_center_x + 0.98F;
+  constexpr float k_stack_z = k_stockpile_center_z - 1.55F;
+  constexpr float k_board_thickness = 0.021F;
+
+  for (int i = 0; i < 4; ++i) {
+    auto const seed = static_cast<std::uint32_t>(733 + (i * 47));
+    box(out,
+        yard,
+        QVector3D(k_stack_x + jitter(seed, 0.025F),
+                  k_ground + k_board_thickness +
+                      (static_cast<float>(i) * k_board_thickness * 2.2F),
+                  k_stack_z + jitter(seed * 3U, 0.05F)),
+        QVector3D(0.125F, k_board_thickness, 0.40F),
+        jitter(seed * 5U, 3.5F),
+        tint(style.timber, 0.84F + (rand01(seed * 7U) * 0.30F)));
+  }
+
+  for (int i = 0; i < 2; ++i) {
+    auto const seed = static_cast<std::uint32_t>(811 + (i * 53));
+    float const radius = 0.145F + (rand01(seed) * 0.025F);
+    rock(out,
+         yard,
+         QVector3D(k_stack_x + 0.31F + (static_cast<float>(i) * 0.27F),
+                   k_ground + (radius * 0.78F),
+                   k_stack_z + 0.30F + (static_cast<float>(i) * 0.22F)),
+         QVector3D(radius, radius * 0.86F, radius * 0.82F),
+         rand01(seed * 5U) * 360.0F,
+         jitter(seed * 7U, 12.0F),
+         tint(style.earth_light, 1.04F + (rand01(seed * 11U) * 0.12F)));
+  }
+}
+
+void draw_fence(ISubmitter& out, const Yard& yard, const StockpileYardStyle& style) {
+  constexpr float k_post_height = 0.44F;
+  constexpr float k_gate_post_height = 0.62F;
+
+  rail_along_z(out,
+               yard,
+               k_yard_back_x,
+               k_yard_near_z,
+               k_yard_far_z,
+               k_rail_low_y,
+               style.timber);
+  rail_along_z(out,
+               yard,
+               k_yard_back_x,
+               k_yard_near_z,
+               k_yard_far_z,
+               k_rail_high_y,
+               style.timber);
+  for (int i = 0; i < 4; ++i) {
+    float const t = static_cast<float>(i) / 3.0F;
+    fence_post(out,
+               yard,
+               k_yard_back_x,
+               k_yard_near_z + (t * (k_yard_far_z - k_yard_near_z)),
+               k_post_height,
+               style);
+  }
+
+  for (int side = 0; side < 2; ++side) {
+    float const z = (side == 0) ? k_yard_near_z : k_yard_far_z;
+    rail_along_x(out, yard, z, k_yard_back_x, k_gate_x, k_rail_low_y, style.timber);
+    rail_along_x(out, yard, z, k_yard_back_x, k_gate_x, k_rail_high_y, style.timber);
+    fence_post(out, yard, (k_yard_back_x + k_gate_x) * 0.5F, z, k_post_height, style);
+    fence_post(out, yard, k_gate_x, z, k_gate_post_height, style);
   }
 }
 
@@ -190,63 +284,72 @@ void draw_timber_pile(ISubmitter& out,
                       const StockpileYardStyle& style,
                       float fill,
                       float flash) {
+  constexpr float k_log_radius = 0.115F;
+  constexpr float k_log_half_length = 0.60F;
+  constexpr float k_stake_half_z = k_log_half_length + 0.13F;
+
+  for (int side = 0; side < 2; ++side) {
+    float const z = k_wood_pile_z + ((side == 0) ? -k_stake_half_z : k_stake_half_z);
+    box(out,
+        yard,
+        QVector3D(k_pile_center_x, 0.085F, z),
+        QVector3D(0.50F, 0.075F, 0.045F),
+        0.0F,
+        style.timber_dark);
+    for (int end = 0; end < 2; ++end) {
+      float const x = k_pile_center_x + ((end == 0) ? -0.47F : 0.47F);
+      box(out,
+          yard,
+          QVector3D(x, 0.31F, z),
+          QVector3D(0.045F, 0.31F, 0.045F),
+          0.0F,
+          style.timber_dark);
+    }
+  }
+
   if (fill <= 0.01F) {
     return;
   }
 
   constexpr std::array<int, 3> k_row_counts{4, 3, 2};
-  constexpr float k_log_half_length = 0.62F;
-  constexpr float k_log_radius = 0.115F;
+  constexpr std::array<float, 3> k_row_offsets{-0.36F, -0.24F, -0.12F};
   int const logs = std::max(1, static_cast<int>(std::lround(fill * 9.0F)));
   int drawn = 0;
 
-  QVector3D const cut_face = brighten(style.timber, 0.35F);
+  QVector3D const cut_face = brighten(style.timber, 0.42F);
 
   for (std::size_t row = 0; row < k_row_counts.size() && drawn < logs; ++row) {
-    float const y = 0.15F + (static_cast<float>(row) * 0.19F);
+    float const y = 0.135F + (static_cast<float>(row) * 0.199F);
     int const count = k_row_counts.at(row);
     for (int i = 0; i < count && drawn < logs; ++i, ++drawn) {
       auto const seed = static_cast<std::uint32_t>(211 + (drawn * 29));
-      float const offset =
-          (static_cast<float>(i) - ((static_cast<float>(count) - 1.0F) * 0.5F)) * 0.27F;
-      float const x = k_pile_center_x + offset;
-      float const half_length = k_log_half_length + jitter(seed * 3U, 0.05F);
+      float const x =
+          k_pile_center_x + k_row_offsets.at(row) + (static_cast<float>(i) * 0.24F);
+      float const half_length = k_log_half_length + jitter(seed * 3U, 0.045F);
+      float const shift = jitter(seed * 5U, 0.04F);
       QVector3D const color =
-          brighten(tint(style.timber, 0.82F + (rand01(seed) * 0.34F)), flash * 0.25F);
+          brighten(tint(style.timber, 0.80F + (rand01(seed) * 0.36F)), flash * 0.25F);
 
       submit_building_cylinder(out,
                                yard.frame,
-                               QVector3D(x, y, k_wood_pile_z - half_length),
-                               QVector3D(x, y, k_wood_pile_z + half_length),
+                               QVector3D(x, y, k_wood_pile_z + shift - half_length),
+                               QVector3D(x, y, k_wood_pile_z + shift + half_length),
                                k_log_radius,
                                color,
                                yard.white);
       if (yard.detailed) {
-        box(out,
-            yard,
-            QVector3D(x, y, k_wood_pile_z - half_length),
-            QVector3D(k_log_radius * 0.8F, k_log_radius * 0.8F, 0.02F),
-            0.0F,
-            cut_face);
-        box(out,
-            yard,
-            QVector3D(x, y, k_wood_pile_z + half_length),
-            QVector3D(k_log_radius * 0.8F, k_log_radius * 0.8F, 0.02F),
-            0.0F,
-            cut_face);
+        for (int end = 0; end < 2; ++end) {
+          float const z =
+              k_wood_pile_z + shift + ((end == 0) ? -half_length : half_length);
+          box(out,
+              yard,
+              QVector3D(x, y, z),
+              QVector3D(k_log_radius * 0.78F, k_log_radius * 0.78F, 0.018F),
+              0.0F,
+              tint(cut_face, 0.94F + (rand01(seed * 7U) * 0.12F)));
+        }
       }
     }
-  }
-
-  for (int side = 0; side < 2; ++side) {
-    float const z = k_wood_pile_z + ((side == 0) ? -(k_log_half_length + 0.12F)
-                                                 : (k_log_half_length + 0.12F));
-    box(out,
-        yard,
-        QVector3D(k_pile_center_x, 0.10F, z),
-        QVector3D(0.46F, 0.09F, 0.05F),
-        0.0F,
-        style.timber_dark);
   }
 }
 
@@ -259,27 +362,64 @@ void draw_stone_pile(ISubmitter& out,
     return;
   }
 
-  int const blocks = std::max(1, static_cast<int>(std::lround(fill * 8.0F)));
+  struct Course {
+    float y;
+    int count;
+    float first_z;
+  };
+  constexpr std::array<Course, 3> k_courses{
+      {{0.185F, 3, -0.38F}, {0.415F, 2, -0.19F}, {0.645F, 1, 0.0F}}};
+  constexpr float k_block_pitch = 0.38F;
+
+  int const blocks = std::max(1, static_cast<int>(std::lround(fill * 6.0F)));
   int drawn = 0;
 
-  for (int layer = 0; layer < 3 && drawn < blocks; ++layer) {
-    int const per_layer = (layer == 0) ? 4 : ((layer == 1) ? 3 : 1);
-    float const y = 0.15F + (static_cast<float>(layer) * 0.21F);
-    for (int i = 0; i < per_layer && drawn < blocks; ++i, ++drawn) {
+  for (const auto& course : k_courses) {
+    if (drawn >= blocks) {
+      break;
+    }
+    for (int i = 0; i < course.count && drawn < blocks; ++i, ++drawn) {
       auto const seed = static_cast<std::uint32_t>(331 + (drawn * 43));
-      float const spread =
-          (static_cast<float>(i) - ((static_cast<float>(per_layer) - 1.0F) * 0.5F));
-      QVector3D const color = brighten(
-          tint(style.stone_light, 0.86F + (rand01(seed) * 0.3F)), flash * 0.3F);
+
+      QVector3D const base = ((drawn % 2) == 0) ? style.stone_light : style.stone_mid;
+      QVector3D const color =
+          brighten(tint(base, 0.92F + (rand01(seed) * 0.16F)), flash * 0.3F);
       box(out,
           yard,
-          QVector3D(k_pile_center_x + jitter(seed * 3U, 0.05F),
-                    y,
-                    k_stone_pile_z + (spread * 0.34F) + jitter(seed * 5U, 0.03F)),
-          QVector3D(0.22F, 0.11F, 0.155F),
-          jitter(seed * 7U, 7.0F),
+          QVector3D(k_pile_center_x + jitter(seed * 3U, 0.016F),
+                    course.y,
+                    k_stone_pile_z + course.first_z +
+                        (static_cast<float>(i) * k_block_pitch)),
+          QVector3D(0.225F, 0.105F, 0.163F),
+          jitter(seed * 7U, 2.0F),
           color);
     }
+  }
+
+  if (fill > 0.35F) {
+    box(out,
+        yard,
+        QVector3D(k_pile_center_x + 0.40F, 0.108F, k_stone_pile_z - 0.46F),
+        QVector3D(0.215F, 0.098F, 0.155F),
+        -14.0F,
+        brighten(tint(style.stone_dark, 1.28F), flash * 0.25F));
+  }
+  if (!yard.detailed) {
+    return;
+  }
+  for (int i = 0; i < 4; ++i) {
+    auto const seed = static_cast<std::uint32_t>(509 + (i * 37));
+    rock(out,
+         yard,
+         QVector3D(k_pile_center_x + jitter(seed, 0.42F),
+                   k_ground + 0.02F,
+                   k_stone_pile_z + jitter(seed * 3U, 0.48F)),
+         QVector3D(0.075F + (rand01(seed * 5U) * 0.045F),
+                   0.035F,
+                   0.065F + (rand01(seed * 7U) * 0.04F)),
+         rand01(seed * 11U) * 360.0F,
+         0.0F,
+         tint(style.stone_dark, 0.95F + (rand01(seed * 13U) * 0.25F)));
   }
 }
 
@@ -288,41 +428,99 @@ void draw_ore_pile(ISubmitter& out,
                    const StockpileYardStyle& style,
                    float fill,
                    float flash) {
+  constexpr float k_bin_half_x = 0.46F;
+  constexpr float k_bin_half_z = 0.50F;
+  constexpr float k_wall = 0.045F;
+  constexpr float k_bin_height = 0.27F;
+
+  for (int side = 0; side < 2; ++side) {
+    float const sign = (side == 0) ? -1.0F : 1.0F;
+    box(out,
+        yard,
+        QVector3D(k_pile_center_x + (sign * k_bin_half_x),
+                  k_bin_height * 0.5F,
+                  k_iron_pile_z),
+        QVector3D(k_wall, k_bin_height * 0.5F, k_bin_half_z),
+        0.0F,
+        style.timber_dark);
+    box(out,
+        yard,
+        QVector3D(k_pile_center_x,
+                  k_bin_height * 0.5F,
+                  k_iron_pile_z + (sign * k_bin_half_z)),
+        QVector3D(k_bin_half_x, k_bin_height * 0.5F, k_wall),
+        0.0F,
+        style.timber_dark);
+  }
+  for (int corner = 0; corner < 4; ++corner) {
+    float const sx = ((corner & 1) == 0) ? -1.0F : 1.0F;
+    float const sz = ((corner & 2) == 0) ? -1.0F : 1.0F;
+    box(out,
+        yard,
+        QVector3D(k_pile_center_x + (sx * k_bin_half_x),
+                  k_bin_height * 0.56F,
+                  k_iron_pile_z + (sz * k_bin_half_z)),
+        QVector3D(0.062F, k_bin_height * 0.56F, 0.062F),
+        0.0F,
+        style.timber);
+  }
+
   if (fill <= 0.01F) {
     return;
   }
 
-  int const lumps = std::max(1, static_cast<int>(std::lround(fill * 8.0F)));
+  float const bed_top = 0.06F + (fill * (k_bin_height - 0.05F));
+  box(out,
+      yard,
+      QVector3D(k_pile_center_x, bed_top * 0.5F, k_iron_pile_z),
+      QVector3D(k_bin_half_x - k_wall, bed_top * 0.5F, k_bin_half_z - k_wall),
+      0.0F,
+      brighten(tint(style.ore, 0.72F), flash * 0.30F));
+
+  constexpr std::array<std::array<float, 2>, 10> k_lump_spots{{{-0.24F, -0.30F},
+                                                               {0.20F, -0.28F},
+                                                               {-0.05F, -0.02F},
+                                                               {0.26F, 0.22F},
+                                                               {-0.27F, 0.26F},
+                                                               {0.04F, 0.36F},
+                                                               {-0.14F, 0.12F},
+                                                               {0.16F, -0.05F},
+                                                               {-0.22F, -0.10F},
+                                                               {0.02F, -0.34F}}};
+  int const lumps = std::clamp(static_cast<int>(std::lround(fill * 10.0F)),
+                               2,
+                               static_cast<int>(k_lump_spots.size()));
   for (int i = 0; i < lumps; ++i) {
     auto const seed = static_cast<std::uint32_t>(457 + (i * 53));
-    float const ring = (i < 5) ? 0.0F : 1.0F;
-    float const y = 0.12F + (ring * 0.16F);
-    float const radius = 0.18F + (rand01(seed) * 0.08F);
-    QVector3D const base = (rand01(seed * 3U) > 0.45F) ? style.ore_rust : style.ore;
-    rock(out,
-         yard,
-         QVector3D(k_pile_center_x + jitter(seed * 5U, 0.34F - (ring * 0.18F)),
-                   y,
-                   k_iron_pile_z + jitter(seed * 7U, 0.38F - (ring * 0.20F))),
-         QVector3D(radius, radius * 0.78F, radius * 0.92F),
-         rand01(seed * 11U) * 360.0F,
-         jitter(seed * 13U, 20.0F),
-         brighten(tint(base, 0.95F + (rand01(seed * 17U) * 0.35F)),
-                  0.10F + (flash * 0.35F)));
+    float const radius = 0.10F + (rand01(seed) * 0.05F);
+    QVector3D const base = (rand01(seed * 3U) > 0.62F) ? style.ore_rust : style.ore;
+    rock(
+        out,
+        yard,
+        QVector3D(k_pile_center_x + k_lump_spots.at(i).at(0) + jitter(seed * 5U, 0.05F),
+                  bed_top + (radius * 0.5F) + (rand01(seed * 19U) * 0.04F),
+                  k_iron_pile_z + k_lump_spots.at(i).at(1) + jitter(seed * 7U, 0.05F)),
+        QVector3D(radius, radius * 0.76F, radius * 0.92F),
+        rand01(seed * 11U) * 360.0F,
+        jitter(seed * 13U, 22.0F),
+        brighten(tint(base, 0.88F + (rand01(seed * 17U) * 0.28F)), flash * 0.35F));
   }
 
-  if (fill > 0.55F) {
-    for (int i = 0; i < 3; ++i) {
-      auto const seed = static_cast<std::uint32_t>(613 + (i * 31));
-      box(out,
-          yard,
-          QVector3D(k_pile_center_x + 0.46F,
-                    0.09F + (static_cast<float>(i) * 0.07F),
-                    k_iron_pile_z - 0.30F + (static_cast<float>(i) * 0.05F)),
-          QVector3D(0.17F, 0.035F, 0.09F),
-          jitter(seed, 12.0F),
-          brighten(tint(style.ore, 1.15F), flash * 0.35F));
-    }
+  if (!yard.detailed) {
+    return;
+  }
+  for (int i = 0; i < 3; ++i) {
+    auto const seed = static_cast<std::uint32_t>(661 + (i * 31));
+    float const radius = 0.07F + (rand01(seed) * 0.035F);
+    rock(out,
+         yard,
+         QVector3D(k_pile_center_x + 0.62F + jitter(seed * 3U, 0.16F),
+                   k_ground + (radius * 0.5F),
+                   k_iron_pile_z + jitter(seed * 5U, 0.44F)),
+         QVector3D(radius, radius * 0.7F, radius * 0.9F),
+         rand01(seed * 7U) * 360.0F,
+         jitter(seed * 11U, 18.0F),
+         tint(style.ore_rust, 0.9F + (rand01(seed * 13U) * 0.3F)));
   }
 }
 
@@ -351,9 +549,9 @@ void draw_barracks_stockpile(const DrawContext& ctx,
   yard.detailed = ctx.distance_sq <= k_detail_distance_sq;
 
   draw_bed(out, yard, style);
-  draw_kerb(out, yard, style);
+  draw_fence(out, yard, style);
   if (yard.detailed) {
-    draw_flagstones(out, yard, style);
+    draw_yard_clutter(out, yard, style);
   }
 
   if (resolve_building_state(ctx) == BuildingState::Destroyed) {

--- a/render/entity/barracks_stockpile.h
+++ b/render/entity/barracks_stockpile.h
@@ -11,6 +11,7 @@ class Texture;
 
 struct StockpileYardStyle {
   QVector3D gravel{0.42F, 0.38F, 0.31F};
+  QVector3D earth_light{0.54F, 0.48F, 0.39F};
   QVector3D stone_light{0.76F, 0.73F, 0.66F};
   QVector3D stone_mid{0.62F, 0.59F, 0.53F};
   QVector3D stone_dark{0.44F, 0.42F, 0.38F};

--- a/render/entity/nations/carthage/barracks_renderer.cpp
+++ b/render/entity/nations/carthage/barracks_renderer.cpp
@@ -889,18 +889,20 @@ void draw_stockpile_yard(const DrawContext& p,
                          Mesh* unit,
                          Texture* white,
                          const CarthagePalette& c) {
-  draw_barracks_stockpile(p,
-                          out,
-                          unit,
-                          white,
-                          StockpileYardStyle{.gravel = c.stone_base * 0.82F,
-                                             .stone_light = c.stone_light,
-                                             .stone_mid = c.stone_base,
-                                             .stone_dark = c.stone_dark,
-                                             .timber = c.wood,
-                                             .timber_dark = c.wood_dark,
-                                             .ore = c.iron * 1.55F,
-                                             .ore_rust = c.brick_dark});
+  draw_barracks_stockpile(
+      p,
+      out,
+      unit,
+      white,
+      StockpileYardStyle{.gravel = QVector3D(0.58F, 0.49F, 0.36F),
+                         .earth_light = QVector3D(0.69F, 0.60F, 0.45F),
+                         .stone_light = c.stone_light,
+                         .stone_mid = c.stone_base,
+                         .stone_dark = c.stone_dark,
+                         .timber = c.wood,
+                         .timber_dark = c.wood_dark,
+                         .ore = c.iron * 1.55F,
+                         .ore_rust = c.brick_dark});
 }
 
 void draw_barracks_ornaments(const DrawContext& p,

--- a/render/entity/nations/roman/barracks_renderer.cpp
+++ b/render/entity/nations/roman/barracks_renderer.cpp
@@ -754,14 +754,15 @@ void draw_stockpile_yard(const DrawContext& p,
       out,
       unit,
       white,
-      StockpileYardStyle{.gravel = c.limestone_dark * 0.78F,
+      StockpileYardStyle{.gravel = QVector3D(0.62F, 0.55F, 0.44F),
+                         .earth_light = QVector3D(0.72F, 0.65F, 0.53F),
                          .stone_light = c.limestone,
                          .stone_mid = c.limestone_shade,
                          .stone_dark = c.limestone_dark,
                          .timber = c.cedar,
                          .timber_dark = c.cedar_dark,
-                         .ore = QVector3D(0.47F, 0.46F, 0.50F),
-                         .ore_rust = QVector3D(0.58F, 0.35F, 0.19F)});
+                         .ore = QVector3D(0.35F, 0.34F, 0.36F),
+                         .ore_rust = QVector3D(0.46F, 0.28F, 0.16F)});
 }
 
 void draw_barracks_ornaments(const DrawContext& p,

--- a/tools/building_preview/main.cpp
+++ b/tools/building_preview/main.cpp
@@ -200,13 +200,18 @@ auto render_building(EntityRendererRegistry& registry,
   unit->health = static_cast<int>(static_cast<float>(unit->max_health) * health_ratio);
   unit->nation_id = (nation == "carthage") ? Game::Systems::NationID::Carthage
                                            : Game::Systems::NationID::RomanRepublic;
+  if (type == "barracks") {
+    auto* stockpile = entity.add_component<Engine::Core::StockpileComponent>();
+    stockpile->wood_fill = 0.75F;
+    stockpile->stone_fill = 0.6F;
+    stockpile->iron_fill = 0.85F;
+  }
 
   DrawContext ctx;
   ctx.entity = &entity;
   ctx.resources = resources;
   ctx.model = QMatrix4x4{};
   ctx.distance_sq = 0.0F;
-  (void)type;
 
   CapturingSubmitter sub;
   func(ctx, sub);


### PR DESCRIPTION
Add fenced yard structure, richer resource pile geometry, and grounded clutter details. Tune Roman and Carthaginian palettes and populate stockpile fills in the building preview.