### PR TITLE
Add settlement life, standing gathers, and shared nation ornaments

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,10 @@ The engine is moving from a single hardcoded nation toward a scalable multi-fact
 - A _resource economy_ with gathering, spending, and marketplace trade. Gathered goods are
   carried to the stockpile yard beside a barracks before they count; see
   [docs/RESOURCE_STOCKPILE.md](docs/RESOURCE_STOCKPILE.md).
+- _Settlement life_: workers keep their own round between the tree line and the yard
+  after one order, villagers work and loiter around the buildings and props of their
+  settlement, and they scatter when armed strangers arrive. See
+  [docs/SETTLEMENT_LIFE.md](docs/SETTLEMENT_LIFE.md).
 - _Campaign progression_ with mission unlocking and per-slot save metadata.
 - A _simulation kernel_ (`game_sim`) that builds and runs with no renderer linked, exercised by `bin/simulation_tests`, which links that kernel and nothing else.
 - A _session context_ that owns all per-match state, so two matches can run in one process and tests get isolation.

--- a/docs/RESOURCE_STOCKPILE.md
+++ b/docs/RESOURCE_STOCKPILE.md
@@ -109,6 +109,15 @@ already uses for civilians tells the player what it is doing.
 - **The load survives a save.** `ResourceCarryComponent` is authoritative serialized
   state — dropping it would either delete the goods or hand them over for free.
 
+### The next load
+
+Unloading is no longer the end of the job. A worker that finished a harvest carries a
+**standing gather order**, and once the load is off its back `GatherLoopSystem` sends it
+back to the next node of the same kind near the one it last worked. A forest is one
+click, not one click per tree. The rules that end a round — and why the faction AI is
+deliberately left out of it — are in
+[SETTLEMENT_LIFE.md](https://github.com/djeada/Standard-of-Iron/blob/main/docs/SETTLEMENT_LIFE.md).
+
 ### What this changes elsewhere
 
 - Mission `accumulate_resources` objectives count a yield at unload, not at harvest, so a

--- a/docs/SETTLEMENT_ASSETS.md
+++ b/docs/SETTLEMENT_ASSETS.md
@@ -268,6 +268,41 @@ the colouring. The cart's wheel bands in the shader were updated to match the en
 wheels; the rack's weapon geometry was deliberately left where it is, and the additions
 sit in regions the shader treats as wood.
 
+## Nation emblems: one eagle, one crescent
+
+Every Roman building carries the **same aquila**, and every Carthaginian building the
+**same crescent-and-disc**. They are not per-renderer geometry: both are built once in
+`render/entity/building_ornaments.h` and used everywhere.
+
+- `Detail::add_eagle_silhouette` is the aquila itself — four swept wing feathers a side
+  over a darker shadow layer, a fanned tail, breast, neck, a head turned to its right and
+  a cone beak. That beak is what makes the silhouette read as a bird rather than a cross
+  at the game camera, which is what the old box-and-crossbar version looked like.
+- `add_roman_aquila_relief` mounts it on a wall inside a laurel wreath on an oxblood
+  plaque; `add_roman_roof_standard` mounts the _same function_ on a vexillum standard.
+- `Detail::add_tanit_sign` is the Punic sign — a true disc head, upturned arms and a
+  stepped triangular body — used by `add_punic_tanit_relief`.
+  `add_punic_horned_crown` is the roof piece: pedestal, pole, bronze disc, and a
+  continuous crescent arc with horn cones.
+
+Two rules the geometry has to keep:
+
+- **The roof signature survives minimal LOD.** `add_eagle_silhouette` and
+  `add_tanit_sign` take a `core_lod`: the relief passes `Full` (a wall carving is not
+  worth drawing at distance), the roof standard passes `All`, so the core body, head,
+  beak, inner wings and centre tail still draw when the fine feathers are dropped. A
+  distant building must still fly its bird. `building_archetype_desc_test` enforces both
+  halves of that.
+- **Recorder-based renderers use the same source.** The two barracks build their
+  archetypes from recorded draw commands rather than from a `BuildingArchetypeDesc`, so
+  they would otherwise need a second, drifting copy of the emblem. Instead
+  `render/entity/building_ornament_emit.h` replays a desc through an ordinary submitter,
+  and the barracks build the shared ornament into a throwaway desc and emit it. Adding a
+  feather to the eagle changes every Roman building at once, barracks included.
+
+Walls are deliberately left bare: a timber palisade is not a civic facade, and one
+emblem per segment would be both wrong and expensive.
+
 ## Arena scenarios
 
 - `world_prop_lineup` — every authored prop side by side, now including
@@ -282,3 +317,21 @@ Arena wall groups must land on even grid cells, so a `WallSegment` group needs a
 `count` when its origin sits on an even coordinate — `arena_scenarios_test` enforces it.
 Any scenario spawning `settlement_resident` groups must also assert
 `MovementAnimationObserved` for one of them.
+
+### Where scenario dressing actually lands
+
+`ArenaViewport::place_scenario_resource_patches` does not drop a `resource_patch` prop
+exactly where it is authored. Each prop is given a ground radius
+(`Game::Map::world_prop_ground_radius`, a per-type fraction of the render scale — camp
+props are wide, tree trunks are narrow) and is only placed where it stands clear of:
+
+- a building footprint plus `k_prop_building_clearance`,
+- water and bridges plus a dry margin,
+- a road plus a small clearance,
+- every prop already placed in the same pass, plus `k_prop_gap`.
+
+If the authored spot fails, the prop is nudged outward through three rings of candidate
+positions; if none is clear it is **skipped**. That is what stops a tent growing out of
+a house wall or a grove standing in a river, and it applies to every scenario, including
+new ones — but a patch authored somewhere hopeless still silently loses props, so author
+the dressing where it belongs and let the pass tidy the edges rather than relying on it.

--- a/docs/SETTLEMENT_LIFE.md
+++ b/docs/SETTLEMENT_LIFE.md
@@ -1,0 +1,241 @@
+# Settlement Life
+
+A village whose people stand still is scenery. This document covers the two systems that
+keep the civilian side of a map moving on its own: the **errand loop** that sends
+residents about their settlement, and the **standing gather order** that keeps a worker
+running its own round between the tree line and the barracks yard.
+
+Neither system takes a decision away from the player. Both retire the moment the player
+gives an order, and both are cheap enough to leave running on every map.
+
+## Residents and their errands
+
+`SettlementLifeSystem` owns `SettlementResidentComponent`. A resident has a **hearth**
+(the point its life is centred on), a **roam radius**, and one errand at a time:
+
+| Errand      | Meaning                                              |
+| ----------- | ---------------------------------------------------- |
+| `Settling`  | No errand yet; pick one on the next think.           |
+| `WalkingTo` | Walking to the errand point, with a travel deadline. |
+| `Working`   | Standing at the errand point for `planned_dwell`.    |
+
+Every `k_think_interval` (0.35 s) a resident advances that small state machine. When it
+needs a new errand it collects the candidates inside its roam radius — friendly
+non-wall buildings, and the "life" world props (fire camps, tents, supply carts, weapon
+racks, plants, olive trees) — and rolls one of three destinations:
+
+- **At a building**, standing off past the building's own collision footprint so it never
+  tries to walk into the wall.
+- **At a prop**, standing off by a fixed clearance.
+- **On the street**, a point somewhere between a quarter and 85% of the roam radius from
+  the hearth.
+
+A proposal closer than `k_min_errand_distance` to where the resident already is gets
+rejected and re-rolled, which is what stops residents shuffling on the spot. Destinations
+are snapped to walkable ground before the move is issued, and the walk is a
+`ScriptedMove` so it does not read as a player order anywhere else in the codebase.
+
+Every errand carries a **travel allowance** proportional to its distance. Miss the
+deadline, or go idle before arriving, and the resident abandons the errand and picks
+another instead of standing in the road forever.
+
+### Errand roles: what a resident does once it arrives
+
+Arriving is only half of it. Each errand at a building or a prop rolls a
+`SettlementErrandRole`:
+
+- **`Labour`** (62%) — the resident works with its hands for the dwell. The dwell is
+  extended by `k_labour_dwell_bonus` so the work reads at the game camera instead of
+  flickering past.
+- **`Loiter`** — the resident simply stands, and the humanoid ambient idle system takes
+  over with its usual shuffles and weight shifts.
+
+Street errands are always `Loiter`.
+
+On arrival the resident turns to **face its focus** — the building or prop it walked to,
+or the hearth for a street errand — through `TransformComponent::desired_yaw`, so a
+worker at a market stall faces the stall rather than whatever direction it happened to
+arrive from.
+
+### How labour is drawn
+
+There is no separate civilian work animation. `World::publish_creature_presentation_entity`
+feeds a labouring resident into the **same construction action inputs** a builder uses,
+with `work_elapsed` as the elapsed time and `k_settlement_labour_cycles_per_second` as the
+cycle rate. The humanoid rig therefore plays its hammer/saw/chisel loop, which at the RTS
+camera reads as "busy with both hands" — exactly what an ambient villager needs.
+
+`work_elapsed` is advanced **every frame**, not on the 0.35 s think tick, because the
+pose phase is derived from it; ticking it at think rate produced a visibly stepped
+animation.
+
+Two exclusions matter, and both are load-bearing:
+
+- **A real builder job wins.** The construction inputs are only taken from the resident
+  when `BuilderProductionComponent::in_progress` is false.
+- **A dead resident is never labouring.** A villager cut down mid-errand used to keep
+  `Working`/`Labour` frozen on its component, and feeding that to the pose pipeline
+  alongside the death sequence **segfaulted `village_raid`** in the optimised build — a
+  creature cannot be both constructing and dead. Two guards close it: the system resets a
+  dead resident's errand to `Settling`/`Loiter` instead of skipping it outright, and the
+  presentation requires `DeathAnimationComponent == nullptr` before it reads the resident
+  at all.
+
+## The alarm: residents run from armed strangers
+
+A villager who keeps hammering a stall while a raider walks up to him is worse than a
+villager who stands still. Every `k_alarm_interval` (0.3 s) the system builds one list of
+**armed units** — everything that `can_use_attack_mode`, minus civilians — and each
+resident checks it.
+
+An enemy (by `OwnerRegistry::are_enemies`) inside `k_alarm_radius` (11) puts the resident
+into the `Fleeing` errand: it drops its work, drops any attack target it had picked up,
+and is sent `k_flee_distance` (11) away from the threat. The direction is **away from the
+danger, blended halfway toward the hearth** when the hearth is on that side, so a crowd
+scatters inward through its own village rather than each villager running off the map on
+its own vector.
+
+A new leg is issued when the last one runs out (`k_flee_leg_seconds`) or the resident goes
+idle before arriving, so the flight tracks a threat that keeps advancing. The all-clear
+uses a wider radius (`k_all_clear_radius`, 15) than the alarm, so a resident does not
+stop dead the moment it crosses back over the alarm line and immediately re-trigger.
+
+Two rules keep this from becoming a bug factory:
+
+- **The alarm never touches combat state.** A resident that already has an
+  `AttackTargetComponent` is skipped entirely — parked in `Settling` and left to the
+  combat system. Residents scatter as raiders _approach_; once one is actually engaged,
+  combat owns it. Pulling a live attack target out from under the engagement,
+  melee-lock and formation-contact bookkeeping mid-tick is not a supported move, so the
+  alarm does not try.
+- **A player order still beats fleeing.** The claim check (`CivilianDeliveryComponent`,
+  `PlayerOrderIntentComponent`) runs before the alarm.
+
+## Adoption: who becomes a resident
+
+Before this existed, `SettlementResidentComponent` was only ever attached by arena
+scenarios and by save loading — so villages were alive in the arena and dead in the
+shipped game, where every civilian a home produced stood where it spawned until the
+player clicked it.
+
+`adopt_idle_civilians` closes that. Every `k_adoption_interval` (2 s) it looks for
+civilians that are:
+
+- alive, of `SpawnType::Civilian`, and not already residents;
+- **unclaimed by the player** — no `CivilianDeliveryComponent`, no
+  `PlayerOrderIntentComponent`, no attack target, and no movement target;
+- within `k_adoption_radius` (20) of a friendly, non-wall building.
+
+Such a civilian is given a resident component whose hearth is that **nearest friendly
+building**, not its own position, so a crowd produced by one home gathers around the
+settlement rather than around each individual spawn point.
+
+The last condition is why this cannot animate a civilian stranded in open country: with
+no friendly building nearby there is no settlement to be a resident of, and the civilian
+is left alone.
+
+### Release: an ordered civilian stops being a resident
+
+Adoption is for civilians nobody is managing. The moment the player moves a civilian by
+hand — a `PlayerMove`, a `FormationMove`, or a stop — `OrderService` **releases** it:
+the resident component is marked `released` (and added, if the civilian did not have
+one) and the system skips it from then on. Because adoption also skips anything that
+already carries the component, a released civilian is never re-adopted.
+
+The rule is the same one the standing gather order follows: _order it and it is yours to
+manage_. Without it a civilian walked somewhere deliberately would stroll off to the
+nearest village a few seconds after arriving, which is a lost unit as far as the player
+is concerned — and it is exactly what broke `riverside_mill_town`'s carrying party, which
+crossed its bridge, arrived, and then wandered out of its own destination check.
+
+### Re-anchoring
+
+While a resident is busy elsewhere — being walked to a barracks for its manpower, under
+attack, or carrying out a player move — the system parks it (`Settling`, `Loiter`, work
+cleared) and marks the hearth unassigned. The hearth is re-derived from the nearest
+friendly building the next time the resident is free. Walk a civilian from one town to
+another and it settles into the town it is standing in, instead of trudging back to the
+old one.
+
+## The standing gather order
+
+The harvest loop used to stall on its last step. A worker chopped a tree, hauled the load
+to a barracks yard (see [RESOURCE_STOCKPILE.md](RESOURCE_STOCKPILE.md)) — and then stood
+there. Every single tree in a forest was a separate click.
+
+`BuilderProductionComponent` now carries a standing order:
+
+| Field                 | Meaning                                           |
+| --------------------- | ------------------------------------------------- |
+| `has_gather_order`    | This worker is on its own round.                  |
+| `gather_product_type` | Which harvest job to repeat.                      |
+| `gather_anchor_x/z`   | The last node it worked — the centre of its round |
+
+`ProductionSystem` sets it the moment a harvest **succeeds**, so every path that can
+assign a harvest job — the player's build card, the arena's `HarvestResource` step —
+gets the loop for free without knowing about it.
+
+`GatherLoopSystem` then does the resuming. Every `k_think_interval` (0.6 s) it looks for
+a worker with a standing order that is genuinely free: not building, not repairing, no
+task target, no queued wall sites, **not carrying a load**, no attack target, and not
+walking anywhere. It finds the nearest unreserved node of the right kind within
+`k_search_radius` (22) **of the anchor**, reserves it, and assigns the same job the
+player would have. Searching from the anchor rather than from the worker is deliberate:
+the worker returns to the grove it was working, instead of taking whatever happens to
+grow next to the barracks.
+
+The worker is sent to a point `k_work_standoff` (1.8) short of the node, on the side it
+approaches from, so it stands beside the tree it is felling.
+
+### What ends a round
+
+- **A manual move or a stop.** `OrderService` clears the standing order alongside the
+  other auxiliary orders on a `PlayerMove` or `FormationMove`, and on `apply_stop`.
+  Taking the worker somewhere by hand is how you take it off the job. A `ScriptedMove` —
+  which is what hauling a load home is — does not count, or the round would end on its
+  own first trip.
+- **An exhausted area.** No unreserved node of the right kind within the search radius of
+  the anchor, and the order is dropped rather than left re-scanning forever.
+
+A **builder job in between does not end the round**. Borrow a woodcutter to raise a
+house or mend a wall and it goes back to the tree line when the job is done, because
+`GatherLoopSystem` keys off `gather_product_type` and only ever acts on a worker with no
+job at all. That is the whole point of the feature: the interesting order is the one the
+player gives, and going back to work afterwards is not one.
+
+### Why the AI is excluded
+
+`ProductionSystem` only records the standing order for workers **without**
+`AIControlledComponent`. The faction AI already re-issues harvest jobs on its own
+cadence, and its builder behaviour picks workers by `!movement.has_target` — a worker
+kept permanently busy by a standing order would never be free for the AI to send to a
+construction site. Leaving the AI on its existing loop keeps its economy behaviour
+byte-for-byte unchanged.
+
+## Saving
+
+Both features are authoritative state and are serialized:
+`has_gather_order` / `gather_product_type` / `gather_anchor_*` on the builder, and
+`role` / `focus_x` / `focus_z` / `work_elapsed` on the resident. Dropping them would
+either abandon a worker mid-round or reset every villager to the middle of the street on
+load.
+
+## Seeing it
+
+`village_day_life` is the reference scene, authored for ambience capture rather than for
+a contact test:
+
+```bash
+build/bin/arena_app --scenario village_day_life
+```
+
+The camera sits close enough to read hands and gait. Two woodcutters and two quarriers
+are given one harvest order each at the start and are never told anything again — every
+further trip they make is the standing gather order. Ten residents work the lane, the
+market and the house yards, a flock grazes the meadow, and birds pass overhead. The
+scenario asserts `OwnerHarvestsResource` at a threshold of 8, which four workers cannot
+reach with one job each; the expectation fails if the gather loop stops resuming.
+
+`village_harvest_cycle` remains the wider, AI-driven economy scene. See
+[docs/SETTLEMENT_ASSETS.md](SETTLEMENT_ASSETS.md) for the rules arena settlement
+scenarios have to satisfy.

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -150,6 +150,7 @@ add_library(
     systems/production_system.cpp
     systems/civilian_delivery_system.cpp
     systems/resource_delivery_system.cpp
+    systems/gather_loop_system.cpp
     systems/capture_system.cpp
     systems/terrain_alignment_system.cpp
     systems/healing_rules.cpp

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -1206,8 +1206,20 @@ public:
 
   EntityID structure_task_entity_id{0};
 
+  bool has_gather_order{false};
+  std::string gather_product_type{};
+  float gather_anchor_x{0.0F};
+  float gather_anchor_z{0.0F};
+
   BuilderTaskFault fault{BuilderTaskFault::None};
   float fault_display_remaining{0.0F};
+
+  void clear_gather_order() {
+    has_gather_order = false;
+    gather_product_type.clear();
+    gather_anchor_x = 0.0F;
+    gather_anchor_z = 0.0F;
+  }
 };
 
 class WallSegmentComponent : public Component {
@@ -1781,7 +1793,15 @@ enum class SettlementErrand : std::uint8_t {
   Settling = 0,
   WalkingTo = 1,
   Working = 2,
+  Fleeing = 3,
 };
+
+enum class SettlementErrandRole : std::uint8_t {
+  Loiter = 0,
+  Labour = 1,
+};
+
+inline constexpr float k_settlement_labour_cycles_per_second = 1.15F;
 
 class SettlementResidentComponent : public Component {
 public:
@@ -1792,14 +1812,24 @@ public:
   float roam_radius{16.0F};
   bool hearth_assigned{false};
 
+  bool released{false};
+
   SettlementErrand errand{SettlementErrand::Settling};
+  SettlementErrandRole role{SettlementErrandRole::Loiter};
   EntityID focus_id{0};
   float errand_x{0.0F};
   float errand_z{0.0F};
+  float focus_x{0.0F};
+  float focus_z{0.0F};
   float errand_remaining{0.0F};
   float planned_dwell{3.0F};
   float think_cooldown{0.0F};
+  float work_elapsed{0.0F};
   std::uint32_t rng_state{0U};
+
+  [[nodiscard]] auto is_labouring() const -> bool {
+    return errand == SettlementErrand::Working && role == SettlementErrandRole::Labour;
+  }
 };
 
 class WildlifeComponent : public Component {

--- a/game/core/serialization.cpp
+++ b/game/core/serialization.cpp
@@ -648,6 +648,11 @@ auto Serialization::serialize_entity(const Entity* entity) -> QJsonObject {
     builder_obj["bypass_movement_active"] = builder->bypass_movement_active;
     builder_obj["bypass_target_x"] = static_cast<double>(builder->bypass_target_x);
     builder_obj["bypass_target_z"] = static_cast<double>(builder->bypass_target_z);
+    builder_obj["has_gather_order"] = builder->has_gather_order;
+    builder_obj["gather_product_type"] =
+        QString::fromStdString(builder->gather_product_type);
+    builder_obj["gather_anchor_x"] = static_cast<double>(builder->gather_anchor_x);
+    builder_obj["gather_anchor_z"] = static_cast<double>(builder->gather_anchor_z);
     entity_obj["builder_production"] = builder_obj;
   }
 
@@ -793,10 +798,15 @@ auto Serialization::serialize_entity(const Entity* entity) -> QJsonObject {
     resident_obj["hearth_z"] = static_cast<double>(resident->hearth_z);
     resident_obj["roam_radius"] = static_cast<double>(resident->roam_radius);
     resident_obj["hearth_assigned"] = resident->hearth_assigned;
+    resident_obj["released"] = resident->released;
     resident_obj["errand"] = static_cast<int>(resident->errand);
+    resident_obj["role"] = static_cast<int>(resident->role);
     resident_obj["focus_id"] = static_cast<qint64>(resident->focus_id);
     resident_obj["errand_x"] = static_cast<double>(resident->errand_x);
     resident_obj["errand_z"] = static_cast<double>(resident->errand_z);
+    resident_obj["focus_x"] = static_cast<double>(resident->focus_x);
+    resident_obj["focus_z"] = static_cast<double>(resident->focus_z);
+    resident_obj["work_elapsed"] = static_cast<double>(resident->work_elapsed);
     resident_obj["errand_remaining"] = static_cast<double>(resident->errand_remaining);
     resident_obj["planned_dwell"] = static_cast<double>(resident->planned_dwell);
     resident_obj["think_cooldown"] = static_cast<double>(resident->think_cooldown);
@@ -1540,6 +1550,13 @@ void Serialization::deserialize_entity(Entity* entity, const QJsonObject& json) 
         static_cast<float>(builder_obj["bypass_target_x"].toDouble(0.0));
     builder->bypass_target_z =
         static_cast<float>(builder_obj["bypass_target_z"].toDouble(0.0));
+    builder->has_gather_order = builder_obj["has_gather_order"].toBool(false);
+    builder->gather_product_type =
+        builder_obj["gather_product_type"].toString().toStdString();
+    builder->gather_anchor_x =
+        static_cast<float>(builder_obj["gather_anchor_x"].toDouble(0.0));
+    builder->gather_anchor_z =
+        static_cast<float>(builder_obj["gather_anchor_z"].toDouble(0.0));
   }
 
   if (json.contains("wall_segment")) {
@@ -1713,11 +1730,17 @@ void Serialization::deserialize_entity(Entity* entity, const QJsonObject& json) 
     resident->roam_radius =
         static_cast<float>(resident_obj["roam_radius"].toDouble(16.0));
     resident->hearth_assigned = resident_obj["hearth_assigned"].toBool(false);
+    resident->released = resident_obj["released"].toBool(false);
     resident->errand = static_cast<SettlementErrand>(resident_obj["errand"].toInt(0));
+    resident->role = static_cast<SettlementErrandRole>(resident_obj["role"].toInt(0));
     resident->focus_id =
         static_cast<EntityID>(resident_obj["focus_id"].toVariant().toULongLong());
     resident->errand_x = static_cast<float>(resident_obj["errand_x"].toDouble(0.0));
     resident->errand_z = static_cast<float>(resident_obj["errand_z"].toDouble(0.0));
+    resident->focus_x = static_cast<float>(resident_obj["focus_x"].toDouble(0.0));
+    resident->focus_z = static_cast<float>(resident_obj["focus_z"].toDouble(0.0));
+    resident->work_elapsed =
+        static_cast<float>(resident_obj["work_elapsed"].toDouble(0.0));
     resident->errand_remaining =
         static_cast<float>(resident_obj["errand_remaining"].toDouble(0.0));
     resident->planned_dwell =

--- a/game/core/world.cpp
+++ b/game/core/world.cpp
@@ -378,6 +378,17 @@ void publish_creature_presentation_entity(Entity* entity, World* world) {
         .build_time = builder->build_time,
         .time_remaining = builder->time_remaining,
     };
+  } else if (auto const* resident =
+                 entity->get_component<SettlementResidentComponent>();
+
+             death == nullptr && resident != nullptr && resident->is_labouring()) {
+
+    action_inputs.construction = {
+        .active = true,
+        .build_time = resident->work_elapsed,
+        .time_remaining = 0.0F,
+        .cycles_per_second = k_settlement_labour_cycles_per_second,
+    };
   }
   if (combat != nullptr) {
     action_inputs.combat = {

--- a/game/map/map_definition.h
+++ b/game/map/map_definition.h
@@ -269,7 +269,7 @@ world_prop_type_to_string(WorldProp::Type type) -> QLatin1String {
   case WorldProp::Type::SupplyCart:
     return 1.28F;
   case WorldProp::Type::WeaponRack:
-    return 1.35F;
+    return 0.68F;
   case WorldProp::Type::Ruins:
     return 2.90F;
   case WorldProp::Type::DeadTree:
@@ -292,6 +292,35 @@ world_prop_type_to_string(WorldProp::Type type) -> QLatin1String {
     return 1.05F;
   }
   return 1.0F;
+}
+
+[[nodiscard]] constexpr auto world_prop_ground_fraction(WorldProp::Type type) -> float {
+  switch (type) {
+
+  case WorldProp::Type::PineTree:
+  case WorldProp::Type::OliveTree:
+  case WorldProp::Type::DeadTree:
+    return 0.22F;
+
+  case WorldProp::Type::Tent:
+  case WorldProp::Type::SupplyCart:
+  case WorldProp::Type::WeaponRack:
+  case WorldProp::Type::AbandonedHome:
+  case WorldProp::Type::Ruins:
+    return 0.55F;
+  case WorldProp::Type::FireCamp:
+    return 0.90F;
+  default:
+    break;
+  }
+  return 0.40F;
+}
+
+[[nodiscard]] constexpr auto world_prop_ground_radius(WorldProp::Type type,
+                                                      float authored_scale) -> float {
+  float const radius =
+      world_prop_render_scale(type) * authored_scale * world_prop_ground_fraction(type);
+  return radius > 0.5F ? radius : 0.5F;
 }
 
 enum class CoordSystem {

--- a/game/systems/gather_loop_system.cpp
+++ b/game/systems/gather_loop_system.cpp
@@ -1,0 +1,145 @@
+#include "gather_loop_system.h"
+
+#include <QVector3D>
+
+#include <optional>
+
+#include "../core/component.h"
+#include "../core/world.h"
+#include "../map/terrain_service.h"
+#include "builder_product_types.h"
+#include "command_service.h"
+
+namespace Game::Systems {
+namespace {
+
+constexpr float k_work_standoff = 1.8F;
+
+auto find_next_node(const std::string& product_type,
+                    float anchor_x,
+                    float anchor_z) -> std::optional<Game::Map::WorldPropTarget> {
+  auto const& terrain = Game::Map::TerrainService::instance();
+  float const radius = GatherLoopSystem::k_search_radius;
+
+  if (product_type == k_builder_product_cut_tree) {
+    return terrain.find_tree_near_world(anchor_x, anchor_z, radius);
+  }
+  if (product_type == k_builder_product_collect_stone) {
+    return terrain.find_boulder_near_world(anchor_x, anchor_z, radius);
+  }
+  if (product_type == k_builder_product_collect_iron_ore) {
+    return terrain.find_iron_ore_near_world(anchor_x, anchor_z, radius);
+  }
+  return std::nullopt;
+}
+
+auto work_position_beside(const Game::Map::WorldPropTarget& node,
+                          float worker_x,
+                          float worker_z) -> QVector3D {
+  QVector3D approach(worker_x - node.x, 0.0F, worker_z - node.z);
+  if (approach.lengthSquared() < 0.01F) {
+    approach = QVector3D(1.0F, 0.0F, 0.0F);
+  }
+  approach.normalize();
+
+  return CommandService::snap_to_walkable_ground(
+      QVector3D(node.x + (approach.x() * k_work_standoff),
+                0.0F,
+                node.z + (approach.z() * k_work_standoff)));
+}
+
+auto is_free_for_the_next_load(const Engine::Core::Entity& worker,
+                               const Engine::Core::BuilderProductionComponent& builder)
+    -> bool {
+  if (builder.in_progress || builder.has_construction_site || builder.has_task_target ||
+      builder.structure_task_entity_id != 0 ||
+      !builder.queued_construction_site_ids.empty()) {
+    return false;
+  }
+  if (const auto* carry = worker.get_component<Engine::Core::ResourceCarryComponent>();
+      carry != nullptr && !carry->empty()) {
+    return false;
+  }
+  if (worker.has_component<Engine::Core::AttackTargetComponent>()) {
+    return false;
+  }
+  const auto* movement = worker.get_component<Engine::Core::MovementComponent>();
+  return movement != nullptr && !movement->get_has_target();
+}
+
+} // namespace
+
+void GatherLoopSystem::update(Engine::Core::World* world, float delta_time) {
+  if (world == nullptr) {
+    return;
+  }
+
+  m_think_cooldown -= delta_time;
+  if (m_think_cooldown > 0.0F) {
+    return;
+  }
+  m_think_cooldown = k_think_interval;
+
+  auto& terrain = Game::Map::TerrainService::instance();
+
+  for (auto* entity :
+       world->get_entities_with<Engine::Core::BuilderProductionComponent>()) {
+    auto* builder = entity->get_component<Engine::Core::BuilderProductionComponent>();
+    if (builder == nullptr || !builder->has_gather_order) {
+      continue;
+    }
+
+    auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
+    if (builder->is_placement_preview || unit == nullptr || unit->health <= 0 ||
+        !is_harvest_builder_product(builder->gather_product_type)) {
+      builder->clear_gather_order();
+      continue;
+    }
+
+    if (!is_free_for_the_next_load(*entity, *builder)) {
+      continue;
+    }
+
+    auto* transform = entity->get_component<Engine::Core::TransformComponent>();
+    auto* movement = entity->get_component<Engine::Core::MovementComponent>();
+    if (transform == nullptr || movement == nullptr) {
+      continue;
+    }
+
+    auto const next = find_next_node(builder->gather_product_type,
+                                     builder->gather_anchor_x,
+                                     builder->gather_anchor_z);
+    if (!next.has_value()) {
+      builder->clear_gather_order();
+      continue;
+    }
+
+    if (!terrain.reserve_world_prop(next->id)) {
+      continue;
+    }
+
+    QVector3D const work_position =
+        work_position_beside(*next, transform->position.x, transform->position.z);
+
+    builder->product_type = builder->gather_product_type;
+    builder->time_remaining = builder->build_time;
+    builder->has_construction_site = true;
+    builder->construction_site_x = work_position.x();
+    builder->construction_site_z = work_position.z();
+    builder->construction_site_rotation_y = 0.0F;
+    builder->at_construction_site = false;
+    builder->in_progress = false;
+    builder->construction_complete = false;
+    builder->bypass_movement_active = false;
+    builder->has_task_target = true;
+    builder->task_target_id = next->id;
+    builder->task_target_x = next->x;
+    builder->task_target_z = next->z;
+    builder->task_target_reserved = true;
+    builder->clear_fault();
+
+    movement->set_rest_position(work_position.x(), work_position.z());
+  }
+}
+
+} // namespace Game::Systems

--- a/game/systems/gather_loop_system.h
+++ b/game/systems/gather_loop_system.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../core/system.h"
+
+namespace Game::Systems {
+
+class GatherLoopSystem : public Engine::Core::System {
+public:
+  static constexpr float k_think_interval = 0.6F;
+
+  static constexpr float k_search_radius = 22.0F;
+
+  GatherLoopSystem() = default;
+  ~GatherLoopSystem() override = default;
+
+  void update(Engine::Core::World* world, float delta_time) override;
+
+private:
+  float m_think_cooldown{0.0F};
+};
+
+} // namespace Game::Systems

--- a/game/systems/order_service.cpp
+++ b/game/systems/order_service.cpp
@@ -89,6 +89,42 @@ void OrderService::clear_civilian_delivery(Engine::Core::Entity* entity) {
   entity->remove_component<Engine::Core::CivilianDeliveryComponent>();
 }
 
+void OrderService::release_settlement_resident(Engine::Core::Entity* entity) {
+  if (entity == nullptr) {
+    return;
+  }
+
+  auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
+  if (unit == nullptr || unit->spawn_type != Game::Units::SpawnType::Civilian) {
+    return;
+  }
+
+  auto* resident = entity->get_component<Engine::Core::SettlementResidentComponent>();
+  if (resident == nullptr) {
+    resident = entity->add_component<Engine::Core::SettlementResidentComponent>();
+  }
+  if (resident == nullptr) {
+    return;
+  }
+
+  resident->released = true;
+  resident->errand = Engine::Core::SettlementErrand::Settling;
+  resident->role = Engine::Core::SettlementErrandRole::Loiter;
+  resident->focus_id = 0;
+  resident->work_elapsed = 0.0F;
+}
+
+void OrderService::clear_builder_gather_order(Engine::Core::Entity* entity) {
+  if (entity == nullptr) {
+    return;
+  }
+
+  if (auto* builder =
+          entity->get_component<Engine::Core::BuilderProductionComponent>()) {
+    builder->clear_gather_order();
+  }
+}
+
 void OrderService::clear_builder_task(Engine::Core::Entity* entity) {
   if (entity == nullptr) {
     return;
@@ -203,6 +239,8 @@ void OrderService::prepare_for_move(Engine::Core::Entity* entity,
 
   if (should_clear_auxiliary_orders(kind)) {
     clear_civilian_delivery(entity);
+    clear_builder_gather_order(entity);
+    release_settlement_resident(entity);
     clear_patrol(entity);
   }
 
@@ -260,6 +298,8 @@ void OrderService::apply_stop(Engine::Core::Entity* entity) {
   reset_movement(entity);
   clear_attack_target(entity);
   clear_player_order_intent(entity);
+  clear_builder_gather_order(entity);
+  release_settlement_resident(entity);
   clear_patrol(entity);
   exit_hold_mode(entity);
   set_formation_mode_active(entity, false);

--- a/game/systems/order_service.h
+++ b/game/systems/order_service.h
@@ -23,6 +23,8 @@ public:
   static void clear_civilian_delivery(Engine::Core::Entity* entity);
 
   static void clear_builder_task(Engine::Core::Entity* entity);
+  static void clear_builder_gather_order(Engine::Core::Entity* entity);
+  static void release_settlement_resident(Engine::Core::Entity* entity);
   static void clear_patrol(Engine::Core::Entity* entity);
   static void clear_attack_target(Engine::Core::Entity* entity);
   static void clear_player_order_intent(Engine::Core::Entity* entity);

--- a/game/systems/production_system.cpp
+++ b/game/systems/production_system.cpp
@@ -582,6 +582,13 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
               reward_amount = k_collect_iron_ore_reward;
             }
             load_onto_hauler(e, resource_type, reward_amount);
+
+            if (!e->has_component<Engine::Core::AIControlledComponent>()) {
+              builder_prod->has_gather_order = true;
+              builder_prod->gather_product_type = builder_prod->product_type;
+              builder_prod->gather_anchor_x = builder_prod->task_target_x;
+              builder_prod->gather_anchor_z = builder_prod->task_target_z;
+            }
             if (auto* pathfinder = CommandService::get_pathfinder()) {
               Point const tree_grid = CommandService::world_to_grid(
                   builder_prod->task_target_x, builder_prod->task_target_z);

--- a/game/systems/runtime_system_registry.cpp
+++ b/game/systems/runtime_system_registry.cpp
@@ -18,6 +18,7 @@
 #include "defense_formation_service.h"
 #include "engagement_slot_system.h"
 #include "gate_system.h"
+#include "gather_loop_system.h"
 #include "guard_system.h"
 #include "healing_beam_system.h"
 #include "healing_system.h"
@@ -64,6 +65,7 @@ void register_runtime_systems(Engine::Core::World& world) {
   world.add_system(std::make_unique<HomeSystem>());
   world.add_system(std::make_unique<CivilianDeliverySystem>());
   world.add_system(std::make_unique<ResourceDeliverySystem>());
+  world.add_system(std::make_unique<GatherLoopSystem>());
   world.add_system(std::make_unique<SettlementLifeSystem>());
   world.add_system(std::make_unique<Game::Wildlife::WildlifeSystem>());
   world.add_system(std::make_unique<ShowcaseRoutineSystem>());

--- a/game/systems/settlement_life_system.cpp
+++ b/game/systems/settlement_life_system.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 #include <vector>
 
 #include "../core/component.h"
@@ -12,11 +13,14 @@
 #include "../map/terrain_service.h"
 #include "building_collision_registry.h"
 #include "command_service.h"
+#include "owner_registry.h"
+#include "units/spawn_type.h"
 
 namespace Game::Systems {
 namespace {
 
 using Engine::Core::SettlementErrand;
+using Engine::Core::SettlementErrandRole;
 using Engine::Core::SettlementResidentComponent;
 
 constexpr float k_building_standoff = 1.15F;
@@ -24,6 +28,9 @@ constexpr float k_prop_standoff = 1.25F;
 constexpr float k_travel_allowance_per_metre = 1.6F;
 constexpr float k_min_travel_allowance = 6.0F;
 constexpr int k_pick_attempts = 6;
+
+constexpr float k_labour_chance = 0.62F;
+constexpr float k_labour_dwell_bonus = 6.0F;
 
 auto next_random(std::uint32_t& state) -> float {
   state = (state * 1664525U) + 1013904223U;
@@ -53,7 +60,16 @@ struct Errand {
   float z{0.0F};
   float dwell{3.0F};
   Engine::Core::EntityID focus{0};
+  SettlementErrandRole role{SettlementErrandRole::Loiter};
+
+  float focus_x{0.0F};
+  float focus_z{0.0F};
 };
+
+auto roll_errand_role(std::uint32_t& rng) -> SettlementErrandRole {
+  return next_random(rng) < k_labour_chance ? SettlementErrandRole::Labour
+                                            : SettlementErrandRole::Loiter;
+}
 
 auto errand_at_building(const Engine::Core::TransformComponent& building_transform,
                         Engine::Core::EntityID building_id,
@@ -78,6 +94,12 @@ auto errand_at_building(const Engine::Core::TransformComponent& building_transfo
   errand.z = building_transform.position.z + (std::sin(angle) * reach_z);
   errand.dwell = random_range(rng, 3.5F, 8.0F);
   errand.focus = building_id;
+  errand.focus_x = building_transform.position.x;
+  errand.focus_z = building_transform.position.z;
+  errand.role = roll_errand_role(rng);
+  if (errand.role == SettlementErrandRole::Labour) {
+    errand.dwell += k_labour_dwell_bonus;
+  }
   return errand;
 }
 
@@ -89,6 +111,12 @@ auto errand_at_prop(const QVector3D& prop_position, std::uint32_t& rng) -> Erran
   errand.x = prop_position.x() + (std::cos(angle) * reach);
   errand.z = prop_position.z() + (std::sin(angle) * reach);
   errand.dwell = random_range(rng, 4.0F, 9.5F);
+  errand.focus_x = prop_position.x();
+  errand.focus_z = prop_position.z();
+  errand.role = roll_errand_role(rng);
+  if (errand.role == SettlementErrandRole::Labour) {
+    errand.dwell += k_labour_dwell_bonus;
+  }
   return errand;
 }
 
@@ -102,6 +130,9 @@ auto errand_on_the_street(const SettlementResidentComponent& resident,
   errand.x = resident.hearth_x + (std::cos(angle) * reach);
   errand.z = resident.hearth_z + (std::sin(angle) * reach);
   errand.dwell = random_range(rng, 1.8F, 4.5F);
+
+  errand.focus_x = resident.hearth_x;
+  errand.focus_z = resident.hearth_z;
   return errand;
 }
 
@@ -159,6 +190,187 @@ void collect_settlement_candidates(Engine::Core::World& world,
   }
 }
 
+void face_focus(Engine::Core::TransformComponent& transform,
+                const SettlementResidentComponent& resident) {
+  float const dx = resident.focus_x - transform.position.x;
+  float const dz = resident.focus_z - transform.position.z;
+  if (((dx * dx) + (dz * dz)) < 0.04F) {
+    return;
+  }
+
+  transform.desired_yaw = std::atan2(dx, dz) * 180.0F / 3.14159265F;
+  transform.has_desired_yaw = true;
+}
+
+auto find_settlement_anchor(Engine::Core::World& world,
+                            int owner_id,
+                            float from_x,
+                            float from_z,
+                            float search_radius) -> std::optional<QVector3D> {
+  std::optional<QVector3D> nearest;
+  float nearest_distance_sq = search_radius * search_radius;
+
+  for (auto* entity : world.get_entities_with<Engine::Core::BuildingComponent>()) {
+    auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
+    auto const* transform = entity->get_component<Engine::Core::TransformComponent>();
+    if ((unit == nullptr) || (transform == nullptr) || unit->health <= 0 ||
+        unit->owner_id != owner_id ||
+        Game::Units::is_wall_network_spawn(unit->spawn_type)) {
+      continue;
+    }
+    float const dx = transform->position.x - from_x;
+    float const dz = transform->position.z - from_z;
+    float const distance_sq = (dx * dx) + (dz * dz);
+    if (distance_sq > nearest_distance_sq) {
+      continue;
+    }
+    nearest_distance_sq = distance_sq;
+    nearest = QVector3D(transform->position.x, 0.0F, transform->position.z);
+  }
+
+  return nearest;
+}
+
+auto is_unclaimed_by_the_player(const Engine::Core::Entity& entity) -> bool {
+  if (entity.has_component<Engine::Core::CivilianDeliveryComponent>() ||
+      entity.has_component<Engine::Core::PlayerOrderIntentComponent>() ||
+      entity.has_component<Engine::Core::AttackTargetComponent>()) {
+    return false;
+  }
+  const auto* movement = entity.get_component<Engine::Core::MovementComponent>();
+  return movement != nullptr && !movement->get_has_target();
+}
+
+auto is_armed(Game::Units::SpawnType type) -> bool {
+  return Game::Units::can_use_attack_mode(type) &&
+         type != Game::Units::SpawnType::Civilian;
+}
+
+void collect_armed_units(Engine::Core::World& world,
+                         std::vector<SettlementLifeSystem::ArmedUnit>& out) {
+  out.clear();
+  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+    auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
+    if ((unit == nullptr) || unit->health <= 0 || !is_armed(unit->spawn_type)) {
+      continue;
+    }
+    auto const* transform = entity->get_component<Engine::Core::TransformComponent>();
+    if (transform == nullptr) {
+      continue;
+    }
+    out.push_back({transform->position.x, transform->position.z, unit->owner_id});
+  }
+}
+
+auto nearest_danger(const std::vector<SettlementLifeSystem::ArmedUnit>& armed_units,
+                    int resident_owner_id,
+                    float x,
+                    float z,
+                    float radius) -> std::optional<QVector3D> {
+  std::optional<QVector3D> nearest;
+  float nearest_distance_sq = radius * radius;
+
+  for (auto const& armed : armed_units) {
+    float const dx = armed.x - x;
+    float const dz = armed.z - z;
+    float const distance_sq = (dx * dx) + (dz * dz);
+    if (distance_sq > nearest_distance_sq) {
+      continue;
+    }
+    if (!OwnerRegistry::instance().are_enemies(resident_owner_id, armed.owner_id)) {
+      continue;
+    }
+    nearest_distance_sq = distance_sq;
+    nearest = QVector3D(armed.x, 0.0F, armed.z);
+  }
+
+  return nearest;
+}
+
+void run_from(Engine::Core::World& world,
+              Engine::Core::Entity& entity,
+              const Engine::Core::TransformComponent& transform,
+              SettlementResidentComponent& resident,
+              const QVector3D& danger) {
+  float away_x = transform.position.x - danger.x();
+  float away_z = transform.position.z - danger.z();
+  float const length_sq = (away_x * away_x) + (away_z * away_z);
+  if (length_sq < 0.01F) {
+    away_x = 1.0F;
+    away_z = 0.0F;
+  } else {
+    float const length = std::sqrt(length_sq);
+    away_x /= length;
+    away_z /= length;
+  }
+
+  float const hearth_dx = resident.hearth_x - transform.position.x;
+  float const hearth_dz = resident.hearth_z - transform.position.z;
+  float const hearth_length =
+      std::sqrt((hearth_dx * hearth_dx) + (hearth_dz * hearth_dz));
+
+  if (hearth_length > 1.0F && (((hearth_dx / hearth_length) * away_x) +
+                               ((hearth_dz / hearth_length) * away_z)) > 0.0F) {
+
+    away_x = ((away_x + (hearth_dx / hearth_length)) * 0.5F);
+    away_z = ((away_z + (hearth_dz / hearth_length)) * 0.5F);
+    float const blended = std::sqrt((away_x * away_x) + (away_z * away_z));
+    if (blended > 0.01F) {
+      away_x /= blended;
+      away_z /= blended;
+    }
+  }
+
+  QVector3D const destination = CommandService::snap_to_walkable_ground(QVector3D(
+      transform.position.x + (away_x * SettlementLifeSystem::k_flee_distance),
+      0.0F,
+      transform.position.z + (away_z * SettlementLifeSystem::k_flee_distance)));
+
+  resident.errand = SettlementErrand::Fleeing;
+  resident.errand_x = destination.x();
+  resident.errand_z = destination.z();
+  resident.errand_remaining = SettlementLifeSystem::k_flee_leg_seconds;
+
+  CommandService::MoveOptions options;
+  options.kind = MoveOrderKind::ScriptedMove;
+  CommandService::move_unit(world, entity.get_id(), destination, options);
+}
+
+void adopt_idle_civilians(Engine::Core::World& world) {
+  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+    auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
+    if ((unit == nullptr) || unit->spawn_type != Game::Units::SpawnType::Civilian ||
+        unit->health <= 0) {
+      continue;
+    }
+    if (entity->has_component<SettlementResidentComponent>()) {
+      continue;
+    }
+    auto const* transform = entity->get_component<Engine::Core::TransformComponent>();
+    if ((transform == nullptr) || !is_unclaimed_by_the_player(*entity)) {
+      continue;
+    }
+
+    auto const anchor = find_settlement_anchor(world,
+                                               unit->owner_id,
+                                               transform->position.x,
+                                               transform->position.z,
+                                               SettlementLifeSystem::k_adoption_radius);
+    if (!anchor.has_value()) {
+      continue;
+    }
+
+    auto* resident = entity->add_component<SettlementResidentComponent>();
+    if (resident == nullptr) {
+      continue;
+    }
+    resident->hearth_x = anchor->x();
+    resident->hearth_z = anchor->z();
+    resident->hearth_assigned = true;
+    resident->roam_radius = SettlementLifeSystem::k_adopted_roam_radius;
+  }
+}
+
 } // namespace
 
 void SettlementLifeSystem::update(Engine::Core::World* world, float delta_time) {
@@ -166,9 +378,22 @@ void SettlementLifeSystem::update(Engine::Core::World* world, float delta_time) 
     return;
   }
 
+  m_adoption_cooldown -= delta_time;
+  if (m_adoption_cooldown <= 0.0F) {
+    m_adoption_cooldown = k_adoption_interval;
+    adopt_idle_civilians(*world);
+  }
+
   auto residents = world->get_entities_with<SettlementResidentComponent>();
   if (residents.empty()) {
     return;
+  }
+
+  m_alarm_cooldown -= delta_time;
+  bool const alarm_due = m_alarm_cooldown <= 0.0F;
+  if (alarm_due) {
+    m_alarm_cooldown = k_alarm_interval;
+    collect_armed_units(*world, m_armed_units);
   }
 
   std::vector<Candidate> candidates;
@@ -180,32 +405,99 @@ void SettlementLifeSystem::update(Engine::Core::World* world, float delta_time) 
     auto* movement = entity->get_component<Engine::Core::MovementComponent>();
 
     if ((resident == nullptr) || (unit == nullptr) || (transform == nullptr) ||
-        (movement == nullptr) || unit->health <= 0) {
+        (movement == nullptr)) {
       continue;
     }
 
-    auto const* attack_target =
-        entity->get_component<Engine::Core::AttackTargetComponent>();
-    bool const busy_elsewhere =
-        ((attack_target != nullptr) && attack_target->target_id != 0) ||
+    if (unit->health <= 0) {
+
+      resident->errand = SettlementErrand::Settling;
+      resident->role = SettlementErrandRole::Loiter;
+      resident->work_elapsed = 0.0F;
+      resident->focus_id = 0;
+      continue;
+    }
+
+    if (resident->released) {
+      continue;
+    }
+
+    bool const claimed_by_the_player =
         entity->has_component<Engine::Core::CivilianDeliveryComponent>() ||
         entity->has_component<Engine::Core::PlayerOrderIntentComponent>();
-    if (busy_elsewhere) {
+    if (claimed_by_the_player) {
       resident->errand = SettlementErrand::Settling;
+      resident->role = SettlementErrandRole::Loiter;
       resident->focus_id = 0;
+      resident->work_elapsed = 0.0F;
+
+      resident->hearth_assigned = false;
       continue;
     }
 
     if (resident->rng_state == 0U) {
       resident->rng_state =
           static_cast<std::uint32_t>((entity->get_id() * 2654435761ULL) | 1ULL);
-      if (!resident->hearth_assigned) {
-        resident->hearth_x = transform->position.x;
-        resident->hearth_z = transform->position.z;
-        resident->hearth_assigned = true;
+      resident->think_cooldown = random_range(resident->rng_state, 0.0F, 2.5F);
+    }
+
+    if (!resident->hearth_assigned) {
+      auto const anchor = find_settlement_anchor(*world,
+                                                 unit->owner_id,
+                                                 transform->position.x,
+                                                 transform->position.z,
+                                                 k_adoption_radius);
+      resident->hearth_x = anchor.has_value() ? anchor->x() : transform->position.x;
+      resident->hearth_z = anchor.has_value() ? anchor->z() : transform->position.z;
+      resident->hearth_assigned = true;
+    }
+
+    auto const* attack_target =
+        entity->get_component<Engine::Core::AttackTargetComponent>();
+    bool const fighting = (attack_target != nullptr) && attack_target->target_id != 0;
+
+    if (alarm_due && !fighting) {
+      bool const already_fleeing = resident->errand == SettlementErrand::Fleeing;
+      auto const danger =
+          nearest_danger(m_armed_units,
+                         unit->owner_id,
+                         transform->position.x,
+                         transform->position.z,
+                         already_fleeing ? k_all_clear_radius : k_alarm_radius);
+
+      if (danger.has_value()) {
+        resident->role = SettlementErrandRole::Loiter;
+        resident->work_elapsed = 0.0F;
+        resident->focus_id = 0;
+        resident->errand_remaining -= k_alarm_interval;
+
+        if (!already_fleeing || resident->errand_remaining <= 0.0F ||
+            movement->get_state() == Engine::Core::MovementState::Idle) {
+          run_from(*world, *entity, *transform, *resident, *danger);
+        }
+        continue;
       }
 
-      resident->think_cooldown = random_range(resident->rng_state, 0.0F, 2.5F);
+      if (already_fleeing) {
+        resident->errand = SettlementErrand::Settling;
+        resident->think_cooldown = 0.0F;
+      }
+    }
+
+    if (fighting) {
+      resident->errand = SettlementErrand::Settling;
+      resident->role = SettlementErrandRole::Loiter;
+      resident->focus_id = 0;
+      resident->work_elapsed = 0.0F;
+      continue;
+    }
+
+    if (resident->errand == SettlementErrand::Fleeing) {
+      continue;
+    }
+
+    if (resident->is_labouring()) {
+      resident->work_elapsed += delta_time;
     }
 
     resident->think_cooldown -= delta_time;
@@ -229,6 +521,8 @@ void SettlementLifeSystem::update(Engine::Core::World* world, float delta_time) 
         movement->stop();
         resident->errand = SettlementErrand::Working;
         resident->errand_remaining = resident->planned_dwell;
+        resident->work_elapsed = 0.0F;
+        face_focus(*transform, *resident);
       } else if (resident->errand_remaining <= 0.0F) {
         pick_new_errand = true;
       } else if (movement->get_state() == Engine::Core::MovementState::Idle) {
@@ -294,6 +588,8 @@ void SettlementLifeSystem::update(Engine::Core::World* world, float delta_time) 
 
     if (!has_choice) {
       resident->errand = SettlementErrand::Working;
+      resident->role = SettlementErrandRole::Loiter;
+      resident->work_elapsed = 0.0F;
       resident->errand_remaining = random_range(resident->rng_state, 1.0F, 3.0F);
       continue;
     }
@@ -302,10 +598,14 @@ void SettlementLifeSystem::update(Engine::Core::World* world, float delta_time) 
         CommandService::snap_to_walkable_ground(QVector3D(chosen.x, 0.0F, chosen.z));
 
     resident->errand = SettlementErrand::WalkingTo;
+    resident->role = chosen.role;
     resident->focus_id = chosen.focus;
     resident->errand_x = destination.x();
     resident->errand_z = destination.z();
+    resident->focus_x = chosen.focus_x;
+    resident->focus_z = chosen.focus_z;
     resident->planned_dwell = chosen.dwell;
+    resident->work_elapsed = 0.0F;
 
     float const travel_x = destination.x() - transform->position.x;
     float const travel_z = destination.z() - transform->position.z;

--- a/game/systems/settlement_life_system.h
+++ b/game/systems/settlement_life_system.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "../core/system.h"
 
 namespace Game::Systems {
@@ -10,10 +12,31 @@ public:
   static constexpr float k_arrival_radius = 1.35F;
   static constexpr float k_min_errand_distance = 2.5F;
 
+  static constexpr float k_adoption_interval = 2.0F;
+  static constexpr float k_adoption_radius = 20.0F;
+  static constexpr float k_adopted_roam_radius = 14.0F;
+
+  static constexpr float k_alarm_interval = 0.3F;
+  static constexpr float k_alarm_radius = 11.0F;
+  static constexpr float k_all_clear_radius = 15.0F;
+  static constexpr float k_flee_distance = 11.0F;
+  static constexpr float k_flee_leg_seconds = 2.5F;
+
+  struct ArmedUnit {
+    float x{0.0F};
+    float z{0.0F};
+    int owner_id{0};
+  };
+
   SettlementLifeSystem() = default;
   ~SettlementLifeSystem() override = default;
 
   void update(Engine::Core::World* world, float delta_time) override;
+
+private:
+  float m_adoption_cooldown{k_adoption_interval};
+  float m_alarm_cooldown{0.0F};
+  std::vector<ArmedUnit> m_armed_units;
 };
 
 } // namespace Game::Systems

--- a/render/entity/building_ornament_emit.h
+++ b/render/entity/building_ornament_emit.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <QMatrix4x4>
+#include <QVector3D>
+
+#include "../geom/transforms.h"
+#include "../gl/primitives.h"
+#include "../submitter.h"
+#include "building_archetype_desc.h"
+
+namespace Render::GL {
+
+inline void emit_building_ornament(const BuildingArchetypeDesc& desc,
+                                   const QMatrix4x4& model,
+                                   ISubmitter& out,
+                                   Mesh* unit_cube,
+                                   Texture* white,
+                                   bool detailed,
+                                   const QVector3D* palette = nullptr,
+                                   std::size_t palette_size = 0) {
+  Mesh* const cube = unit_cube != nullptr ? unit_cube : get_unit_cube();
+  if (cube == nullptr) {
+    return;
+  }
+
+  auto const resolve_color = [&](const BuildingPartDesc& part) {
+    const bool palette_part = part.kind == BuildingPartKind::PaletteBox ||
+                              part.kind == BuildingPartKind::PaletteRotatedBox ||
+                              part.kind == BuildingPartKind::PaletteCylinder;
+    if (!palette_part) {
+      return part.color;
+    }
+    if (palette == nullptr || part.palette_slot >= palette_size) {
+      return part.color;
+    }
+    return palette[part.palette_slot];
+  };
+
+  for (const auto& part : desc.parts()) {
+    if (!detailed && (part.lod & BuildingLODMask::Minimal) == BuildingLODMask::None) {
+      continue;
+    }
+
+    const QVector3D color = resolve_color(part);
+    switch (part.kind) {
+    case BuildingPartKind::Box:
+    case BuildingPartKind::PaletteBox: {
+      QMatrix4x4 local;
+      local.translate(part.point_a);
+      local.scale(part.point_b);
+      out.mesh(cube, model * local, color, white, part.alpha, part.material_id);
+      break;
+    }
+    case BuildingPartKind::RotatedBox:
+    case BuildingPartKind::PaletteRotatedBox: {
+      QMatrix4x4 local;
+      local.translate(part.point_a);
+      local.rotate(part.euler_deg.z(), 0.0F, 0.0F, 1.0F);
+      local.rotate(part.euler_deg.y(), 0.0F, 1.0F, 0.0F);
+      local.rotate(part.euler_deg.x(), 1.0F, 0.0F, 0.0F);
+      local.scale(part.point_b);
+      out.mesh(cube, model * local, color, white, part.alpha, part.material_id);
+      break;
+    }
+    case BuildingPartKind::Cylinder:
+    case BuildingPartKind::PaletteCylinder:
+      out.mesh(get_unit_cylinder(),
+               model * Render::Geom::cylinder_between(
+                           part.point_a, part.point_b, part.radius),
+               color,
+               white,
+               part.alpha,
+               part.material_id);
+      break;
+    case BuildingPartKind::Cone:
+      out.mesh(get_unit_cone(),
+               model *
+                   Render::Geom::cone_from_to(part.point_a, part.point_b, part.radius),
+               color,
+               white,
+               part.alpha,
+               part.material_id);
+      break;
+    }
+  }
+}
+
+} // namespace Render::GL

--- a/render/entity/building_ornaments.h
+++ b/render/entity/building_ornaments.h
@@ -3,7 +3,10 @@
 #include <QVector3D>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstddef>
+#include <utility>
 
 #include "building_archetype_desc.h"
 
@@ -207,6 +210,199 @@ inline auto facade_rotation(BuildingFacadePlane plane, float degrees) -> QVector
   return {degrees, 0.0F, 0.0F};
 }
 
+struct EagleFeather {
+  float horizontal;
+  float vertical;
+  float half_length;
+  float half_thickness;
+  float sweep_degrees;
+};
+
+inline constexpr std::array<EagleFeather, 4> k_eagle_wing{{
+    {0.115F, 0.055F, 0.150F, 0.062F, 8.0F},
+    {0.255F, 0.105F, 0.130F, 0.048F, 24.0F},
+    {0.370F, 0.170F, 0.105F, 0.036F, 42.0F},
+    {0.455F, 0.245F, 0.075F, 0.026F, 58.0F},
+}};
+
+inline constexpr std::array<EagleFeather, 3> k_eagle_tail{{
+    {0.000F, -0.205F, 0.100F, 0.030F, 0.0F},
+    {0.058F, -0.190F, 0.090F, 0.026F, 16.0F},
+    {0.115F, -0.160F, 0.075F, 0.022F, 30.0F},
+}};
+
+inline void add_eagle_silhouette(BuildingArchetypeDesc& desc,
+                                 const QVector3D& center,
+                                 BuildingFacadePlane plane,
+                                 float scale,
+                                 float depth,
+                                 const QVector3D& bronze,
+                                 const QVector3D& shade,
+                                 BuildingStateMask states,
+                                 BuildingLODMask core_lod = BuildingLODMask::Full) {
+  const auto point = [&](float horizontal, float vertical, float normal) {
+    return facade_point(center, plane, horizontal * scale, vertical * scale, normal);
+  };
+  const auto size = [&](float horizontal, float vertical, float thickness) {
+    return facade_scale(plane, horizontal * scale, vertical * scale, thickness);
+  };
+
+  const float relief = depth * 0.55F;
+
+  for (float const side : {-1.0F, 1.0F}) {
+    std::size_t feather_index = 0;
+    for (auto const& feather : k_eagle_wing) {
+      const BuildingLODMask lod = feather_index < 2 ? core_lod : BuildingLODMask::Full;
+      desc.add_rotated_box(point(side * feather.horizontal, feather.vertical, relief),
+                           size(feather.half_length, feather.half_thickness, relief),
+                           facade_rotation(plane, side * feather.sweep_degrees),
+                           shade,
+                           states,
+                           BuildingLODMask::Full);
+      desc.add_rotated_box(
+          point(side * feather.horizontal, feather.vertical + 0.022F, depth),
+          size(feather.half_length * 0.88F, feather.half_thickness * 0.72F, depth),
+          facade_rotation(plane, side * feather.sweep_degrees),
+          bronze,
+          states,
+          lod);
+      ++feather_index;
+    }
+
+    desc.add_rotated_box(point(side * 0.085F, 0.115F, depth),
+                         size(0.085F, 0.050F, depth),
+                         facade_rotation(plane, side * 34.0F),
+                         bronze,
+                         states,
+                         BuildingLODMask::Full);
+  }
+
+  for (auto const& feather : k_eagle_tail) {
+    for (float const side : {-1.0F, 1.0F}) {
+      if (feather.horizontal == 0.0F && side < 0.0F) {
+        continue;
+      }
+      desc.add_rotated_box(point(side * feather.horizontal, feather.vertical, depth),
+                           size(feather.half_thickness, feather.half_length, depth),
+                           facade_rotation(plane, side * feather.sweep_degrees),
+                           bronze,
+                           states,
+                           feather.horizontal == 0.0F ? core_lod
+                                                      : BuildingLODMask::Full);
+    }
+  }
+
+  desc.add_box(point(0.0F, -0.015F, depth),
+               size(0.072F, 0.155F, depth * 1.25F),
+               bronze,
+               states,
+               core_lod);
+  desc.add_box(point(0.0F, 0.075F, depth * 1.15F),
+               size(0.055F, 0.070F, depth * 1.35F),
+               bronze,
+               states,
+               BuildingLODMask::Full);
+
+  desc.add_box(point(0.018F, 0.180F, depth * 1.2F),
+               size(0.046F, 0.055F, depth * 1.4F),
+               bronze,
+               states,
+               core_lod);
+  desc.add_cone(point(0.048F, 0.184F, depth * 1.2F),
+                point(0.104F, 0.156F, depth * 1.2F),
+                0.020F * scale,
+                bronze,
+                states,
+                core_lod);
+}
+
+inline void add_laurel_wreath(BuildingArchetypeDesc& desc,
+                              const QVector3D& center,
+                              BuildingFacadePlane plane,
+                              float scale,
+                              float depth,
+                              float radius,
+                              const QVector3D& color,
+                              BuildingStateMask states) {
+  constexpr int k_leaves = 14;
+  for (int index = 0; index < k_leaves; ++index) {
+    float const t = static_cast<float>(index) / static_cast<float>(k_leaves);
+    float const angle = (t * 6.2831853F) - 1.5707963F;
+
+    if (std::sin(angle) > 0.72F) {
+      continue;
+    }
+    float const horizontal = std::cos(angle) * radius;
+    float const vertical = std::sin(angle) * radius;
+    desc.add_rotated_box(
+        facade_point(center, plane, horizontal * scale, vertical * scale, depth * 0.6F),
+        facade_scale(plane, 0.052F * scale, 0.024F * scale, depth * 0.6F),
+        facade_rotation(plane, (angle * 180.0F / 3.14159265F) + 90.0F),
+        color,
+        states,
+        BuildingLODMask::Full);
+  }
+}
+
+inline void add_tanit_sign(BuildingArchetypeDesc& desc,
+                           const QVector3D& center,
+                           BuildingFacadePlane plane,
+                           float scale,
+                           float depth,
+                           const QVector3D& symbol,
+                           const QVector3D& shade,
+                           BuildingStateMask states,
+                           BuildingLODMask core_lod = BuildingLODMask::Full) {
+  const auto point = [&](float horizontal, float vertical, float normal) {
+    return facade_point(center, plane, horizontal * scale, vertical * scale, normal);
+  };
+  const auto size = [&](float horizontal, float vertical, float thickness) {
+    return facade_scale(plane, horizontal * scale, vertical * scale, thickness);
+  };
+
+  desc.add_cylinder(point(0.0F, 0.235F, depth * 0.2F),
+                    point(0.0F, 0.235F, depth * 1.9F),
+                    0.098F * scale,
+                    symbol,
+                    states,
+                    core_lod);
+  desc.add_cylinder(point(0.0F, 0.235F, 0.0F),
+                    point(0.0F, 0.235F, depth * 0.35F),
+                    0.114F * scale,
+                    shade,
+                    states,
+                    BuildingLODMask::Full);
+
+  desc.add_box(point(0.0F, 0.085F, depth),
+               size(0.235F, 0.032F, depth),
+               symbol,
+               states,
+               core_lod);
+  for (float const side : {-1.0F, 1.0F}) {
+    desc.add_rotated_box(point(side * 0.272F, 0.124F, depth),
+                         size(0.075F, 0.030F, depth),
+                         facade_rotation(plane, side * -38.0F),
+                         symbol,
+                         states,
+                         BuildingLODMask::Full);
+  }
+
+  constexpr std::array<std::pair<float, float>, 4> k_body{
+      {{0.060F, 0.020F}, {0.104F, -0.058F}, {0.148F, -0.136F}, {0.192F, -0.214F}}};
+  for (auto const& course : k_body) {
+    desc.add_box(point(0.0F, course.second, depth),
+                 size(course.first, 0.042F, depth),
+                 symbol,
+                 states,
+                 core_lod);
+  }
+  desc.add_box(point(0.0F, -0.262F, depth),
+               size(0.215F, 0.030F, depth),
+               shade,
+               states,
+               BuildingLODMask::Full);
+}
+
 } // namespace Detail
 
 inline void
@@ -217,49 +413,17 @@ add_roman_aquila_relief(BuildingArchetypeDesc& desc,
                         const QVector3D& bronze,
                         const QVector3D& shadow,
                         BuildingStateMask states = k_building_state_mask_intact) {
-  const float depth = 0.025F * scale;
+  const float depth = 0.028F * scale;
+
   desc.add_box(Detail::facade_point(center, plane, 0.0F, 0.0F),
-               Detail::facade_scale(plane, 0.62F * scale, 0.42F * scale, depth),
-               shadow,
+               Detail::facade_scale(plane, 0.58F * scale, 0.54F * scale, depth * 0.5F),
+               weathered(shadow, 3, 0.10F),
                states,
                BuildingLODMask::Full);
 
-  desc.add_box(Detail::facade_point(center, plane, 0.0F, 0.01F, depth),
-               Detail::facade_scale(plane, 0.08F * scale, 0.25F * scale, depth),
-               bronze,
-               states,
-               BuildingLODMask::Full);
-  desc.add_box(
-      Detail::facade_point(center, plane, 0.035F * scale, 0.17F * scale, depth),
-      Detail::facade_scale(plane, 0.10F * scale, 0.09F * scale, depth),
-      bronze,
-      states,
-      BuildingLODMask::Full);
-
-  for (float side : {-1.0F, 1.0F}) {
-    desc.add_rotated_box(
-        Detail::facade_point(center, plane, side * 0.16F * scale, 0.06F * scale, depth),
-        Detail::facade_scale(plane, 0.27F * scale, 0.065F * scale, depth),
-        Detail::facade_rotation(plane, side * 18.0F),
-        bronze,
-        states,
-        BuildingLODMask::Full);
-    desc.add_rotated_box(
-        Detail::facade_point(center, plane, side * 0.24F * scale, 0.13F * scale, depth),
-        Detail::facade_scale(plane, 0.20F * scale, 0.055F * scale, depth),
-        Detail::facade_rotation(plane, side * 38.0F),
-        bronze,
-        states,
-        BuildingLODMask::Full);
-    desc.add_rotated_box(
-        Detail::facade_point(
-            center, plane, side * 0.045F * scale, -0.15F * scale, depth),
-        Detail::facade_scale(plane, 0.055F * scale, 0.16F * scale, depth),
-        Detail::facade_rotation(plane, side * 20.0F),
-        bronze,
-        states,
-        BuildingLODMask::Full);
-  }
+  Detail::add_laurel_wreath(desc, center, plane, scale, depth, 0.36F, bronze, states);
+  Detail::add_eagle_silhouette(
+      desc, center, plane, scale, depth, bronze, shadow, states);
 }
 
 inline void
@@ -270,37 +434,29 @@ add_punic_tanit_relief(BuildingArchetypeDesc& desc,
                        const QVector3D& symbol,
                        const QVector3D& backing,
                        BuildingStateMask states = k_building_state_mask_intact) {
-  const float depth = 0.025F * scale;
+  const float depth = 0.028F * scale;
+
   desc.add_box(Detail::facade_point(center, plane, 0.0F, 0.0F),
-               Detail::facade_scale(plane, 0.48F * scale, 0.52F * scale, depth),
+               Detail::facade_scale(plane, 0.58F * scale, 0.74F * scale, depth * 0.7F),
                backing,
                states,
                BuildingLODMask::Full);
-  desc.add_box(Detail::facade_point(center, plane, 0.0F, 0.08F * scale, depth),
-               Detail::facade_scale(plane, 0.38F * scale, 0.045F * scale, depth),
-               symbol,
+  desc.add_box(Detail::facade_point(center, plane, 0.0F, 0.0F, depth * 0.25F),
+               Detail::facade_scale(plane, 0.48F * scale, 0.64F * scale, depth * 0.35F),
+               weathered(backing, 7, 0.12F),
                states,
                BuildingLODMask::Full);
-  desc.add_box(Detail::facade_point(center, plane, 0.0F, 0.20F * scale, depth),
-               Detail::facade_scale(plane, 0.11F * scale, 0.11F * scale, depth),
-               symbol,
-               states,
-               BuildingLODMask::Full);
-  for (float side : {-1.0F, 1.0F}) {
-    desc.add_rotated_box(
-        Detail::facade_point(
-            center, plane, side * 0.075F * scale, -0.08F * scale, depth),
-        Detail::facade_scale(plane, 0.055F * scale, 0.27F * scale, depth),
-        Detail::facade_rotation(plane, side * 31.0F),
+
+  for (float const side : {-1.0F, 1.0F}) {
+    desc.add_box(
+        Detail::facade_point(center, plane, side * 0.52F * scale, 0.0F, depth * 0.3F),
+        Detail::facade_scale(plane, 0.032F * scale, 0.72F * scale, depth * 0.45F),
         symbol,
         states,
         BuildingLODMask::Full);
   }
-  desc.add_box(Detail::facade_point(center, plane, 0.0F, -0.21F * scale, depth),
-               Detail::facade_scale(plane, 0.30F * scale, 0.045F * scale, depth),
-               symbol,
-               states,
-               BuildingLODMask::Full);
+
+  Detail::add_tanit_sign(desc, center, plane, scale, depth, symbol, backing, states);
 }
 
 inline void
@@ -310,51 +466,53 @@ add_roman_roof_standard(BuildingArchetypeDesc& desc,
                         const QVector3D& bronze,
                         const QVector3D& crimson,
                         BuildingStateMask states = k_building_state_mask_intact) {
-  desc.add_box(base + QVector3D(0.0F, 0.035F * scale, 0.0F),
-               QVector3D(0.16F, 0.035F, 0.13F) * scale,
+
+  desc.add_box(base + QVector3D(0.0F, 0.030F * scale, 0.0F),
+               QVector3D(0.150F, 0.030F, 0.120F) * scale,
                crimson,
                states);
-  desc.add_box(base + QVector3D(0.0F, 0.09F * scale, 0.0F),
-               QVector3D(0.11F, 0.025F, 0.09F) * scale,
+  desc.add_box(base + QVector3D(0.0F, 0.078F * scale, 0.0F),
+               QVector3D(0.100F, 0.022F, 0.082F) * scale,
                bronze,
                states);
-  desc.add_cylinder(base + QVector3D(0.0F, 0.10F * scale, 0.0F),
-                    base + QVector3D(0.0F, 0.58F * scale, 0.0F),
-                    0.028F * scale,
+  desc.add_cylinder(base + QVector3D(0.0F, 0.085F * scale, 0.0F),
+                    base + QVector3D(0.0F, 0.560F * scale, 0.0F),
+                    0.026F * scale,
                     bronze,
                     states);
 
-  desc.add_box(base + QVector3D(0.0F, 0.37F * scale, 0.0F),
-               QVector3D(0.15F, 0.09F, 0.035F) * scale,
+  desc.add_box(base + QVector3D(0.0F, 0.330F * scale, 0.0F),
+               QVector3D(0.150F, 0.088F, 0.030F) * scale,
                crimson,
                states);
-  desc.add_box(base + QVector3D(0.0F, 0.37F * scale, 0.038F * scale),
-               QVector3D(0.10F, 0.045F, 0.012F) * scale,
+  desc.add_box(base + QVector3D(0.0F, 0.330F * scale, 0.033F * scale),
+               QVector3D(0.098F, 0.044F, 0.011F) * scale,
                bronze,
                states,
                BuildingLODMask::Full);
-
-  for (float side : {-1.0F, 1.0F}) {
-    desc.add_rotated_box(base + QVector3D(side * 0.15F * scale, 0.60F * scale, 0.0F),
-                         QVector3D(0.18F, 0.045F, 0.055F) * scale,
-                         QVector3D(0.0F, 0.0F, side * 18.0F),
-                         bronze,
-                         states);
-    desc.add_rotated_box(base + QVector3D(side * 0.25F * scale, 0.66F * scale, 0.0F),
-                         QVector3D(0.11F, 0.035F, 0.045F) * scale,
-                         QVector3D(0.0F, 0.0F, side * 36.0F),
-                         bronze,
-                         states,
-                         BuildingLODMask::Full);
+  for (float const side : {-1.0F, 1.0F}) {
+    desc.add_box(base + QVector3D(side * 0.135F * scale, 0.238F * scale, 0.0F),
+                 QVector3D(0.016F, 0.030F, 0.016F) * scale,
+                 bronze,
+                 states,
+                 BuildingLODMask::Full);
   }
-  desc.add_box(base + QVector3D(0.0F, 0.62F * scale, 0.0F),
-               QVector3D(0.065F, 0.13F, 0.065F) * scale,
-               bronze,
-               states);
-  desc.add_box(base + QVector3D(0.035F * scale, 0.73F * scale, 0.0F),
-               QVector3D(0.055F, 0.045F, 0.055F) * scale,
-               bronze,
-               states);
+
+  desc.add_cylinder(base + QVector3D(0.0F, 0.560F * scale, -0.02F * scale),
+                    base + QVector3D(0.0F, 0.560F * scale, 0.02F * scale),
+                    0.058F * scale,
+                    bronze,
+                    states);
+
+  Detail::add_eagle_silhouette(desc,
+                               base + QVector3D(0.0F, 0.700F * scale, 0.0F),
+                               BuildingFacadePlane::XY,
+                               scale * 0.68F,
+                               0.030F * scale,
+                               bronze,
+                               crimson,
+                               states,
+                               BuildingLODMask::All);
 }
 
 inline void
@@ -365,50 +523,62 @@ add_punic_horned_crown(BuildingArchetypeDesc& desc,
                        const QVector3D& bronze,
                        const QVector3D& ember,
                        BuildingStateMask states = k_building_state_mask_intact) {
-  desc.add_box(base + QVector3D(0.0F, 0.035F * scale, 0.0F),
-               QVector3D(0.28F, 0.035F, 0.22F) * scale,
+
+  desc.add_box(base + QVector3D(0.0F, 0.030F * scale, 0.0F),
+               QVector3D(0.170F, 0.028F, 0.140F) * scale,
                obsidian,
                states);
-  desc.add_box(base + QVector3D(0.0F, 0.10F * scale, 0.0F),
-               QVector3D(0.20F, 0.035F, 0.16F) * scale,
+  desc.add_box(base + QVector3D(0.0F, 0.078F * scale, 0.0F),
+               QVector3D(0.118F, 0.026F, 0.098F) * scale,
                bronze,
                states);
-  desc.add_box(base + QVector3D(0.0F, 0.17F * scale, 0.0F),
-               QVector3D(0.13F, 0.045F, 0.12F) * scale,
+  desc.add_box(base + QVector3D(0.0F, 0.128F * scale, 0.0F),
+               QVector3D(0.076F, 0.032F, 0.070F) * scale,
                obsidian,
                states);
 
-  desc.add_cylinder(base + QVector3D(0.0F, 0.17F * scale, 0.0F),
-                    base + QVector3D(0.0F, 0.62F * scale, 0.0F),
-                    0.055F * scale,
+  desc.add_cylinder(base + QVector3D(0.0F, 0.150F * scale, 0.0F),
+                    base + QVector3D(0.0F, 0.620F * scale, 0.0F),
+                    0.040F * scale,
                     obsidian,
                     states);
-  desc.add_box(base + QVector3D(0.0F, 0.45F * scale, 0.0F),
-               QVector3D(0.075F, 0.13F, 0.075F) * scale,
+  desc.add_box(base + QVector3D(0.0F, 0.370F * scale, 0.0F),
+               QVector3D(0.058F, 0.090F, 0.058F) * scale,
                ember,
                states);
-  desc.add_rotated_box(base + QVector3D(0.0F, 0.69F * scale, 0.0F),
-                       QVector3D(0.075F, 0.16F, 0.075F) * scale,
-                       QVector3D(0.0F, 0.0F, 45.0F),
-                       bronze,
-                       states);
 
-  for (float side : {-1.0F, 1.0F}) {
-    desc.add_rotated_box(base + QVector3D(side * 0.16F * scale, 0.39F * scale, 0.0F),
-                         QVector3D(0.18F, 0.045F, 0.065F) * scale,
-                         QVector3D(0.0F, 0.0F, side * 43.0F),
-                         bronze,
-                         states);
-    desc.add_rotated_box(base + QVector3D(side * 0.29F * scale, 0.53F * scale, 0.0F),
-                         QVector3D(0.14F, 0.040F, 0.055F) * scale,
-                         QVector3D(0.0F, 0.0F, side * 67.0F),
-                         obsidian,
-                         states);
-    desc.add_box(base + QVector3D(side * 0.34F * scale, 0.65F * scale, 0.0F),
-                 QVector3D(0.045F, 0.10F, 0.045F) * scale,
-                 bronze,
-                 states,
-                 BuildingLODMask::Full);
+  desc.add_box(base + QVector3D(0.0F, 0.690F * scale, 0.0F),
+               QVector3D(0.105F, 0.100F, 0.105F) * scale,
+               bronze,
+               states);
+  desc.add_box(base + QVector3D(0.0F, 0.690F * scale, 0.0F),
+               QVector3D(0.128F, 0.038F, 0.128F) * scale,
+               ember,
+               states,
+               BuildingLODMask::Full);
+
+  constexpr int k_crescent_steps = 9;
+  constexpr float k_crescent_span = 0.74F;
+  for (int index = 0; index < k_crescent_steps; ++index) {
+    float const t =
+        static_cast<float>(index) / static_cast<float>(k_crescent_steps - 1);
+    float const angle = 3.14159265F * (k_crescent_span * (t - 0.5F));
+    float const radius = 0.255F * scale;
+    desc.add_rotated_box(
+        base + QVector3D(std::sin(angle) * radius,
+                         (0.900F * scale) + (std::cos(angle) * radius * 0.55F),
+                         0.0F),
+        QVector3D(0.036F, 0.052F, 0.036F) * scale,
+        QVector3D(0.0F, 0.0F, -(angle * 180.0F / 3.14159265F)),
+        bronze,
+        states);
+  }
+  for (float const side : {-1.0F, 1.0F}) {
+    desc.add_cone(base + QVector3D(side * 0.222F * scale, 0.928F * scale, 0.0F),
+                  base + QVector3D(side * 0.262F * scale, 1.115F * scale, 0.0F),
+                  0.036F * scale,
+                  bronze,
+                  states);
   }
 }
 

--- a/render/entity/nations/carthage/barracks_renderer.cpp
+++ b/render/entity/nations/carthage/barracks_renderer.cpp
@@ -20,6 +20,7 @@
 #include "../../barracks_renderer_common.h"
 #include "../../barracks_stockpile.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_ornament_emit.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../building_state.h"
@@ -722,45 +723,12 @@ void draw_carthage_roof(const DrawContext& p,
                QVector3D(0.06F, 0.05F, 0.06F),
                c.brick);
     }
-
-    draw_cyl(out,
-             p.model,
-             QVector3D(0.0F, 1.98F, -0.12F),
-             QVector3D(0.0F, 2.58F, -0.12F),
-             0.045F,
-             c.iron,
-             white);
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 2.34F, -0.12F),
-             QVector3D(0.09F, 0.13F, 0.08F),
-             c.ember);
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 2.62F, -0.12F),
-             QVector3D(0.08F, 0.14F, 0.08F),
-             c.bronze);
-    for (float const side : {-1.0F, 1.0F}) {
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(side * 0.20F, 2.42F, -0.12F),
-               QVector3D(0.16F, 0.045F, 0.06F),
-               c.bronze);
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(side * 0.34F, 2.56F, -0.12F),
-               QVector3D(0.05F, 0.16F, 0.05F),
-               c.iron);
-    }
   }
+
+  BuildingArchetypeDesc crown("carthage_barracks_crown");
+  add_punic_horned_crown(
+      crown, QVector3D(0.0F, 1.94F, -0.12F), 0.92F, c.iron, c.bronze, c.ember);
+  emit_building_ornament(crown, p.model, out, unit, white, detailed);
 }
 
 void draw_gate(const DrawContext& p,

--- a/render/entity/nations/roman/barracks_renderer.cpp
+++ b/render/entity/nations/roman/barracks_renderer.cpp
@@ -23,6 +23,7 @@
 #include "../../barracks_renderer_common.h"
 #include "../../barracks_stockpile.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_ornament_emit.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../building_state.h"
@@ -665,36 +666,12 @@ void draw_roofline(const DrawContext& p,
                QVector3D(0.0F, 2.74F, 0.92F),
                QVector3D(0.08F, 0.10F, 0.04F),
                c.gold);
-
-      draw_cyl(out,
-               p.model,
-               QVector3D(0.0F, 2.66F, 0.92F),
-               QVector3D(0.0F, 3.12F, 0.92F),
-               0.025F,
-               c.gold,
-               white);
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(0.0F, 2.90F, 0.92F),
-               QVector3D(0.12F, 0.07F, 0.035F),
-               c.terracotta_dark);
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(0.0F, 3.10F, 0.92F),
-               QVector3D(0.30F, 0.045F, 0.055F),
-               c.gold);
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(0.0F, 3.16F, 0.92F),
-               QVector3D(0.06F, 0.10F, 0.06F),
-               c.gold);
     }
+
+    BuildingArchetypeDesc aquila("roman_barracks_aquila");
+    add_roman_roof_standard(
+        aquila, QVector3D(0.0F, 2.64F, 0.92F), 0.86F, c.gold, c.terracotta_dark);
+    emit_building_ornament(aquila, p.model, out, unit, white, detailed);
   }
 }
 

--- a/render/entity/nations/roman/defense_tower_renderer.cpp
+++ b/render/entity/nations/roman/defense_tower_renderer.cpp
@@ -270,7 +270,7 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
         BuildingFacadePlane::XY,
         damaged ? 0.54F : 0.68F,
         c.gold,
-        c.blue_accent);
+        c.terracotta_dark);
     add_roman_roof_standard(desc,
                             QVector3D(0.0F, battlement_y + 0.20F, 0.0F),
                             damaged ? 0.48F : 0.66F,

--- a/render/entity/nations/roman/home_renderer.cpp
+++ b/render/entity/nations/roman/home_renderer.cpp
@@ -326,11 +326,11 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
                        BuildingLODMask::Full);
 
   add_roman_aquila_relief(desc,
-                          QVector3D(0.0F, cornice_y + 0.34F, 0.985F),
+                          QVector3D(0.0F, cornice_y - 0.30F, 1.00F),
                           BuildingFacadePlane::XY,
-                          0.62F,
+                          0.46F,
                           c.gold,
-                          c.blue_accent);
+                          c.terracotta_dark);
   add_roman_roof_standard(desc,
                           QVector3D(0.0F, eave_y + roof_rise + 0.04F, 0.0F),
                           0.62F,

--- a/render/entity/nations/roman/marketplace_renderer.cpp
+++ b/render/entity/nations/roman/marketplace_renderer.cpp
@@ -427,7 +427,7 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                           BuildingFacadePlane::ZY,
                           0.72F,
                           c.gold,
-                          c.blue_accent);
+                          c.terracotta_dark);
   add_roman_roof_standard(
       desc, QVector3D(0.72F, hall_roof_y + 0.10F, 0.0F), 0.58F, c.gold, c.cloth_red);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,8 @@ add_executable(
     systems/pathfinding_test.cpp
     systems/production_system_test.cpp
     systems/resource_delivery_system_test.cpp
+    systems/gather_loop_system_test.cpp
+    systems/settlement_life_system_test.cpp
     systems/unit_activity_test.cpp
     systems/victory_service_test.cpp
     systems/undead_awakening_system_test.cpp

--- a/tests/render/building_archetype_desc_test.cpp
+++ b/tests/render/building_archetype_desc_test.cpp
@@ -212,10 +212,12 @@ TEST(BuildingCulturalOrnaments, RomanAndPunicReliefsKeepDistinctProfiles) {
   const RenderArchetype punic_archetype =
       build_building_archetype(punic, BuildingState::Normal);
 
-  EXPECT_EQ(roman_archetype.lods[0].draws.size(), 9U);
-  EXPECT_EQ(punic_archetype.lods[0].draws.size(), 6U);
+  EXPECT_EQ(roman_archetype.lods[0].draws.size(), 39U);
+  EXPECT_EQ(punic_archetype.lods[0].draws.size(), 14U);
+
   EXPECT_TRUE(roman_archetype.lods[1].draws.empty());
   EXPECT_TRUE(punic_archetype.lods[1].draws.empty());
+  EXPECT_NE(roman_archetype.lods[0].draws.size(), punic_archetype.lods[0].draws.size());
   EXPECT_NE(roman_archetype.lods[0].draws[0].local_model,
             punic_archetype.lods[0].draws[0].local_model);
 }

--- a/tests/systems/gather_loop_system_test.cpp
+++ b/tests/systems/gather_loop_system_test.cpp
@@ -1,0 +1,203 @@
+#include <QVector3D>
+
+#include <gtest/gtest.h>
+
+#include "core/component.h"
+#include "core/world.h"
+#include "game/map/map_definition.h"
+#include "game/map/terrain_service.h"
+#include "game/systems/builder_product_types.h"
+#include "game/systems/command_service.h"
+#include "game/systems/gather_loop_system.h"
+#include "game/systems/order_service.h"
+#include "game/units/spawn_type.h"
+
+namespace {
+
+class GatherLoopSystemTest : public ::testing::Test {
+protected:
+  void SetUp() override { lay_out_a_grove(3); }
+
+  static void lay_out_a_grove(int tree_count) {
+    Game::Map::MapDefinition map_def;
+    map_def.grid.width = 64;
+    map_def.grid.height = 64;
+    map_def.grid.tile_size = 1.0F;
+    for (int index = 0; index < tree_count; ++index) {
+      map_def.world_props.push_back({.type = Game::Map::WorldProp::Type::PineTree,
+                                     .x = 32.0F + (static_cast<float>(index) * 3.0F),
+                                     .z = 32.0F});
+    }
+    Game::Map::TerrainService::instance().initialize(map_def);
+    Game::Systems::CommandService::initialize(map_def.grid.width, map_def.grid.height);
+  }
+
+  static auto add_woodcutter(Engine::Core::World& world,
+                             float x,
+                             float z) -> Engine::Core::Entity* {
+    auto* worker = world.create_entity();
+    auto* transform = worker->add_component<Engine::Core::TransformComponent>();
+    transform->position = {x, 0.0F, z};
+    auto* unit = worker->add_component<Engine::Core::UnitComponent>();
+    unit->spawn_type = Game::Units::SpawnType::Builder;
+    unit->owner_id = 1;
+    unit->health = 100;
+    unit->max_health = 100;
+    unit->speed = 3.0F;
+    worker->add_component<Engine::Core::MovementComponent>();
+
+    auto* builder = worker->add_component<Engine::Core::BuilderProductionComponent>();
+    builder->build_time = 6.0F;
+    builder->has_gather_order = true;
+    builder->gather_product_type =
+        std::string(Game::Systems::k_builder_product_cut_tree);
+    builder->gather_anchor_x = 0.0F;
+    builder->gather_anchor_z = 0.0F;
+    return worker;
+  }
+
+  static void think(Engine::Core::World& world) {
+    Game::Systems::GatherLoopSystem system;
+
+    system.update(&world, Game::Systems::GatherLoopSystem::k_think_interval + 0.1F);
+  }
+};
+
+TEST_F(GatherLoopSystemTest, AFreeWorkerTakesTheNextTreeInTheGroveByItself) {
+  Engine::Core::World world;
+  auto* worker = add_woodcutter(world, 6.0F, 6.0F);
+
+  think(world);
+
+  const auto* builder =
+      worker->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(builder, nullptr);
+  EXPECT_TRUE(builder->has_task_target);
+  EXPECT_TRUE(builder->task_target_reserved);
+  EXPECT_TRUE(builder->has_construction_site);
+  EXPECT_EQ(builder->product_type,
+            std::string(Game::Systems::k_builder_product_cut_tree));
+  EXPECT_FLOAT_EQ(builder->time_remaining, builder->build_time);
+  EXPECT_TRUE(Game::Map::TerrainService::instance().is_world_prop_reserved(
+      builder->task_target_id));
+}
+
+TEST_F(GatherLoopSystemTest, TwoWorkersNeverClaimTheSameTree) {
+  Engine::Core::World world;
+  auto* first = add_woodcutter(world, 6.0F, 6.0F);
+  auto* second = add_woodcutter(world, -6.0F, 6.0F);
+
+  think(world);
+  think(world);
+
+  const auto* first_builder =
+      first->get_component<Engine::Core::BuilderProductionComponent>();
+  const auto* second_builder =
+      second->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(first_builder, nullptr);
+  ASSERT_NE(second_builder, nullptr);
+  EXPECT_TRUE(first_builder->has_task_target);
+  EXPECT_TRUE(second_builder->has_task_target);
+  EXPECT_NE(first_builder->task_target_id, second_builder->task_target_id);
+}
+
+TEST_F(GatherLoopSystemTest, AWorkerStillCarryingALoadIsLeftToWalkItHome) {
+  Engine::Core::World world;
+  auto* worker = add_woodcutter(world, 6.0F, 6.0F);
+  auto* carry = worker->add_component<Engine::Core::ResourceCarryComponent>();
+  carry->amounts.add(Game::Systems::ResourceType::Wood, 20);
+
+  think(world);
+
+  const auto* builder =
+      worker->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(builder, nullptr);
+  EXPECT_FALSE(builder->has_task_target);
+  EXPECT_TRUE(builder->has_gather_order);
+}
+
+TEST_F(GatherLoopSystemTest, AManualMoveOrderEndsTheStandingOrder) {
+  Engine::Core::World world;
+  auto* worker = add_woodcutter(world, 6.0F, 6.0F);
+
+  Game::Systems::OrderService::prepare_for_move(
+      worker, Game::Systems::MoveOrderKind::PlayerMove, false);
+  think(world);
+
+  const auto* builder =
+      worker->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(builder, nullptr);
+  EXPECT_FALSE(builder->has_gather_order);
+  EXPECT_FALSE(builder->has_task_target);
+}
+
+TEST_F(GatherLoopSystemTest, AHaulHomeIsNotMistakenForAManualMove) {
+  Engine::Core::World world;
+  auto* worker = add_woodcutter(world, 6.0F, 6.0F);
+
+  Game::Systems::OrderService::prepare_for_move(
+      worker, Game::Systems::MoveOrderKind::ScriptedMove, false);
+
+  const auto* builder =
+      worker->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(builder, nullptr);
+  EXPECT_TRUE(builder->has_gather_order);
+}
+
+TEST_F(GatherLoopSystemTest, AnExhaustedRoundIsRetiredInsteadOfRescannedForever) {
+  Engine::Core::World world;
+  auto* worker = add_woodcutter(world, 6.0F, 6.0F);
+  auto* anchored = worker->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(anchored, nullptr);
+
+  anchored->gather_anchor_x = 400.0F;
+  anchored->gather_anchor_z = 400.0F;
+
+  think(world);
+
+  const auto* builder =
+      worker->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(builder, nullptr);
+  EXPECT_FALSE(builder->has_gather_order);
+  EXPECT_FALSE(builder->has_task_target);
+}
+
+TEST_F(GatherLoopSystemTest, AWorkerSentToBuildIsNotPulledOffTheBuildingSite) {
+  Engine::Core::World world;
+  auto* worker = add_woodcutter(world, 6.0F, 6.0F);
+  auto* builder = worker->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(builder, nullptr);
+  builder->product_type = "home";
+  builder->has_construction_site = true;
+  builder->construction_site_x = 8.0F;
+  builder->construction_site_z = 8.0F;
+
+  think(world);
+
+  EXPECT_EQ(builder->product_type, std::string("home"));
+  EXPECT_FLOAT_EQ(builder->construction_site_x, 8.0F);
+  EXPECT_FALSE(builder->has_task_target);
+}
+
+TEST_F(GatherLoopSystemTest, AWorkerBorrowedForABuildGoesBackToTheTreeLine) {
+  Engine::Core::World world;
+  auto* worker = add_woodcutter(world, 6.0F, 6.0F);
+  auto* builder = worker->get_component<Engine::Core::BuilderProductionComponent>();
+  ASSERT_NE(builder, nullptr);
+  builder->product_type = "home";
+  builder->has_construction_site = true;
+
+  think(world);
+  ASSERT_TRUE(builder->has_gather_order);
+
+  builder->product_type.clear();
+  builder->has_construction_site = false;
+  builder->construction_complete = true;
+  think(world);
+
+  EXPECT_TRUE(builder->has_task_target);
+  EXPECT_EQ(builder->product_type,
+            std::string(Game::Systems::k_builder_product_cut_tree));
+}
+
+} // namespace

--- a/tests/systems/settlement_life_system_test.cpp
+++ b/tests/systems/settlement_life_system_test.cpp
@@ -1,0 +1,232 @@
+#include <QVector3D>
+
+#include <gtest/gtest.h>
+
+#include "core/component.h"
+#include "core/world.h"
+#include "game/map/map_definition.h"
+#include "game/map/terrain_service.h"
+#include "game/systems/building_collision_registry.h"
+#include "game/systems/command_service.h"
+#include "game/systems/order_service.h"
+#include "game/systems/owner_registry.h"
+#include "game/systems/settlement_life_system.h"
+#include "game/units/spawn_type.h"
+
+namespace {
+
+using Engine::Core::SettlementErrand;
+using Engine::Core::SettlementResidentComponent;
+
+class SettlementLifeSystemTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    auto& owners = Game::Systems::OwnerRegistry::instance();
+    owners.clear();
+    owners.register_owner_with_id(1, Game::Systems::OwnerType::Player);
+    owners.register_owner_with_id(2, Game::Systems::OwnerType::AI);
+    owners.set_owner_team(1, 1);
+    owners.set_owner_team(2, 2);
+
+    Game::Map::MapDefinition map_def;
+    map_def.grid.width = 96;
+    map_def.grid.height = 96;
+    map_def.grid.tile_size = 1.0F;
+    Game::Map::TerrainService::instance().initialize(map_def);
+    Game::Systems::CommandService::initialize(map_def.grid.width, map_def.grid.height);
+  }
+
+  void TearDown() override {
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Systems::OwnerRegistry::instance().clear();
+  }
+
+  static auto add_home(Engine::Core::World& world,
+                       int owner_id,
+                       float x,
+                       float z) -> Engine::Core::Entity* {
+    auto* home = world.create_entity();
+    auto* transform = home->add_component<Engine::Core::TransformComponent>();
+    transform->position = {x, 0.0F, z};
+    auto* unit = home->add_component<Engine::Core::UnitComponent>();
+    unit->spawn_type = Game::Units::SpawnType::Home;
+    unit->owner_id = owner_id;
+    unit->health = 600;
+    unit->max_health = 600;
+    home->add_component<Engine::Core::BuildingComponent>();
+    return home;
+  }
+
+  static auto add_villager(Engine::Core::World& world,
+                           int owner_id,
+                           float x,
+                           float z) -> Engine::Core::Entity* {
+    auto* villager = world.create_entity();
+    auto* transform = villager->add_component<Engine::Core::TransformComponent>();
+    transform->position = {x, 0.0F, z};
+    auto* unit = villager->add_component<Engine::Core::UnitComponent>();
+    unit->spawn_type = Game::Units::SpawnType::Civilian;
+    unit->owner_id = owner_id;
+    unit->health = 35;
+    unit->max_health = 35;
+    unit->speed = 2.3F;
+    villager->add_component<Engine::Core::MovementComponent>();
+    return villager;
+  }
+
+  static auto add_spearman(Engine::Core::World& world,
+                           int owner_id,
+                           float x,
+                           float z) -> Engine::Core::Entity* {
+    auto* soldier = world.create_entity();
+    auto* transform = soldier->add_component<Engine::Core::TransformComponent>();
+    transform->position = {x, 0.0F, z};
+    auto* unit = soldier->add_component<Engine::Core::UnitComponent>();
+    unit->spawn_type = Game::Units::SpawnType::Spearman;
+    unit->owner_id = owner_id;
+    unit->health = 100;
+    unit->max_health = 100;
+    soldier->add_component<Engine::Core::MovementComponent>();
+    return soldier;
+  }
+
+  static void run_for(Game::Systems::SettlementLifeSystem& system,
+                      Engine::Core::World& world,
+                      float seconds) {
+    constexpr float k_step = 0.1F;
+    for (float elapsed = 0.0F; elapsed < seconds; elapsed += k_step) {
+      system.update(&world, k_step);
+    }
+  }
+};
+
+TEST_F(SettlementLifeSystemTest, AnIdleVillagerBesideAHomeIsGivenALifeOfItsOwn) {
+  Engine::Core::World world;
+  add_home(world, 1, 0.0F, 0.0F);
+  auto* villager = add_villager(world, 1, 4.0F, 0.0F);
+
+  Game::Systems::SettlementLifeSystem system;
+  run_for(system, world, 3.0F);
+
+  const auto* resident = villager->get_component<SettlementResidentComponent>();
+  ASSERT_NE(resident, nullptr);
+  EXPECT_TRUE(resident->hearth_assigned);
+  EXPECT_FLOAT_EQ(resident->hearth_x, 0.0F);
+  EXPECT_FLOAT_EQ(resident->hearth_z, 0.0F);
+}
+
+TEST_F(SettlementLifeSystemTest, AVillagerInOpenCountryIsLeftAlone) {
+  Engine::Core::World world;
+  auto* villager = add_villager(world, 1, 60.0F, 60.0F);
+
+  Game::Systems::SettlementLifeSystem system;
+  run_for(system, world, 3.0F);
+
+  EXPECT_EQ(villager->get_component<SettlementResidentComponent>(), nullptr);
+}
+
+TEST_F(SettlementLifeSystemTest, AVillagerTheCommanderIsUsingIsNotAdopted) {
+  Engine::Core::World world;
+  add_home(world, 1, 0.0F, 0.0F);
+  auto* villager = add_villager(world, 1, 4.0F, 0.0F);
+  villager->add_component<Engine::Core::PlayerOrderIntentComponent>();
+
+  Game::Systems::SettlementLifeSystem system;
+  run_for(system, world, 3.0F);
+
+  EXPECT_EQ(villager->get_component<SettlementResidentComponent>(), nullptr);
+}
+
+TEST_F(SettlementLifeSystemTest, AVillagerThePlayerMovesStopsBeingAResident) {
+  Engine::Core::World world;
+  add_home(world, 1, 0.0F, 0.0F);
+  auto* villager = add_villager(world, 1, 4.0F, 0.0F);
+
+  Game::Systems::SettlementLifeSystem system;
+  run_for(system, world, 3.0F);
+  ASSERT_NE(villager->get_component<SettlementResidentComponent>(), nullptr);
+
+  Game::Systems::OrderService::prepare_for_move(
+      villager, Game::Systems::MoveOrderKind::PlayerMove, false);
+  villager->remove_component<Engine::Core::PlayerOrderIntentComponent>();
+  run_for(system, world, 5.0F);
+
+  const auto* resident = villager->get_component<SettlementResidentComponent>();
+  ASSERT_NE(resident, nullptr);
+  EXPECT_TRUE(resident->released);
+  EXPECT_EQ(resident->errand, SettlementErrand::Settling);
+}
+
+TEST_F(SettlementLifeSystemTest, AVillagerThePlayerMovedIsNeverReadopted) {
+  Engine::Core::World world;
+  add_home(world, 1, 0.0F, 0.0F);
+  auto* villager = add_villager(world, 1, 4.0F, 0.0F);
+
+  Game::Systems::OrderService::prepare_for_move(
+      villager, Game::Systems::MoveOrderKind::PlayerMove, false);
+  villager->remove_component<Engine::Core::PlayerOrderIntentComponent>();
+
+  Game::Systems::SettlementLifeSystem system;
+  run_for(system, world, 6.0F);
+
+  const auto* resident = villager->get_component<SettlementResidentComponent>();
+  ASSERT_NE(resident, nullptr);
+  EXPECT_TRUE(resident->released);
+}
+
+TEST_F(SettlementLifeSystemTest, ResidentsRunFromAnArmedEnemy) {
+  Engine::Core::World world;
+  add_home(world, 1, 0.0F, 0.0F);
+  auto* villager = add_villager(world, 1, 4.0F, 0.0F);
+
+  Game::Systems::SettlementLifeSystem system;
+  run_for(system, world, 3.0F);
+  ASSERT_NE(villager->get_component<SettlementResidentComponent>(), nullptr);
+
+  add_spearman(world, 2, 9.0F, 0.0F);
+  run_for(system, world, 1.0F);
+
+  const auto* resident = villager->get_component<SettlementResidentComponent>();
+  ASSERT_NE(resident, nullptr);
+  EXPECT_EQ(resident->errand, SettlementErrand::Fleeing);
+
+  EXPECT_LT(resident->errand_x, 4.0F);
+}
+
+TEST_F(SettlementLifeSystemTest, AFriendlyGarrisonIsNotAThreat) {
+  Engine::Core::World world;
+  add_home(world, 1, 0.0F, 0.0F);
+  auto* villager = add_villager(world, 1, 4.0F, 0.0F);
+  add_spearman(world, 1, 6.0F, 0.0F);
+
+  Game::Systems::SettlementLifeSystem system;
+  run_for(system, world, 4.0F);
+
+  const auto* resident = villager->get_component<SettlementResidentComponent>();
+  ASSERT_NE(resident, nullptr);
+  EXPECT_NE(resident->errand, SettlementErrand::Fleeing);
+}
+
+TEST_F(SettlementLifeSystemTest, AVillagerAlreadyInAFightIsLeftToTheCombatSystem) {
+  Engine::Core::World world;
+  add_home(world, 1, 0.0F, 0.0F);
+  auto* villager = add_villager(world, 1, 4.0F, 0.0F);
+
+  Game::Systems::SettlementLifeSystem system;
+  run_for(system, world, 3.0F);
+
+  auto* raider = add_spearman(world, 2, 8.0F, 0.0F);
+  auto* target = villager->add_component<Engine::Core::AttackTargetComponent>();
+  target->target_id = raider->get_id();
+
+  run_for(system, world, 1.0F);
+
+  ASSERT_NE(villager->get_component<Engine::Core::AttackTargetComponent>(), nullptr);
+  const auto* resident = villager->get_component<SettlementResidentComponent>();
+  ASSERT_NE(resident, nullptr);
+  EXPECT_EQ(resident->errand, SettlementErrand::Settling);
+  EXPECT_FALSE(resident->is_labouring());
+}
+
+} // namespace

--- a/tests/tools/arena_scenarios_test.cpp
+++ b/tests/tools/arena_scenarios_test.cpp
@@ -810,6 +810,7 @@ TEST(ArenaScenariosTest, RetargetScenarioChecksBothAmmunitionTypes) {
 
 TEST(ArenaScenariosTest, ListsEverySettlementAndEconomyScenario) {
   for (auto const* settlement_id : {Arena::Scenarios::k_village_harvest_cycle_id,
+                                    Arena::Scenarios::k_village_day_life_id,
                                     Arena::Scenarios::k_colony_founding_id,
                                     Arena::Scenarios::k_village_raid_id,
                                     Arena::Scenarios::k_frontier_outpost_id,

--- a/tools/arena/README.md
+++ b/tools/arena/README.md
@@ -22,6 +22,7 @@ build-debug/bin/arena_app --scenario water_showcase
 build-debug/bin/arena_app --scenario unit_activity_showcase
 
 # Inhabited settlements, camps and the economy around them
+build-debug/bin/arena_app --scenario village_day_life
 build-debug/bin/arena_app --scenario village_harvest_cycle
 build-debug/bin/arena_app --scenario colony_founding
 build-debug/bin/arena_app --scenario village_raid
@@ -36,6 +37,13 @@ speed for visual inspection. Running without `--scenario` still opens the
 general Arena UI; use the **Units** panel to choose and load scenarios. The
 status bar reports the first automated failure and final PASS/FAIL result while
 the viewport remains available for normal RTS camera controls.
+
+`village_day_life` is the ambience reference scene: a close camera over a hamlet whose
+residents work its buildings and props and whose woodcutters and quarriers run their own
+round on a standing gather order after one initial job each. It is the scene to record
+for ambience footage and the scene to check after touching
+`SettlementLifeSystem` or `GatherLoopSystem` — see
+[docs/SETTLEMENT_LIFE.md](../../docs/SETTLEMENT_LIFE.md).
 
 ## Unit activity markers
 

--- a/tools/arena/arena_scenario_catalog.cpp
+++ b/tools/arena/arena_scenario_catalog.cpp
@@ -9,6 +9,7 @@
 #include "arena_scenarios.h"
 #include "arena_showcase_scenarios.h"
 #include "arena_wildlife_scenarios.h"
+#include "game/wildlife/wildlife_config.h"
 
 namespace Arena::Scenarios {
 namespace {
@@ -84,6 +85,14 @@ auto at(float time,
   result.command = command;
   result.group = std::move(source);
   result.target_group = std::move(target);
+  return result;
+}
+
+auto harvest_at(float time,
+                QString source,
+                QString resource_kind) -> ArenaScenarioStep {
+  auto result = at(time, Command::HarvestResource, std::move(source));
+  result.resource_kind = std::move(resource_kind);
   return result;
 }
 
@@ -6299,6 +6308,187 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
 
   {
     auto s = definition(
+        QString::fromLatin1(k_village_day_life_id),
+        QStringLiteral("Village Day Life"),
+        QStringLiteral("A close morning pass over a hamlet that keeps itself busy: "
+                       "the lane crowd works between the market, the houses and the "
+                       "temple porch, woodcutters and quarriers run their own round "
+                       "from the tree line to the barracks yard without being told "
+                       "twice, and the flock grazes the meadow behind the houses. "
+                       "This is the ambience reference scene - the camera sits close "
+                       "enough to read hands and gait."),
+        120.0F,
+        {36.0F, 47.0F, 26.0F});
+    s.camera_focus = QVector3D(-2.0F, 0.0F, 1.0F);
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    s.environment.start_time = 11.5F;
+    s.environment.time_mode = Game::Map::TimeMode::Locked;
+
+    s.wildlife = Game::Wildlife::default_settings();
+    s.wildlife.enabled = true;
+    s.wildlife.seed = 20260805U;
+    s.wildlife.wolves.enabled = false;
+    s.wildlife.wolves.group_count = 0;
+    s.wildlife.sheep.enabled = true;
+    s.wildlife.sheep.group_count = 1;
+    s.wildlife.sheep.group_size_min = 5;
+    s.wildlife.sheep.group_size_max = 6;
+    s.wildlife.sheep.roam_radius = 6.0F;
+    s.wildlife.sheep.spawn_areas = {{-16.0F, 15.0F, 4.0F}};
+    s.wildlife.birds.enabled = true;
+    s.wildlife.birds.group_count = 1;
+    s.wildlife.birds.spawn_areas = {{6.0F, -14.0F, 8.0F}};
+
+    s.roads = {
+        street({-26.0F, 0.0F, 0.0F}, {26.0F, 0.0F, 0.0F}, 3.4F, "stone"),
+        street({-2.0F, 0.0F, 0.0F}, {-2.0F, 0.0F, 13.0F}, 2.6F, "stone"),
+        street({9.0F, 0.0F, 0.0F}, {9.0F, 0.0F, -10.0F}, 2.6F, "stone"),
+    };
+
+    s.resource_patches = {
+        patch("olive_tree", 5, {-17.0F, 0.0F, -11.0F}, {0.0F, 0.0F, 4.2F}, 1.15F),
+        patch("olive_tree", 4, {-22.0F, 0.0F, -9.0F}, {0.0F, 0.0F, 4.4F}, 1.1F),
+        patch("pine_tree", 4, {-21.0F, 0.0F, 4.0F}, {0.0F, 0.0F, 4.4F}, 1.05F),
+        patch("boulder", 5, {-15.0F, 0.0F, 14.0F}, {3.2F, 0.0F, 0.0F}, 1.15F),
+        patch("boulder", 3, {-4.0F, 0.0F, 17.0F}, {3.2F, 0.0F, 0.0F}, 1.05F),
+        patch("fire_camp", 1, {-5.0F, 0.0F, 11.5F}, {}, 0.85F),
+        patch("supply_cart", 3, {2.5F, 0.0F, -2.0F}, {3.4F, 0.0F, 0.0F}, 0.95F),
+        patch("tent", 2, {-20.0F, 0.0F, 12.0F}, {4.2F, 0.0F, 0.0F}, 0.8F),
+        patch("weapon_rack", 1, {12.0F, 0.0F, 3.5F}, {}, 1.0F),
+        patch("plant", 7, {-8.0F, 0.0F, 15.0F}, {2.8F, 0.0F, 0.0F}, 0.9F),
+    };
+
+    auto woodcutters = group(QStringLiteral("village_woodcutters"),
+                             Troop::Builder,
+                             2,
+                             2,
+                             {-13.0F, 0.0F, -6.0F},
+                             1,
+                             {3.2F, 0.0F, 0.0F});
+    woodcutters.nation_id = Nation::RomanRepublic;
+
+    auto quarriers = group(QStringLiteral("village_quarriers"),
+                           Troop::Builder,
+                           2,
+                           2,
+                           {-11.0F, 0.0F, 10.0F},
+                           1,
+                           {3.2F, 0.0F, 0.0F});
+    quarriers.nation_id = Nation::RomanRepublic;
+
+    s.groups = {
+        building(QStringLiteral("day_market"),
+                 Game::Units::SpawnType::Marketplace,
+                 Nation::RomanRepublic,
+                 2,
+                 1,
+                 {0.0F, 0.0F, -6.0F},
+                 {},
+                 180.0F),
+        building(QStringLiteral("day_temple"),
+                 Game::Units::SpawnType::Temple,
+                 Nation::RomanRepublic,
+                 2,
+                 1,
+                 {9.0F, 0.0F, -12.0F},
+                 {},
+                 180.0F),
+        building(QStringLiteral("day_houses_west"),
+                 Game::Units::SpawnType::Home,
+                 Nation::RomanRepublic,
+                 2,
+                 3,
+                 {-10.0F, 0.0F, 6.0F},
+                 {6.6F, 0.0F, 0.0F}),
+        building(QStringLiteral("day_houses_east"),
+                 Game::Units::SpawnType::Home,
+                 Nation::RomanRepublic,
+                 2,
+                 2,
+                 {8.5F, 0.0F, 6.0F},
+                 {6.6F, 0.0F, 0.0F}),
+        building(QStringLiteral("day_granary"),
+                 Game::Units::SpawnType::Home,
+                 Nation::RomanRepublic,
+                 2,
+                 1,
+                 {-10.0F, 0.0F, -7.0F},
+                 {},
+                 180.0F),
+        building(QStringLiteral("day_barracks"),
+                 Game::Units::SpawnType::Barracks,
+                 Nation::RomanRepublic,
+                 2,
+                 1,
+                 {14.0F, 0.0F, -4.0F},
+                 {},
+                 180.0F),
+        residents(QStringLiteral("day_lane_folk"),
+                  Nation::RomanRepublic,
+                  2,
+                  4,
+                  {-3.0F, 0.0F, 2.5F},
+                  {4.0F, 0.0F, 0.0F},
+                  12.0F),
+        residents(QStringLiteral("day_market_folk"),
+                  Nation::RomanRepublic,
+                  2,
+                  3,
+                  {3.5F, 0.0F, -3.0F},
+                  {3.6F, 0.0F, 0.0F},
+                  10.0F),
+        residents(QStringLiteral("day_yard_folk"),
+                  Nation::RomanRepublic,
+                  2,
+                  3,
+                  {-9.0F, 0.0F, 9.0F},
+                  {3.6F, 0.0F, 0.0F},
+                  9.0F),
+        residents(QStringLiteral("day_temple_folk"),
+                  Nation::RomanRepublic,
+                  2,
+                  3,
+                  {10.0F, 0.0F, -8.0F},
+                  {3.4F, 0.0F, 0.0F},
+                  9.0F),
+        woodcutters,
+        quarriers,
+    };
+
+    s.steps = {
+        harvest_at(1.0F, QStringLiteral("village_woodcutters"), QStringLiteral("tree")),
+        harvest_at(
+            1.6F, QStringLiteral("village_quarriers"), QStringLiteral("boulder")),
+    };
+
+    add_settlement_acceptance(s,
+                              {QStringLiteral("day_market"),
+                               QStringLiteral("day_temple"),
+                               QStringLiteral("day_houses_west"),
+                               QStringLiteral("day_houses_east"),
+                               QStringLiteral("day_granary"),
+                               QStringLiteral("day_barracks")});
+    add_visual_stability(s,
+                         {QStringLiteral("day_lane_folk"),
+                          QStringLiteral("day_market_folk"),
+                          QStringLiteral("day_yard_folk"),
+                          QStringLiteral("day_temple_folk"),
+                          QStringLiteral("village_woodcutters"),
+                          QStringLiteral("village_quarriers")});
+    s.expectations.push_back(expectation(Expect::MovementAnimationObserved,
+                                         QStringLiteral("day_lane_folk")));
+
+    s.expectations.push_back(expectation(Expect::OwnerHarvestsResource,
+                                         QStringLiteral("village_woodcutters"),
+                                         {},
+                                         8.0F));
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
         QString::fromLatin1(k_colony_founding_id),
         QStringLiteral("Colony Founding"),
         QStringLiteral("A Carthaginian colony breaks ground on the far side of the "
@@ -6643,13 +6833,13 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
     };
 
     s.resource_patches = {
-        patch("olive_tree", 4, {-22.0F, 0.0F, -14.0F}, {0.0F, 0.0F, 5.0F}, 1.1F),
-        patch("olive_tree", 4, {22.0F, 0.0F, 4.0F}, {0.0F, 0.0F, 5.0F}, 1.1F),
-        patch("supply_cart", 3, {-8.0F, 0.0F, -12.5F}, {3.4F, 0.0F, 0.0F}, 0.95F),
-        patch("fire_camp", 1, {6.0F, 0.0F, 12.0F}, {}, 0.85F),
-        patch("tent", 2, {8.0F, 0.0F, -12.5F}, {4.5F, 0.0F, 0.0F}, 0.8F),
-        patch("plant", 6, {-14.0F, 0.0F, 5.0F}, {3.0F, 0.0F, 0.0F}, 0.9F),
-        patch("plant", 6, {8.0F, 0.0F, -5.0F}, {3.0F, 0.0F, 0.0F}, 0.9F),
+        patch("olive_tree", 4, {-22.0F, 0.0F, -19.0F}, {0.0F, 0.0F, 4.0F}, 1.1F),
+        patch("olive_tree", 4, {22.0F, 0.0F, 11.0F}, {0.0F, 0.0F, 4.0F}, 1.1F),
+        patch("supply_cart", 3, {-8.0F, 0.0F, -11.5F}, {3.4F, 0.0F, 0.0F}, 0.95F),
+        patch("fire_camp", 1, {6.0F, 0.0F, 12.5F}, {}, 0.85F),
+        patch("tent", 2, {13.0F, 0.0F, -11.0F}, {4.5F, 0.0F, 0.0F}, 0.8F),
+        patch("plant", 6, {-15.0F, 0.0F, 11.0F}, {3.0F, 0.0F, 0.0F}, 0.9F),
+        patch("plant", 6, {8.0F, 0.0F, -19.5F}, {3.0F, 0.0F, 0.0F}, 0.9F),
     };
 
     s.groups = {

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -136,6 +136,7 @@ inline constexpr char k_carthage_fortification_showcase_id[] =
     "carthage_fortification_showcase";
 inline constexpr char k_rival_economies_id[] = "rival_economies";
 inline constexpr char k_village_harvest_cycle_id[] = "village_harvest_cycle";
+inline constexpr char k_village_day_life_id[] = "village_day_life";
 inline constexpr char k_colony_founding_id[] = "colony_founding";
 inline constexpr char k_village_raid_id[] = "village_raid";
 inline constexpr char k_frontier_outpost_id[] = "frontier_outpost";

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -23,10 +23,13 @@
 #include <QtMath>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <numbers>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include "animation/showcase_pose_manifest.h"
 #include "app/core/commander_control_controller.h"
@@ -2269,24 +2272,95 @@ void ArenaViewport::place_scenario_resource_patches(
     return;
   }
 
-  constexpr float k_prop_building_clearance = 1.6F;
+  constexpr float k_prop_building_clearance = 2.6F;
+
+  constexpr float k_prop_gap = 1.0F;
+
+  constexpr float k_prop_dry_margin = 1.0F;
+
+  constexpr float k_prop_road_clearance = 0.25F;
+
+  constexpr std::array<float, 4> k_nudge_rings{0.0F, 1.2F, 2.4F, 3.6F};
+  constexpr int k_nudge_directions = 8;
 
   auto& collision = Game::Systems::BuildingCollisionRegistry::instance();
-  const auto& terrain_field = Game::Map::TerrainService::instance().terrain_field();
+  auto& terrain_service = Game::Map::TerrainService::instance();
+  const auto& terrain_field = terrain_service.terrain_field();
+
+  struct PlacedProp {
+    float x{0.0F};
+    float z{0.0F};
+    float radius{0.0F};
+  };
+  std::vector<PlacedProp> placed;
+  placed.reserve(m_world_props.size() + (definition.resource_patches.size() * 4));
+
+  for (const auto& existing : m_world_props) {
+    const QVector3D at = terrain_service.world_prop_world_position(existing);
+    placed.push_back(
+        {at.x(),
+         at.z(),
+         Game::Map::world_prop_ground_radius(existing.type, existing.scale)});
+  }
+
+  auto const stands_clear = [&](float x, float z, float radius) {
+    if (collision.is_circle_overlapping_building(
+            x, z, radius + k_prop_building_clearance)) {
+      return false;
+    }
+    if (terrain_service.is_point_near_water(x, z, radius + k_prop_dry_margin) ||
+        terrain_service.is_point_near_bridge(x, z, radius + k_prop_dry_margin)) {
+      return false;
+    }
+    if (terrain_service.is_point_near_road(x, z, radius + k_prop_road_clearance)) {
+      return false;
+    }
+    for (const auto& other : placed) {
+      float const dx = other.x - x;
+      float const dz = other.z - z;
+      float const minimum = other.radius + radius + k_prop_gap;
+      if (((dx * dx) + (dz * dz)) < (minimum * minimum)) {
+        return false;
+      }
+    }
+    return true;
+  };
 
   for (const auto& patch : definition.resource_patches) {
+    const auto type = world_prop_type_from_string(patch.prop_type);
+    float const radius = Game::Map::world_prop_ground_radius(type, patch.scale);
+
     for (int index = 0; index < patch.count; ++index) {
-      const QVector3D world_position =
-          scenario_origin + patch.origin + patch.spacing * index;
-      if (collision.is_circle_overlapping_building(
-              world_position.x(), world_position.z(), k_prop_building_clearance)) {
+      const QVector3D wanted = scenario_origin + patch.origin + patch.spacing * index;
+
+      std::optional<QVector3D> spot;
+      for (std::size_t ring = 0; ring < k_nudge_rings.size() && !spot.has_value();
+           ++ring) {
+        float const reach = k_nudge_rings.at(ring);
+        int const directions = reach <= 0.0F ? 1 : k_nudge_directions;
+        float const bias = static_cast<float>(ring) * 0.4F;
+        for (int step = 0; step < directions; ++step) {
+          float const angle = bias + (6.2831853F * static_cast<float>(step) /
+                                      static_cast<float>(std::max(1, directions)));
+          QVector3D const candidate(wanted.x() + (std::cos(angle) * reach),
+                                    wanted.y(),
+                                    wanted.z() + (std::sin(angle) * reach));
+          if (stands_clear(candidate.x(), candidate.z(), radius)) {
+            spot = candidate;
+            break;
+          }
+        }
+      }
+
+      if (!spot.has_value()) {
         continue;
       }
 
-      const QVector2D grid_position =
-          grid_position_from_world(terrain_field, world_position);
+      placed.push_back({spot->x(), spot->z(), radius});
+
+      const QVector2D grid_position = grid_position_from_world(terrain_field, *spot);
       Game::Map::WorldProp prop;
-      prop.type = world_prop_type_from_string(patch.prop_type);
+      prop.type = type;
       prop.x = grid_position.x();
       prop.z = grid_position.y();
       prop.scale = patch.scale;

--- a/tools/arena/promos/village_day_life.json
+++ b/tools/arena/promos/village_day_life.json
@@ -1,0 +1,290 @@
+{
+  "id": "village_day_life",
+  "title": "A DAY IN THE HAMLET",
+  "subtitle": "STANDARD OF IRON",
+  "width": 1920,
+  "height": 1080,
+  "fps": 60,
+  "supersample": 1,
+  "transition": {
+    "type": "dissolve",
+    "duration": 0.5
+  },
+  "shots": [
+    {
+      "name": "lane",
+      "scenario": "village_day_life",
+      "seed": 8051,
+      "start": 14.0,
+      "duration": 6.0,
+      "focus": {
+        "mode": "point",
+        "point": [-2.0, 0.0, 1.0],
+        "smoothing": 0.6
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 27,
+          "pitch": 24,
+          "yaw": 28,
+          "fov": 40,
+          "height": 1.8
+        },
+        {
+          "time": 6.0,
+          "distance": 23,
+          "pitch": 27,
+          "yaw": 46,
+          "fov": 40,
+          "height": 2.0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE LANE"
+    },
+    {
+      "name": "market",
+      "scenario": "village_day_life",
+      "seed": 8051,
+      "start": 26.0,
+      "duration": 5.0,
+      "focus": {
+        "mode": "group",
+        "group": "day_market_folk",
+        "smoothing": 0.45
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 15,
+          "pitch": 23,
+          "yaw": 34,
+          "fov": 38,
+          "height": 1.4
+        },
+        {
+          "time": 5.0,
+          "distance": 13,
+          "pitch": 26,
+          "yaw": 50,
+          "fov": 38,
+          "height": 1.5,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "MARKET DAY",
+      "transition": {
+        "type": "dip",
+        "duration": 0.4
+      }
+    },
+    {
+      "name": "woodline",
+      "scenario": "village_day_life",
+      "seed": 8051,
+      "start": 9.0,
+      "duration": 5.5,
+      "focus": {
+        "mode": "group",
+        "group": "village_woodcutters",
+        "smoothing": 0.4
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 12,
+          "pitch": 14,
+          "yaw": 96,
+          "fov": 38,
+          "height": 1.2
+        },
+        {
+          "time": 5.5,
+          "distance": 10,
+          "pitch": 18,
+          "yaw": 78,
+          "fov": 38,
+          "height": 1.3,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE TREE LINE"
+    },
+    {
+      "name": "haul",
+      "scenario": "village_day_life",
+      "seed": 8051,
+      "start": 20.0,
+      "duration": 6.0,
+      "focus": {
+        "mode": "group",
+        "group": "village_woodcutters",
+        "smoothing": 0.7
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 17,
+          "pitch": 20,
+          "yaw": 330,
+          "fov": 40,
+          "height": 1.5
+        },
+        {
+          "time": 6.0,
+          "distance": 15,
+          "pitch": 24,
+          "yaw": 350,
+          "fov": 40,
+          "height": 1.7,
+          "ease": "linear"
+        }
+      ],
+      "caption": "EVERY LOAD WALKS HOME"
+    },
+    {
+      "name": "quarry",
+      "scenario": "village_day_life",
+      "seed": 8051,
+      "start": 44.0,
+      "duration": 5.0,
+      "focus": {
+        "mode": "group",
+        "group": "village_quarriers",
+        "smoothing": 0.4
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 12,
+          "pitch": 15,
+          "yaw": 24,
+          "fov": 38,
+          "height": 1.2
+        },
+        {
+          "time": 5.0,
+          "distance": 11,
+          "pitch": 20,
+          "yaw": 8,
+          "fov": 38,
+          "height": 1.4,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "AND THEY GO BACK ON THEIR OWN",
+      "transition": {
+        "type": "whip",
+        "duration": 0.22
+      }
+    },
+    {
+      "name": "hearth",
+      "scenario": "village_day_life",
+      "seed": 8051,
+      "start": 58.0,
+      "duration": 5.0,
+      "focus": {
+        "mode": "group",
+        "group": "day_yard_folk",
+        "smoothing": 0.5
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 14,
+          "pitch": 22,
+          "yaw": 44,
+          "fov": 38,
+          "height": 1.4
+        },
+        {
+          "time": 5.0,
+          "distance": 15,
+          "pitch": 25,
+          "yaw": 26,
+          "fov": 38,
+          "height": 1.6,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE HOUSE YARDS"
+    },
+    {
+      "name": "flock",
+      "scenario": "village_day_life",
+      "seed": 8051,
+      "start": 70.0,
+      "duration": 4.5,
+      "focus": {
+        "mode": "point",
+        "point": [-16.0, 0.0, 15.0],
+        "smoothing": 0.5
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 16,
+          "pitch": 20,
+          "yaw": 6,
+          "fov": 38,
+          "height": 1.5
+        },
+        {
+          "time": 4.5,
+          "distance": 18,
+          "pitch": 24,
+          "yaw": 24,
+          "fov": 38,
+          "height": 1.7,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE MEADOW"
+    },
+    {
+      "name": "wide",
+      "scenario": "village_day_life",
+      "seed": 8051,
+      "start": 82.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "point",
+        "point": [-2.0, 0.0, 1.0],
+        "smoothing": 0.7
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 26,
+          "pitch": 22,
+          "yaw": 20,
+          "fov": 40,
+          "height": 2.0
+        },
+        {
+          "time": 7.0,
+          "distance": 42,
+          "pitch": 34,
+          "yaw": 44,
+          "fov": 40,
+          "height": 3.0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "A PLACE THAT KEEPS ITSELF"
+    }
+  ],
+  "grade": {
+    "contrast": 1.08,
+    "saturation": 1.12,
+    "brightness": 0.04,
+    "gamma": 1.06,
+    "grain": 2,
+    "vignette": 0.08,
+    "sharpen": 0.6
+  },
+  "music": "assets/audio/music/base/base_army_camp_resting.ogg",
+  "music_start": 0.0
+}


### PR DESCRIPTION
Introduce autonomous settlement activity for civilians and player-directed harvesters. Idle civilians near friendly buildings are adopted as residents with hearth-based errands, labour and loiter roles, focus-facing, danger detection, flee behavior, all-clear hysteresis, release-on-player-order semantics, and hearth re-anchoring when a resident becomes available again. Labour feeds the existing construction presentation path so ambient workers receive a readable hands-on work cycle without adding a separate animation pipeline.

Add a persistent standing gather order to BuilderProductionComponent and serialize it together with resident state. ProductionSystem records a successful player harvest, while GatherLoopSystem reserves the next nearby tree, boulder, or iron node around the previous work anchor after the worker unloads. Manual moves and stops clear the order, scripted hauling does not, construction jobs can temporarily borrow the worker, and exhausted resource areas retire cleanly. Register the system in the runtime and game targets.

Unify Roman and Punic building emblems around reusable archetype ornament helpers. Replace the earlier blocky reliefs and roof pieces with a shared Roman aquila and Punic Tanit/crescent treatment, preserve recognizable roof signatures through minimal LOD, and replay the same archetype descriptions in the recorder-based barracks renderers. Refresh affected nation placements, materials, and cultural ornament expectations.

Make arena resource-patch placement account for per-prop ground radii, buildings, water, bridges, roads, and neighboring props, with bounded nudge rings and graceful skipping for impossible placements. Add the village_day_life ambience scenario, its promo shot list, documentation, and focused coverage for gather-loop, settlement-life, ornament, and scenario behavior.

Validation: make format passed. Builds and tests were intentionally not run.