### PR TITLE
Fix assault waves breaching defenses and refresh scatter incrementally

### DIFF
--- a/app/core/mission_setup_coordinator.cpp
+++ b/app/core/mission_setup_coordinator.cpp
@@ -1057,6 +1057,9 @@ auto MissionSetupCoordinator::spawn_wave(const MissionWaveContext& ctx,
         if (ai_controlled) {
           auto* assault = entity->add_component<Engine::Core::AssaultWaveComponent>();
           assault->wave_phase = wave.phase_index;
+          assault->has_march_target = true;
+          assault->march_target_x = wave.defense_reference_world_position.x();
+          assault->march_target_z = wave.defense_reference_world_position.z();
         }
         auto* renderable = entity->get_component<Engine::Core::RenderableComponent>();
         if (renderable != nullptr) {

--- a/assets/shaders/include/activity_indicator.glsl
+++ b/assets/shaders/include/activity_indicator.glsl
@@ -7,56 +7,49 @@ vec4 activity_indicator_shade(float layer,
                               vec3 tint,
                               float alpha,
                               float time,
-                              float phase) {
+                              float phase,
+                              float height) {
   vec3 normal = normalize(raw_normal);
-  vec3 light_dir = normalize(vec3(-0.42, 0.58, 0.70));
+  vec3 light_dir = normalize(vec3(-0.38, 0.62, 0.68));
   vec3 view_dir = vec3(0.0, 0.0, 1.0);
   vec3 half_dir = normalize(light_dir + view_dir);
 
   float lambert = max(dot(normal, light_dir), 0.0);
-  float specular = pow(max(dot(normal, half_dir), 0.0), 30.0);
+  float specular = pow(max(dot(normal, half_dir), 0.0), 42.0);
   float fresnel = pow(1.0 - clamp(normal.z, 0.0, 1.0), 3.0);
   float breathe = 0.5 + 0.5 * sin(time * 2.0 + phase);
 
-  if (layer > 6.5) {
-    float t = clamp(radial, 0.0, 1.0);
-    float falloff = pow(1.0 - t, 2.2);
-    float strength = 0.42 + 0.22 * breathe;
-    return vec4(tint * 1.45, alpha * falloff * strength);
+  if (layer < 0.5) {
+    float strength = mix(0.40, 0.15, clamp(radial, 0.0, 1.0));
+    return vec4(vec3(0.0), alpha * strength);
   }
 
-  if (layer < 0.5) {
-    float falloff = 1.0 - smoothstep(0.62, 1.20, radial);
-    return vec4(vec3(0.0), alpha * 0.62 * falloff * falloff);
+  if (layer < 1.5) {
+    return vec4(mix(vec3(0.0), tint, 0.14) * 0.10, clamp(alpha, 0.0, 1.0));
   }
+
+  float sheen = clamp(height * 0.5 + 0.5, 0.0, 1.0);
 
   vec3 base;
   float gloss;
-  if (layer < 1.5) {
-
-    base = mix(vec3(0.042, 0.045, 0.055), tint * 0.22, 0.30);
-    gloss = 0.25;
-  } else if (layer < 2.5) {
-    base = tint * (0.95 + 0.18 * breathe);
-    gloss = 1.55;
+  if (layer < 2.5) {
+    vec3 lit = mix(tint, vec3(1.0), 0.16);
+    vec3 deep = mix(tint, vec3(0.0), 0.34);
+    base = mix(deep, lit, sheen * sheen * (3.0 - 2.0 * sheen));
+    gloss = 0.70;
   } else if (layer < 3.5) {
-    base = vec3(0.016, 0.018, 0.024);
-    gloss = 0.0;
-  } else if (layer < 4.5) {
-    base = mix(tint, vec3(1.0), 0.58);
-    gloss = 0.85;
-  } else if (layer < 5.5) {
-    base = mix(tint, vec3(1.0), 0.80);
-    gloss = 1.20;
+    base = mix(tint, vec3(1.0), 0.55);
+    gloss = 1.05;
   } else {
-    base = tint * 0.62;
-    gloss = 1.00;
+    base = mix(tint, vec3(0.0), 0.62);
+    gloss = 0.35;
   }
 
-  float ambient = 0.30 + 0.16 * (normal.z * 0.5 + 0.5);
-  vec3 color = base * (ambient + 0.90 * lambert);
-  color += vec3(1.0) * specular * gloss * 0.55;
-  color += tint * fresnel * 0.22;
+  float ambient = 0.42 + 0.14 * (normal.z * 0.5 + 0.5);
+  vec3 color = base * (ambient + 0.60 * lambert);
+  color += vec3(1.0) * specular * gloss * 0.42;
+  color += tint * fresnel * 0.30;
+  color *= 0.96 + 0.08 * breathe;
 
   return vec4(color, clamp(alpha, 0.0, 1.0));
 }

--- a/assets/shaders/mode_indicator.frag
+++ b/assets/shaders/mode_indicator.frag
@@ -5,6 +5,7 @@ in vec3 v_normal;
 in float v_layer;
 in float v_radial;
 in float v_phase;
+in float v_height;
 
 uniform vec3 u_mode_color;
 uniform float u_alpha;
@@ -14,5 +15,5 @@ out vec4 frag_color;
 
 void main() {
   frag_color = activity_indicator_shade(
-      v_layer, v_radial, v_normal, u_mode_color, u_alpha, u_time, v_phase);
+      v_layer, v_radial, v_normal, u_mode_color, u_alpha, u_time, v_phase, v_height);
 }

--- a/assets/shaders/mode_indicator.vert
+++ b/assets/shaders/mode_indicator.vert
@@ -11,6 +11,7 @@ out vec3 v_normal;
 out float v_layer;
 out float v_radial;
 out float v_phase;
+out float v_height;
 
 void main() {
   v_normal = a_normal;
@@ -20,6 +21,7 @@ void main() {
 
   float pulse = 1.0 + 0.015 * sin(u_time * 2.0);
   vec3 pos = vec3(a_position.xy * pulse, a_position.z);
+  v_height = a_position.y * 2.0;
 
   gl_Position = u_mvp * vec4(pos, 1.0);
 }

--- a/assets/shaders/mode_indicator_instanced.frag
+++ b/assets/shaders/mode_indicator_instanced.frag
@@ -7,12 +7,19 @@ in vec3 v_normal;
 in float v_layer;
 in float v_radial;
 in float v_phase;
+in float v_height;
 
 uniform float u_time;
 
 out vec4 frag_color;
 
 void main() {
-  frag_color = activity_indicator_shade(
-      v_layer, v_radial, v_normal, v_instance_color, v_instance_alpha, u_time, v_phase);
+  frag_color = activity_indicator_shade(v_layer,
+                                        v_radial,
+                                        v_normal,
+                                        v_instance_color,
+                                        v_instance_alpha,
+                                        u_time,
+                                        v_phase,
+                                        v_height);
 }

--- a/assets/shaders/mode_indicator_instanced.vert
+++ b/assets/shaders/mode_indicator_instanced.vert
@@ -21,6 +21,7 @@ out vec3 v_normal;
 out float v_layer;
 out float v_radial;
 out float v_phase;
+out float v_height;
 
 void main() {
   mat4 model = mat4(vec4(a_instance_model_col0.xyz, 0.0),
@@ -43,6 +44,7 @@ void main() {
 
   float pulse = 1.0 + 0.015 * sin(u_time * 2.0 + v_phase);
   vec3 pos = vec3(a_position.xy * pulse, a_position.z);
+  v_height = a_position.y * 2.0;
 
   gl_Position = u_view_proj * model * vec4(pos, 1.0);
 }

--- a/assets/shaders/olive_instanced.frag
+++ b/assets/shaders/olive_instanced.frag
@@ -21,10 +21,6 @@ out vec4 frag_color;
 const float PI = 3.14159265359;
 const float TWO_PI = 6.28318530718;
 
-float hash3(vec3 p) {
-  return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453);
-}
-
 float noise2_d(vec2 p) {
   vec2 i = floor(p);
   vec2 f = fract(p);
@@ -36,82 +32,69 @@ float noise2_d(vec2 p) {
   return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
 }
 
-vec2 rotate2_d(vec2 p, float angle) {
-  float s = sin(angle);
-  float c = cos(angle);
-  return mat2(c, -s, s, c) * p;
-}
-
-float olive_leaf_mask(vec2 p, float seed) {
-  vec2 cell = floor(p);
-  vec2 local = fract(p) - vec2(0.5);
-  float angle = soi_hash_15a407(cell + vec2(seed, seed * 1.7)) * TWO_PI;
-  vec2 q = rotate2_d(local, angle);
-
-  float half_length =
-      mix(0.34, 0.46, soi_hash_15a407(cell + vec2(3.1, 5.7) + vec2(seed)));
-  float half_width =
-      mix(0.08, 0.13, soi_hash_15a407(cell + vec2(8.2, 1.4) + vec2(seed * 0.7)));
-
-  q.x /= half_length;
-  q.y /= half_width;
-
-  float body = 1.0 - smoothstep(0.82, 1.08, length(q));
-  float taper = 1.0 - smoothstep(0.90, 1.15, abs(q.x) + abs(q.y) * 0.30);
-  float center = 1.0 - smoothstep(0.12, 0.45, abs(q.y));
-  return body * taper * mix(0.90, 1.0, center);
-}
-
 void main() {
 
-  vec3 n = normalize(v_normal);
+  vec3 geometric_normal = normalize(v_normal);
   vec3 l = environment_primary_direction();
-  float diffuse = max(dot(n, l), 0.0);
-  float wrap = clamp((dot(n, l) + 0.28) / 1.28, 0.0, 1.0);
-  float backlight = max(dot(-n, l), 0.0);
+
+  vec3 leaf_seed_offset =
+      vec3(v_leaf_seed * 37.0, v_branch_id * 11.0, v_leaf_seed * 59.0);
+  float footprint = max(fwidth(v_local_pos.x), fwidth(v_local_pos.z));
+  float fine_detail = 1.0 - smoothstep(0.004, 0.020, footprint);
+  float mid_detail = 1.0 - smoothstep(0.012, 0.048, footprint);
+
+  float leaf_fine = soi_noise3(v_local_pos * vec3(26.0, 21.0, 26.0) + leaf_seed_offset);
+  float leaf_clump = soi_noise3(v_local_pos * 9.5 + leaf_seed_offset.zxy);
+  float leaf_mass = soi_noise3(v_local_pos * 4.5 + leaf_seed_offset.yzx);
+  leaf_fine = mix(0.5, leaf_fine, fine_detail);
+  leaf_clump = mix(0.5, leaf_clump, mid_detail);
+
+  float canopy_height = clamp((v_tex_coord.y - 0.52) / 0.58, 0.0, 1.0);
+  float canopy_radius = length(v_local_pos_xz);
+  float canopy_edge = smoothstep(0.10, 0.32, canopy_radius);
+  float canopy_core = 1.0 - smoothstep(0.14, 0.40, canopy_radius);
+
+  vec3 leaf_dark_green = vec3(0.085, 0.150, 0.100);
+  vec3 leaf_mid_green = vec3(0.215, 0.310, 0.175);
+  vec3 leaf_light_green = vec3(0.375, 0.455, 0.250);
+  vec3 leaf_silver = vec3(0.500, 0.540, 0.455);
+
+  float color_choice =
+      clamp(leaf_clump * 0.90 + (leaf_fine - 0.5) * 0.26 + 0.10, 0.0, 1.0);
+  vec3 leaf_color = mix(leaf_dark_green, leaf_mid_green, color_choice);
+  leaf_color =
+      mix(leaf_color, leaf_light_green, smoothstep(0.40, 0.90, leaf_mass) * 0.62);
+
+  vec3 n = geometric_normal;
+
+  float ndl = dot(n, l);
+  float diffuse = max(ndl, 0.0);
+  float wrap = clamp((ndl + 0.24) / 1.24, 0.0, 1.0);
+  wrap *= wrap * (3.0 - 2.0 * wrap);
+  float backlight = max(-ndl, 0.0);
   float ambient = environment_ambient_intensity();
-  float sky_fill = smoothstep(-0.15, 0.85, n.y) * mix(0.04, 0.10, v_foliage_mask);
-  float lighting = ambient + wrap * mix(0.27, 0.42, v_foliage_mask) + sky_fill;
+  float sky_fill = smoothstep(-0.20, 0.85, n.y) * mix(0.05, 0.14, v_foliage_mask);
+  float lighting = ambient + wrap * mix(0.30, 0.66, v_foliage_mask) + sky_fill;
 
   vec3 sun_color = environment_primary_color() * environment_primary_intensity();
   vec3 sky_color = environment_sky_color();
   float lit_t = clamp(wrap * 1.2, 0.0, 1.0);
   vec3 light_tint = mix(sky_color * 0.55, sun_color, lit_t);
 
-  vec2 leaf_pos = vec2(dot(v_local_pos_xz, vec2(0.82, 0.57)), v_tex_coord.y) * 16.0 +
-                  vec2(v_leaf_seed * 13.7, v_branch_id * 2.3);
-  float leaf_mottle_a = noise2_d(leaf_pos);
-  float leaf_mottle_b = noise2_d(leaf_pos * 2.1 + vec2(v_bark_seed * 5.0));
-  float leaf_fine = soi_hash_15a407(floor(leaf_pos * 3.0 + vec2(v_branch_id * 7.0)));
-  float canopy_height = clamp((v_tex_coord.y - 0.52) / 0.58, 0.0, 1.0);
-  float canopy_edge = smoothstep(0.10, 0.30, length(v_local_pos_xz));
-  float canopy_core = 1.0 - smoothstep(0.16, 0.42, length(v_local_pos_xz));
-
-  vec3 leaf_dark_green = vec3(0.14, 0.21, 0.16);
-  vec3 leaf_mid_green = vec3(0.22, 0.29, 0.21);
-  vec3 leaf_light_green = vec3(0.33, 0.39, 0.31);
-  vec3 leaf_silver = vec3(0.48, 0.51, 0.48);
-
-  float color_choice = mix(leaf_mottle_a, leaf_fine, 0.25);
-  vec3 leaf_color = mix(leaf_dark_green, leaf_mid_green, color_choice);
-  leaf_color = mix(leaf_color, leaf_mid_green * 0.92, canopy_core * 0.18);
-
-  float backfacing = 1.0 - max(dot(n, l), 0.0);
-  float silver_show = smoothstep(0.35, 0.85, backfacing) * leaf_mottle_b;
+  float silver_show =
+      smoothstep(0.30, 0.80, 1.0 - diffuse) * smoothstep(0.35, 0.85, leaf_clump);
   leaf_color =
-      mix(leaf_color, leaf_silver, silver_show * mix(0.25, 0.42, canopy_height));
+      mix(leaf_color, leaf_silver, silver_show * mix(0.12, 0.24, canopy_height));
 
-  float highlight = smoothstep(0.64, 0.92, leaf_mottle_a * 0.65 + leaf_fine * 0.35);
-  leaf_color =
-      mix(leaf_color, leaf_light_green, highlight * mix(0.18, 0.34, canopy_height));
-  leaf_color = mix(leaf_color, leaf_light_green, canopy_edge * 0.10);
+  leaf_color = mix(leaf_color, v_color, 0.34);
 
-  leaf_color = mix(leaf_color, v_color, 0.38);
+  leaf_color *= mix(vec3(0.84, 0.95, 1.10), vec3(1.08, 1.03, 0.85), lit_t);
 
-  float canopy_depth = 1.0 - smoothstep(0.0, 0.35, length(v_local_pos_xz));
-  float canopy_occlusion =
-      mix(0.72, 1.05, canopy_edge) * mix(0.90, 1.07, canopy_height);
-  leaf_color *= mix(0.78, 1.0, canopy_depth) * canopy_occlusion;
+  float underside = 1.0 - smoothstep(-0.10, 0.42, geometric_normal.y);
+  float canopy_ao = mix(0.74, 1.06, canopy_edge) * mix(0.90, 1.08, canopy_height);
+  leaf_color *= canopy_ao;
+  leaf_color *= mix(1.0, 0.66, canopy_core * v_foliage_mask);
+  leaf_color *= mix(1.0, 0.78, underside * v_foliage_mask);
 
   float bark_u = v_tex_coord.x * TWO_PI;
   float bark_v = v_tex_coord.y;
@@ -124,30 +107,37 @@ void main() {
   float bark_texture =
       furrows * 0.46 + vertical_grain * 0.32 + bark_noise + bark_knots * 0.18;
 
-  vec3 bark_dark = vec3(0.13, 0.13, 0.12);
-  vec3 bark_mid = vec3(0.23, 0.22, 0.20);
-  vec3 bark_light = vec3(0.36, 0.34, 0.30);
-  vec3 bark_lichen = vec3(0.23, 0.26, 0.22);
+  vec3 bark_dark = vec3(0.25, 0.23, 0.20);
+  vec3 bark_mid = vec3(0.40, 0.37, 0.31);
+  vec3 bark_light = vec3(0.52, 0.49, 0.42);
+  vec3 bark_lichen = vec3(0.30, 0.33, 0.27);
 
   vec3 bark_color = mix(bark_dark, bark_mid, bark_texture);
   float bark_highlight =
-      smoothstep(0.75, 0.95, soi_hash_15a407(vec2(bark_v * 15.0, bark_u * 3.0)));
-  bark_color = mix(bark_color, bark_light, bark_highlight * 0.30);
-  bark_color = mix(bark_color, bark_lichen, smoothstep(0.72, 0.96, bark_knots) * 0.10);
+      smoothstep(0.72, 0.95, soi_hash_15a407(vec2(bark_v * 15.0, bark_u * 3.0)));
+  bark_color = mix(bark_color, bark_light, bark_highlight * 0.38);
+  bark_color = mix(bark_color, bark_lichen, smoothstep(0.72, 0.96, bark_knots) * 0.14);
   float basal_lichen = (1.0 - smoothstep(0.04, 0.30, v_local_pos.y)) *
                        smoothstep(0.50, 0.84, vertical_grain);
   bark_color = mix(bark_color, bark_lichen, basal_lichen * 0.42);
+  bark_color *= mix(0.72, 1.0, smoothstep(0.0, 0.14, v_local_pos.y));
 
   vec3 base_color = mix(bark_color, leaf_color, v_foliage_mask);
   vec3 color = base_color * lighting * light_tint * environment_exposure();
-  color += leaf_color * vec3(0.16, 0.20, 0.09) *
-           (backlight * backlight * 0.12 * v_foliage_mask);
+
+  float translucency =
+      backlight * backlight * v_foliage_mask * (0.14 + canopy_edge * 0.26);
+  color += leaf_color * vec3(0.42, 0.50, 0.22) * translucency;
+
+  float leaf_sheen = pow(max(dot(n, normalize(l + vec3(0.0, 0.9, 0.3))), 0.0), 12.0) *
+                     v_foliage_mask * 0.085;
+  color += mix(sky_color, vec3(1.0), 0.35) * leaf_sheen;
 
   if (v_tex_coord.y < 0.035)
     discard;
 
-  color += color * local_lighting(v_world_pos, normalize(v_normal));
-  color = apply_directional_shadow(color, v_world_pos, v_normal);
+  color += color * local_lighting(v_world_pos, n);
+  color = apply_directional_shadow(color, v_world_pos, geometric_normal);
   color = apply_visibility_memory(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/pine_instanced.frag
+++ b/assets/shaders/pine_instanced.frag
@@ -20,78 +20,122 @@ out vec4 frag_color;
 const float PI = 3.14159265359;
 const float TWO_PI = 6.28318530718;
 
+vec3 perturb_normal(vec3 n, vec3 world_pos, float height, float strength) {
+  vec3 dpdx = dFdx(world_pos);
+  vec3 dpdy = dFdy(world_pos);
+  vec3 r1 = cross(dpdy, n);
+  vec3 r2 = cross(n, dpdx);
+  float det = dot(dpdx, r1);
+  vec3 gradient = sign(det) * (dFdx(height) * r1 + dFdy(height) * r2);
+  return normalize(abs(det) * n - strength * gradient);
+}
+
 void main() {
 
-  vec3 n = normalize(v_normal);
+  vec3 geometric_normal = normalize(v_normal);
   vec3 l = environment_primary_direction();
-  float diffuse = max(dot(n, l), 0.0);
-  float wrap = clamp((dot(n, l) + 0.35) / 1.35, 0.0, 1.0);
-  float backlight = max(dot(-n, l), 0.0);
+
+  vec3 needle_seed_offset =
+      vec3(v_needle_seed * 41.0, v_needle_seed * 17.0, v_needle_seed * 63.0);
+
+  float footprint = max(fwidth(v_local_pos.x), fwidth(v_local_pos.z));
+  float fine_detail = 1.0 - smoothstep(0.010, 0.045, footprint);
+  float mid_detail = 1.0 - smoothstep(0.026, 0.090, footprint);
+
+  float needle_fine =
+      soi_noise3(v_local_pos * vec3(30.0, 13.0, 30.0) + needle_seed_offset);
+  float needle_clump = soi_noise3(v_local_pos * 11.0 + needle_seed_offset.zxy);
+  float needle_tuft = soi_noise3(v_local_pos * 4.6 + needle_seed_offset.yzx);
+  needle_fine = mix(0.5, needle_fine, fine_detail);
+  needle_clump = mix(0.5, needle_clump, mid_detail);
+
+  vec3 needle_deep = vec3(0.042, 0.105, 0.070);
+  vec3 needle_mid = vec3(0.115, 0.250, 0.125);
+  vec3 needle_light = vec3(0.235, 0.420, 0.175);
+  vec3 needle_sun = vec3(0.470, 0.605, 0.250);
+
+  float grain =
+      clamp(needle_clump * 0.80 + (needle_fine - 0.5) * 0.20 + 0.10, 0.0, 1.0);
+  vec3 needle_color = mix(needle_deep, needle_mid, grain);
+  needle_color =
+      mix(needle_color, needle_light, smoothstep(0.48, 0.92, needle_tuft) * 0.45);
+
+  needle_color = mix(needle_color, v_color, 0.42);
+
+  float bump_height = needle_clump + needle_tuft * 0.55;
+  vec3 n = mix(geometric_normal,
+               perturb_normal(geometric_normal, v_world_pos, bump_height, 0.20),
+               v_foliage_mask * mid_detail);
+
+  float ndl = dot(n, l);
+  float diffuse = max(ndl, 0.0);
+  float wrap = clamp((ndl + 0.26) / 1.26, 0.0, 1.0);
+  wrap *= wrap * (3.0 - 2.0 * wrap);
+  float backlight = max(-ndl, 0.0);
   float ambient = environment_ambient_intensity();
-  float sky_fill = smoothstep(-0.2, 0.8, n.y) * mix(0.09, 0.11, v_foliage_mask);
-  float lighting = ambient + wrap * mix(0.36, 0.44, v_foliage_mask) + sky_fill;
+  float sky_fill = smoothstep(-0.25, 0.85, n.y) * mix(0.08, 0.16, v_foliage_mask);
+  float lighting = ambient + wrap * mix(0.42, 0.70, v_foliage_mask) + sky_fill;
 
   vec3 sun_color = environment_primary_color() * environment_primary_intensity();
   vec3 sky_color = environment_sky_color();
   float lit_t = clamp(wrap * 1.15, 0.0, 1.0);
   vec3 light_tint = mix(sky_color * 0.55, sun_color, lit_t);
 
-  float needle_noise =
-      soi_hash_15a407(vec2(v_tex_coord.x * 28.0 + v_needle_seed * 7.1,
-                           v_tex_coord.y * 24.0 + v_needle_seed * 5.3));
+  float underside = 1.0 - smoothstep(0.02, 0.44, geometric_normal.y);
+  float radius = length(v_local_pos.xz);
+  float canopy_core = 1.0 - smoothstep(0.06, 0.42, radius);
+  float shelf_ao = underside * (0.40 + canopy_core * 0.55);
+  needle_color *= mix(1.0, 0.38, clamp(shelf_ao, 0.0, 1.0) * v_foliage_mask);
 
-  float needle_streak =
-      soi_hash_15a407(vec2(v_tex_coord.x * 12.0 + v_needle_seed * 3.7,
-                           floor(v_tex_coord.y * 6.0 + v_needle_seed * 2.0)));
+  float bough_edge = smoothstep(0.30, 0.95, v_bough) * (1.0 - underside);
+  needle_color *= mix(1.0, 1.14, bough_edge * v_foliage_mask);
+  needle_color *= mix(1.0, 0.72, canopy_core * v_foliage_mask * 0.85);
 
-  vec3 needle_deep = vec3(0.11, 0.20, 0.14);
-  vec3 needle_mid = vec3(0.18, 0.30, 0.20);
-  vec3 needle_light = vec3(0.31, 0.42, 0.28);
-  vec3 needle_color = mix(needle_deep, needle_mid, needle_noise);
-  needle_color = mix(needle_color, needle_light, needle_streak * 0.45);
+  float canopy_height = clamp(v_tex_coord.y, 0.0, 1.12);
+  needle_color *= mix(0.80, 1.14, smoothstep(0.34, 1.06, canopy_height));
 
-  needle_color = mix(needle_color, v_color, 0.62);
+  float tip_lit = smoothstep(0.20, 0.80, diffuse) * bough_edge;
+  needle_color = mix(needle_color, needle_sun, tip_lit * 0.26 * needle_clump);
 
-  float bough_ramp = mix(0.74, 1.26, smoothstep(0.05, 0.85, v_bough));
-  float tier = fract(v_tex_coord.y * 4.65 + v_needle_seed * 0.17);
-  float tier_shadow = 1.0 - smoothstep(0.08, 0.34, tier);
-  float canopy_core = 1.0 - smoothstep(0.08, 0.46, length(v_local_pos.xz));
-  needle_color *= mix(1.0, bough_ramp, v_foliage_mask);
-  needle_color *= mix(1.0, 0.80, tier_shadow * (0.25 + canopy_core * 0.55));
+  needle_color *= mix(vec3(0.86, 0.96, 1.10), vec3(1.07, 1.02, 0.86), lit_t);
+
   float old_needles = (1.0 - smoothstep(0.42, 0.70, v_tex_coord.y)) *
-                      smoothstep(0.68, 0.94, needle_noise);
-  needle_color = mix(needle_color, vec3(0.29, 0.23, 0.13), old_needles * 0.34);
-
-  float tip_blend = smoothstep(0.82, 1.02, v_tex_coord.y);
-  needle_color = mix(needle_color, needle_color * vec3(1.10, 1.05, 1.08), tip_blend);
+                      smoothstep(0.72, 0.96, needle_fine);
+  needle_color = mix(needle_color, vec3(0.30, 0.235, 0.125), old_needles * 0.30);
 
   float bark_stripe = sin(v_tex_coord.y * 45.0 + v_bark_seed * TWO_PI) * 0.1 + 0.9;
   float bark_noise = soi_hash_15a407(vec2(v_tex_coord.x * 18.0 + v_bark_seed * 4.3,
                                           v_tex_coord.y * 10.0 + v_bark_seed * 7.7));
 
-  vec3 bark_grey = vec3(0.30, 0.27, 0.24);
-  vec3 bark_red = vec3(0.42, 0.28, 0.19);
+  vec3 bark_grey = vec3(0.36, 0.32, 0.28);
+  vec3 bark_red = vec3(0.48, 0.32, 0.21);
   vec3 trunk_base = mix(bark_grey, bark_red, v_bark_seed) * bark_stripe;
-  vec3 trunk_color = trunk_base * (0.85 + bark_noise * 0.35);
+  vec3 trunk_color = trunk_base * (0.82 + bark_noise * 0.40);
   float trunk_moss = (1.0 - smoothstep(0.02, 0.24, v_local_pos.y)) *
                      smoothstep(0.55, 0.86, bark_noise);
-  trunk_color = mix(trunk_color, vec3(0.18, 0.23, 0.16), trunk_moss * 0.48);
+  trunk_color = mix(trunk_color, vec3(0.20, 0.25, 0.17), trunk_moss * 0.48);
+
+  trunk_color *= mix(0.68, 1.0, smoothstep(0.0, 0.16, v_local_pos.y));
+  trunk_color *= mix(1.0, 0.62, smoothstep(0.30, 0.58, v_local_pos.y));
 
   vec3 base_color = mix(trunk_color, needle_color, v_foliage_mask);
   vec3 color = base_color * lighting * light_tint * environment_exposure();
-  float translucency =
-      backlight * backlight * (0.12 + tip_blend * 0.16) * v_foliage_mask;
-  color += needle_color * vec3(0.15, 0.19, 0.10) * translucency;
+
+  float translucency = backlight * backlight *
+                       (0.20 + smoothstep(0.82, 1.02, v_tex_coord.y) * 0.22) *
+                       v_foliage_mask * (0.35 + bough_edge * 0.85);
+  color += needle_color * vec3(0.34, 0.46, 0.20) * translucency;
+
   float needle_sheen =
-      pow(max(dot(n, normalize(l + vec3(0.0, 0.8, 0.35))), 0.0), 18.0) *
-      v_foliage_mask * 0.045;
-  color += sky_color * needle_sheen;
+      pow(max(dot(n, normalize(l + vec3(0.0, 0.8, 0.35))), 0.0), 14.0) *
+      v_foliage_mask * 0.055;
+  color += mix(sky_color, sun_color, 0.5) * needle_sheen;
 
   if (v_tex_coord.y < 0.028)
     discard;
 
-  color += color * local_lighting(v_world_pos, normalize(v_normal));
-  color = apply_directional_shadow(color, v_world_pos, v_normal);
+  color += color * local_lighting(v_world_pos, n);
+  color = apply_directional_shadow(color, v_world_pos, geometric_normal);
   color = apply_visibility_memory(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -1408,6 +1408,10 @@ public:
 
   bool active{true};
   int wave_phase{0};
+
+  bool has_march_target{false};
+  float march_target_x{0.0F};
+  float march_target_z{0.0F};
 };
 
 class HoldModeComponent : public Component {

--- a/game/core/serialization.cpp
+++ b/game/core/serialization.cpp
@@ -409,6 +409,9 @@ auto Serialization::serialize_entity(const Entity* entity) -> QJsonObject {
     QJsonObject assault_obj;
     assault_obj["active"] = assault_wave->active;
     assault_obj["wave_phase"] = assault_wave->wave_phase;
+    assault_obj["has_march_target"] = assault_wave->has_march_target;
+    assault_obj["march_target_x"] = static_cast<double>(assault_wave->march_target_x);
+    assault_obj["march_target_z"] = static_cast<double>(assault_wave->march_target_z);
     entity_obj["assault_wave"] = assault_obj;
   }
 
@@ -1217,6 +1220,11 @@ void Serialization::deserialize_entity(Entity* entity, const QJsonObject& json) 
     auto* assault_wave = entity->add_component<AssaultWaveComponent>();
     assault_wave->active = assault_obj["active"].toBool(true);
     assault_wave->wave_phase = assault_obj["wave_phase"].toInt(0);
+    assault_wave->has_march_target = assault_obj["has_march_target"].toBool(false);
+    assault_wave->march_target_x =
+        static_cast<float>(assault_obj["march_target_x"].toDouble(0.0));
+    assault_wave->march_target_z =
+        static_cast<float>(assault_obj["march_target_z"].toDouble(0.0));
   }
 
   if (json.contains("hold_mode")) {

--- a/game/systems/ai_system/ai_snapshot_builder.cpp
+++ b/game/systems/ai_system/ai_snapshot_builder.cpp
@@ -146,6 +146,11 @@ auto AISnapshotBuilder::build(const Engine::Core::World& world,
     data.is_building = entity->has_component<Engine::Core::BuildingComponent>();
     data.is_commander = entity->has_component<Engine::Core::CommanderComponent>();
     data.is_assault = is_assault;
+    if (is_assault) {
+      data.has_march_target = assault_wave->has_march_target;
+      data.march_target_x = assault_wave->march_target_x;
+      data.march_target_z = assault_wave->march_target_z;
+    }
 
     if (auto* transform = entity->get_component<Engine::Core::TransformComponent>()) {
       data.pos_x = transform->position.x;

--- a/game/systems/ai_system/ai_types.h
+++ b/game/systems/ai_system/ai_types.h
@@ -119,6 +119,10 @@ struct EntitySnapshot {
   float pos_y = 0.0F;
   float pos_z = 0.0F;
 
+  bool has_march_target = false;
+  float march_target_x = 0.0F;
+  float march_target_z = 0.0F;
+
   MovementSnapshot movement;
   ProductionSnapshot production;
   BuilderProductionSnapshot builder_production;

--- a/game/systems/ai_system/behaviors/assault_behavior.cpp
+++ b/game/systems/ai_system/behaviors/assault_behavior.cpp
@@ -18,9 +18,96 @@ constexpr float k_assault_update_interval = 1.0F;
 constexpr float k_engage_radius = 14.0F;
 constexpr float k_formation_spread = 2.4F;
 
+constexpr float k_wall_half_extent = 2.5F;
+constexpr float k_gate_half_extent = 5.0F;
+constexpr float k_barrier_search_radius = 120.0F;
+
+constexpr float k_breach_stand_off = 2.0F;
+constexpr float k_breach_spread = 1.6F;
+constexpr float k_breach_engage_radius = 4.0F;
+
+auto is_barrier(const ContactSnapshot& contact) -> bool {
+  return contact.spawn_type == Game::Units::SpawnType::WallSegment ||
+         contact.spawn_type == Game::Units::SpawnType::WallGate;
+}
+
+auto barrier_half_extent(const ContactSnapshot& contact) -> float {
+  return contact.spawn_type == Game::Units::SpawnType::WallGate ? k_gate_half_extent
+                                                                : k_wall_half_extent;
+}
+
+auto distance_to_segment(float point_x,
+                         float point_z,
+                         float from_x,
+                         float from_z,
+                         float to_x,
+                         float to_z) -> float {
+  const float span_x = to_x - from_x;
+  const float span_z = to_z - from_z;
+  const float span_length_sq = (span_x * span_x) + (span_z * span_z);
+  float travel = 0.0F;
+  if (span_length_sq > 1.0e-4F) {
+    travel = (((point_x - from_x) * span_x) + ((point_z - from_z) * span_z)) /
+             span_length_sq;
+    travel = std::clamp(travel, 0.0F, 1.0F);
+  }
+  const float nearest_x = from_x + (span_x * travel);
+  const float nearest_z = from_z + (span_z * travel);
+  return std::sqrt(
+      distance_squared(point_x, 0.0F, point_z, nearest_x, 0.0F, nearest_z));
+}
+
+auto select_breach_target(const AISnapshot& snapshot,
+                          float reference_x,
+                          float reference_z,
+                          float objective_x,
+                          float objective_z) -> const ContactSnapshot* {
+  const ContactSnapshot* best = nullptr;
+  float best_distance_sq = std::numeric_limits<float>::infinity();
+
+  auto consider = [&](const ContactSnapshot& candidate) {
+    if (!is_barrier(candidate) || candidate.health <= 0) {
+      return;
+    }
+    const float distance_sq = distance_squared(
+        candidate.pos_x, 0.0F, candidate.pos_z, reference_x, 0.0F, reference_z);
+    if (distance_sq > k_barrier_search_radius * k_barrier_search_radius) {
+      return;
+    }
+    if (distance_to_segment(candidate.pos_x,
+                            candidate.pos_z,
+                            reference_x,
+                            reference_z,
+                            objective_x,
+                            objective_z) > barrier_half_extent(candidate)) {
+      return;
+    }
+
+    const bool candidate_is_gate =
+        candidate.spawn_type == Game::Units::SpawnType::WallGate;
+    const bool best_is_gate =
+        best != nullptr && best->spawn_type == Game::Units::SpawnType::WallGate;
+    if (best == nullptr || (candidate_is_gate && !best_is_gate) ||
+        (candidate_is_gate == best_is_gate && distance_sq < best_distance_sq)) {
+      best = &candidate;
+      best_distance_sq = distance_sq;
+    }
+  };
+
+  for (const auto& candidate : snapshot.visible_enemies) {
+    consider(candidate);
+  }
+  for (const auto& candidate : snapshot.strategic_objectives) {
+    consider(candidate);
+  }
+
+  return best;
+}
+
 auto select_assault_target(const AISnapshot& snapshot,
                            float reference_x,
-                           float reference_z) -> const ContactSnapshot* {
+                           float reference_z,
+                           bool skip_barriers) -> const ContactSnapshot* {
   const ContactSnapshot* best = nullptr;
   float best_score = std::numeric_limits<float>::infinity();
 
@@ -28,6 +115,9 @@ auto select_assault_target(const AISnapshot& snapshot,
 
   for (const auto& candidate : snapshot.visible_enemies) {
     if (troops_in_sight && candidate.is_building) {
+      continue;
+    }
+    if (skip_barriers && is_barrier(candidate)) {
       continue;
     }
     const float score = distance_squared(
@@ -43,6 +133,9 @@ auto select_assault_target(const AISnapshot& snapshot,
   }
 
   for (const auto& objective : snapshot.strategic_objectives) {
+    if (skip_barriers && is_barrier(objective)) {
+      continue;
+    }
     const float score = distance_squared(
         objective.pos_x, 0.0F, objective.pos_z, reference_x, 0.0F, reference_z);
     if (score < best_score) {
@@ -88,9 +181,37 @@ void AssaultBehavior::execute(const AISnapshot& snapshot,
   center_x *= scale;
   center_z *= scale;
 
-  const auto* target = select_assault_target(snapshot, center_x, center_z);
-  if (target == nullptr) {
-    return;
+  const auto* objective = select_assault_target(snapshot, center_x, center_z, true);
+
+  float objective_x = 0.0F;
+  float objective_z = 0.0F;
+  if (objective != nullptr) {
+    objective_x = objective->pos_x;
+    objective_z = objective->pos_z;
+  } else {
+
+    const auto marching =
+        std::find_if(assault_units.begin(),
+                     assault_units.end(),
+                     [](const EntitySnapshot* unit) { return unit->has_march_target; });
+    if (marching != assault_units.end()) {
+      objective_x = (*marching)->march_target_x;
+      objective_z = (*marching)->march_target_z;
+    } else {
+      objective = select_assault_target(snapshot, center_x, center_z, false);
+      if (objective == nullptr) {
+        return;
+      }
+      objective_x = objective->pos_x;
+      objective_z = objective->pos_z;
+    }
+  }
+
+  const ContactSnapshot* target = objective;
+  const auto* breach =
+      select_breach_target(snapshot, center_x, center_z, objective_x, objective_z);
+  if (breach != nullptr) {
+    target = breach;
   }
 
   std::vector<Engine::Core::EntityID> engage_ids;
@@ -99,24 +220,57 @@ void AssaultBehavior::execute(const AISnapshot& snapshot,
   std::vector<float> advance_y;
   std::vector<float> advance_z;
 
-  const float engage_radius_sq = k_engage_radius * k_engage_radius;
+  const bool breaching = breach != nullptr;
+  const float attack_point_x = target != nullptr ? target->pos_x : objective_x;
+  const float attack_point_z = target != nullptr ? target->pos_z : objective_z;
+  float approach_x = attack_point_x;
+  float approach_z = attack_point_z;
+  float lateral_x = 0.0F;
+  float lateral_z = 0.0F;
+  if (breaching) {
+    float outward_x = center_x - objective_x;
+    float outward_z = center_z - objective_z;
+    const float span = std::sqrt((outward_x * outward_x) + (outward_z * outward_z));
+    if (span > 1.0e-3F) {
+      outward_x /= span;
+      outward_z /= span;
+    } else {
+      outward_x = 1.0F;
+      outward_z = 0.0F;
+    }
+    approach_x = attack_point_x + (outward_x * k_breach_stand_off);
+    approach_z = attack_point_z + (outward_z * k_breach_stand_off);
+    lateral_x = -outward_z;
+    lateral_z = outward_x;
+  }
+
+  const float engage_radius = breaching ? k_breach_engage_radius : k_engage_radius;
+  const float engage_radius_sq = engage_radius * engage_radius;
 
   for (std::size_t index = 0; index < assault_units.size(); ++index) {
     const auto* unit = assault_units[index];
     const float distance_to_target_sq = distance_squared(
-        unit->pos_x, 0.0F, unit->pos_z, target->pos_x, 0.0F, target->pos_z);
+        unit->pos_x, 0.0F, unit->pos_z, attack_point_x, 0.0F, attack_point_z);
 
-    if (distance_to_target_sq <= engage_radius_sq) {
+    if (target != nullptr && distance_to_target_sq <= engage_radius_sq) {
       engage_ids.push_back(unit->id);
+      continue;
+    }
+
+    advance_ids.push_back(unit->id);
+    if (breaching) {
+      const float offset = (static_cast<float>(index % 4) - 1.5F) * k_breach_spread;
+      advance_x.push_back(approach_x + (lateral_x * offset));
+      advance_y.push_back(0.0F);
+      advance_z.push_back(approach_z + (lateral_z * offset));
       continue;
     }
 
     const float angle = static_cast<float>(index) * 0.9F;
     const float ring = k_formation_spread * static_cast<float>(1 + (index % 3));
-    advance_ids.push_back(unit->id);
-    advance_x.push_back(target->pos_x + std::cos(angle) * ring);
+    advance_x.push_back(attack_point_x + std::cos(angle) * ring);
     advance_y.push_back(0.0F);
-    advance_z.push_back(target->pos_z + std::sin(angle) * ring);
+    advance_z.push_back(attack_point_z + std::sin(angle) * ring);
   }
 
   if (!engage_ids.empty()) {
@@ -127,7 +281,8 @@ void AssaultBehavior::execute(const AISnapshot& snapshot,
       attack.type = AICommandType::AttackTarget;
       attack.units = std::move(claimed);
       attack.target_id = target->id;
-      attack.should_chase = !target->is_building;
+
+      attack.should_chase = true;
       out_commands.push_back(std::move(attack));
     }
   }
@@ -169,7 +324,15 @@ auto AssaultBehavior::should_execute(const AISnapshot& snapshot,
   if (context.assault_unit_count <= 0) {
     return false;
   }
-  return !snapshot.visible_enemies.empty() || !snapshot.strategic_objectives.empty();
+  if (!snapshot.visible_enemies.empty() || !snapshot.strategic_objectives.empty()) {
+    return true;
+  }
+
+  return std::any_of(snapshot.friendly_units.begin(),
+                     snapshot.friendly_units.end(),
+                     [](const EntitySnapshot& entity) {
+                       return entity.is_assault && entity.has_march_target;
+                     });
 }
 
 } // namespace Game::Systems::AI

--- a/game/systems/command_service.cpp
+++ b/game/systems/command_service.cpp
@@ -401,14 +401,11 @@ void CommandService::attack_target(Engine::Core::World& world,
           locked_unit != nullptr && locked_unit->health > 0 &&
           !locked_target->has_component<Engine::Core::PendingRemovalComponent>();
 
-      auto* new_target = world.get_entity(target_id);
-      bool const leaves_structure_for_troop =
+      bool const leaves_structure =
           locked_target != nullptr &&
-          locked_target->has_component<Engine::Core::BuildingComponent>() &&
-          new_target != nullptr &&
-          !new_target->has_component<Engine::Core::BuildingComponent>();
+          locked_target->has_component<Engine::Core::BuildingComponent>();
 
-      if (locked_opponent_alive && !leaves_structure_for_troop) {
+      if (locked_opponent_alive && !leaves_structure) {
         continue;
       }
       CombatRules::clear_rts_melee_lock(e);

--- a/game/systems/movement_orders.cpp
+++ b/game/systems/movement_orders.cpp
@@ -151,10 +151,14 @@ auto prepare_move(Engine::Core::World& world,
         locked_target != nullptr
             ? locked_target->get_component<Engine::Core::UnitComponent>()
             : nullptr;
+
+    bool const locked_to_structure =
+        locked_target != nullptr &&
+        locked_target->has_component<Engine::Core::BuildingComponent>();
     bool const opponent_alive =
         locked_unit != nullptr && locked_unit->health > 0 &&
         !locked_target->has_component<Engine::Core::PendingRemovalComponent>();
-    if (opponent_alive) {
+    if (opponent_alive && !locked_to_structure) {
       return {};
     }
     CombatRules::clear_rts_melee_lock(entity);

--- a/render/geom/icon_glyph.cpp
+++ b/render/geom/icon_glyph.cpp
@@ -112,13 +112,16 @@ void GlyphBuilder::end_glyph(const GlyphExtrusion& extrusion) {
   GlyphLayer const saved_layer = m_layer;
   auto const edges = collect_boundary_edges();
 
-  emit_skirt(edges,
-             GlyphLayer::Glow,
-             extrusion.glow_depth,
-             extrusion.outline_width,
-             extrusion.outline_width + extrusion.glow_width,
-             0.0F,
-             1.0F);
+  emit_silhouette(GlyphLayer::Shadow,
+                  extrusion.shadow_depth,
+                  extrusion.halo_grow,
+                  extrusion.shadow_offset,
+                  1.0F);
+  emit_silhouette(GlyphLayer::Shadow,
+                  extrusion.shadow_depth,
+                  extrusion.shadow_grow,
+                  extrusion.shadow_offset,
+                  0.0F);
 
   emit_skirt(edges,
              GlyphLayer::Outline,
@@ -211,6 +214,39 @@ void GlyphBuilder::emit_glyph_walls(const std::vector<BoundaryEdge>& edges,
     QVector3D const p3(edge.from.x(), edge.from.y(), face_depth);
     emit_positioned(p0, p1, p2, normal, normal, normal);
     emit_positioned(p0, p2, p3, normal, normal, normal);
+  }
+}
+
+void GlyphBuilder::emit_silhouette(
+    GlyphLayer layer, float depth, float grow, QVector2D offset, float shade) {
+  if (m_recorded.empty() || grow <= 0.0F) {
+    return;
+  }
+
+  QVector2D low(m_recorded.front().a);
+  QVector2D high(m_recorded.front().a);
+  auto extend = [&](QVector2D point) {
+    low.setX(std::min(low.x(), point.x()));
+    low.setY(std::min(low.y(), point.y()));
+    high.setX(std::max(high.x(), point.x()));
+    high.setY(std::max(high.y(), point.y()));
+  };
+  for (PendingTri const& tri : m_recorded) {
+    extend(tri.a);
+    extend(tri.b);
+    extend(tri.c);
+  }
+  QVector2D const center = (low + high) * 0.5F;
+
+  float const scale = 1.0F + grow;
+  auto place = [&](QVector2D point) {
+    return center + (point - center) * scale + offset;
+  };
+
+  for (PendingTri const& tri : m_recorded) {
+    for (QVector2D const point : {place(tri.a), place(tri.b), place(tri.c)}) {
+      push_skirt_vertex(layer, point, depth, shade);
+    }
   }
 }
 
@@ -384,73 +420,6 @@ void GlyphBuilder::arrow_head(QVector2D tip,
   tri(tip, back - side, back + side);
 }
 
-void GlyphBuilder::gradient_ring(GlyphLayer layer,
-                                 float inner_radius,
-                                 float outer_radius,
-                                 float depth,
-                                 float inner_falloff,
-                                 float outer_falloff,
-                                 int segments) {
-  int const count = std::max(segments, 3);
-  for (int i = 0; i < count; ++i) {
-    float const a0 =
-        (static_cast<float>(i) / static_cast<float>(count)) * k_glyph_two_pi;
-    float const a1 =
-        (static_cast<float>(i + 1) / static_cast<float>(count)) * k_glyph_two_pi;
-    QVector2D const d0(std::cos(a0), std::sin(a0));
-    QVector2D const d1(std::cos(a1), std::sin(a1));
-
-    push_skirt_vertex(layer, d0 * inner_radius, depth, inner_falloff);
-    push_skirt_vertex(layer, d0 * outer_radius, depth, outer_falloff);
-    push_skirt_vertex(layer, d1 * outer_radius, depth, outer_falloff);
-
-    push_skirt_vertex(layer, d0 * inner_radius, depth, inner_falloff);
-    push_skirt_vertex(layer, d1 * outer_radius, depth, outer_falloff);
-    push_skirt_vertex(layer, d1 * inner_radius, depth, inner_falloff);
-  }
-}
-
-void GlyphBuilder::revolved_band(float inner_radius,
-                                 float inner_depth,
-                                 float outer_radius,
-                                 float outer_depth,
-                                 int segments) {
-  int const count = std::max(segments, 3);
-
-  float const profile_dr = outer_radius - inner_radius;
-  float const profile_dz = outer_depth - inner_depth;
-  float const profile_length =
-      std::sqrt(profile_dr * profile_dr + profile_dz * profile_dz);
-  float const radial_component =
-      profile_length > 1.0e-6F ? -profile_dz / profile_length : 0.0F;
-  float const axial_component =
-      profile_length > 1.0e-6F ? profile_dr / profile_length : 1.0F;
-
-  for (int i = 0; i < count; ++i) {
-    float const a0 =
-        (static_cast<float>(i) / static_cast<float>(count)) * k_glyph_two_pi;
-    float const a1 =
-        (static_cast<float>(i + 1) / static_cast<float>(count)) * k_glyph_two_pi;
-    QVector2D const d0(std::cos(a0), std::sin(a0));
-    QVector2D const d1(std::cos(a1), std::sin(a1));
-
-    QVector3D const n0 =
-        QVector3D(d0.x() * radial_component, d0.y() * radial_component, axial_component)
-            .normalized();
-    QVector3D const n1 =
-        QVector3D(d1.x() * radial_component, d1.y() * radial_component, axial_component)
-            .normalized();
-
-    QVector3D const i0(d0.x() * inner_radius, d0.y() * inner_radius, inner_depth);
-    QVector3D const i1(d1.x() * inner_radius, d1.y() * inner_radius, inner_depth);
-    QVector3D const o0(d0.x() * outer_radius, d0.y() * outer_radius, outer_depth);
-    QVector3D const o1(d1.x() * outer_radius, d1.y() * outer_radius, outer_depth);
-
-    emit_positioned(i0, o0, o1, n0, n0, n1);
-    emit_positioned(i0, o1, i1, n0, n1, n1);
-  }
-}
-
 void GlyphBuilder::fit_since(std::size_t mark, float target_radius) {
   if (mark >= m_vertices.size() || target_radius <= 0.0F) {
     return;
@@ -472,7 +441,32 @@ void GlyphBuilder::fit_since(std::size_t mark, float target_radius) {
     Render::GL::Vertex& vertex = m_vertices[i];
     vertex.position[0] *= factor;
     vertex.position[1] *= factor;
-    vertex.tex_coord[1] *= factor;
+  }
+}
+
+void GlyphBuilder::center_since(std::size_t mark) {
+  if (mark >= m_vertices.size()) {
+    return;
+  }
+
+  float min_x = m_vertices[mark].position[0];
+  float max_x = min_x;
+  float min_y = m_vertices[mark].position[1];
+  float max_y = min_y;
+  for (std::size_t i = mark; i < m_vertices.size(); ++i) {
+    const Render::GL::Vertex& vertex = m_vertices[i];
+    min_x = std::min(min_x, vertex.position[0]);
+    max_x = std::max(max_x, vertex.position[0]);
+    min_y = std::min(min_y, vertex.position[1]);
+    max_y = std::max(max_y, vertex.position[1]);
+  }
+
+  float const shift_x = (min_x + max_x) * 0.5F;
+  float const shift_y = (min_y + max_y) * 0.5F;
+  for (std::size_t i = mark; i < m_vertices.size(); ++i) {
+    Render::GL::Vertex& vertex = m_vertices[i];
+    vertex.position[0] -= shift_x;
+    vertex.position[1] -= shift_y;
   }
 }
 
@@ -491,7 +485,6 @@ void GlyphBuilder::normalize_extent(float target_half_extent) {
     vertex.position[0] *= factor;
     vertex.position[1] *= factor;
     vertex.position[2] *= factor;
-    vertex.tex_coord[1] *= factor;
   }
 }
 

--- a/render/geom/icon_glyph.h
+++ b/render/geom/icon_glyph.h
@@ -17,16 +17,13 @@ inline constexpr float k_glyph_two_pi = 2.0F * std::numbers::pi_v<float>;
 
 enum class GlyphLayer : std::uint8_t {
   Shadow = 0,
-  Plaque = 1,
-  Rim = 2,
-  Outline = 3,
-  Glyph = 4,
-  Accent = 5,
-  GlyphSide = 6,
-  Glow = 7,
+  Outline = 1,
+  Glyph = 2,
+  Accent = 3,
+  GlyphSide = 4,
 };
 
-inline constexpr std::uint8_t k_glyph_layer_count = 8;
+inline constexpr std::uint8_t k_glyph_layer_count = 5;
 
 enum class GlyphNormal : std::uint8_t {
   Front,
@@ -44,15 +41,19 @@ public:
 
   [[nodiscard]] auto vertex_mark() const -> std::size_t { return m_vertices.size(); }
   void fit_since(std::size_t mark, float target_radius);
+  void center_since(std::size_t mark);
 
   void begin_glyph();
   struct GlyphExtrusion {
-    float glow_depth = 0.0F;
-    float glow_width = 0.0F;
     float outline_depth = 0.0F;
     float outline_width = 0.0F;
     float back_depth = 0.0F;
     float face_depth = 0.0F;
+
+    float shadow_depth = 0.0F;
+    float shadow_grow = 0.0F;
+    float halo_grow = 0.0F;
+    QVector2D shadow_offset{};
   };
 
   void end_glyph(const GlyphExtrusion& extrusion);
@@ -71,20 +72,6 @@ public:
             float start_angle = 0.0F,
             float sweep = k_glyph_two_pi);
   void arrow_head(QVector2D tip, QVector2D direction, float length, float half_width);
-
-  void gradient_ring(GlyphLayer layer,
-                     float inner_radius,
-                     float outer_radius,
-                     float depth,
-                     float inner_falloff,
-                     float outer_falloff,
-                     int segments = 40);
-
-  void revolved_band(float inner_radius,
-                     float inner_depth,
-                     float outer_radius,
-                     float outer_depth,
-                     int segments);
 
   [[nodiscard]] auto vertices() const -> const std::vector<Render::GL::Vertex>& {
     return m_vertices;
@@ -119,6 +106,8 @@ private:
   };
 
   [[nodiscard]] auto collect_boundary_edges() const -> std::vector<BoundaryEdge>;
+  void emit_silhouette(
+      GlyphLayer layer, float depth, float grow, QVector2D offset, float shade);
   void emit_glyph_walls(const std::vector<BoundaryEdge>& edges,
                         float back_depth,
                         float face_depth);

--- a/render/geom/mode_indicator.cpp
+++ b/render/geom/mode_indicator.cpp
@@ -11,35 +11,19 @@ namespace {
 
 constexpr float k_pi = std::numbers::pi_v<float>;
 
-constexpr float k_badge_outer_radius = 0.500F;
-constexpr float k_badge_halo_inner_radius = 0.330F;
-constexpr float k_badge_shadow_core_radius = 0.300F;
-constexpr float k_badge_shadow_edge_radius = 0.470F;
-constexpr float k_badge_contour_inner_radius = 0.360F;
-constexpr float k_badge_contour_outer_radius = 0.404F;
-constexpr float k_badge_rim_inner_radius = 0.300F;
-constexpr float k_badge_rim_outer_radius = 0.382F;
-constexpr float k_badge_face_radius = 0.318F;
-constexpr int k_badge_segments = 44;
-
-constexpr float k_badge_shadow_depth = -0.130F;
-constexpr float k_badge_halo_depth = -0.100F;
-constexpr float k_badge_contour_depth = -0.030F;
-constexpr float k_badge_face_depth = 0.000F;
-constexpr float k_badge_rim_crest_depth = 0.040F;
-constexpr float k_badge_rim_lip_depth = -0.008F;
-
-constexpr float k_glyph_fit_radius = 0.262F;
-constexpr float k_glyph_face_depth = 0.088F;
-constexpr float k_glyph_detail_depth = 0.100F;
+constexpr float k_glyph_fit_radius = 0.360F;
+constexpr float k_glyph_face_depth = 0.105F;
+constexpr float k_glyph_detail_depth = 0.118F;
 
 constexpr GlyphBuilder::GlyphExtrusion k_glyph_extrusion{
-    .glow_depth = 0.0F,
-    .glow_width = 0.0F,
-    .outline_depth = 0.052F,
-    .outline_width = 0.046F,
-    .back_depth = 0.056F,
+    .outline_depth = 0.030F,
+    .outline_width = 0.036F,
+    .back_depth = 0.030F,
     .face_depth = k_glyph_face_depth,
+    .shadow_depth = -0.070F,
+    .shadow_grow = 0.052F,
+    .halo_grow = 0.118F,
+    .shadow_offset = {0.004F, -0.009F},
 };
 
 struct KindStyle {
@@ -75,51 +59,6 @@ constexpr std::array<KindStyle, k_indicator_kind_count> k_kind_styles = {{
   return k_kind_styles.front();
 }
 
-void add_medallion(GlyphBuilder& builder) {
-  builder.set_normal_style(GlyphNormal::Front);
-  builder.reset_transform();
-
-  builder.set_layer(GlyphLayer::Shadow);
-  builder.set_depth(k_badge_shadow_depth);
-  builder.disc({0.0F, 0.0F}, k_badge_shadow_core_radius, k_badge_segments);
-  builder.gradient_ring(GlyphLayer::Shadow,
-                        k_badge_shadow_core_radius,
-                        k_badge_shadow_edge_radius,
-                        k_badge_shadow_depth,
-                        k_badge_shadow_core_radius / 0.5F,
-                        1.30F,
-                        k_badge_segments);
-
-  builder.gradient_ring(GlyphLayer::Glow,
-                        k_badge_halo_inner_radius,
-                        k_badge_outer_radius,
-                        k_badge_halo_depth,
-                        0.0F,
-                        1.0F,
-                        k_badge_segments);
-
-  builder.set_layer(GlyphLayer::Outline);
-  builder.set_depth(k_badge_contour_depth);
-  builder.ring({0.0F, 0.0F},
-               k_badge_contour_inner_radius,
-               k_badge_contour_outer_radius,
-               k_badge_segments);
-
-  builder.set_layer(GlyphLayer::Plaque);
-  builder.set_depth(k_badge_face_depth);
-  builder.disc({0.0F, 0.0F}, k_badge_face_radius, k_badge_segments);
-
-  builder.set_layer(GlyphLayer::Rim);
-  builder.revolved_band(k_badge_rim_inner_radius,
-                        k_badge_rim_crest_depth,
-                        k_badge_rim_outer_radius,
-                        k_badge_rim_lip_depth,
-                        k_badge_segments);
-
-  builder.set_layer(GlyphLayer::Glyph);
-  builder.set_depth(k_glyph_face_depth);
-}
-
 void add_sword(GlyphBuilder& builder, float rotation) {
   builder.set_transform({0.0F, -0.02F}, rotation);
   builder.bar({0.0F, -0.02F}, {0.0F, 0.26F}, 0.135F);
@@ -150,9 +89,9 @@ void build_guard(GlyphBuilder& builder) {
   builder.convex(shield);
   builder.end_glyph(k_glyph_extrusion);
 
-  builder.set_layer(GlyphLayer::Outline);
+  builder.set_layer(GlyphLayer::Accent);
   builder.set_depth(k_glyph_detail_depth);
-  builder.ring({0.0F, 0.0F}, 0.070F, 0.130F, 16);
+  builder.disc({0.0F, 0.0F}, 0.105F, 18);
 }
 
 void build_hold(GlyphBuilder& builder) {
@@ -228,11 +167,6 @@ void build_dismantle(GlyphBuilder& builder) {
   builder.rect({-0.18F, 0.14F}, {0.15F, 0.090F});
   builder.rect({0.21F, 0.24F}, {0.14F, 0.085F}, 0.62F);
   builder.end_glyph(k_glyph_extrusion);
-
-  builder.set_layer(GlyphLayer::Accent);
-  builder.set_depth(k_glyph_detail_depth);
-  builder.disc({-0.02F, 0.32F}, 0.055F, 10);
-  builder.disc({0.36F, 0.02F}, 0.042F, 10);
 }
 
 void build_chop_wood(GlyphBuilder& builder) {
@@ -251,39 +185,35 @@ void build_chop_wood(GlyphBuilder& builder) {
 
 void build_mine_stone(GlyphBuilder& builder) {
   const std::array<QVector2D, 5> head = {{
-      {-0.28F, 0.10F},
-      {-0.15F, 0.22F},
-      {0.00F, 0.26F},
-      {0.15F, 0.22F},
-      {0.28F, 0.10F},
+      {-0.40F, -0.08F},
+      {-0.22F, 0.16F},
+      {0.00F, 0.24F},
+      {0.22F, 0.16F},
+      {0.40F, -0.08F},
   }};
   builder.begin_glyph();
-
-  builder.bar({0.0F, 0.36F}, {0.0F, -0.40F}, 0.115F);
-  builder.polyline(head, 0.105F);
-  builder.arrow_head({-0.44F, -0.06F}, {-0.62F, -0.79F}, 0.24F, 0.095F);
-  builder.arrow_head({0.44F, -0.06F}, {0.62F, -0.79F}, 0.24F, 0.095F);
+  builder.bar({0.0F, 0.22F}, {0.0F, -0.38F}, 0.105F);
+  builder.polyline(head, 0.100F);
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_mine_iron(GlyphBuilder& builder) {
-  const std::array<QVector2D, 7> chunk = {{
-      {-0.34F, -0.06F},
-      {-0.20F, 0.20F},
-      {0.05F, 0.30F},
-      {0.28F, 0.20F},
-      {0.34F, -0.06F},
-      {0.17F, -0.29F},
-      {-0.17F, -0.29F},
+  const std::array<QVector2D, 4> lower = {{
+      {-0.38F, -0.30F},
+      {0.38F, -0.30F},
+      {0.27F, -0.04F},
+      {-0.27F, -0.04F},
+  }};
+  const std::array<QVector2D, 4> upper = {{
+      {-0.25F, -0.01F},
+      {0.25F, -0.01F},
+      {0.15F, 0.25F},
+      {-0.15F, 0.25F},
   }};
   builder.begin_glyph();
-  builder.convex(chunk);
+  builder.convex(lower);
+  builder.convex(upper);
   builder.end_glyph(k_glyph_extrusion);
-
-  builder.set_layer(GlyphLayer::Outline);
-  builder.set_depth(k_glyph_detail_depth);
-  builder.bar({-0.15F, 0.06F}, {0.02F, -0.14F}, 0.085F);
-  builder.bar({0.10F, 0.16F}, {0.20F, 0.04F}, 0.070F);
 }
 
 void build_deliver(GlyphBuilder& builder) {
@@ -347,8 +277,9 @@ void build_blocked(GlyphBuilder& builder) {
 
 void build_idle(GlyphBuilder& builder) {
   builder.begin_glyph();
-  builder.ring({0.0F, 0.0F}, 0.15F, 0.26F, 24);
-  builder.disc({0.0F, 0.0F}, 0.07F, 14);
+  builder.disc({-0.30F, 0.0F}, 0.115F, 16);
+  builder.disc({0.0F, 0.0F}, 0.115F, 16);
+  builder.disc({0.30F, 0.0F}, 0.115F, 16);
   builder.end_glyph(k_glyph_extrusion);
 }
 
@@ -373,7 +304,8 @@ auto indicator_color(IndicatorKind kind, IndicatorState state) noexcept -> QVect
   case IndicatorState::Active:
     return base;
   case IndicatorState::Queued:
-    return base * 0.68F + QVector3D(0.20F, 0.21F, 0.24F);
+
+    return base * 0.80F + QVector3D(0.06F, 0.06F, 0.07F);
   case IndicatorState::Unavailable:
     return base * 0.35F + QVector3D(1.0F, 0.30F, 0.22F) * 0.65F;
   case IndicatorState::Interrupted:
@@ -397,7 +329,10 @@ auto indicator_state_alpha(IndicatorState state) noexcept -> float {
 
 auto build_indicator_glyph(IndicatorKind kind) -> GlyphBuilder {
   GlyphBuilder builder;
-  add_medallion(builder);
+  builder.set_normal_style(GlyphNormal::Front);
+  builder.reset_transform();
+  builder.set_layer(GlyphLayer::Glyph);
+  builder.set_depth(k_glyph_face_depth);
   std::size_t const glyph_start = builder.vertex_mark();
 
   switch (kind) {
@@ -451,6 +386,7 @@ auto build_indicator_glyph(IndicatorKind kind) -> GlyphBuilder {
     break;
   }
 
+  builder.center_since(glyph_start);
   builder.fit_since(glyph_start, k_glyph_fit_radius);
   builder.normalize_extent(0.5F);
   return builder;

--- a/render/geom/mode_indicator.h
+++ b/render/geom/mode_indicator.h
@@ -27,7 +27,7 @@ constexpr float k_indicator_head_gap = 0.45F;
 constexpr float k_frustum_cull_margin = 1.5F;
 constexpr float k_indicator_tilt_radians = 0.24F;
 
-constexpr float k_indicator_world_size = 1.05F;
+constexpr float k_indicator_world_size = 0.80F;
 
 constexpr float k_indicator_fade_start_sq = 3600.0F;
 constexpr float k_indicator_fade_end_sq = 8100.0F;

--- a/render/gl/backend/vegetation_pipeline_natural.cpp
+++ b/render/gl/backend/vegetation_pipeline_natural.cpp
@@ -359,36 +359,36 @@ void VegetationPipeline::initialize_pine_pipeline() {
     }
   };
 
-  const int trunk_bottom = add_ring(0.14F, -0.01F, -0.08F, 0.00F, 0.0F);
+  const int trunk_bottom = add_ring(0.088F, -0.01F, -0.08F, 0.00F, 0.0F);
   const int trunk_kink =
-      add_ring(0.105F, 0.18F, 0.00F, 0.08F, 0.0F, QVector2D(0.010F, 0.006F));
+      add_ring(0.068F, 0.18F, 0.00F, 0.08F, 0.0F, QVector2D(0.010F, 0.006F));
   const int trunk_mid =
-      add_ring(0.085F, 0.36F, 0.03F, 0.16F, 0.0F, QVector2D(0.022F, 0.012F));
+      add_ring(0.056F, 0.36F, 0.03F, 0.16F, 0.0F, QVector2D(0.022F, 0.012F));
   const int trunk_top =
-      add_ring(0.075F, 0.56F, 0.08F, 0.26F, 0.0F, QVector2D(0.020F, 0.014F));
+      add_ring(0.050F, 0.56F, 0.08F, 0.26F, 0.0F, QVector2D(0.020F, 0.014F));
 
   const QVector2D t1o(-0.032F, 0.050F);
-  const int c1_inner = add_ring(0.18F, 0.60F, 0.12F, 0.34F, 0.00F, t1o * 0.15F);
-  const int c1_base = add_ring(0.34F, 0.65F, 0.24F, 0.42F, 0.60F, t1o * 0.40F);
-  const int c1_outer = add_ring(0.50F, 0.70F, 0.34F, 0.50F, 1.00F, t1o);
-  const int c1_mid = add_ring(0.45F, 0.77F, 0.56F, 0.58F, 0.74F, t1o * 0.55F);
-  const int c1_top = add_ring(0.28F, 0.83F, 0.72F, 0.64F, 0.30F, t1o * 0.22F);
+  const int c1_inner = add_ring(0.135F, 0.62F, 0.12F, 0.34F, 0.00F, t1o * 0.15F);
+  const int c1_base = add_ring(0.245F, 0.67F, 0.24F, 0.42F, 0.60F, t1o * 0.40F);
+  const int c1_outer = add_ring(0.355F, 0.72F, 0.34F, 0.50F, 1.00F, t1o);
+  const int c1_mid = add_ring(0.315F, 0.79F, 0.56F, 0.58F, 0.74F, t1o * 0.55F);
+  const int c1_top = add_ring(0.205F, 0.85F, 0.72F, 0.64F, 0.30F, t1o * 0.22F);
 
   const QVector2D t2o(0.040F, -0.026F);
-  const int c2_inner = add_ring(0.15F, 0.85F, 0.16F, 0.66F, 0.00F, t2o * 0.12F);
-  const int c2_base = add_ring(0.28F, 0.90F, 0.30F, 0.73F, 0.60F, t2o * 0.38F);
-  const int c2_outer = add_ring(0.37F, 0.95F, 0.42F, 0.80F, 1.00F, t2o);
-  const int c2_mid = add_ring(0.30F, 1.01F, 0.64F, 0.86F, 0.74F, t2o * 0.52F);
-  const int c2_top = add_ring(0.18F, 1.06F, 0.78F, 0.90F, 0.30F, t2o * 0.20F);
+  const int c2_inner = add_ring(0.120F, 0.87F, 0.16F, 0.66F, 0.00F, t2o * 0.12F);
+  const int c2_base = add_ring(0.220F, 0.92F, 0.30F, 0.73F, 0.60F, t2o * 0.38F);
+  const int c2_outer = add_ring(0.295F, 0.97F, 0.42F, 0.80F, 1.00F, t2o);
+  const int c2_mid = add_ring(0.240F, 1.03F, 0.64F, 0.86F, 0.74F, t2o * 0.52F);
+  const int c2_top = add_ring(0.145F, 1.08F, 0.78F, 0.90F, 0.30F, t2o * 0.20F);
 
   const QVector2D t3o(-0.022F, -0.032F);
-  const int c3_inner = add_ring(0.10F, 1.08F, 0.20F, 0.91F, 0.00F, t3o * 0.10F);
-  const int c3_base = add_ring(0.18F, 1.12F, 0.38F, 0.95F, 0.60F, t3o * 0.35F);
-  const int c3_outer = add_ring(0.255F, 1.16F, 0.52F, 0.98F, 1.00F, t3o);
-  const int c3_mid = add_ring(0.18F, 1.21F, 0.74F, 1.02F, 0.74F, t3o * 0.48F);
-  const int c3_top = add_ring(0.09F, 1.25F, 0.86F, 1.06F, 0.30F, t3o * 0.15F);
+  const int c3_inner = add_ring(0.085F, 1.10F, 0.20F, 0.91F, 0.00F, t3o * 0.10F);
+  const int c3_base = add_ring(0.150F, 1.15F, 0.38F, 0.95F, 0.60F, t3o * 0.35F);
+  const int c3_outer = add_ring(0.205F, 1.19F, 0.52F, 0.98F, 1.00F, t3o);
+  const int c3_mid = add_ring(0.150F, 1.25F, 0.74F, 1.02F, 0.74F, t3o * 0.48F);
+  const int c3_top = add_ring(0.075F, 1.30F, 0.86F, 1.06F, 0.30F, t3o * 0.15F);
 
-  const int tip_ring = add_ring(0.03F, 1.30F, 0.95F, 1.12F, 0.20F);
+  const int tip_ring = add_ring(0.028F, 1.36F, 0.95F, 1.12F, 0.20F);
 
   connect_rings(trunk_bottom, trunk_kink);
   connect_rings(trunk_kink, trunk_mid);
@@ -422,7 +422,7 @@ void VegetationPipeline::initialize_pine_pipeline() {
   }
 
   const auto apex_index = static_cast<unsigned short>(vertices.size());
-  vertices.push_back({QVector3D(0.0F, 1.36F, 0.0F),
+  vertices.push_back({QVector3D(0.0F, 1.44F, 0.0F),
                       QVector3D(0.5F, 1.18F, 0.30F),
                       QVector3D(0.0F, 1.0F, 0.0F)});
   for (int i = 0; i < k_segments; ++i) {

--- a/render/ground/boulder_renderer.cpp
+++ b/render/ground/boulder_renderer.cpp
@@ -35,9 +35,31 @@ void BoulderRenderer::configure(
     const std::vector<Game::Map::WorldProp>& scatter_seed_world_props,
     const std::vector<Game::Map::WorldProp>& runtime_world_props,
     bool use_world_props_exclusively) {
-  configure_biome_common(biome_settings, use_world_props_exclusively);
+  configure_height_scatter_common(height_map,
+                                  biome_settings,
+                                  scatter_seed_world_props,
+                                  runtime_world_props,
+                                  use_world_props_exclusively);
   m_state.params.light_direction = m_light_direction;
-  generate_instances(scatter_seed_world_props, runtime_world_props, height_map);
+  rebuild_boulder_instances();
+}
+
+void BoulderRenderer::refresh_world_props(
+    const std::vector<Game::Map::WorldProp>& runtime_world_props,
+    bool use_world_props_exclusively) {
+  adopt_runtime_world_props(runtime_world_props, use_world_props_exclusively);
+  rebuild_boulder_instances();
+}
+
+void BoulderRenderer::rebuild_boulder_instances() {
+  m_state.instances.clear();
+  append_world_prop_boulders();
+  if (!m_use_world_props_exclusively) {
+    append_procedural_instances([this](std::vector<StoneInstanceGpu>& out) {
+      generate_procedural_boulders(out);
+    });
+  }
+  finish_instance_rebuild();
 }
 
 void BoulderRenderer::set_light_direction(const QVector3D& dir) {
@@ -54,30 +76,56 @@ void BoulderRenderer::submit(Renderer& renderer, ResourceManager* resources) {
       });
 }
 
-void BoulderRenderer::generate_instances(
-    const std::vector<Game::Map::WorldProp>& scatter_seed_world_props,
-    const std::vector<Game::Map::WorldProp>& runtime_world_props,
-    const Game::Map::TerrainHeightMap& height_map) {
-
+void BoulderRenderer::append_world_prop_boulders() {
   auto& terrain_service = Game::Map::TerrainService::instance();
-  const float tile_size = height_map.get_tile_size();
-  const int width = height_map.get_width();
-  const int map_height = height_map.get_height();
-
   const auto surface_profile = Game::Map::make_surface_profile(m_biome_settings);
+
+  for (const auto& prop : m_runtime_world_props) {
+    if (prop.type != Game::Map::WorldProp::Type::Boulder) {
+      continue;
+    }
+    const QVector3D resolved = terrain_service.world_prop_world_position(prop);
+
+    uint32_t state = hash_coords(static_cast<int>(prop.x),
+                                 static_cast<int>(prop.z),
+                                 m_biome_settings.seed ^ 0xD3A4B1C2U);
+    float const color_var = remap(rand_01(state), 0.0F, 1.0F);
+    QVector3D const base_rock = surface_profile.rock_low;
+    QVector3D const high_rock = surface_profile.rock_high;
+    QVector3D color = base_rock * (1.0F - color_var) + high_rock * color_var;
+    float const earth_mix = remap(rand_01(state), 0.08F, 0.30F);
+    QVector3D const earth_tint(0.34F, 0.31F, 0.27F);
+    color = color * (1.0F - earth_mix) + earth_tint * earth_mix;
+    color *= 0.86F;
+
+    StoneInstanceGpu inst;
+    inst.pos_scale = QVector4D(resolved.x(),
+                               resolved.y(),
+                               resolved.z(),
+                               prop.scale * Game::Map::world_prop_render_scale(
+                                                Game::Map::WorldProp::Type::Boulder));
+    inst.color_rot = QVector4D(color.x(), color.y(), color.z(), prop.rotation);
+    m_state.instances.push_back(inst);
+  }
+}
+
+void BoulderRenderer::generate_procedural_boulders(
+    std::vector<StoneInstanceGpu>& out) const {
+  if (m_width < 2 || m_height < 2 || m_height_data.empty()) {
+    return;
+  }
+
   const auto scatter_profile = Game::Map::make_scatter_profile(m_biome_settings);
+  const auto surface_profile = Game::Map::make_surface_profile(m_biome_settings);
 
   SpawnTerrainCache terrain_cache;
-  terrain_cache.build_from_height_map(height_map.get_height_data(),
-                                      height_map.getTerrainTypes(),
-                                      width,
-                                      map_height,
-                                      tile_size);
+  terrain_cache.build_from_height_map(
+      m_height_data, m_terrain_types, m_width, m_height, m_tile_size);
 
   SpawnValidationConfig config = make_stone_spawn_config();
-  config.grid_width = width;
-  config.grid_height = map_height;
-  config.tile_size = tile_size;
+  config.grid_width = m_width;
+  config.grid_height = m_height;
+  config.tile_size = m_tile_size;
   config.edge_padding = scatter_profile.spawn_edge_padding * 0.45F;
   config.max_slope = 0.38F;
   config.allow_hill = true;
@@ -86,11 +134,11 @@ void BoulderRenderer::generate_instances(
 
   SpawnValidator validator(terrain_cache, config);
   ScatterCompositionContext composition(terrain_cache,
-                                        width,
-                                        map_height,
-                                        tile_size,
+                                        m_width,
+                                        m_height,
+                                        m_tile_size,
                                         m_biome_settings,
-                                        scatter_seed_world_props);
+                                        m_scatter_seed_world_props);
 
   auto add_boulder = [&](float gx,
                          float gz,
@@ -130,59 +178,25 @@ void BoulderRenderer::generate_instances(
     inst.pos_scale = QVector4D(world_x, world_y + 0.01F, world_z, scale);
     inst.color_rot = QVector4D(
         color.x(), color.y(), color.z(), rand_01(state) * MathConstants::k_two_pi);
-    m_state.instances.push_back(inst);
+    out.push_back(inst);
     return true;
   };
 
-  for (const auto& prop : runtime_world_props) {
-    if (prop.type != Game::Map::WorldProp::Type::Boulder) {
-      continue;
-    }
-    const QVector3D resolved = terrain_service.world_prop_world_position(prop);
-
-    uint32_t state = hash_coords(static_cast<int>(prop.x),
-                                 static_cast<int>(prop.z),
-                                 m_biome_settings.seed ^ 0xD3A4B1C2U);
-    float const color_var = remap(rand_01(state), 0.0F, 1.0F);
-    QVector3D const base_rock = surface_profile.rock_low;
-    QVector3D const high_rock = surface_profile.rock_high;
-    QVector3D color = base_rock * (1.0F - color_var) + high_rock * color_var;
-    float const earth_mix = remap(rand_01(state), 0.08F, 0.30F);
-    QVector3D const earth_tint(0.34F, 0.31F, 0.27F);
-    color = color * (1.0F - earth_mix) + earth_tint * earth_mix;
-    color *= 0.86F;
-
-    StoneInstanceGpu inst;
-    inst.pos_scale = QVector4D(resolved.x(),
-                               resolved.y(),
-                               resolved.z(),
-                               prop.scale * Game::Map::world_prop_render_scale(
-                                                Game::Map::WorldProp::Type::Boulder));
-    inst.color_rot = QVector4D(color.x(), color.y(), color.z(), prop.rotation);
-    m_state.instances.push_back(inst);
-  }
-
-  if (m_use_world_props_exclusively) {
-    m_state.instance_count = m_state.instances.size();
-    m_state.instances_dirty = m_state.instance_count > 0;
-    return;
-  }
-
-  if (width >= 2 && map_height >= 2 && !height_map.get_height_data().empty()) {
+  {
     float const base_density =
         std::clamp(0.090F + m_biome_settings.rock_exposure * 0.120F -
                        m_biome_settings.moisture_level * 0.020F,
                    0.055F,
                    0.200F);
     float const area_scale =
-        std::sqrt(static_cast<float>(std::max(width, 1) * std::max(map_height, 1)) /
+        std::sqrt(static_cast<float>(std::max(m_width, 1) * std::max(m_height, 1)) /
                   (k_reference_scatter_extent * k_reference_scatter_extent));
     int const sampling_scale = std::max(1, static_cast<int>(std::round(area_scale)));
     int const cell_span = 6 * sampling_scale;
-    for (int z = 0; z < map_height; z += cell_span) {
-      for (int x = 0; x < width; x += cell_span) {
-        int const sample_x = std::min(x + cell_span / 2, width - 1);
-        int const sample_z = std::min(z + cell_span / 2, map_height - 1);
+    for (int z = 0; z < m_height; z += cell_span) {
+      for (int x = 0; x < m_width; x += cell_span) {
+        int const sample_x = std::min(x + cell_span / 2, m_width - 1);
+        int const sample_z = std::min(z + cell_span / 2, m_height - 1);
         uint32_t state = hash_coords(x, z, m_biome_settings.seed ^ 0x6D1A75B3U);
         auto const scene = composition.sample_grid(static_cast<float>(sample_x),
                                                    static_cast<float>(sample_z),
@@ -200,9 +214,6 @@ void BoulderRenderer::generate_instances(
       }
     }
   }
-
-  m_state.instance_count = m_state.instances.size();
-  m_state.instances_dirty = m_state.instance_count > 0;
 }
 
 } // namespace Render::GL

--- a/render/ground/boulder_renderer.h
+++ b/render/ground/boulder_renderer.h
@@ -22,15 +22,18 @@ public:
                  const std::vector<Game::Map::WorldProp>& scatter_seed_world_props = {},
                  const std::vector<Game::Map::WorldProp>& runtime_world_props = {},
                  bool use_world_props_exclusively = false);
+
+  void refresh_world_props(const std::vector<Game::Map::WorldProp>& runtime_world_props,
+                           bool use_world_props_exclusively);
+
   void set_light_direction(const QVector3D& dir) override;
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
 private:
-  void
-  generate_instances(const std::vector<Game::Map::WorldProp>& scatter_seed_world_props,
-                     const std::vector<Game::Map::WorldProp>& runtime_world_props,
-                     const Game::Map::TerrainHeightMap& height_map);
+  void rebuild_boulder_instances();
+  void append_world_prop_boulders();
+  void generate_procedural_boulders(std::vector<StoneInstanceGpu>& out) const;
 };
 
 } // namespace Render::GL

--- a/render/ground/dead_tree_renderer.cpp
+++ b/render/ground/dead_tree_renderer.cpp
@@ -41,12 +41,30 @@ namespace Render::GL {
 DeadTreeRenderer::DeadTreeRenderer() = default;
 DeadTreeRenderer::~DeadTreeRenderer() = default;
 
-void DeadTreeRenderer::configure(const Game::Map::TerrainHeightMap& height_map,
-                                 const Game::Map::BiomeSettings& biome_settings,
-                                 const std::vector<Game::Map::WorldProp>& world_props) {
-  configure_biome_common(biome_settings);
+void DeadTreeRenderer::configure(
+    const Game::Map::TerrainHeightMap& height_map,
+    const Game::Map::BiomeSettings& biome_settings,
+    const std::vector<Game::Map::WorldProp>& scatter_seed_world_props,
+    const std::vector<Game::Map::WorldProp>& runtime_world_props) {
+  configure_height_scatter_common(
+      height_map, biome_settings, scatter_seed_world_props, runtime_world_props, false);
   m_state.params.light_direction = m_light_direction;
-  generate_instances(world_props, height_map);
+  rebuild_dead_tree_instances();
+}
+
+void DeadTreeRenderer::refresh_world_props(
+    const std::vector<Game::Map::WorldProp>& runtime_world_props) {
+  adopt_runtime_world_props(runtime_world_props, false);
+  rebuild_dead_tree_instances();
+}
+
+void DeadTreeRenderer::rebuild_dead_tree_instances() {
+  m_state.instances.clear();
+  append_world_prop_dead_trees();
+  append_procedural_instances([this](std::vector<PropInstanceGpu>& out) {
+    generate_procedural_dead_trees(out);
+  });
+  finish_instance_rebuild();
 }
 
 void DeadTreeRenderer::set_light_direction(const QVector3D& dir) {
@@ -57,29 +75,55 @@ void DeadTreeRenderer::submit(Renderer& renderer, ResourceManager* resources) {
   submit_prop_common(renderer, resources, TerrainScatterCmd::Species::DeadTree);
 }
 
-void DeadTreeRenderer::generate_instances(
-    const std::vector<Game::Map::WorldProp>& world_props,
-    const Game::Map::TerrainHeightMap& height_map) {
-
+void DeadTreeRenderer::append_world_prop_dead_trees() {
   auto& terrain_service = Game::Map::TerrainService::instance();
-  const float tile_size = height_map.get_tile_size();
-  const int width = height_map.get_width();
-  const int map_height = height_map.get_height();
-  const float half_w = static_cast<float>(width) * 0.5F;
-  const float half_h = static_cast<float>(map_height) * 0.5F;
+  const float half_w = static_cast<float>(m_width) * 0.5F;
+  const float half_h = static_cast<float>(m_height) * 0.5F;
+  const float tile_size = m_tile_size;
+
+  for (const auto& prop : m_runtime_world_props) {
+    if (prop.type != Game::Map::WorldProp::Type::DeadTree) {
+      continue;
+    }
+    const float wx = (prop.x - half_w) * tile_size;
+    const float wz = (prop.z - half_h) * tile_size;
+    const QVector3D resolved =
+        terrain_service.resolve_surface_world_position(wx, wz, 0.0F, 0.0F);
+
+    uint32_t state = hash_coords(static_cast<int>(prop.x),
+                                 static_cast<int>(prop.z),
+                                 m_biome_settings.seed ^ 0x51A3C7D9U);
+    QVector3D const base_color(k_base_color_r, k_base_color_g, k_base_color_b);
+    QVector3D const dry_color(0.43F, 0.36F, 0.27F);
+    float const color_var = remap(rand_01(state), 0.35F, 0.85F);
+    QVector3D const color = base_color * (1.0F - color_var) + dry_color * color_var;
+
+    PropInstanceGpu inst;
+    inst.pos_scale = QVector4D(resolved.x(),
+                               resolved.y(),
+                               resolved.z(),
+                               prop.scale * Game::Map::world_prop_render_scale(
+                                                Game::Map::WorldProp::Type::DeadTree));
+    inst.color_rot = QVector4D(color.x(), color.y(), color.z(), prop.rotation);
+    m_state.instances.push_back(inst);
+  }
+}
+
+void DeadTreeRenderer::generate_procedural_dead_trees(
+    std::vector<PropInstanceGpu>& out) const {
+  if (m_width < 2 || m_height < 2 || m_height_data.empty()) {
+    return;
+  }
 
   SpawnTerrainCache terrain_cache;
-  terrain_cache.build_from_height_map(height_map.get_height_data(),
-                                      height_map.getTerrainTypes(),
-                                      width,
-                                      map_height,
-                                      tile_size);
+  terrain_cache.build_from_height_map(
+      m_height_data, m_terrain_types, m_width, m_height, m_tile_size);
 
   const auto scatter_profile = Game::Map::make_scatter_profile(m_biome_settings);
   SpawnValidationConfig config = make_camp_prop_spawn_config();
-  config.grid_width = width;
-  config.grid_height = map_height;
-  config.tile_size = tile_size;
+  config.grid_width = m_width;
+  config.grid_height = m_height;
+  config.tile_size = m_tile_size;
   config.edge_padding = scatter_profile.spawn_edge_padding * 0.55F;
   config.max_slope = 0.42F;
   config.building_clearance = 3.2F;
@@ -87,8 +131,12 @@ void DeadTreeRenderer::generate_instances(
   config.river_clearance = 1.4F;
 
   SpawnValidator validator(terrain_cache, config);
-  ScatterCompositionContext composition(
-      terrain_cache, width, map_height, tile_size, m_biome_settings, world_props);
+  ScatterCompositionContext composition(terrain_cache,
+                                        m_width,
+                                        m_height,
+                                        m_tile_size,
+                                        m_biome_settings,
+                                        m_scatter_seed_world_props);
 
   auto add_dead_tree = [&](float gx,
                            float gz,
@@ -131,47 +179,20 @@ void DeadTreeRenderer::generate_instances(
     inst.pos_scale = QVector4D(world_pos.x(), world_pos.y(), world_pos.z(), scale);
     inst.color_rot = QVector4D(
         color.x(), color.y(), color.z(), rand_01(state) * MathConstants::k_two_pi);
-    m_state.instances.push_back(inst);
+    out.push_back(inst);
     return true;
   };
 
-  for (const auto& prop : world_props) {
-    if (prop.type != Game::Map::WorldProp::Type::DeadTree) {
-      continue;
-    }
-    const float wx = (prop.x - half_w) * tile_size;
-    const float wz = (prop.z - half_h) * tile_size;
-    const QVector3D resolved =
-        terrain_service.resolve_surface_world_position(wx, wz, 0.0F, 0.0F);
-
-    uint32_t state = hash_coords(static_cast<int>(prop.x),
-                                 static_cast<int>(prop.z),
-                                 m_biome_settings.seed ^ 0x51A3C7D9U);
-    QVector3D const base_color(k_base_color_r, k_base_color_g, k_base_color_b);
-    QVector3D const dry_color(0.43F, 0.36F, 0.27F);
-    float const color_var = remap(rand_01(state), 0.35F, 0.85F);
-    QVector3D const color = base_color * (1.0F - color_var) + dry_color * color_var;
-
-    PropInstanceGpu inst;
-    inst.pos_scale = QVector4D(resolved.x(),
-                               resolved.y(),
-                               resolved.z(),
-                               prop.scale * Game::Map::world_prop_render_scale(
-                                                Game::Map::WorldProp::Type::DeadTree));
-    inst.color_rot = QVector4D(color.x(), color.y(), color.z(), prop.rotation);
-    m_state.instances.push_back(inst);
-  }
-
-  if (width >= 2 && map_height >= 2 && !height_map.get_height_data().empty()) {
+  {
     float const base_density =
         std::clamp(0.030F + (1.0F - m_biome_settings.moisture_level) * 0.038F +
                        m_biome_settings.rock_exposure * 0.030F,
                    0.018F,
                    0.090F);
-    for (int z = 0; z < map_height; z += 10) {
-      for (int x = 0; x < width; x += 10) {
-        int const sample_x = std::min(x + 5, width - 1);
-        int const sample_z = std::min(z + 5, map_height - 1);
+    for (int z = 0; z < m_height; z += 10) {
+      for (int x = 0; x < m_width; x += 10) {
+        int const sample_x = std::min(x + 5, m_width - 1);
+        int const sample_z = std::min(z + 5, m_height - 1);
         uint32_t state = hash_coords(x, z, m_biome_settings.seed ^ 0xB91CF237U);
         auto const scene = composition.sample_grid(static_cast<float>(sample_x),
                                                    static_cast<float>(sample_z),
@@ -189,9 +210,6 @@ void DeadTreeRenderer::generate_instances(
       }
     }
   }
-
-  m_state.instance_count = m_state.instances.size();
-  m_state.instances_dirty = m_state.instance_count > 0;
 }
 
 } // namespace Render::GL

--- a/render/ground/dead_tree_renderer.h
+++ b/render/ground/dead_tree_renderer.h
@@ -20,14 +20,20 @@ public:
 
   void configure(const Game::Map::TerrainHeightMap& height_map,
                  const Game::Map::BiomeSettings& biome_settings,
-                 const std::vector<Game::Map::WorldProp>& world_props = {});
+                 const std::vector<Game::Map::WorldProp>& scatter_seed_world_props = {},
+                 const std::vector<Game::Map::WorldProp>& runtime_world_props = {});
+
+  void
+  refresh_world_props(const std::vector<Game::Map::WorldProp>& runtime_world_props);
+
   void set_light_direction(const QVector3D& dir) override;
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
 private:
-  void generate_instances(const std::vector<Game::Map::WorldProp>& world_props,
-                          const Game::Map::TerrainHeightMap& height_map);
+  void rebuild_dead_tree_instances();
+  void append_world_prop_dead_trees();
+  void generate_procedural_dead_trees(std::vector<PropInstanceGpu>& out) const;
 };
 
 } // namespace Render::GL

--- a/render/ground/firecamp_renderer.cpp
+++ b/render/ground/firecamp_renderer.cpp
@@ -33,6 +33,8 @@ void FireCampRenderer::configure(const Game::Map::TerrainHeightMap& height_map,
                                  const std::vector<Game::Map::WorldProp>& world_props) {
   configure_height_scatter_common(height_map, biome_settings, {}, world_props, false);
 
+  m_state.track_visible_instances = true;
+
   auto& firecamp_params = m_state.params;
   firecamp_params.time = 0.0F;
   firecamp_params.flicker_speed = 4.4F;

--- a/render/ground/magic_shrine_renderer.cpp
+++ b/render/ground/magic_shrine_renderer.cpp
@@ -32,6 +32,8 @@ void MagicShrineRenderer::configure(
     const Game::Map::BiomeSettings& biome_settings,
     const std::vector<Game::Map::WorldProp>& world_props) {
   configure_biome_common(biome_settings);
+
+  m_state.track_visible_instances = true;
   m_state.params.light_direction = m_light_direction;
   generate_instances(world_props, height_map);
 }

--- a/render/ground/olive_renderer.cpp
+++ b/render/ground/olive_renderer.cpp
@@ -66,7 +66,24 @@ void OliveRenderer::configure(
   olive_params.wind_strength = wind_profile.sway_strength;
   olive_params.wind_speed = wind_profile.sway_speed;
 
-  generate_olive_instances();
+  rebuild_olive_instances();
+}
+
+void OliveRenderer::refresh_world_props(
+    const std::vector<Game::Map::WorldProp>& runtime_world_props,
+    bool use_world_props_exclusively) {
+  adopt_runtime_world_props(runtime_world_props, use_world_props_exclusively);
+  rebuild_olive_instances();
+}
+
+void OliveRenderer::rebuild_olive_instances() {
+  m_state.instances.clear();
+  append_world_prop_olives();
+  if (!m_use_world_props_exclusively) {
+    append_procedural_instances(
+        [this](std::vector<TreeInstanceGpu>& out) { generate_procedural_olives(out); });
+  }
+  finish_instance_rebuild();
 }
 
 void OliveRenderer::set_light_direction(const QVector3D& dir) {
@@ -83,11 +100,8 @@ void OliveRenderer::submit(Renderer& renderer, ResourceManager* resources) {
       });
 }
 
-void OliveRenderer::generate_olive_instances() {
+void OliveRenderer::append_world_prop_olives() {
   auto& olive_instances = m_state.instances;
-  auto& olive_instance_count = m_state.instance_count;
-  auto& olive_instances_dirty = m_state.instances_dirty;
-  olive_instances.clear();
 
   {
     auto& terrain_service = Game::Map::TerrainService::instance();
@@ -101,9 +115,11 @@ void OliveRenderer::generate_olive_instances() {
                                        static_cast<int>(std::round(prop.z)),
                                        m_noise_seed ^ 0x7B3E5F1CU);
       const float color_var = rand_01(var_state);
-      const QVector3D base_color(0.25F, 0.31F, 0.23F);
-      const QVector3D var_color(0.31F, 0.37F, 0.29F);
-      const QVector3D tint = base_color * (1.0F - color_var) + var_color * color_var;
+      const QVector3D base_color(0.17F, 0.25F, 0.17F);
+      const QVector3D var_color(0.40F, 0.45F, 0.34F);
+      QVector3D tint = base_color * (1.0F - color_var) + var_color * color_var;
+
+      tint *= remap(rand_01(var_state), 0.82F, 1.20F);
       const float sway_phase = rand_01(var_state) * MathConstants::k_two_pi;
       const float silhouette_seed = rand_01(var_state);
       const float leaf_seed = rand_01(var_state);
@@ -121,24 +137,19 @@ void OliveRenderer::generate_olive_instances() {
       olive_instances.push_back(inst);
     }
   }
+}
 
-  if (m_use_world_props_exclusively) {
-    olive_instance_count = olive_instances.size();
-    olive_instances_dirty = olive_instance_count > 0;
-    return;
-  }
+void OliveRenderer::generate_procedural_olives(
+    std::vector<TreeInstanceGpu>& out) const {
+  auto& olive_instances = out;
 
   if (m_width < 2 || m_height < 2 || m_height_data.empty()) {
-    olive_instance_count = olive_instances.size();
-    olive_instances_dirty = olive_instance_count > 0;
     return;
   }
 
   const auto scatter_profile = Game::Map::make_scatter_profile(m_biome_settings);
   const auto scatter_rules = Game::Map::make_scatter_rules(scatter_profile.ground_type);
   if (!scatter_rules.allow_olives) {
-    olive_instance_count = olive_instances.size();
-    olive_instances_dirty = olive_instance_count > 0;
     return;
   }
 
@@ -189,18 +200,20 @@ void OliveRenderer::generate_olive_instances() {
 
     float const color_var = remap(rand_01(state), 0.0F, 1.0F);
 
-    QVector3D const base_color(0.20F + scene.dryness * 0.05F,
-                               0.26F + scene.rockiness * 0.03F,
-                               0.19F + scene.dryness * 0.03F);
-    QVector3D const var_color(0.38F + scene.cluster_bias * 0.04F,
-                              0.44F + scene.rockiness * 0.04F,
-                              0.34F + scene.cluster_bias * 0.03F);
+    QVector3D const base_color(0.14F + scene.dryness * 0.05F,
+                               0.21F + scene.rockiness * 0.03F,
+                               0.15F + scene.dryness * 0.03F);
+    QVector3D const var_color(0.44F + scene.cluster_bias * 0.05F,
+                              0.50F + scene.rockiness * 0.05F,
+                              0.37F + scene.cluster_bias * 0.04F);
     QVector3D tint_color = base_color * (1.0F - color_var) + var_color * color_var;
 
     float const gray_mix = remap(
         rand_01(state), 0.08F + scene.rockiness * 0.04F, 0.18F + scene.dryness * 0.08F);
-    QVector3D const gray_tint(0.38F, 0.41F, 0.38F);
+    QVector3D const gray_tint(0.44F, 0.47F, 0.43F);
     tint_color = tint_color * (1.0F - gray_mix) + gray_tint * gray_mix;
+
+    tint_color *= remap(rand_01(state), 0.80F, 1.22F);
 
     float const sway_phase = rand_01(state) * MathConstants::k_two_pi;
 
@@ -300,9 +313,6 @@ void OliveRenderer::generate_olive_instances() {
       }
     }
   }
-
-  olive_instance_count = olive_instances.size();
-  olive_instances_dirty = olive_instance_count > 0;
 }
 
 } // namespace Render::GL

--- a/render/ground/olive_renderer.h
+++ b/render/ground/olive_renderer.h
@@ -26,6 +26,9 @@ public:
                  const std::vector<Game::Map::WorldProp>& runtime_world_props = {},
                  bool use_world_props_exclusively = false);
 
+  void refresh_world_props(const std::vector<Game::Map::WorldProp>& runtime_world_props,
+                           bool use_world_props_exclusively);
+
   void set_light_direction(const QVector3D& dir) override;
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
@@ -35,7 +38,9 @@ public:
   }
 
 private:
-  void generate_olive_instances();
+  void rebuild_olive_instances();
+  void append_world_prop_olives();
+  void generate_procedural_olives(std::vector<TreeInstanceGpu>& out) const;
 };
 
 } // namespace Render::GL

--- a/render/ground/pine_renderer.cpp
+++ b/render/ground/pine_renderer.cpp
@@ -66,7 +66,24 @@ void PineRenderer::configure(
   pine_params.wind_strength = wind_profile.sway_strength;
   pine_params.wind_speed = wind_profile.sway_speed;
 
-  generate_pine_instances();
+  rebuild_pine_instances();
+}
+
+void PineRenderer::refresh_world_props(
+    const std::vector<Game::Map::WorldProp>& runtime_world_props,
+    bool use_world_props_exclusively) {
+  adopt_runtime_world_props(runtime_world_props, use_world_props_exclusively);
+  rebuild_pine_instances();
+}
+
+void PineRenderer::rebuild_pine_instances() {
+  m_state.instances.clear();
+  append_world_prop_pines();
+  if (!m_use_world_props_exclusively) {
+    append_procedural_instances(
+        [this](std::vector<TreeInstanceGpu>& out) { generate_procedural_pines(out); });
+  }
+  finish_instance_rebuild();
 }
 
 void PineRenderer::set_light_direction(const QVector3D& dir) {
@@ -83,11 +100,8 @@ void PineRenderer::submit(Renderer& renderer, ResourceManager* resources) {
       });
 }
 
-void PineRenderer::generate_pine_instances() {
+void PineRenderer::append_world_prop_pines() {
   auto& pine_instances = m_state.instances;
-  auto& pine_instance_count = m_state.instance_count;
-  auto& pine_instances_dirty = m_state.instances_dirty;
-  pine_instances.clear();
 
   {
     auto& terrain_service = Game::Map::TerrainService::instance();
@@ -101,9 +115,11 @@ void PineRenderer::generate_pine_instances() {
                                        static_cast<int>(std::round(prop.z)),
                                        m_noise_seed ^ 0x4A7F2C9EU);
       const float color_var = rand_01(var_state);
-      const QVector3D base_color(0.12F, 0.24F, 0.17F);
-      const QVector3D var_color(0.19F, 0.33F, 0.23F);
-      const QVector3D tint = base_color * (1.0F - color_var) + var_color * color_var;
+      const QVector3D base_color(0.09F, 0.20F, 0.13F);
+      const QVector3D var_color(0.28F, 0.42F, 0.23F);
+      QVector3D tint = base_color * (1.0F - color_var) + var_color * color_var;
+
+      tint *= remap(rand_01(var_state), 0.80F, 1.22F);
       const float sway_phase = rand_01(var_state) * MathConstants::k_two_pi;
       const float silhouette_seed = rand_01(var_state);
       const float needle_seed = rand_01(var_state);
@@ -121,24 +137,18 @@ void PineRenderer::generate_pine_instances() {
       pine_instances.push_back(inst);
     }
   }
+}
 
-  if (m_use_world_props_exclusively) {
-    pine_instance_count = pine_instances.size();
-    pine_instances_dirty = pine_instance_count > 0;
-    return;
-  }
+void PineRenderer::generate_procedural_pines(std::vector<TreeInstanceGpu>& out) const {
+  auto& pine_instances = out;
 
   if (m_width < 2 || m_height < 2 || m_height_data.empty()) {
-    pine_instance_count = pine_instances.size();
-    pine_instances_dirty = pine_instance_count > 0;
     return;
   }
 
   const auto scatter_profile = Game::Map::make_scatter_profile(m_biome_settings);
   const auto scatter_rules = Game::Map::make_scatter_rules(scatter_profile.ground_type);
   if (!scatter_rules.allow_pines) {
-    pine_instance_count = pine_instances.size();
-    pine_instances_dirty = pine_instance_count > 0;
     return;
   }
 
@@ -192,18 +202,20 @@ void PineRenderer::generate_pine_instances() {
                         tile_safe * scatter_scale_bias(ScatterRuleSpecies::Pine, scene);
 
     float const color_var = remap(rand_01(state), 0.0F, 1.0F);
-    QVector3D const base_color(0.09F + scene.shelter * 0.03F,
-                               0.19F + scene.shelter * 0.07F,
-                               0.16F + scene.shelter * 0.04F);
-    QVector3D const var_color(0.27F + scene.cluster_bias * 0.04F,
-                              0.44F + scene.shelter * 0.06F,
-                              0.23F + scene.cluster_bias * 0.03F);
+    QVector3D const base_color(0.07F + scene.shelter * 0.03F,
+                               0.16F + scene.shelter * 0.07F,
+                               0.13F + scene.shelter * 0.04F);
+    QVector3D const var_color(0.33F + scene.cluster_bias * 0.05F,
+                              0.49F + scene.shelter * 0.07F,
+                              0.25F + scene.cluster_bias * 0.04F);
     QVector3D tint_color = base_color * (1.0F - color_var) + var_color * color_var;
 
     float const brown_mix = remap(
         rand_01(state), 0.03F + scene.dryness * 0.05F, 0.10F + scene.rockiness * 0.06F);
     QVector3D const brown_tint(0.27F, 0.25F, 0.19F);
     tint_color = tint_color * (1.0F - brown_mix) + brown_tint * brown_mix;
+
+    tint_color *= remap(rand_01(state), 0.78F, 1.24F);
 
     float const sway_phase = rand_01(state) * MathConstants::k_two_pi;
 
@@ -295,9 +307,6 @@ void PineRenderer::generate_pine_instances() {
       }
     }
   }
-
-  pine_instance_count = pine_instances.size();
-  pine_instances_dirty = pine_instance_count > 0;
 }
 
 } // namespace Render::GL

--- a/render/ground/pine_renderer.h
+++ b/render/ground/pine_renderer.h
@@ -26,6 +26,9 @@ public:
                  const std::vector<Game::Map::WorldProp>& runtime_world_props = {},
                  bool use_world_props_exclusively = false);
 
+  void refresh_world_props(const std::vector<Game::Map::WorldProp>& runtime_world_props,
+                           bool use_world_props_exclusively);
+
   void set_light_direction(const QVector3D& dir) override;
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
@@ -35,7 +38,9 @@ public:
   }
 
 private:
-  void generate_pine_instances();
+  void rebuild_pine_instances();
+  void append_world_prop_pines();
+  void generate_procedural_pines(std::vector<TreeInstanceGpu>& out) const;
 };
 
 } // namespace Render::GL

--- a/render/ground/scatter_renderer_base.h
+++ b/render/ground/scatter_renderer_base.h
@@ -56,6 +56,7 @@ protected:
     m_biome_settings = biome_settings;
     m_noise_seed = biome_settings.seed;
     m_state.reset_instances();
+    invalidate_procedural_cache();
   }
 
   void configure_biome_common(const Game::Map::BiomeSettings& biome_settings,
@@ -63,8 +64,47 @@ protected:
     m_biome_settings = biome_settings;
     m_use_world_props_exclusively = use_world_props_exclusively;
     m_state.reset_instances();
+    invalidate_procedural_cache();
   }
 
+  void adopt_runtime_world_props(
+      const std::vector<Game::Map::WorldProp>& runtime_world_props,
+      bool use_world_props_exclusively) {
+    m_runtime_world_props = runtime_world_props;
+    m_world_props = runtime_world_props;
+    m_use_world_props_exclusively = use_world_props_exclusively;
+  }
+
+  void invalidate_procedural_cache() {
+    m_procedural_cached = false;
+    m_procedural_instances.clear();
+    m_procedural_generations = 0;
+  }
+
+  template <typename GenerateProcedural>
+  void append_procedural_instances(GenerateProcedural&& generate) {
+    if (!m_procedural_cached) {
+      m_procedural_instances.clear();
+      generate(m_procedural_instances);
+      m_procedural_cached = true;
+      ++m_procedural_generations;
+    }
+    m_state.instances.insert(m_state.instances.end(),
+                             m_procedural_instances.begin(),
+                             m_procedural_instances.end());
+  }
+
+  void finish_instance_rebuild() {
+    m_state.instance_count = m_state.instances.size();
+    m_state.instances_dirty = m_state.instance_count > 0;
+  }
+
+public:
+  [[nodiscard]] auto procedural_generations_for_test() const -> std::size_t {
+    return m_procedural_generations;
+  }
+
+protected:
   void set_light_direction_common(const QVector3D& dir,
                                   const QVector3D& default_direction) {
     m_light_direction = dir.isNull() ? default_direction : dir.normalized();
@@ -128,6 +168,10 @@ protected:
   Game::Map::BiomeSettings m_biome_settings;
   std::uint32_t m_noise_seed = 0U;
   QVector3D m_light_direction{0.35F, 0.8F, 0.45F};
+
+  std::vector<Instance> m_procedural_instances;
+  bool m_procedural_cached = false;
+  std::size_t m_procedural_generations = 0;
 
   State m_state;
 };

--- a/render/ground/scatter_renderer_state.h
+++ b/render/ground/scatter_renderer_state.h
@@ -16,10 +16,17 @@
 
 namespace Render::Ground::Scatter {
 
+inline constexpr float k_chunk_world_size = 24.0F;
+inline constexpr float k_chunk_bounds_padding = 8.0F;
+
 template <typename Instance>
 struct SpatialChunk {
-  std::vector<Instance> instances;
+  std::size_t first = 0;
+  std::size_t count = 0;
+  std::vector<std::uint8_t> accepted;
   std::unique_ptr<Render::GL::Buffer> buffer;
+  std::size_t visible_count = 0;
+  bool all_accepted = false;
   QVector3D center;
   float radius = 0.0F;
 };
@@ -51,7 +58,10 @@ struct FilteredRendererState {
   std::size_t instance_count = 0;
   Params params{};
   bool instances_dirty = false;
+
+  bool track_visible_instances = false;
   std::vector<Instance> visible_instances;
+
   std::vector<SpatialChunk<Instance>> spatial_chunks;
   std::uint64_t cached_visibility_version = 0;
   bool visibility_dirty = true;
@@ -69,13 +79,16 @@ struct FilteredRendererState {
   }
 
   [[nodiscard]] auto is_gpu_ready() const -> bool {
-    if (instances.empty() || (!visibility_dirty && visible_instances.empty())) {
+    if (instances.empty()) {
       return true;
     }
-    return !visibility_dirty &&
-           std::all_of(spatial_chunks.begin(),
-                       spatial_chunks.end(),
-                       [](const auto& chunk) { return chunk.buffer != nullptr; });
+    if (visibility_dirty) {
+      return false;
+    }
+    return std::all_of(
+        spatial_chunks.begin(), spatial_chunks.end(), [](const auto& chunk) {
+          return chunk.visible_count == 0 || chunk.buffer != nullptr;
+        });
   }
 };
 
@@ -92,6 +105,112 @@ enum class ScatterMemoryMode : std::uint8_t {
   VisibleOnly,
   Remembered
 };
+
+template <typename Instance, typename PositionAccessor>
+void rebuild_spatial_partition(std::vector<Instance>& instances,
+                               std::vector<SpatialChunk<Instance>>& chunks,
+                               PositionAccessor position_accessor) {
+  chunks.clear();
+  if (instances.empty()) {
+    return;
+  }
+
+  std::unordered_map<std::uint64_t, std::size_t> chunk_indices;
+  chunk_indices.reserve(instances.size() / 16U + 1U);
+  std::vector<std::size_t> chunk_of_instance(instances.size(), 0U);
+  std::vector<std::size_t> counts;
+
+  for (std::size_t index = 0; index < instances.size(); ++index) {
+    const auto position = position_accessor(instances[index]);
+    const auto chunk_x =
+        static_cast<std::int32_t>(std::floor(position.x() / k_chunk_world_size));
+    const auto chunk_z =
+        static_cast<std::int32_t>(std::floor(position.z() / k_chunk_world_size));
+    const std::uint64_t key =
+        (static_cast<std::uint64_t>(static_cast<std::uint32_t>(chunk_x)) << 32U) |
+        static_cast<std::uint32_t>(chunk_z);
+    auto [it, inserted] = chunk_indices.emplace(key, chunks.size());
+    if (inserted) {
+      chunks.emplace_back();
+      counts.push_back(0U);
+    }
+    chunk_of_instance[index] = it->second;
+    ++counts[it->second];
+  }
+
+  std::size_t offset = 0;
+  std::vector<std::size_t> cursor(chunks.size(), 0U);
+  for (std::size_t index = 0; index < chunks.size(); ++index) {
+    chunks[index].first = offset;
+    chunks[index].count = counts[index];
+    cursor[index] = offset;
+    offset += counts[index];
+  }
+
+  std::vector<Instance> reordered(instances.size());
+  for (std::size_t index = 0; index < instances.size(); ++index) {
+    reordered[cursor[chunk_of_instance[index]]++] = instances[index];
+  }
+  instances = std::move(reordered);
+
+  for (auto& chunk : chunks) {
+    QVector3D min{std::numeric_limits<float>::max(),
+                  std::numeric_limits<float>::max(),
+                  std::numeric_limits<float>::max()};
+    QVector3D max{std::numeric_limits<float>::lowest(),
+                  std::numeric_limits<float>::lowest(),
+                  std::numeric_limits<float>::lowest()};
+    for (std::size_t i = 0; i < chunk.count; ++i) {
+      const auto position = position_accessor(instances[chunk.first + i]);
+      min.setX(std::min(min.x(), position.x()));
+      min.setY(std::min(min.y(), position.y()));
+      min.setZ(std::min(min.z(), position.z()));
+      max.setX(std::max(max.x(), position.x()));
+      max.setY(std::max(max.y(), position.y()));
+      max.setZ(std::max(max.z(), position.z()));
+    }
+    chunk.center = (min + max) * 0.5F;
+    chunk.radius = (max - chunk.center).length() + k_chunk_bounds_padding;
+    chunk.accepted.assign(chunk.count, 0U);
+    chunk.visible_count = 0;
+    chunk.all_accepted = false;
+    chunk.buffer.reset();
+  }
+}
+
+template <typename Instance, typename PositionAccessor, typename Accepts>
+auto refresh_chunk_acceptance(const std::vector<Instance>& instances,
+                              SpatialChunk<Instance>& chunk,
+                              PositionAccessor position_accessor,
+                              Accepts accepts,
+                              std::vector<std::uint8_t>& flags,
+                              std::vector<Instance>& packed) -> bool {
+  flags.assign(chunk.count, 0U);
+  packed.clear();
+
+  bool changed = chunk.accepted.size() != chunk.count;
+  for (std::size_t i = 0; i < chunk.count; ++i) {
+    const auto& instance = instances[chunk.first + i];
+    const auto position = position_accessor(instance);
+    const bool is_accepted = accepts(position.x(), position.z());
+    flags[i] = is_accepted ? std::uint8_t{1} : std::uint8_t{0};
+    if (is_accepted) {
+      packed.push_back(instance);
+    }
+    if (!changed && flags[i] != chunk.accepted[i]) {
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return false;
+  }
+
+  chunk.accepted.assign(flags.begin(), flags.end());
+  chunk.visible_count = packed.size();
+  chunk.all_accepted = chunk.visible_count == chunk.count;
+  return true;
+}
 
 template <typename Instance, typename Params, typename PositionAccessor>
 auto sync_filtered_state(FilteredRendererState<Instance, Params>& state,
@@ -110,80 +229,78 @@ auto sync_filtered_state(FilteredRendererState<Instance, Params>& state,
   }
 
   const std::uint64_t version = snapshot != nullptr ? snapshot->version : 0;
-  const bool rebuild = state.instances_dirty || state.visibility_dirty ||
-                       version != state.cached_visibility_version ||
-                       (state.instance_count > 0 && state.spatial_chunks.empty());
-  if (!rebuild) {
+  const bool structure_dirty = state.instances_dirty || state.spatial_chunks.empty();
+  const bool visibility_changed =
+      state.visibility_dirty || version != state.cached_visibility_version;
+  if (!structure_dirty && !visibility_changed) {
     return static_cast<std::uint32_t>(state.instance_count);
   }
 
   ++state.last_sync_stats.visibility_rebuilds;
-  state.visible_instances.clear();
-  state.visible_instances.reserve(state.instances.size());
-  state.spatial_chunks.clear();
-
-  constexpr float k_chunk_world_size = 24.0F;
-  constexpr float k_bounds_padding = 8.0F;
-  struct Bounds {
-    QVector3D min{std::numeric_limits<float>::max(),
-                  std::numeric_limits<float>::max(),
-                  std::numeric_limits<float>::max()};
-    QVector3D max{std::numeric_limits<float>::lowest(),
-                  std::numeric_limits<float>::lowest(),
-                  std::numeric_limits<float>::lowest()};
-  };
-  std::vector<Bounds> bounds;
-  std::unordered_map<std::uint64_t, std::size_t> chunk_indices;
-  chunk_indices.reserve(state.instances.size() / 16U + 1U);
-
-  for (const auto& instance : state.instances) {
-    const auto position = position_accessor(instance);
-    if (snapshot != nullptr) {
-      const auto state_at_instance =
-          Game::Map::classify_world_visibility(*snapshot, position.x(), position.z());
-      const bool accepted =
-          memory_mode == ScatterMemoryMode::Remembered
-              ? state_at_instance != Game::Map::RenderVisibilityState::Hidden
-              : state_at_instance == Game::Map::RenderVisibilityState::Visible;
-      if (!accepted) {
-        continue;
-      }
-    }
-    state.visible_instances.push_back(instance);
-    const auto chunk_x =
-        static_cast<std::int32_t>(std::floor(position.x() / k_chunk_world_size));
-    const auto chunk_z =
-        static_cast<std::int32_t>(std::floor(position.z() / k_chunk_world_size));
-    const std::uint64_t key =
-        (static_cast<std::uint64_t>(static_cast<std::uint32_t>(chunk_x)) << 32U) |
-        static_cast<std::uint32_t>(chunk_z);
-    auto [it, inserted] = chunk_indices.emplace(key, state.spatial_chunks.size());
-    if (inserted) {
-      state.spatial_chunks.emplace_back();
-      bounds.emplace_back();
-    }
-    const std::size_t index = it->second;
-    state.spatial_chunks[index].instances.push_back(instance);
-    auto& chunk_bounds = bounds[index];
-    chunk_bounds.min.setX(std::min(chunk_bounds.min.x(), position.x()));
-    chunk_bounds.min.setY(std::min(chunk_bounds.min.y(), position.y()));
-    chunk_bounds.min.setZ(std::min(chunk_bounds.min.z(), position.z()));
-    chunk_bounds.max.setX(std::max(chunk_bounds.max.x(), position.x()));
-    chunk_bounds.max.setY(std::max(chunk_bounds.max.y(), position.y()));
-    chunk_bounds.max.setZ(std::max(chunk_bounds.max.z(), position.z()));
+  if (structure_dirty) {
+    rebuild_spatial_partition(state.instances, state.spatial_chunks, position_accessor);
   }
 
-  for (std::size_t index = 0; index < state.spatial_chunks.size(); ++index) {
-    auto& chunk = state.spatial_chunks[index];
-    chunk.center = (bounds[index].min + bounds[index].max) * 0.5F;
-    chunk.radius = (bounds[index].max - chunk.center).length() + k_bounds_padding;
-    chunk.buffer =
-        std::make_unique<Render::GL::Buffer>(Render::GL::Buffer::Type::Vertex);
-    chunk.buffer->set_data(chunk.instances, Render::GL::Buffer::Usage::Static);
+  const bool remembered = memory_mode == ScatterMemoryMode::Remembered;
+  const auto accepts = [snapshot, remembered](float world_x, float world_z) -> bool {
+    if (snapshot == nullptr) {
+      return true;
+    }
+    const auto visibility =
+        Game::Map::classify_world_visibility(*snapshot, world_x, world_z);
+    return remembered ? visibility != Game::Map::RenderVisibilityState::Hidden
+                      : visibility == Game::Map::RenderVisibilityState::Visible;
+  };
+
+  std::vector<std::uint8_t> flags;
+  std::vector<Instance> packed;
+  std::size_t total_visible = 0;
+  bool any_chunk_changed = false;
+
+  for (auto& chunk : state.spatial_chunks) {
+
+    if (remembered && chunk.all_accepted && chunk.buffer != nullptr) {
+      total_visible += chunk.visible_count;
+      continue;
+    }
+
+    ++state.last_sync_stats.chunks_rescanned;
+    const bool changed = refresh_chunk_acceptance(
+        state.instances, chunk, position_accessor, accepts, flags, packed);
+    total_visible += chunk.visible_count;
+    if (!changed && chunk.buffer != nullptr) {
+      continue;
+    }
+    any_chunk_changed = true;
+
+    if (chunk.visible_count == 0) {
+      if (chunk.buffer != nullptr) {
+        chunk.buffer.reset();
+        ++state.last_sync_stats.buffer_resets;
+      }
+      continue;
+    }
+    if (!chunk.buffer) {
+      chunk.buffer =
+          std::make_unique<Render::GL::Buffer>(Render::GL::Buffer::Type::Vertex);
+    }
+    chunk.buffer->set_data(packed, Render::GL::Buffer::Usage::Static);
     ++state.last_sync_stats.buffer_uploads;
   }
 
-  state.instance_count = state.visible_instances.size();
+  if (state.track_visible_instances && (any_chunk_changed || structure_dirty)) {
+    state.visible_instances.clear();
+    state.visible_instances.reserve(total_visible);
+    for (const auto& chunk : state.spatial_chunks) {
+      for (std::size_t i = 0; i < chunk.count; ++i) {
+        if (chunk.accepted[i] != 0U) {
+          state.visible_instances.push_back(state.instances[chunk.first + i]);
+        }
+      }
+    }
+  }
+
+  state.instance_count = total_visible;
   state.instances_dirty = false;
   state.visibility_dirty = false;
   state.cached_visibility_version = version;

--- a/render/ground/scatter_runtime.h
+++ b/render/ground/scatter_runtime.h
@@ -25,6 +25,7 @@ struct SyncStats {
   std::uint32_t visibility_rebuilds = 0;
   std::uint32_t buffer_uploads = 0;
   std::uint32_t buffer_resets = 0;
+  std::uint32_t chunks_rescanned = 0;
 
   [[nodiscard]] auto did_upload_or_rebuild() const noexcept -> bool {
     return visibility_rebuilds != 0U || buffer_uploads != 0U || buffer_resets != 0U;
@@ -34,6 +35,7 @@ struct SyncStats {
     visibility_rebuilds += other.visibility_rebuilds;
     buffer_uploads += other.buffer_uploads;
     buffer_resets += other.buffer_resets;
+    chunks_rescanned += other.chunks_rescanned;
     return *this;
   }
 };

--- a/render/ground/scatter_submission.h
+++ b/render/ground/scatter_submission.h
@@ -10,7 +10,7 @@ void submit_visible_chunks(Render::GL::Renderer& renderer,
                            const FilteredRendererState<Instance, Params>& state,
                            Render::GL::TerrainScatterCmd command) {
   for (const auto& chunk : state.spatial_chunks) {
-    if (chunk.instances.empty() || chunk.buffer == nullptr) {
+    if (chunk.visible_count == 0 || chunk.buffer == nullptr) {
       continue;
     }
     if (!renderer.submission_visibility().accepts_sphere(
@@ -18,7 +18,7 @@ void submit_visible_chunks(Render::GL::Renderer& renderer,
       continue;
     }
     command.instance_buffer = chunk.buffer.get();
-    command.instance_count = chunk.instances.size();
+    command.instance_count = chunk.visible_count;
     renderer.terrain_scatter(command);
   }
 }
@@ -29,19 +29,19 @@ void submit_visible_chunks_lod(Render::GL::Renderer& renderer,
                                Render::GL::TerrainScatterCmd command,
                                ChunkBudget chunk_budget) {
   for (const auto& chunk : state.spatial_chunks) {
-    if (chunk.instances.empty() || chunk.buffer == nullptr) {
+    if (chunk.visible_count == 0 || chunk.buffer == nullptr) {
       continue;
     }
     if (!renderer.submission_visibility().accepts_sphere(
             chunk.center, chunk.radius, Render::GL::SubmissionFogMode::Ignore)) {
       continue;
     }
-    const std::size_t budget = chunk_budget(chunk.center, chunk.instances.size());
+    const std::size_t budget = chunk_budget(chunk.center, chunk.visible_count);
     if (budget == 0) {
       continue;
     }
     command.instance_buffer = chunk.buffer.get();
-    command.instance_count = std::min(budget, chunk.instances.size());
+    command.instance_count = std::min(budget, chunk.visible_count);
     renderer.terrain_scatter(command);
   }
 }

--- a/render/ground/terrain_scatter_manager.cpp
+++ b/render/ground/terrain_scatter_manager.cpp
@@ -116,7 +116,8 @@ void TerrainScatterManager::configure(
   m_supply_cart->configure(height_map, biome_settings, runtime_world_props);
   m_weapon_rack->configure(height_map, biome_settings, runtime_world_props);
   m_ruins->configure(height_map, biome_settings, runtime_world_props);
-  m_dead_tree->configure(height_map, biome_settings, runtime_world_props);
+  m_dead_tree->configure(
+      height_map, biome_settings, m_scatter_seed_world_props, runtime_world_props);
   m_boulder->configure(height_map,
                        biome_settings,
                        m_scatter_seed_world_props,
@@ -139,21 +140,11 @@ void TerrainScatterManager::refresh_runtime_world_props(
   m_use_world_props_exclusively =
       should_use_runtime_harvest_props_exclusively(runtime_world_props, false);
 
-  m_pine->configure(*m_height_map,
-                    m_biome_settings,
-                    m_scatter_seed_world_props,
-                    runtime_world_props,
-                    m_use_world_props_exclusively);
-  m_olive->configure(*m_height_map,
-                     m_biome_settings,
-                     m_scatter_seed_world_props,
-                     runtime_world_props,
-                     m_use_world_props_exclusively);
-  m_boulder->configure(*m_height_map,
-                       m_biome_settings,
-                       m_scatter_seed_world_props,
-                       runtime_world_props,
-                       m_use_world_props_exclusively);
+  m_pine->refresh_world_props(runtime_world_props, m_use_world_props_exclusively);
+  m_olive->refresh_world_props(runtime_world_props, m_use_world_props_exclusively);
+  m_boulder->refresh_world_props(runtime_world_props, m_use_world_props_exclusively);
+  m_dead_tree->refresh_world_props(runtime_world_props);
+
   m_iron_ore->configure(*m_height_map, m_biome_settings, runtime_world_props);
 
   m_firecamp->configure(*m_height_map, m_biome_settings, runtime_world_props);
@@ -161,7 +152,6 @@ void TerrainScatterManager::refresh_runtime_world_props(
   m_supply_cart->configure(*m_height_map, m_biome_settings, runtime_world_props);
   m_weapon_rack->configure(*m_height_map, m_biome_settings, runtime_world_props);
   m_ruins->configure(*m_height_map, m_biome_settings, runtime_world_props);
-  m_dead_tree->configure(*m_height_map, m_biome_settings, runtime_world_props);
   m_magic_shrine->configure(*m_height_map, m_biome_settings, runtime_world_props);
   m_abandoned_home->configure(*m_height_map, m_biome_settings, runtime_world_props);
   m_statue->configure(*m_height_map, m_biome_settings, runtime_world_props);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,6 +127,7 @@ add_executable(
     headless/headless_simulation_test.cpp
     headless/gate_traversal_test.cpp
     headless/wall_siege_test.cpp
+    headless/mission_wave_assault_test.cpp
     architecture/layering_test.cpp
     architecture/qml_surface_test.cpp
     architecture/documentation_accuracy_test.cpp

--- a/tests/headless/mission_wave_assault_test.cpp
+++ b/tests/headless/mission_wave_assault_test.cpp
@@ -1,0 +1,273 @@
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <limits>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "game/core/component.h"
+#include "game/core/world.h"
+#include "game/map/map_definition.h"
+#include "game/map/terrain_service.h"
+#include "game/session/session_context.h"
+#include "game/session/simulation_clock.h"
+#include "game/systems/ai_system.h"
+#include "game/systems/ai_system/ai_strategy.h"
+#include "game/systems/command_service.h"
+#include "game/systems/nation_registry.h"
+#include "game/systems/owner_registry.h"
+#include "game/systems/pathfinding.h"
+#include "game/systems/runtime_system_registry.h"
+#include "game/systems/wall_network_service.h"
+#include "game/units/factory.h"
+#include "game/units/spawn_type.h"
+
+namespace {
+
+using Engine::Core::EntityID;
+using Engine::Core::TransformComponent;
+using Engine::Core::UnitComponent;
+using Game::Session::SessionContext;
+
+constexpr int k_player = 1;
+constexpr int k_wave_ai = 2;
+constexpr int k_map_size = 64;
+
+constexpr int k_camp_grid_x = 20;
+constexpr int k_wave_grid_x = 58;
+constexpr int k_gate_grid_z = 30;
+
+constexpr int k_ring_west_x = 4;
+constexpr int k_ring_east_x = 40;
+constexpr int k_ring_north_z = 10;
+constexpr int k_ring_south_z = 50;
+
+class MissionWaveAssaultTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Game::Systems::CommandService::initialize(k_map_size, k_map_size);
+    m_factory = std::make_shared<Game::Units::UnitFactoryRegistry>();
+    Game::Units::register_built_in_units(*m_factory);
+  }
+
+  auto make_match() -> SessionContext& {
+    m_session = std::make_unique<SessionContext>();
+    auto& session = *m_session;
+    session.world().set_presentation_enabled(false);
+    m_scope = std::make_unique<Game::Session::ScopedSession>(session);
+    auto& owners = session.owners();
+    owners.register_owner_with_id(k_player, Game::Systems::OwnerType::Player, "carth");
+    owners.register_owner_with_id(k_wave_ai, Game::Systems::OwnerType::AI, "rome");
+    owners.set_owner_team(k_player, 0);
+    owners.set_owner_team(k_wave_ai, 1);
+    session.nations().initialize_defaults();
+    Game::Systems::register_runtime_systems(session.world());
+
+    Game::Map::MapDefinition map_definition;
+    map_definition.grid.width = k_map_size;
+    map_definition.grid.height = k_map_size;
+    map_definition.grid.tile_size = 1.0F;
+    session.terrain().initialize(map_definition);
+    return session;
+  }
+
+  void TearDown() override {
+    m_scope.reset();
+    m_session.reset();
+  }
+
+  static void run_for(SessionContext& session, double seconds) {
+    const double step = session.clock().tick_seconds();
+    for (double elapsed = 0.0; elapsed < seconds; elapsed += step) {
+      session.clock().advance(step);
+      while (session.clock().consume_tick()) {
+        session.world().update(static_cast<float>(step));
+      }
+    }
+  }
+
+  auto spawn(SessionContext& session,
+             Game::Units::SpawnType type,
+             int owner_id,
+             QVector3D position,
+             bool ai_controlled = false,
+             float rotation_y = 0.0F) -> EntityID {
+    Game::Units::SpawnParams params;
+    params.position = position;
+    params.player_id = owner_id;
+    params.spawn_type = type;
+    params.ai_controlled = ai_controlled;
+    params.rotation_y = rotation_y;
+    params.nation_id = Game::Systems::NationID::RomanRepublic;
+    auto unit = m_factory->create(type, session.world(), params);
+    return unit ? unit->id() : 0;
+  }
+
+  static auto position_of(SessionContext& session, EntityID id) -> QVector3D {
+    auto* entity = session.world().get_entity(id);
+    if (entity == nullptr) {
+      return {};
+    }
+    auto* transform = entity->get_component<TransformComponent>();
+    return transform == nullptr
+               ? QVector3D()
+               : QVector3D(transform->position.x, 0.0F, transform->position.z);
+  }
+
+  static auto world_of(int grid_x, int grid_z) -> QVector3D {
+    return Game::Systems::CommandService::grid_to_world(
+        Game::Systems::Point(grid_x, grid_z));
+  }
+
+  void build_camp_ring(SessionContext& session) {
+    constexpr int k_pitch = Game::Systems::WallNetworkService::k_segment_spacing;
+    auto place = [&](int grid_x, int grid_z) {
+      const bool is_gate = grid_x == k_ring_east_x && grid_z == k_gate_grid_z;
+      spawn(session,
+            is_gate ? Game::Units::SpawnType::WallGate
+                    : Game::Units::SpawnType::WallSegment,
+            k_player,
+            world_of(grid_x, grid_z),
+            false,
+            is_gate ? 90.0F : 0.0F);
+    };
+    for (int grid_x = k_ring_west_x; grid_x <= k_ring_east_x; grid_x += k_pitch) {
+      place(grid_x, k_ring_north_z);
+      place(grid_x, k_ring_south_z);
+    }
+    for (int grid_z = k_ring_north_z + k_pitch; grid_z < k_ring_south_z;
+         grid_z += k_pitch) {
+      place(k_ring_west_x, grid_z);
+      place(k_ring_east_x, grid_z);
+    }
+    Game::Systems::WallNetworkService::refresh_world(session.world());
+  }
+
+  static auto is_inside_ring(const QVector3D& position) -> bool {
+    const QVector3D north_west = world_of(k_ring_west_x, k_ring_north_z);
+    const QVector3D south_east = world_of(k_ring_east_x, k_ring_south_z);
+    return position.x() > north_west.x() + 1.0F &&
+           position.x() < south_east.x() - 1.0F &&
+           position.z() > north_west.z() + 1.0F && position.z() < south_east.z() - 1.0F;
+  }
+
+  auto spawn_wave(SessionContext& session, int count) -> std::vector<EntityID> {
+    const QVector3D entry = world_of(k_wave_grid_x, k_gate_grid_z - 2);
+    std::vector<EntityID> wave;
+    for (int i = 0; i < count; ++i) {
+      const EntityID id =
+          spawn(session,
+                Game::Units::SpawnType::Knight,
+                k_wave_ai,
+                entry + QVector3D(static_cast<float>(i) * 2.0F, 0.0F, 0.0F),
+                true);
+      if (id == 0) {
+        continue;
+      }
+      session.world()
+          .get_entity(id)
+          ->add_component<Engine::Core::AssaultWaveComponent>();
+      wave.push_back(id);
+    }
+    return wave;
+  }
+
+  static void make_defensive(SessionContext& session) {
+    auto* ai_system = session.world().get_system<Game::Systems::AISystem>();
+    ASSERT_NE(ai_system, nullptr);
+    ai_system->set_ai_strategy(k_wave_ai,
+                               Game::Systems::AI::AIStrategy::Defensive,
+                               0.35F,
+                               0.85F,
+                               0.15F,
+                               "medium");
+  }
+
+  static auto closest_wave_distance_to(SessionContext& session,
+                                       const std::vector<EntityID>& wave,
+                                       const QVector3D& point) -> float {
+    float best = std::numeric_limits<float>::max();
+    for (const auto id : wave) {
+      if (session.world().get_entity(id) == nullptr) {
+        continue;
+      }
+      best = std::min(best, (position_of(session, id) - point).length());
+    }
+    return best;
+  }
+
+  std::unique_ptr<SessionContext> m_session;
+  std::unique_ptr<Game::Session::ScopedSession> m_scope;
+  std::shared_ptr<Game::Units::UnitFactoryRegistry> m_factory;
+};
+
+TEST_F(MissionWaveAssaultTest, WaveUnitsMarchOnAnOpenCamp) {
+  auto& session = make_match();
+
+  const QVector3D camp = world_of(k_camp_grid_x, k_gate_grid_z);
+  spawn(session, Game::Units::SpawnType::Barracks, k_player, camp);
+  spawn(session,
+        Game::Units::SpawnType::Spearman,
+        k_player,
+        camp + QVector3D(3.0F, 0.0F, 0.0F));
+
+  make_defensive(session);
+  const auto wave = spawn_wave(session, 2);
+  ASSERT_EQ(wave.size(), 2U);
+
+  const float start = closest_wave_distance_to(session, wave, camp);
+  run_for(session, 40.0);
+  const float end = closest_wave_distance_to(session, wave, camp);
+
+  EXPECT_LT(end, start * 0.5F) << "start " << start << " end " << end;
+}
+
+TEST_F(MissionWaveAssaultTest, WaveUnitsAttackTheRampartInTheirWay) {
+  auto& session = make_match();
+
+  build_camp_ring(session);
+
+  const QVector3D camp = world_of(k_camp_grid_x, k_gate_grid_z);
+  spawn(session, Game::Units::SpawnType::Barracks, k_player, camp);
+  spawn(session,
+        Game::Units::SpawnType::Spearman,
+        k_player,
+        world_of(k_ring_east_x - 6, k_gate_grid_z));
+
+  make_defensive(session);
+  const auto wave = spawn_wave(session, 6);
+  ASSERT_EQ(wave.size(), 6U);
+
+  run_for(session, 240.0);
+
+  int damage_dealt = 0;
+  std::unordered_set<EntityID> barriers;
+  for (auto* entity :
+       session.world().get_entities_with<Engine::Core::WallSegmentComponent>()) {
+    const auto* unit = entity->get_component<UnitComponent>();
+    if (unit == nullptr) {
+      continue;
+    }
+    barriers.insert(entity->get_id());
+    damage_dealt += unit->max_health - unit->health;
+  }
+
+  int attacking_the_rampart = 0;
+  for (const auto id : wave) {
+    auto* entity = session.world().get_entity(id);
+    if (entity == nullptr) {
+      continue;
+    }
+    const auto* attack_target =
+        entity->get_component<Engine::Core::AttackTargetComponent>();
+    if (attack_target != nullptr && barriers.contains(attack_target->target_id)) {
+      attacking_the_rampart++;
+    }
+  }
+
+  EXPECT_GT(attacking_the_rampart, 0)
+      << "no wave unit was working on the rampart between it and the camp";
+  EXPECT_GT(damage_dealt, 0) << "the wave stood at the wall without ever striking it";
+}
+
+} // namespace

--- a/tests/render/mode_indicator_test.cpp
+++ b/tests/render/mode_indicator_test.cpp
@@ -60,8 +60,9 @@ TEST(ModeIndicator, EveryNoteworthyActivityHasGlyphGeometry) {
     EXPECT_TRUE(layers.contains(static_cast<int>(GlyphLayer::Outline)))
         << "activity " << Game::Systems::activity_kind_id(kind)
         << " has no silhouette to read against terrain";
-    EXPECT_TRUE(layers.contains(static_cast<int>(GlyphLayer::Glow)))
-        << "activity " << Game::Systems::activity_kind_id(kind) << " has no glow";
+    EXPECT_TRUE(layers.contains(static_cast<int>(GlyphLayer::Shadow)))
+        << "activity " << Game::Systems::activity_kind_id(kind)
+        << " has nothing dropped behind it to lift it off the terrain";
   }
 }
 
@@ -119,27 +120,41 @@ TEST(ModeIndicator, DrawsEveryOrderAtOneWorldSize) {
                   Render::Geom::k_indicator_world_size);
 }
 
-TEST(ModeIndicator, StampsEveryActivityOnTheSameMedallion) {
+auto face_coverage(const Render::Geom::GlyphBuilder& builder) -> float {
+  auto const& vertices = builder.vertices();
+  auto const& indices = builder.indices();
+  float area = 0.0F;
+  for (std::size_t i = 0; i + 2U < indices.size(); i += 3U) {
+    auto const& a = vertices[indices[i]];
+    auto const& b = vertices[indices[i + 1U]];
+    auto const& c = vertices[indices[i + 2U]];
+    if (static_cast<int>(a.tex_coord[0]) != static_cast<int>(GlyphLayer::Glyph)) {
+      continue;
+    }
+    area += 0.5F *
+            std::abs((b.position[0] - a.position[0]) * (c.position[1] - a.position[1]) -
+                     (c.position[0] - a.position[0]) * (b.position[1] - a.position[1]));
+  }
+  return area;
+}
+
+TEST(ModeIndicator, DrawsTheIconAloneWithNoPlateBehindIt) {
+  constexpr float k_footprint_area = 1.0F;
   for (IndicatorKind const kind : all_kinds()) {
     auto const builder = Render::Geom::build_indicator_glyph(kind);
-    auto const layers = layers_used(builder);
-    EXPECT_TRUE(layers.contains(static_cast<int>(GlyphLayer::Plaque)))
-        << "activity " << Game::Systems::activity_kind_id(kind) << " has no plaque";
-    EXPECT_TRUE(layers.contains(static_cast<int>(GlyphLayer::Rim)))
+    EXPECT_LT(face_coverage(builder), k_footprint_area * 0.62F)
         << "activity " << Game::Systems::activity_kind_id(kind)
-        << " has no coloured rim";
-    EXPECT_TRUE(layers.contains(static_cast<int>(GlyphLayer::Shadow)))
-        << "activity " << Game::Systems::activity_kind_id(kind)
-        << " has nothing to lift it off the terrain";
+        << " covers its whole footprint, which is what a badge behind the icon "
+           "would look like";
   }
 }
 
-TEST(ModeIndicator, FitsEveryIconToTheSameRadiusInsideTheMedallion) {
+TEST(ModeIndicator, ReadsAtOneSizeAcrossEveryActivity) {
   float smallest = 1.0e9F;
   float largest = 0.0F;
   for (IndicatorKind const kind : all_kinds()) {
     auto const builder = Render::Geom::build_indicator_glyph(kind);
-    float radius_sq = 0.0F;
+    float extent = 0.0F;
     for (auto const& vertex : builder.vertices()) {
       auto const layer = static_cast<int>(vertex.tex_coord[0]);
       if (layer != static_cast<int>(GlyphLayer::Glyph) &&
@@ -147,21 +162,18 @@ TEST(ModeIndicator, FitsEveryIconToTheSameRadiusInsideTheMedallion) {
           layer != static_cast<int>(GlyphLayer::GlyphSide)) {
         continue;
       }
-      radius_sq = std::max(radius_sq,
-                           vertex.position[0] * vertex.position[0] +
-                               vertex.position[1] * vertex.position[1]);
+      extent = std::max(
+          extent, std::max(std::abs(vertex.position[0]), std::abs(vertex.position[1])));
     }
 
-    float const radius = std::sqrt(radius_sq);
-
-    EXPECT_LT(radius, 0.318F) << "activity " << Game::Systems::activity_kind_id(kind)
-                              << " overflows the medallion face";
-    smallest = std::min(smallest, radius);
-    largest = std::max(largest, radius);
+    EXPECT_LT(extent, 0.5F) << "activity " << Game::Systems::activity_kind_id(kind)
+                            << " overflows the marker footprint";
+    smallest = std::min(smallest, extent);
+    largest = std::max(largest, extent);
   }
 
-  EXPECT_GT(smallest, 0.20F);
-  EXPECT_LT(largest - smallest, 0.03F)
+  EXPECT_GT(smallest, 0.34F) << "an icon reads far smaller than the space it owns";
+  EXPECT_LT(largest - smallest, 0.09F)
       << "one activity reads at a noticeably different size than the others";
 }
 

--- a/tests/render/scatter_runtime_test.cpp
+++ b/tests/render/scatter_runtime_test.cpp
@@ -410,4 +410,184 @@ TEST(ScatterRuntimeTest, RuntimePlantedShrineReachesTheScatterPass) {
   terrain.clear();
 }
 
+TEST(ScatterRuntimeTest, WorldPropRefreshReusesTheProceduralBiomeScatter) {
+  auto& terrain = Game::Map::TerrainService::instance();
+  terrain.initialize(make_tree_map_definition(Game::Map::GroundType::ForestMud, 8081U));
+  auto const* height_map = terrain.get_height_map();
+  ASSERT_NE(height_map, nullptr);
+
+  const auto& seed_props = terrain.authored_world_props();
+  auto runtime_props = terrain.world_props();
+
+  Render::GL::PineRenderer pines;
+  Render::GL::BoulderRenderer boulders;
+  Render::GL::DeadTreeRenderer dead_trees;
+  pines.configure(*height_map, terrain.biome_settings(), seed_props, runtime_props);
+  boulders.configure(*height_map, terrain.biome_settings(), seed_props, runtime_props);
+  dead_trees.configure(
+      *height_map, terrain.biome_settings(), seed_props, runtime_props);
+
+  ASSERT_GT(pines.instance_count(), 0U)
+      << "forest mud must scatter pines procedurally for this test to mean anything";
+  ASSERT_EQ(pines.procedural_generations_for_test(), 1U);
+  ASSERT_EQ(boulders.procedural_generations_for_test(), 1U);
+  ASSERT_EQ(dead_trees.procedural_generations_for_test(), 1U);
+
+  const std::size_t pine_count = pines.instance_count();
+  const std::size_t boulder_count = boulders.instance_count();
+  const std::size_t dead_tree_count = dead_trees.instance_count();
+
+  Game::Map::WorldProp shrine;
+  shrine.type = Game::Map::WorldProp::Type::MagicShrine;
+  shrine.x = 12.0F;
+  shrine.z = 9.0F;
+  runtime_props.push_back(shrine);
+
+  pines.refresh_world_props(runtime_props, false);
+  boulders.refresh_world_props(runtime_props, false);
+  dead_trees.refresh_world_props(runtime_props);
+
+  EXPECT_EQ(pines.procedural_generations_for_test(), 1U)
+      << "planting a prop must not re-run the map-wide pine scatter";
+  EXPECT_EQ(boulders.procedural_generations_for_test(), 1U);
+  EXPECT_EQ(dead_trees.procedural_generations_for_test(), 1U);
+
+  EXPECT_EQ(pines.instance_count(), pine_count);
+  EXPECT_EQ(boulders.instance_count(), boulder_count);
+  EXPECT_EQ(dead_trees.instance_count(), dead_tree_count)
+      << "an unrelated prop must not shift the biome scatter around it";
+
+  pines.configure(*height_map, terrain.biome_settings(), seed_props, runtime_props);
+  EXPECT_EQ(pines.procedural_generations_for_test(), 1U)
+      << "a full reconfigure must drop the cache and generate exactly once";
+  EXPECT_EQ(pines.instance_count(), pine_count);
+
+  terrain.clear();
+}
+
+struct FakeScatterInstance {
+  QVector4D pos_scale;
+};
+
+using FakeChunk = Render::Ground::Scatter::SpatialChunk<FakeScatterInstance>;
+
+auto fake_position(const FakeScatterInstance& instance) -> const QVector4D& {
+  return instance.pos_scale;
+}
+
+auto make_grid_instances(int side, float spacing) -> std::vector<FakeScatterInstance> {
+  std::vector<FakeScatterInstance> instances;
+  instances.reserve(static_cast<std::size_t>(side) * static_cast<std::size_t>(side));
+  for (int z = 0; z < side; ++z) {
+    for (int x = 0; x < side; ++x) {
+      instances.push_back({QVector4D(static_cast<float>(x) * spacing,
+                                     0.0F,
+                                     static_cast<float>(z) * spacing,
+                                     1.0F)});
+    }
+  }
+  return instances;
+}
+
+TEST(ScatterRuntimeTest, SpatialPartitionGivesEveryChunkAContiguousInstanceSlice) {
+  auto instances = make_grid_instances(24, 4.0F);
+  const std::size_t total = instances.size();
+  std::vector<FakeChunk> chunks;
+
+  Render::Ground::Scatter::rebuild_spatial_partition(instances, chunks, fake_position);
+
+  ASSERT_GT(chunks.size(), 1U) << "a 92-unit grid must span several 24-unit chunks";
+  EXPECT_EQ(instances.size(), total) << "partitioning reorders, it must not drop";
+
+  std::size_t expected_first = 0;
+  std::size_t counted = 0;
+  for (const auto& chunk : chunks) {
+    EXPECT_EQ(chunk.first, expected_first)
+        << "chunk slices must tile the instance vector without gaps";
+    EXPECT_GT(chunk.count, 0U);
+    EXPECT_EQ(chunk.accepted.size(), chunk.count);
+    EXPECT_EQ(chunk.visible_count, 0U);
+    EXPECT_FALSE(chunk.all_accepted);
+
+    for (std::size_t i = 0; i < chunk.count; ++i) {
+      const auto& position = instances[chunk.first + i].pos_scale;
+      EXPECT_LE((position.toVector3D() - chunk.center).length(), chunk.radius)
+          << "the chunk bounding sphere must contain every instance it owns";
+    }
+    expected_first += chunk.count;
+    counted += chunk.count;
+  }
+  EXPECT_EQ(counted, total);
+}
+
+TEST(ScatterRuntimeTest, UnchangedVisibilityLeavesChunkAcceptanceAlone) {
+  auto instances = make_grid_instances(12, 4.0F);
+  std::vector<FakeChunk> chunks;
+  Render::Ground::Scatter::rebuild_spatial_partition(instances, chunks, fake_position);
+  ASSERT_FALSE(chunks.empty());
+
+  std::vector<std::uint8_t> flags;
+  std::vector<FakeScatterInstance> packed;
+  auto reveal_west = [](float world_x, float) {
+    return world_x < 24.0F;
+  };
+
+  bool any_changed_first_pass = false;
+  for (auto& chunk : chunks) {
+    any_changed_first_pass |= Render::Ground::Scatter::refresh_chunk_acceptance(
+        instances, chunk, fake_position, reveal_west, flags, packed);
+  }
+  EXPECT_TRUE(any_changed_first_pass)
+      << "the first scan must always report a change so the buffers get filled";
+
+  for (auto& chunk : chunks) {
+    EXPECT_FALSE(Render::Ground::Scatter::refresh_chunk_acceptance(
+        instances, chunk, fake_position, reveal_west, flags, packed))
+        << "re-scanning against the same visibility must not request an upload";
+  }
+}
+
+TEST(ScatterRuntimeTest, RevealingGroundOnlyDirtiesTheChunksItTouches) {
+  auto instances = make_grid_instances(12, 6.0F);
+  std::vector<FakeChunk> chunks;
+  Render::Ground::Scatter::rebuild_spatial_partition(instances, chunks, fake_position);
+  ASSERT_GT(chunks.size(), 2U);
+
+  std::vector<std::uint8_t> flags;
+  std::vector<FakeScatterInstance> packed;
+  auto reveal_west = [](float world_x, float) {
+    return world_x < 24.0F;
+  };
+  auto reveal_more = [](float world_x, float) {
+    return world_x < 48.0F;
+  };
+
+  for (auto& chunk : chunks) {
+    Render::Ground::Scatter::refresh_chunk_acceptance(
+        instances, chunk, fake_position, reveal_west, flags, packed);
+  }
+
+  std::size_t changed_chunks = 0;
+  for (auto& chunk : chunks) {
+    if (Render::Ground::Scatter::refresh_chunk_acceptance(
+            instances, chunk, fake_position, reveal_more, flags, packed)) {
+      ++changed_chunks;
+    }
+  }
+
+  EXPECT_GT(changed_chunks, 0U) << "widening the reveal must expose more scatter";
+  EXPECT_LT(changed_chunks, chunks.size())
+      << "chunks outside the newly revealed band must not re-upload";
+
+  std::size_t visible_total = 0;
+  for (const auto& chunk : chunks) {
+    visible_total += chunk.visible_count;
+    if (chunk.center.x() < 24.0F) {
+      EXPECT_TRUE(chunk.all_accepted);
+    }
+  }
+  EXPECT_GT(visible_total, 0U);
+  EXPECT_LT(visible_total, instances.size());
+}
+
 } // namespace


### PR DESCRIPTION
Persist the target location assigned during mission wave setup and carry it through AI snapshots so assault units continue marching when no target is currently visible. Update assault targeting to ignore walls as objectives, select the first live barrier on the route while preferring gates, form attackers on the breach face, and keep attack and move locks from pinning units to structures. Serialize the new march fields for save and load compatibility.

Refactor natural scatter renderers to separate authored and runtime props from cached procedural generation. Partition instances into spatial chunks, retain acceptance state per chunk, and upload only chunks whose visibility changed. Add renderer refresh hooks and test seams so runtime planting no longer regenerates the complete biome scatter.

Refresh mode-indicator glyph silhouettes, activity and vegetation shader presentation, and tree and prop palette variation while preserving the existing renderer paths. Add headless assault regression coverage and render tests for cache reuse, chunk partitioning, and selective visibility refresh.