### PR TITLE
Fix assault routing and enrich damaged building rendering

### DIFF
--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -3377,25 +3377,8 @@ void GameEngine::restore_mission_waves(const QJsonObject& wave_state) {
 
   const auto& mission = *m_campaign_manager->current_mission_definition();
 
-  QVector3D defense_reference{0.0F, 0.0F, 0.0F};
-  int anchor_count = 0;
-  for (auto* entity : m_world->get_entities_with<Engine::Core::UnitComponent>()) {
-    if (entity == nullptr) {
-      continue;
-    }
-    const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
-    const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
-    if (unit == nullptr || transform == nullptr ||
-        unit->owner_id != m_runtime.local_owner_id || unit->health <= 0) {
-      continue;
-    }
-    defense_reference +=
-        QVector3D(transform->position.x, transform->position.y, transform->position.z);
-    anchor_count++;
-  }
-  if (anchor_count > 0) {
-    defense_reference /= static_cast<float>(anchor_count);
-  }
+  const QVector3D defense_reference =
+      App::Core::resolve_defense_reference(*m_world, m_runtime.local_owner_id);
 
   m_pending_mission_waves = App::Core::build_pending_mission_waves(
       {.mission = mission,

--- a/app/core/mission_setup_coordinator.cpp
+++ b/app/core/mission_setup_coordinator.cpp
@@ -132,6 +132,56 @@ void assign_wave_phases(std::vector<PendingMissionWave>& waves, std::size_t begi
 
 } // namespace
 
+auto resolve_defense_reference(Engine::Core::World& world,
+                               int local_owner_id) -> QVector3D {
+
+  QVector3D barracks;
+  QVector3D halls;
+  QVector3D troops;
+  int barracks_count = 0;
+  int hall_count = 0;
+  int troop_count = 0;
+
+  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+    if (entity == nullptr) {
+      continue;
+    }
+    const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
+    const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
+    if (unit == nullptr || transform == nullptr || unit->owner_id != local_owner_id ||
+        unit->health <= 0) {
+      continue;
+    }
+
+    const QVector3D position(
+        transform->position.x, transform->position.y, transform->position.z);
+    if (unit->spawn_type == Game::Units::SpawnType::Barracks) {
+      barracks += position;
+      barracks_count++;
+    } else if (entity->has_component<Engine::Core::BuildingComponent>()) {
+      if (unit->spawn_type != Game::Units::SpawnType::WallSegment &&
+          unit->spawn_type != Game::Units::SpawnType::WallGate) {
+        halls += position;
+        hall_count++;
+      }
+    } else {
+      troops += position;
+      troop_count++;
+    }
+  }
+
+  if (barracks_count > 0) {
+    return barracks / static_cast<float>(barracks_count);
+  }
+  if (hall_count > 0) {
+    return halls / static_cast<float>(hall_count);
+  }
+  if (troop_count > 0) {
+    return troops / static_cast<float>(troop_count);
+  }
+  return {0.0F, 0.0F, 0.0F};
+}
+
 auto wave_unit_total(const PendingMissionWave& wave) -> int {
   int total = 0;
   for (const auto& comp : wave.composition) {
@@ -631,25 +681,8 @@ auto MissionSetupCoordinator::apply_mission_setup(
   spawn_buildings_for_owner(
       local_owner_id, player_nation_id, mission.player_setup.starting_buildings);
 
-  QVector3D defense_reference_world_position{0.0F, 0.0F, 0.0F};
-  int local_force_anchor_count = 0;
-  for (auto* entity : ctx.world.get_entities_with<Engine::Core::UnitComponent>()) {
-    if (entity == nullptr) {
-      continue;
-    }
-    const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
-    const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
-    if (unit == nullptr || transform == nullptr || unit->owner_id != local_owner_id ||
-        unit->health <= 0) {
-      continue;
-    }
-    defense_reference_world_position +=
-        QVector3D(transform->position.x, transform->position.y, transform->position.z);
-    local_force_anchor_count++;
-  }
-  if (local_force_anchor_count > 0) {
-    defense_reference_world_position /= static_cast<float>(local_force_anchor_count);
-  }
+  const QVector3D defense_reference_world_position =
+      resolve_defense_reference(ctx.world, local_owner_id);
 
   int ai_owner_id = 2;
   int default_team_id = 1;

--- a/app/core/mission_setup_coordinator.h
+++ b/app/core/mission_setup_coordinator.h
@@ -113,6 +113,9 @@ struct MissionWaveEffects {
   std::vector<Engine::Core::EntityID> spawned_entity_ids;
 };
 
+[[nodiscard]] auto resolve_defense_reference(Engine::Core::World& world,
+                                             int local_owner_id) -> QVector3D;
+
 [[nodiscard]] auto wave_unit_total(const PendingMissionWave& wave) -> int;
 
 [[nodiscard]] auto

--- a/assets/shaders/basic.frag
+++ b/assets/shaders/basic.frag
@@ -23,19 +23,22 @@ float wood_grain(vec2 p, float y) {
   return grain * 0.13 + fine - knot;
 }
 
-vec3 procedural_material_variation(vec3 base_color, vec3 world_pos, vec3 normal) {
+vec3 procedural_material_variation(vec3 base_color,
+                                   vec3 world_pos,
+                                   vec3 normal,
+                                   int material_id) {
   vec2 uv = world_pos.xz * 4.0;
 
   float avg_color = (base_color.r + base_color.g + base_color.b) / 3.0;
 
   bool b_is_wood = false, b_is_metal = false, b_is_cloth = false;
-  if (u_material_id == 2) {
+  if (material_id == 2) {
     b_is_wood = true;
-  } else if (u_material_id == 1) {
+  } else if (material_id == 1) {
     b_is_metal = true;
-  } else if (u_material_id == 3) {
+  } else if (material_id == 3) {
     b_is_cloth = true;
-  } else if (u_material_id != 4) {
+  } else if (material_id != 4) {
 
     b_is_wood =
         (base_color.r < base_color.g * 2.5 && base_color.r > base_color.b * 1.45 &&
@@ -82,10 +85,12 @@ void main() {
   }
 
   vec3 normal = normalize(v_normal);
-  color = procedural_material_variation(color, v_world_pos, normal);
+  int soi_material = u_material_id % 10;
+  int soi_damage_tier = u_material_id / 10;
+  color = procedural_material_variation(color, v_world_pos, normal, soi_material);
 
-  if (u_material_id >= 10) {
-    float soot_amt = float(u_material_id - 9) * 0.45;
+  if (soi_damage_tier > 0) {
+    float soot_amt = float(soi_damage_tier) * 0.45;
     vec2 soot_uv = v_world_pos.xz * 3.5;
     float soot_patch =
         soi_noise_3d41e6(soot_uv) * 0.6 + soi_noise_3d41e6(soot_uv * 4.1) * 0.4;

--- a/assets/shaders/basic_instanced.frag
+++ b/assets/shaders/basic_instanced.frag
@@ -23,19 +23,22 @@ float wood_grain(vec2 p, float y) {
   return grain * 0.13 + fine - knot;
 }
 
-vec3 procedural_material_variation(vec3 base_color, vec3 world_pos, vec3 normal) {
+vec3 procedural_material_variation(vec3 base_color,
+                                   vec3 world_pos,
+                                   vec3 normal,
+                                   int material_id) {
   vec2 uv = world_pos.xz * 4.0;
 
   float avg_color = (base_color.r + base_color.g + base_color.b) / 3.0;
 
   bool b_is_wood = false, b_is_metal = false, b_is_cloth = false;
-  if (u_material_id == 2) {
+  if (material_id == 2) {
     b_is_wood = true;
-  } else if (u_material_id == 1) {
+  } else if (material_id == 1) {
     b_is_metal = true;
-  } else if (u_material_id == 3) {
+  } else if (material_id == 3) {
     b_is_cloth = true;
-  } else if (u_material_id != 4) {
+  } else if (material_id != 4) {
 
     b_is_wood =
         (base_color.r < base_color.g * 2.5 && base_color.r > base_color.b * 1.45 &&
@@ -82,10 +85,12 @@ void main() {
   }
 
   vec3 normal = normalize(v_normal);
-  color = procedural_material_variation(color, v_world_pos, normal);
+  int soi_material = u_material_id % 10;
+  int soi_damage_tier = u_material_id / 10;
+  color = procedural_material_variation(color, v_world_pos, normal, soi_material);
 
-  if (u_material_id >= 10) {
-    float soot_amt = float(u_material_id - 9) * 0.45;
+  if (soi_damage_tier > 0) {
+    float soot_amt = float(soi_damage_tier) * 0.45;
     vec2 soot_uv = v_world_pos.xz * 3.5;
     float soot_patch =
         soi_noise_3d41e6(soot_uv) * 0.6 + soi_noise_3d41e6(soot_uv * 4.1) * 0.4;

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -295,7 +295,22 @@ A defensive AI that only ever sits still is a punching bag, so `ChaseBehavior` g
 
 ### Assault waves: always offensive
 
-Scripted waves are the campaign's pressure, so they must not inherit the defensive posture of the AI that owns them. Wave units are spawned with `AssaultWaveComponent`; the snapshot marks them `is_assault`, and they are excluded from every ordinary force pool — attack force, gather, reserve, harass, and base defence recall. `AssaultBehavior` owns them instead: it advances them on the nearest visible enemy (falling back to a strategic objective) and switches to a direct attack once inside engagement range, regardless of whether the parent AI is Idle, Gathering or Defending. The component is serialized, so a save taken mid-wave restores an assault that is still an assault.
+Scripted waves are the campaign's pressure, so they must not inherit the defensive posture of the AI that owns them. Wave units are spawned with `AssaultWaveComponent`; the snapshot marks them `is_assault`, and they are excluded from every ordinary force pool — attack force, gather, reserve, harass, base defence recall, **and retreat**. `AssaultBehavior` owns them instead: it advances them on the nearest visible enemy (falling back to a strategic objective, then to the march target baked into the component) and switches to a direct attack once inside engagement range, regardless of whether the parent AI is Idle, Gathering or Defending. The component is serialized, so a save taken mid-wave restores an assault that is still an assault.
+
+A wave is a one-way trip. `RetreatBehavior` runs at `Critical`, above the assault, so before it skipped assault units a wounded wave unit was pulled back to its owner's home base — which in a campaign mission is usually on the far side of the map. From the player's seat that reads as the wave walking away instead of attacking. Assault units are now exempt from retreat entirely: they press on at any health.
+
+A wave also only hunts things somebody owns. Neutral property — roadside temples, ruins, unclaimed halls — is hostile to every AI and therefore shows up in the snapshot's enemy lists, so an assault used to stop and demolish whatever scenery it happened to march past. `select_assault_target` skips neutral-owned contacts entirely; capturing neutral ground is `ExpandBehavior`'s business and it never gets assault units. Neutral _barriers_ stay eligible as breach targets, because a wall in the corridor is in the way whoever owns it.
+
+#### Breaching versus flanking
+
+`AssaultBehavior` can break fortifications, but only ones that are genuinely in the way. It tracks, per assault unit, the best distance to the current objective and the time that best was last improved. Breaching is unlocked only when a unit has gained no ground for `k_advance_stall_seconds` (8 s); until then the wave keeps advancing and the pathfinder is free to route it around or through an opening. Once stalled, `select_breach_target` picks the barrier lying inside the corridor between the group and the objective (preferring gates) and the wave attacks it, holding a tighter engage radius so it presses the wall rather than milling around.
+
+The stall gate is what keeps the two cases separate:
+
+- **Camp fully enclosed** — no route exists, every unit stalls, the wave breaks the rampart down. This is the behaviour `WaveUnitsAttackTheRampartInTheirWay` pins.
+- **Rampart with open ends** (the first campaign mission's shape) — the wave keeps closing on the camp and the wall is simply walked past. Without the gate it would fixate on the wall in front of its spawn, kill it, then start on the neighbouring segment, and never enter the camp at all.
+
+Progress tracking resets whenever the objective moves more than `k_objective_drift`, so chasing a live target does not read as a stall.
 
 ### Skirmish: take the map, then come home when it burns
 

--- a/docs/MISSION_FRAMEWORK.md
+++ b/docs/MISSION_FRAMEWORK.md
@@ -185,6 +185,23 @@ A wave counts as broken when every unit it spawned is dead, has routed, or when 
 least 90% of it is dead. Routed survivors are deliberately ignored — a single
 fleeing horseman must not be able to stall a `survive_waves` objective forever.
 
+#### What a wave marches on
+
+`entry_point` says where a wave arrives; it never says where it goes. The target is
+the player's camp, resolved once at mission setup by
+`App::Core::resolve_defense_reference` and carried on each spawned unit as the
+`AssaultWaveComponent` march target. The resolution is ordered so the camp, not the
+army's current sprawl, wins: the player's barracks, else the centre of the player's
+other halls, else the centre of the player's troops. Walls and gates are never
+anchors — a rampart's centroid sits on the camp's edge, not in it — and averaging
+every owned entity lets a stray scout or a herd of civilians drag the target off the
+camp entirely.
+
+The march target is a floor, not a leash. Once moving, `AssaultBehavior` prefers a
+live target — the nearest visible enemy troop, then any player building or commander
+— and only falls back to the baked march point when it can see nothing at all. See
+`docs/AI_ARCHITECTURE.md` for how the wave handles fortifications on the way in.
+
 ```json
 "waves": [
   {

--- a/docs/RENDERING_ARCHITECTURE.md
+++ b/docs/RENDERING_ARCHITECTURE.md
@@ -248,9 +248,15 @@ public:
 ### Wrapping a submitter
 
 Some passes want to watch or adjust submissions on their way through without becoming
-the destination. `DamageStateSubmitter` substitutes a damage material id when a caller
-did not pick one; `RiggedBodyProbeSubmitter` counts how many rigged bodies a unit
-renderer actually emitted, so the tracing build can warn when one emits none.
+the destination. `DamageStateSubmitter` folds a damage tier into the material id;
+`RiggedBodyProbeSubmitter` counts how many rigged bodies a unit renderer actually
+emitted, so the tracing build can warn when one emits none.
+
+The damage tier rides in the tens digit: `basic.frag` and `basic_instanced.frag` read
+`u_material_id % 10` as the surface material (wood, metal, cloth) and
+`u_material_id / 10` as the tier, so a sooted plank still shades as wood. It used to
+substitute the whole id, which meant only untagged parts ever caught soot — every
+plank, band, and awning on a burning building stayed factory-fresh.
 
 Both derive from `ForwardingSubmitter`, which implements every `ISubmitter` method by
 passing it to an inner submitter. A decorator then overrides only what it changes —
@@ -516,6 +522,50 @@ We use a fairly conservative subset of OpenGL 3.3:
 | GLSL 330 shaders    | All visual computation       |
 
 What we don't use: geometry shaders (compatibility issues on some drivers), compute shaders (require OpenGL 4.3), tessellation (not needed for our art style), multi-draw indirect (instancing is enough).
+
+## How buildings rot
+
+`get_building_state()` in `entity/building_state.h` maps a building's health ratio onto
+three states: `Normal` above 70%, `Damaged` above 30%, `Destroyed` below it. Every
+building resolves its state per frame and picks an archetype out of a
+`BuildingArchetypeSet` — three pre-built `RenderArchetype`s, one per state, all baked
+from one `BuildingArchetypeDesc`. Nothing is recomputed while a building burns; the
+switch is a pointer swap.
+
+There are three layers to the degraded look, and it matters that they stack:
+
+1. **Parts drop out.** Each part carries a `BuildingStateMask`. Merlons, roof standards,
+   awnings, and market wares are masked to the states where they still exist. This is
+   authored per building, and it is what shapes the silhouette.
+2. **Surviving parts are re-tinted.** `build_building_archetype()` runs every
+   non-palette colour through `decayed_color()` (`entity/building_decay.h`) before it
+   reaches the builder. The ramp desaturates, darkens brightness-proportionally, then
+   mixes patchily toward ash, rot-green, and stone dust using a per-part hash. The
+   darkening is scaled by luminance on purpose: a flat multiply turned dark timber into
+   near-black mud while barely touching white limestone. `Normal` returns the authored
+   colour untouched, so a healthy building is byte-identical to what its author drew.
+3. **Ruin dressing is added.** `add_ruin_dressing()` scatters a rubble field, charred
+   beams, scorch patches, and collapsed roof slabs, all masked to `Damaged` /
+   `Destroyed`. Damaged rubble uses `ring_bias` to hug the outside of the footprint at
+   terrain height, where it is visible; destroyed rubble fills the shell.
+
+Before this, degradation was subtractive only: a ruined home was a shorter, roofless,
+_pristine white_ box that read as unfinished construction rather than as a ruin.
+
+Walls and gates were worse — `build_wall_archetype_set()` and
+`build_wall_gate_archetype()` both hard-coded `BuildingState::Normal`, so the most
+frequently attacked structures in the game rendered identically at full health and at
+one hit from collapse. They now build the full three-state set: stakes snap at
+deterministic indices, rails and braces fall, merlons break off their coping, and the
+masonry core drops to a stump.
+
+Two things deliberately do _not_ decay: palette parts (team colour must stay readable
+for identification) and the shader-side soot, which is a separate signal applied through
+the material tier described above.
+
+The whole matrix is reviewable in seconds with
+`building_preview --states <outdir>`, which renders every type × nation × state into one
+contact sheet.
 
 ## How nations get their look
 

--- a/game/systems/ai_system/behaviors/assault_behavior.cpp
+++ b/game/systems/ai_system/behaviors/assault_behavior.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "../../../core/ownership_constants.h"
 #include "../ai_utils.h"
 #include "systems/ai_system/ai_types.h"
 
@@ -25,6 +26,10 @@ constexpr float k_barrier_search_radius = 120.0F;
 constexpr float k_breach_stand_off = 2.0F;
 constexpr float k_breach_spread = 1.6F;
 constexpr float k_breach_engage_radius = 4.0F;
+
+constexpr float k_advance_stall_seconds = 8.0F;
+constexpr float k_advance_gain_epsilon = 1.0F;
+constexpr float k_objective_drift = 6.0F;
 
 auto is_barrier(const ContactSnapshot& contact) -> bool {
   return contact.spawn_type == Game::Units::SpawnType::WallSegment ||
@@ -104,6 +109,10 @@ auto select_breach_target(const AISnapshot& snapshot,
   return best;
 }
 
+auto is_wave_quarry(const ContactSnapshot& contact) -> bool {
+  return !Game::Core::is_neutral_owner(contact.owner_id) && contact.health > 0;
+}
+
 auto select_assault_target(const AISnapshot& snapshot,
                            float reference_x,
                            float reference_z,
@@ -111,9 +120,17 @@ auto select_assault_target(const AISnapshot& snapshot,
   const ContactSnapshot* best = nullptr;
   float best_score = std::numeric_limits<float>::infinity();
 
-  const bool troops_in_sight = has_troop_contact(snapshot.visible_enemies);
+  const bool troops_in_sight =
+      std::any_of(snapshot.visible_enemies.begin(),
+                  snapshot.visible_enemies.end(),
+                  [](const ContactSnapshot& contact) {
+                    return !contact.is_building && is_wave_quarry(contact);
+                  });
 
   for (const auto& candidate : snapshot.visible_enemies) {
+    if (!is_wave_quarry(candidate)) {
+      continue;
+    }
     if (troops_in_sight && candidate.is_building) {
       continue;
     }
@@ -133,6 +150,9 @@ auto select_assault_target(const AISnapshot& snapshot,
   }
 
   for (const auto& objective : snapshot.strategic_objectives) {
+    if (!is_wave_quarry(objective)) {
+      continue;
+    }
     if (skip_barriers && is_barrier(objective)) {
       continue;
     }
@@ -148,6 +168,41 @@ auto select_assault_target(const AISnapshot& snapshot,
 }
 
 } // namespace
+
+void AssaultBehavior::forget_advance_progress(float objective_x, float objective_z) {
+  if (m_has_tracked_objective && distance_squared(objective_x,
+                                                  0.0F,
+                                                  objective_z,
+                                                  m_tracked_objective_x,
+                                                  0.0F,
+                                                  m_tracked_objective_z) <=
+                                     k_objective_drift * k_objective_drift) {
+    return;
+  }
+  m_advance_progress.clear();
+  m_tracked_objective_x = objective_x;
+  m_tracked_objective_z = objective_z;
+  m_has_tracked_objective = true;
+}
+
+auto AssaultBehavior::advance_is_stalled(Engine::Core::EntityID unit_id,
+                                         float distance_to_objective,
+                                         float game_time) -> bool {
+  auto [entry, inserted] = m_advance_progress.try_emplace(
+      unit_id, AdvanceProgress{distance_to_objective, game_time});
+  if (inserted) {
+    return false;
+  }
+
+  auto& progress = entry->second;
+  if (distance_to_objective < progress.best_distance - k_advance_gain_epsilon) {
+    progress.best_distance = distance_to_objective;
+    progress.last_gain_time = game_time;
+    return false;
+  }
+
+  return (game_time - progress.last_gain_time) >= k_advance_stall_seconds;
+}
 
 void AssaultBehavior::execute(const AISnapshot& snapshot,
                               AIContext& context,
@@ -207,9 +262,31 @@ void AssaultBehavior::execute(const AISnapshot& snapshot,
     }
   }
 
+  forget_advance_progress(objective_x, objective_z);
+
+  bool advance_stalled = false;
+  std::unordered_set<Engine::Core::EntityID> advancing_ids;
+  advancing_ids.reserve(assault_units.size());
+  for (const auto* unit : assault_units) {
+    const float distance_to_objective = std::sqrt(distance_squared(
+        unit->pos_x, 0.0F, unit->pos_z, objective_x, 0.0F, objective_z));
+    if (distance_to_objective <= k_engage_radius) {
+      continue;
+    }
+    advancing_ids.insert(unit->id);
+    if (advance_is_stalled(unit->id, distance_to_objective, snapshot.game_time)) {
+      advance_stalled = true;
+    }
+  }
+  std::erase_if(m_advance_progress, [&advancing_ids](const auto& entry) {
+    return !advancing_ids.contains(entry.first);
+  });
+
   const ContactSnapshot* target = objective;
   const auto* breach =
-      select_breach_target(snapshot, center_x, center_z, objective_x, objective_z);
+      advance_stalled
+          ? select_breach_target(snapshot, center_x, center_z, objective_x, objective_z)
+          : nullptr;
   if (breach != nullptr) {
     target = breach;
   }

--- a/game/systems/ai_system/behaviors/assault_behavior.h
+++ b/game/systems/ai_system/behaviors/assault_behavior.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 #include "../ai_behavior.h"
 
 namespace Game::Systems::AI {
@@ -21,7 +23,21 @@ public:
   [[nodiscard]] auto can_run_concurrently() const -> bool override { return true; }
 
 private:
+  struct AdvanceProgress {
+    float best_distance = 0.0F;
+    float last_gain_time = 0.0F;
+  };
+
+  [[nodiscard]] auto advance_is_stalled(Engine::Core::EntityID unit_id,
+                                        float distance_to_objective,
+                                        float game_time) -> bool;
+  void forget_advance_progress(float objective_x, float objective_z);
+
   float m_assault_timer = 0.0F;
+  std::unordered_map<Engine::Core::EntityID, AdvanceProgress> m_advance_progress;
+  float m_tracked_objective_x = 0.0F;
+  float m_tracked_objective_z = 0.0F;
+  bool m_has_tracked_objective = false;
 };
 
 } // namespace Game::Systems::AI

--- a/game/systems/ai_system/behaviors/retreat_behavior.cpp
+++ b/game/systems/ai_system/behaviors/retreat_behavior.cpp
@@ -45,6 +45,10 @@ void RetreatBehavior::execute(const AISnapshot& snapshot,
       continue;
     }
 
+    if (entity.is_assault) {
+      continue;
+    }
+
     if (entity.max_health <= 0) {
       continue;
     }
@@ -133,7 +137,7 @@ auto RetreatBehavior::should_execute(const AISnapshot& snapshot,
   const float critical_health = context.strategy_config.retreat_threshold;
 
   for (const auto& entity : snapshot.friendly_units) {
-    if (entity.is_building) {
+    if (entity.is_building || entity.is_assault) {
       continue;
     }
 

--- a/render/draw_queue.h
+++ b/render/draw_queue.h
@@ -309,52 +309,160 @@ using DrawCmd = std::variant<GridCmd,
                              DrawPartCmd,
                              RiggedCreatureCmd>;
 
-enum class DrawCmdType : std::uint8_t {
-  Grid = 0,
-  GroundMarker = 1,
-  SelectionSmoke = 2,
-  Cylinder = 3,
-  Mesh = 4,
-  FogBatch = 5,
-  TerrainScatter = 6,
-  RainBatch = 7,
-  TerrainSurface = 8,
-  TerrainFeature = 9,
-  PrimitiveBatch = 10,
-  EffectBatch = 11,
-  ModeIndicator = 12,
-  DrawPart = 13,
-  RiggedCreature = 14
+namespace detail {
+
+template <typename Cmd, typename Variant>
+struct DrawCmdIndexOf;
+
+template <typename Cmd, typename... Alternatives>
+struct DrawCmdIndexOf<Cmd, std::variant<Alternatives...>> {
+  static constexpr std::size_t value = [] {
+    constexpr bool matches[] = {std::is_same_v<Cmd, Alternatives>...};
+    std::size_t found = sizeof...(Alternatives);
+    for (std::size_t i = 0; i < sizeof...(Alternatives); ++i) {
+      if (matches[i]) {
+        found = i;
+        break;
+      }
+    }
+    return found;
+  }();
 };
 
-constexpr std::size_t MeshCmdIndex = static_cast<std::size_t>(DrawCmdType::Mesh);
-constexpr std::size_t GridCmdIndex = static_cast<std::size_t>(DrawCmdType::Grid);
-constexpr std::size_t GroundMarkerCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::GroundMarker);
-constexpr std::size_t SelectionSmokeCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::SelectionSmoke);
-constexpr std::size_t CylinderCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::Cylinder);
-constexpr std::size_t FogBatchCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::FogBatch);
-constexpr std::size_t TerrainScatterCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::TerrainScatter);
-constexpr std::size_t RainBatchCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::RainBatch);
-constexpr std::size_t TerrainSurfaceCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::TerrainSurface);
-constexpr std::size_t TerrainFeatureCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::TerrainFeature);
-constexpr std::size_t PrimitiveBatchCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::PrimitiveBatch);
-constexpr std::size_t EffectBatchCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::EffectBatch);
-constexpr std::size_t ModeIndicatorCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::ModeIndicator);
-constexpr std::size_t DrawPartCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::DrawPart);
-constexpr std::size_t RiggedCreatureCmdIndex =
-    static_cast<std::size_t>(DrawCmdType::RiggedCreature);
+} // namespace detail
+
+template <typename Cmd>
+inline constexpr std::size_t cmd_index_of = detail::DrawCmdIndexOf<Cmd, DrawCmd>::value;
+
+inline constexpr std::size_t k_draw_cmd_type_count = std::variant_size_v<DrawCmd>;
+
+enum class DrawCmdType : std::uint8_t {
+  Grid = static_cast<std::uint8_t>(cmd_index_of<GridCmd>),
+  GroundMarker = static_cast<std::uint8_t>(cmd_index_of<GroundMarkerCmd>),
+  SelectionSmoke = static_cast<std::uint8_t>(cmd_index_of<SelectionSmokeCmd>),
+  Cylinder = static_cast<std::uint8_t>(cmd_index_of<CylinderCmd>),
+  Mesh = static_cast<std::uint8_t>(cmd_index_of<MeshCmd>),
+  FogBatch = static_cast<std::uint8_t>(cmd_index_of<FogBatchCmd>),
+  TerrainScatter = static_cast<std::uint8_t>(cmd_index_of<TerrainScatterCmd>),
+  RainBatch = static_cast<std::uint8_t>(cmd_index_of<RainBatchCmd>),
+  TerrainSurface = static_cast<std::uint8_t>(cmd_index_of<TerrainSurfaceCmd>),
+  TerrainFeature = static_cast<std::uint8_t>(cmd_index_of<TerrainFeatureCmd>),
+  PrimitiveBatch = static_cast<std::uint8_t>(cmd_index_of<PrimitiveBatchCmd>),
+  EffectBatch = static_cast<std::uint8_t>(cmd_index_of<EffectBatchCmd>),
+  ModeIndicator = static_cast<std::uint8_t>(cmd_index_of<ModeIndicatorCmd>),
+  DrawPart = static_cast<std::uint8_t>(cmd_index_of<DrawPartCmd>),
+  RiggedCreature = static_cast<std::uint8_t>(cmd_index_of<RiggedCreatureCmd>)
+};
+
+constexpr std::size_t MeshCmdIndex = cmd_index_of<MeshCmd>;
+constexpr std::size_t GridCmdIndex = cmd_index_of<GridCmd>;
+constexpr std::size_t GroundMarkerCmdIndex = cmd_index_of<GroundMarkerCmd>;
+constexpr std::size_t SelectionSmokeCmdIndex = cmd_index_of<SelectionSmokeCmd>;
+constexpr std::size_t CylinderCmdIndex = cmd_index_of<CylinderCmd>;
+constexpr std::size_t FogBatchCmdIndex = cmd_index_of<FogBatchCmd>;
+constexpr std::size_t TerrainScatterCmdIndex = cmd_index_of<TerrainScatterCmd>;
+constexpr std::size_t RainBatchCmdIndex = cmd_index_of<RainBatchCmd>;
+constexpr std::size_t TerrainSurfaceCmdIndex = cmd_index_of<TerrainSurfaceCmd>;
+constexpr std::size_t TerrainFeatureCmdIndex = cmd_index_of<TerrainFeatureCmd>;
+constexpr std::size_t PrimitiveBatchCmdIndex = cmd_index_of<PrimitiveBatchCmd>;
+constexpr std::size_t EffectBatchCmdIndex = cmd_index_of<EffectBatchCmd>;
+constexpr std::size_t ModeIndicatorCmdIndex = cmd_index_of<ModeIndicatorCmd>;
+constexpr std::size_t DrawPartCmdIndex = cmd_index_of<DrawPartCmd>;
+constexpr std::size_t RiggedCreatureCmdIndex = cmd_index_of<RiggedCreatureCmd>;
+
+enum class RenderPassOrder : std::uint8_t {
+  TerrainSurface = 0,
+  TerrainFeature = 1,
+  TerrainScatter = 2,
+  RainBatch = 3,
+  PrimitiveBatch = 4,
+  Mesh = 5,
+  Cylinder = 6,
+  FogBatch = 7,
+  SelectionSmoke = 8,
+  Grid = 9,
+  EffectBatch = 10,
+  GroundMarker = 16,
+  ModeIndicator = 17
+};
+
+template <typename Cmd>
+struct DrawCmdTraits;
+
+template <>
+struct DrawCmdTraits<GridCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::Grid;
+};
+template <>
+struct DrawCmdTraits<GroundMarkerCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::GroundMarker;
+};
+template <>
+struct DrawCmdTraits<SelectionSmokeCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::SelectionSmoke;
+};
+template <>
+struct DrawCmdTraits<CylinderCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::Cylinder;
+};
+template <>
+struct DrawCmdTraits<MeshCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::Mesh;
+};
+template <>
+struct DrawCmdTraits<FogBatchCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::FogBatch;
+};
+template <>
+struct DrawCmdTraits<TerrainScatterCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::TerrainScatter;
+};
+template <>
+struct DrawCmdTraits<RainBatchCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::RainBatch;
+};
+template <>
+struct DrawCmdTraits<TerrainSurfaceCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::TerrainSurface;
+};
+template <>
+struct DrawCmdTraits<TerrainFeatureCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::TerrainFeature;
+};
+template <>
+struct DrawCmdTraits<PrimitiveBatchCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::PrimitiveBatch;
+};
+template <>
+struct DrawCmdTraits<EffectBatchCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::EffectBatch;
+};
+template <>
+struct DrawCmdTraits<ModeIndicatorCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::ModeIndicator;
+};
+template <>
+struct DrawCmdTraits<DrawPartCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::Mesh;
+};
+template <>
+struct DrawCmdTraits<RiggedCreatureCmd> {
+  static constexpr RenderPassOrder pass = RenderPassOrder::Mesh;
+};
+
+namespace detail {
+
+template <std::size_t... Index>
+constexpr auto build_render_pass_table(std::index_sequence<Index...>)
+    -> std::array<std::uint8_t, sizeof...(Index)> {
+  return {static_cast<std::uint8_t>(
+      DrawCmdTraits<std::variant_alternative_t<Index, DrawCmd>>::pass)...};
+}
+
+} // namespace detail
+
+inline constexpr auto k_render_pass_by_cmd_type =
+    detail::build_render_pass_table(std::make_index_sequence<k_draw_cmd_type_count>{});
 
 inline auto draw_cmd_type(const DrawCmd& cmd) -> DrawCmdType {
   return static_cast<DrawCmdType>(cmd.index());
@@ -605,94 +713,81 @@ private:
   }
 
   void populate_sort_identity_prefix(const DrawCmd& cmd, SortIdentity& identity) const {
-    enum class RenderOrder : uint8_t {
-      TerrainSurface = 0,
-      TerrainFeature = 1,
-      TerrainScatter = 2,
-      RainBatch = 3,
-      PrimitiveBatch = 4,
-      Mesh = 5,
-      Cylinder = 6,
-      FogBatch = 7,
-      SelectionSmoke = 8,
-      Grid = 9,
-      EffectBatch = 10,
-      GroundMarker = 16,
-      ModeIndicator = 17
-    };
-
-    static constexpr uint8_t k_type_order[] = {
-        static_cast<uint8_t>(RenderOrder::Grid),
-        static_cast<uint8_t>(RenderOrder::GroundMarker),
-        static_cast<uint8_t>(RenderOrder::SelectionSmoke),
-        static_cast<uint8_t>(RenderOrder::Cylinder),
-        static_cast<uint8_t>(RenderOrder::Mesh),
-        static_cast<uint8_t>(RenderOrder::FogBatch),
-        static_cast<uint8_t>(RenderOrder::TerrainScatter),
-        static_cast<uint8_t>(RenderOrder::RainBatch),
-        static_cast<uint8_t>(RenderOrder::TerrainSurface),
-        static_cast<uint8_t>(RenderOrder::TerrainFeature),
-        static_cast<uint8_t>(RenderOrder::PrimitiveBatch),
-        static_cast<uint8_t>(RenderOrder::EffectBatch),
-        static_cast<uint8_t>(RenderOrder::ModeIndicator),
-        static_cast<uint8_t>(RenderOrder::Mesh),
-        static_cast<uint8_t>(RenderOrder::Mesh)};
-
     const std::size_t type_index = cmd.index();
-    constexpr std::size_t type_count = sizeof(k_type_order) / sizeof(k_type_order[0]);
-    const uint8_t type_order = type_index < type_count
-                                   ? k_type_order[type_index]
-                                   : static_cast<uint8_t>(type_index);
+    identity.pass = type_index < k_render_pass_by_cmd_type.size()
+                        ? k_render_pass_by_cmd_type[type_index]
+                        : static_cast<std::uint8_t>(type_index);
 
-    identity.pass = type_order;
-
-    if (cmd.index() == MeshCmdIndex) {
+    switch (draw_cmd_type(cmd)) {
+    case DrawCmdType::Mesh: {
       const auto& mesh = std::get<MeshCmdIndex>(cmd);
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::Mesh);
       identity.transparency_bucket = transparency_bucket(mesh.alpha);
-    } else if (cmd.index() == TerrainScatterCmdIndex) {
+      break;
+    }
+    case DrawCmdType::TerrainScatter: {
       const auto& deco = std::get<TerrainScatterCmdIndex>(cmd);
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::TerrainScatterGrass) +
                           static_cast<std::uint8_t>(deco.species);
-    } else if (cmd.index() == TerrainSurfaceCmdIndex) {
+      break;
+    }
+    case DrawCmdType::TerrainSurface:
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::TerrainSurface);
-    } else if (cmd.index() == TerrainFeatureCmdIndex) {
+      break;
+    case DrawCmdType::TerrainFeature: {
       const auto& feature = std::get<TerrainFeatureCmdIndex>(cmd);
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::TerrainFeatureWater) +
                           static_cast<std::uint8_t>(feature.kind);
       identity.transparency_bucket = transparency_bucket(feature.alpha);
-    } else if (cmd.index() == PrimitiveBatchCmdIndex) {
+      break;
+    }
+    case DrawCmdType::PrimitiveBatch: {
       const auto& prim = std::get<PrimitiveBatchCmdIndex>(cmd);
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::PrimitiveSphere) +
                           static_cast<std::uint8_t>(prim.type);
-    } else if (cmd.index() == DrawPartCmdIndex) {
+      break;
+    }
+    case DrawCmdType::DrawPart: {
       const auto& part = std::get<DrawPartCmdIndex>(cmd);
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::DrawPart);
       identity.transparency_bucket = transparency_bucket(part.alpha);
-    } else if (cmd.index() == RiggedCreatureCmdIndex) {
+      break;
+    }
+    case DrawCmdType::RiggedCreature: {
       const auto& rig = std::get<RiggedCreatureCmdIndex>(cmd);
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::RiggedCreature);
       identity.transparency_bucket = transparency_bucket(rig.alpha);
-    } else if (cmd.index() == CylinderCmdIndex) {
-      const auto& cy = std::get<CylinderCmdIndex>(cmd);
+      break;
+    }
+    case DrawCmdType::Cylinder: {
+      const auto& cylinder = std::get<CylinderCmdIndex>(cmd);
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::Cylinder);
-      identity.transparency_bucket = transparency_bucket(cy.alpha);
-    } else if (cmd.index() == FogBatchCmdIndex) {
+      identity.transparency_bucket = transparency_bucket(cylinder.alpha);
+      break;
+    }
+    case DrawCmdType::FogBatch:
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::Fog);
-    } else if (cmd.index() == RainBatchCmdIndex) {
+      break;
+    case DrawCmdType::RainBatch:
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::Rain);
-    } else if (cmd.index() == EffectBatchCmdIndex) {
+      break;
+    case DrawCmdType::EffectBatch:
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::Effect);
-    } else if (cmd.index() == SelectionSmokeCmdIndex) {
+      break;
+    case DrawCmdType::SelectionSmoke:
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::SelectionSmoke);
       identity.transparency_bucket = 1U;
-    } else if (cmd.index() == GridCmdIndex) {
+      break;
+    case DrawCmdType::Grid:
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::Grid);
-    } else if (cmd.index() == GroundMarkerCmdIndex) {
+      break;
+    case DrawCmdType::GroundMarker:
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::GroundMarker);
       identity.transparency_bucket = 1U;
-    } else if (cmd.index() == ModeIndicatorCmdIndex) {
+      break;
+    case DrawCmdType::ModeIndicator:
       identity.pipeline = static_cast<std::uint8_t>(SortPipeline::ModeIndicator);
+      break;
     }
   }
 
@@ -706,25 +801,30 @@ private:
   }
 
   [[nodiscard]] auto preserves_append_order(const DrawCmd& cmd) const -> bool {
-    switch (cmd.index()) {
-    case TerrainScatterCmdIndex:
-    case RainBatchCmdIndex:
-    case TerrainSurfaceCmdIndex:
-    case PrimitiveBatchCmdIndex:
-    case FogBatchCmdIndex:
-    case SelectionSmokeCmdIndex:
-    case GroundMarkerCmdIndex:
-    case GridCmdIndex:
-    case EffectBatchCmdIndex:
+    switch (draw_cmd_type(cmd)) {
+    case DrawCmdType::TerrainScatter:
+    case DrawCmdType::RainBatch:
+    case DrawCmdType::TerrainSurface:
+    case DrawCmdType::PrimitiveBatch:
+    case DrawCmdType::FogBatch:
+    case DrawCmdType::SelectionSmoke:
+    case DrawCmdType::GroundMarker:
+    case DrawCmdType::Grid:
+    case DrawCmdType::EffectBatch:
       return true;
-    case TerrainFeatureCmdIndex: {
+    case DrawCmdType::TerrainFeature: {
       const auto& feature = std::get<TerrainFeatureCmdIndex>(cmd);
       return feature.kind != LinearFeatureKind::Shoreline ||
              !feature.visibility.enabled;
     }
-    default:
+    case DrawCmdType::Mesh:
+    case DrawCmdType::Cylinder:
+    case DrawCmdType::DrawPart:
+    case DrawCmdType::RiggedCreature:
+    case DrawCmdType::ModeIndicator:
       return false;
     }
+    return false;
   }
 
   void record_submission_bucket(const DrawCmd& cmd) {
@@ -754,51 +854,78 @@ private:
     SortIdentity identity;
     populate_sort_identity_prefix(cmd, identity);
 
-    if (cmd.index() == MeshCmdIndex) {
+    switch (draw_cmd_type(cmd)) {
+    case DrawCmdType::Mesh: {
       const auto& mesh = std::get<MeshCmdIndex>(cmd);
       identity.material = pack_12(sort_id(mesh.shader));
       identity.mesh = pack_16(sort_id(mesh.mesh));
       identity.texture = pack_12(sort_id(mesh.texture));
-    } else if (cmd.index() == TerrainScatterCmdIndex) {
+      break;
+    }
+    case DrawCmdType::TerrainScatter: {
       const auto& deco = std::get<TerrainScatterCmdIndex>(cmd);
       identity.material = pack_12(sort_id(deco.material));
       identity.mesh = pack_16(sort_id(deco.instance_buffer));
-    } else if (cmd.index() == FogBatchCmdIndex) {
+      break;
+    }
+    case DrawCmdType::FogBatch: {
       const auto& fog = std::get<FogBatchCmdIndex>(cmd);
       identity.mesh = pack_16(sort_id(
           fog.instance_buffer != nullptr ? static_cast<const void*>(fog.instance_buffer)
                                          : static_cast<const void*>(fog.instances)));
-    } else if (cmd.index() == TerrainSurfaceCmdIndex) {
+      break;
+    }
+    case DrawCmdType::TerrainSurface: {
       const auto& chunk = std::get<TerrainSurfaceCmdIndex>(cmd);
       identity.material = pack_12(chunk.sort_key);
       identity.mesh = pack_16(sort_id(chunk.mesh));
       identity.texture = pack_12(sort_id(chunk.material));
-    } else if (cmd.index() == TerrainFeatureCmdIndex) {
+      break;
+    }
+    case DrawCmdType::TerrainFeature: {
       const auto& feature = std::get<TerrainFeatureCmdIndex>(cmd);
       identity.mesh = pack_16(sort_id(feature.mesh));
       identity.texture = pack_12(sort_id(feature.visibility.texture));
-    } else if (cmd.index() == PrimitiveBatchCmdIndex) {
+      break;
+    }
+    case DrawCmdType::PrimitiveBatch: {
       const auto& prim = std::get<PrimitiveBatchCmdIndex>(cmd);
       identity.mesh = pack_16(static_cast<std::uint32_t>(std::min<std::size_t>(
           prim.instance_count(), std::numeric_limits<std::uint16_t>::max())));
-    } else if (cmd.index() == DrawPartCmdIndex) {
+      break;
+    }
+    case DrawCmdType::DrawPart: {
       const auto& part = std::get<DrawPartCmdIndex>(cmd);
       identity.material = pack_12(sort_id(part.material));
       identity.mesh = pack_16(sort_id(part.mesh));
       identity.texture = pack_12(sort_id(part.texture));
       identity.skeleton = part.palette.empty() ? 0U : 1U;
-    } else if (cmd.index() == RiggedCreatureCmdIndex) {
+      break;
+    }
+    case DrawCmdType::RiggedCreature: {
       const auto& rig = std::get<RiggedCreatureCmdIndex>(cmd);
       identity.material = pack_12(sort_id(rig.material));
       identity.mesh = pack_16(sort_id(rig.mesh));
       identity.texture = pack_12(sort_id(rig.texture));
       identity.skeleton = pack_4(rig.bone_count);
-    } else if (cmd.index() == EffectBatchCmdIndex) {
+      break;
+    }
+    case DrawCmdType::EffectBatch: {
       const auto& effect = std::get<EffectBatchCmdIndex>(cmd);
       identity.material = pack_12(static_cast<std::uint32_t>(effect.kind));
-    } else if (cmd.index() == ModeIndicatorCmdIndex) {
+      break;
+    }
+    case DrawCmdType::ModeIndicator: {
       const auto& mode = std::get<ModeIndicatorCmdIndex>(cmd);
       identity.material = pack_12(static_cast<std::uint32_t>(mode.mode_type));
+      break;
+    }
+    case DrawCmdType::Grid:
+    case DrawCmdType::GroundMarker:
+    case DrawCmdType::SelectionSmoke:
+    case DrawCmdType::Cylinder:
+    case DrawCmdType::RainBatch:
+      break;
     }
 
     return identity.pack();
@@ -814,21 +941,24 @@ private:
       PreparedBatchKind kind = PreparedBatchKind::Single;
       std::size_t end = i + 1;
 
-      if (head.index() == CylinderCmdIndex) {
+      switch (type) {
+      case DrawCmdType::Cylinder:
         while (end < count && get_sorted(end).index() == CylinderCmdIndex) {
           ++end;
         }
         if (end - i > 1U) {
           kind = PreparedBatchKind::CylinderInstanced;
         }
-      } else if (head.index() == MeshCmdIndex) {
+        break;
+      case DrawCmdType::Mesh:
         while (end < count && can_batch_mesh(i, end)) {
           ++end;
         }
         if (end - i > 1U) {
           kind = PreparedBatchKind::MeshInstanced;
         }
-      } else if (head.index() == DrawPartCmdIndex) {
+        break;
+      case DrawCmdType::DrawPart: {
         while (end < count && can_batch_draw_part(i, end)) {
           ++end;
         }
@@ -838,21 +968,25 @@ private:
         } else {
           end = i + 1;
         }
-      } else if (head.index() == RiggedCreatureCmdIndex) {
+        break;
+      }
+      case DrawCmdType::RiggedCreature:
         while (end < count && can_batch_rigged(i, end)) {
           ++end;
         }
         if (end - i > 1U) {
           kind = PreparedBatchKind::RiggedCreatureInstanced;
         }
-      } else if (head.index() == GroundMarkerCmdIndex) {
+        break;
+      case DrawCmdType::GroundMarker:
         while (end < count && get_sorted(end).index() == GroundMarkerCmdIndex) {
           ++end;
         }
         if (end - i > 1U) {
           kind = PreparedBatchKind::GroundMarkerInstanced;
         }
-      } else if (head.index() == EffectBatchCmdIndex) {
+        break;
+      case DrawCmdType::EffectBatch: {
         const auto& head_eff = std::get<EffectBatchCmdIndex>(head);
         while (end < count) {
           const DrawCmd& next_cmd = get_sorted(end);
@@ -867,7 +1001,9 @@ private:
         if (end - i > 1U) {
           kind = PreparedBatchKind::EffectInstanced;
         }
-      } else if (head.index() == ModeIndicatorCmdIndex) {
+        break;
+      }
+      case DrawCmdType::ModeIndicator: {
         const auto& head_mode = std::get<ModeIndicatorCmdIndex>(head);
         while (end < count) {
           const DrawCmd& next_cmd = get_sorted(end);
@@ -883,14 +1019,25 @@ private:
         if (end - i > 1U) {
           kind = PreparedBatchKind::ModeIndicatorInstanced;
         }
-      } else if (head.index() == TerrainSurfaceCmdIndex) {
+        break;
+      }
+      case DrawCmdType::TerrainSurface:
         while (end < count && can_batch_terrain_surface(i, end)) {
           ++end;
         }
-      } else if (head.index() == TerrainFeatureCmdIndex) {
+        break;
+      case DrawCmdType::TerrainFeature:
         while (end < count && can_batch_terrain_feature(i, end)) {
           ++end;
         }
+        break;
+      case DrawCmdType::Grid:
+      case DrawCmdType::SelectionSmoke:
+      case DrawCmdType::FogBatch:
+      case DrawCmdType::TerrainScatter:
+      case DrawCmdType::RainBatch:
+      case DrawCmdType::PrimitiveBatch:
+        break;
       }
 
       m_prepared_batches.push_back(

--- a/render/entity/barracks_stockpile.cpp
+++ b/render/entity/barracks_stockpile.cpp
@@ -13,6 +13,7 @@
 #include "../geom/stone.h"
 #include "../gl/primitives.h"
 #include "../submitter.h"
+#include "building_decay.h"
 #include "building_render_common.h"
 #include "building_state.h"
 
@@ -547,6 +548,23 @@ void draw_barracks_stockpile(const DrawContext& ctx,
     return;
   }
 
+  const BuildingState state = resolve_building_state(ctx);
+  StockpileYardStyle decayed = style;
+  if (state != BuildingState::Normal) {
+    int seed = 0;
+    for (QVector3D* slot : {&decayed.gravel,
+                            &decayed.earth_light,
+                            &decayed.stone_light,
+                            &decayed.stone_mid,
+                            &decayed.stone_dark,
+                            &decayed.timber,
+                            &decayed.timber_dark,
+                            &decayed.ore,
+                            &decayed.ore_rust}) {
+      *slot = decayed_color(*slot, state, ++seed);
+    }
+  }
+
   Yard yard;
   yard.frame.translate(
       transform->position.x, transform->position.y, transform->position.z);
@@ -556,13 +574,13 @@ void draw_barracks_stockpile(const DrawContext& ctx,
   yard.white = white;
   yard.detailed = ctx.distance_sq <= k_detail_distance_sq;
 
-  draw_bed(out, yard, style);
-  draw_fence(out, yard, style);
+  draw_bed(out, yard, decayed);
+  draw_fence(out, yard, decayed);
   if (yard.detailed) {
-    draw_yard_clutter(out, yard, style);
+    draw_yard_clutter(out, yard, decayed);
   }
 
-  if (resolve_building_state(ctx) == BuildingState::Destroyed) {
+  if (state == BuildingState::Destroyed) {
     return;
   }
 
@@ -574,9 +592,9 @@ void draw_barracks_stockpile(const DrawContext& ctx,
   float const flash = std::clamp(
       stockpile->deposit_flash / k_stockpile_deposit_flash_seconds, 0.0F, 1.0F);
 
-  draw_timber_pile(out, yard, style, stockpile->wood_fill, flash);
-  draw_stone_pile(out, yard, style, stockpile->stone_fill, flash);
-  draw_ore_pile(out, yard, style, stockpile->iron_fill, flash);
+  draw_timber_pile(out, yard, decayed, stockpile->wood_fill, flash);
+  draw_stone_pile(out, yard, decayed, stockpile->stone_fill, flash);
+  draw_ore_pile(out, yard, decayed, stockpile->iron_fill, flash);
 }
 
 } // namespace Render::GL

--- a/render/entity/building_archetype_desc.cpp
+++ b/render/entity/building_archetype_desc.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "../gl/primitives.h"
+#include "building_decay.h"
 
 namespace Render::GL {
 namespace {
@@ -56,12 +57,13 @@ auto supports_lod(BuildingLODMask mask, RenderArchetypeLod lod) -> bool {
 }
 
 void add_part_to_builder(RenderArchetypeBuilder& builder,
-                         const BuildingPartDesc& part) {
+                         const BuildingPartDesc& part,
+                         const QVector3D& color) {
   switch (part.kind) {
   case BuildingPartKind::Box:
     builder.add_box(part.point_a,
                     part.point_b,
-                    part.color,
+                    color,
                     part.texture,
                     part.alpha,
                     part.material_id,
@@ -95,7 +97,7 @@ void add_part_to_builder(RenderArchetypeBuilder& builder,
     } else {
       builder.add_mesh(get_unit_cube(),
                        model,
-                       part.color,
+                       color,
                        part.texture,
                        part.alpha,
                        part.material_id,
@@ -107,7 +109,7 @@ void add_part_to_builder(RenderArchetypeBuilder& builder,
     builder.add_cylinder(part.point_a,
                          part.point_b,
                          part.radius,
-                         part.color,
+                         color,
                          part.texture,
                          part.alpha,
                          part.material_id,
@@ -117,7 +119,7 @@ void add_part_to_builder(RenderArchetypeBuilder& builder,
     builder.add_cone(part.point_a,
                      part.point_b,
                      part.radius,
-                     part.color,
+                     color,
                      part.texture,
                      part.alpha,
                      part.material_id,
@@ -268,42 +270,44 @@ auto build_building_archetype(const BuildingArchetypeDesc& desc,
                               BuildingState state) -> RenderArchetype {
   RenderArchetypeBuilder builder(desc.name());
 
+  const auto emit_parts = [&](RenderArchetypeLod lod) {
+    int seed = 0;
+    for (const auto& part : desc.parts()) {
+      ++seed;
+      if (!supports_state(part.states, state)) {
+        continue;
+      }
+      if (!supports_lod(part.lod, lod)) {
+        continue;
+      }
+      add_part_to_builder(builder, part, decayed_color(part.color, state, seed));
+    }
+  };
+
   builder.use_lod(RenderArchetypeLod::Full);
   builder.set_max_distance(desc.full_lod_max_distance());
-  for (const auto& part : desc.parts()) {
-    if (!supports_state(part.states, state)) {
-      continue;
-    }
-    if (!supports_lod(part.lod, RenderArchetypeLod::Full)) {
-      continue;
-    }
-    add_part_to_builder(builder, part);
-  }
+  emit_parts(RenderArchetypeLod::Full);
 
   builder.use_lod(RenderArchetypeLod::Minimal);
   builder.set_max_distance(std::numeric_limits<float>::infinity());
-  for (const auto& part : desc.parts()) {
-    if (!supports_state(part.states, state)) {
-      continue;
-    }
-    if (!supports_lod(part.lod, RenderArchetypeLod::Minimal)) {
-      continue;
-    }
-    add_part_to_builder(builder, part);
-  }
+  emit_parts(RenderArchetypeLod::Minimal);
 
   return std::move(builder).build();
 }
 
 auto build_building_archetype_from_recorded(
-    std::string name, const std::vector<RecordedMeshCmd>& commands) -> RenderArchetype {
+    std::string name,
+    const std::vector<RecordedMeshCmd>& commands,
+    BuildingState state) -> RenderArchetype {
   RenderArchetypeBuilder builder(std::move(name));
   builder.set_max_distance(std::numeric_limits<float>::infinity());
 
+  int seed = 0;
   for (const auto& cmd : commands) {
+    ++seed;
     builder.add_mesh(cmd.mesh,
                      cmd.local_model,
-                     cmd.color,
+                     decayed_color(cmd.color, state, seed),
                      cmd.texture,
                      cmd.alpha,
                      cmd.material_id,
@@ -317,14 +321,17 @@ auto build_building_archetype_from_recorded_lods(
     std::string name,
     const std::vector<RecordedMeshCmd>& full_commands,
     const std::vector<RecordedMeshCmd>& minimal_commands,
-    float full_lod_max_distance) -> RenderArchetype {
+    float full_lod_max_distance,
+    BuildingState state) -> RenderArchetype {
   RenderArchetypeBuilder builder(std::move(name));
   builder.set_max_distance(full_lod_max_distance);
 
+  int seed = 0;
   for (const auto& cmd : full_commands) {
+    ++seed;
     builder.add_mesh(cmd.mesh,
                      cmd.local_model,
-                     cmd.color,
+                     decayed_color(cmd.color, state, seed),
                      cmd.texture,
                      cmd.alpha,
                      cmd.material_id,
@@ -333,10 +340,12 @@ auto build_building_archetype_from_recorded_lods(
 
   builder.use_lod(RenderArchetypeLod::Minimal);
   builder.set_max_distance(std::numeric_limits<float>::infinity());
+  seed = 0;
   for (const auto& cmd : minimal_commands) {
+    ++seed;
     builder.add_mesh(cmd.mesh,
                      cmd.local_model,
-                     cmd.color,
+                     decayed_color(cmd.color, state, seed),
                      cmd.texture,
                      cmd.alpha,
                      cmd.material_id,

--- a/render/entity/building_archetype_desc.h
+++ b/render/entity/building_archetype_desc.h
@@ -122,12 +122,15 @@ private:
 auto build_building_archetype(const BuildingArchetypeDesc& desc,
                               BuildingState state) -> RenderArchetype;
 auto build_building_archetype_from_recorded(
-    std::string name, const std::vector<RecordedMeshCmd>& commands) -> RenderArchetype;
+    std::string name,
+    const std::vector<RecordedMeshCmd>& commands,
+    BuildingState state = BuildingState::Normal) -> RenderArchetype;
 auto build_building_archetype_from_recorded_lods(
     std::string name,
     const std::vector<RecordedMeshCmd>& full_commands,
     const std::vector<RecordedMeshCmd>& minimal_commands,
-    float full_lod_max_distance = 60.0F) -> RenderArchetype;
+    float full_lod_max_distance = 60.0F,
+    BuildingState state = BuildingState::Normal) -> RenderArchetype;
 
 struct BuildingArchetypeSet {
   std::array<RenderArchetype, 3> states;

--- a/render/entity/building_decay.cpp
+++ b/render/entity/building_decay.cpp
@@ -1,0 +1,298 @@
+#include "building_decay.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace Render::GL {
+namespace {
+
+const QVector3D k_ash{0.19F, 0.175F, 0.16F};
+const QVector3D k_rot{0.21F, 0.25F, 0.15F};
+const QVector3D k_dust{0.45F, 0.42F, 0.38F};
+
+auto smooth_step(float edge0, float edge1, float x) -> float {
+  const float t = std::clamp((x - edge0) / (edge1 - edge0), 0.0F, 1.0F);
+  return t * t * (3.0F - (2.0F * t));
+}
+
+auto mix(const QVector3D& a, const QVector3D& b, float t) -> QVector3D {
+  return a * (1.0F - t) + b * t;
+}
+
+auto luma_of(const QVector3D& c) -> float {
+  return (0.299F * c.x()) + (0.587F * c.y()) + (0.114F * c.z());
+}
+
+auto clamp01(const QVector3D& c) -> QVector3D {
+  return {std::clamp(c.x(), 0.0F, 1.0F),
+          std::clamp(c.y(), 0.0F, 1.0F),
+          std::clamp(c.z(), 0.0F, 1.0F)};
+}
+
+auto hash_at(int seed, int salt) -> float {
+  return decay_hash((seed * 733) + (salt * 197) + 17);
+}
+
+auto signed_hash(int seed, int salt) -> float {
+  return (hash_at(seed, salt) * 2.0F) - 1.0F;
+}
+
+} // namespace
+
+auto decay_hash(int seed) -> float {
+  const float n = std::sin(static_cast<float>(seed) * 12.9898F) * 43758.5453F;
+  return n - std::floor(n);
+}
+
+auto part_supports_state(BuildingStateMask mask, BuildingState state) -> bool {
+  const auto bit = (state == BuildingState::Normal)    ? BuildingStateMask::Normal
+                   : (state == BuildingState::Damaged) ? BuildingStateMask::Damaged
+                                                       : BuildingStateMask::Destroyed;
+  return (mask & bit) != BuildingStateMask::None;
+}
+
+auto building_decay_profile(BuildingState state) -> BuildingDecayProfile {
+  switch (state) {
+  case BuildingState::Normal:
+    return {};
+  case BuildingState::Damaged:
+    return {.desaturation = 0.34F,
+            .darkening = 0.85F,
+            .soot = 0.22F,
+            .moss = 0.09F,
+            .dust = 0.12F,
+            .variation = 0.06F};
+  case BuildingState::Destroyed:
+    return {.desaturation = 0.58F,
+            .darkening = 0.74F,
+            .soot = 0.36F,
+            .moss = 0.20F,
+            .dust = 0.30F,
+            .variation = 0.10F};
+  }
+  return {};
+}
+
+auto decayed_color(const QVector3D& base, BuildingState state, int seed) -> QVector3D {
+  const BuildingDecayProfile profile = building_decay_profile(state);
+  if (profile.desaturation <= 0.0F && profile.soot <= 0.0F && profile.moss <= 0.0F &&
+      profile.dust <= 0.0F && profile.darkening >= 1.0F) {
+    return base;
+  }
+
+  const float luma = luma_of(base);
+  QVector3D color = mix(base, QVector3D(luma, luma, luma), profile.desaturation);
+
+  const float bright_t = smooth_step(0.10F, 0.68F, luma);
+  color *= 1.0F - ((1.0F - profile.darkening) * bright_t);
+
+  const float soot_mask = std::clamp((hash_at(seed, 1) - 0.25F) * 1.7F, 0.0F, 1.0F);
+  color = mix(color, k_ash, profile.soot * soot_mask);
+
+  const float rot_mask = std::clamp((hash_at(seed, 2) - 0.55F) * 2.4F, 0.0F, 1.0F);
+  color = mix(color, k_rot, profile.moss * rot_mask);
+
+  const float dust_t = smooth_step(0.16F, 0.62F, luma);
+  color =
+      mix(color, k_dust, profile.dust * dust_t * (1.0F - soot_mask) * hash_at(seed, 4));
+
+  const float jitter = 1.0F + (signed_hash(seed, 3) * profile.variation);
+  return clamp01(color * jitter);
+}
+
+void add_rubble_field(BuildingArchetypeDesc& desc, const RubbleField& field) {
+  for (int i = 0; i < field.count; ++i) {
+    const int seed = field.seed + (i * 31);
+    const auto spread = [&](float raw) {
+      if (field.ring_bias <= 0.0F) {
+        return raw;
+      }
+      const float magnitude =
+          field.ring_bias + ((1.0F - field.ring_bias) * std::abs(raw));
+      return raw < 0.0F ? -magnitude : magnitude;
+    };
+    const float x =
+        field.center.x() + (spread(signed_hash(seed, 11)) * field.extent.x());
+    const float z =
+        field.center.z() + (spread(signed_hash(seed, 12)) * field.extent.z());
+    const float size = (0.055F + (hash_at(seed, 13) * 0.085F)) * field.chunk_scale;
+    const float height = size * (0.55F + (hash_at(seed, 14) * 0.75F));
+    const float yaw = hash_at(seed, 15) * 90.0F;
+    const float tilt = signed_hash(seed, 16) * 22.0F;
+    const QVector3D color = mix(field.stone_dark, field.stone, hash_at(seed, 17)) *
+                            (0.86F + (hash_at(seed, 18) * 0.24F));
+
+    desc.add_rotated_box(QVector3D(x, field.ground_y + height, z),
+                         QVector3D(size, height, size * 0.82F),
+                         QVector3D(tilt, yaw, tilt * 0.6F),
+                         clamp01(color),
+                         field.states,
+                         field.lod);
+  }
+}
+
+void add_charred_beams(BuildingArchetypeDesc& desc, const CharredBeams& beams) {
+  for (int i = 0; i < beams.count; ++i) {
+    const int seed = beams.seed + (i * 47);
+    const float x = beams.center.x() + (signed_hash(seed, 21) * beams.extent.x());
+    const float z = beams.center.z() + (signed_hash(seed, 22) * beams.extent.z());
+    const float angle = hash_at(seed, 23) * 6.2831853F;
+    const float half = beams.length * (0.5F + (hash_at(seed, 24) * 0.35F));
+    const float lift = beams.radius * (1.0F + (hash_at(seed, 25) * 2.6F));
+    const QVector3D dir(std::cos(angle) * half,
+                        hash_at(seed, 26) * beams.length * 0.22F,
+                        std::sin(angle) * half);
+    const QVector3D color =
+        clamp01(beams.timber * (0.80F + (hash_at(seed, 27) * 0.45F)));
+
+    desc.add_cylinder(QVector3D(x, beams.ground_y + lift, z) - dir,
+                      QVector3D(x, beams.ground_y + lift, z) + dir,
+                      beams.radius * (0.75F + (hash_at(seed, 28) * 0.6F)),
+                      color,
+                      beams.states,
+                      beams.lod);
+  }
+}
+
+void add_scorch_patch(BuildingArchetypeDesc& desc, const ScorchPatch& patch) {
+  for (int i = 0; i < patch.count; ++i) {
+    const int seed = patch.seed + (i * 53);
+    const float x = patch.center.x() + (signed_hash(seed, 31) * patch.radius * 0.62F);
+    const float z = patch.center.z() + (signed_hash(seed, 32) * patch.radius * 0.62F);
+    const float extent = patch.radius * (0.10F + (hash_at(seed, 33) * 0.17F));
+    const float fade = 0.75F + (hash_at(seed, 34) * 0.75F);
+
+    desc.add_rotated_box(QVector3D(x, patch.ground_y + 0.006F, z),
+                         QVector3D(extent, 0.004F, extent * 0.78F),
+                         QVector3D(0.0F, hash_at(seed, 35) * 90.0F, 0.0F),
+                         clamp01(patch.soot * fade),
+                         patch.states,
+                         patch.lod);
+  }
+}
+
+void add_crack_veins(BuildingArchetypeDesc& desc, const CrackVeins& veins) {
+  for (int i = 0; i < veins.count; ++i) {
+    const int seed = veins.seed + (i * 59);
+    const float t = (static_cast<float>(i) + 0.5F) / static_cast<float>(veins.count);
+    const float wander = signed_hash(seed, 41) * 0.22F;
+
+    const QVector3D along = veins.span * ((t - 0.5F) + (wander * 0.12F));
+    const QVector3D base(
+        veins.origin.x() + along.x(), veins.origin.y(), veins.origin.z() + along.z());
+    const float run = veins.span.y() * (0.35F + (hash_at(seed, 42) * 0.5F));
+    const float lean = signed_hash(seed, 43) * 26.0F;
+
+    const QVector3D half_size = (std::abs(veins.span.x()) >= std::abs(veins.span.z()))
+                                    ? QVector3D(veins.width, run, veins.width * 0.6F)
+                                    : QVector3D(veins.width * 0.6F, run, veins.width);
+
+    desc.add_rotated_box(base + QVector3D(0.0F, run, 0.0F),
+                         half_size,
+                         QVector3D(0.0F, 0.0F, lean),
+                         clamp01(veins.color),
+                         veins.states,
+                         veins.lod);
+  }
+}
+
+void add_broken_rim(BuildingArchetypeDesc& desc, const BrokenRim& rim) {
+  for (int i = 0; i < rim.count; ++i) {
+    const int seed = rim.seed + (i * 61);
+    const float angle =
+        (6.2831853F * static_cast<float>(i) / static_cast<float>(rim.count)) +
+        (signed_hash(seed, 61) * 0.22F);
+    const float radius = rim.radius * (0.94F + (hash_at(seed, 62) * 0.12F));
+    const float half = rim.chunk_half * (0.65F + (hash_at(seed, 63) * 0.8F));
+    const float rise = rim.rise * (0.3F + (hash_at(seed, 64) * 1.1F));
+
+    desc.add_rotated_box(QVector3D(std::sin(angle) * radius,
+                                   rim.center.y() + rise,
+                                   std::cos(angle) * radius) +
+                             QVector3D(rim.center.x(), 0.0F, rim.center.z()),
+                         QVector3D(half, rise, half * 0.8F),
+                         QVector3D(signed_hash(seed, 65) * 12.0F,
+                                   -angle * 57.2957795F,
+                                   signed_hash(seed, 66) * 10.0F),
+                         clamp01(rim.color * (0.85F + (hash_at(seed, 67) * 0.28F))),
+                         rim.states,
+                         rim.lod);
+  }
+}
+
+void add_ruin_dressing(BuildingArchetypeDesc& desc, const RuinDressing& dressing) {
+  const QVector3D apron =
+      dressing.apron_extent.isNull() ? dressing.extent * 1.05F : dressing.apron_extent;
+  const auto both = static_cast<BuildingStateMask>(
+      static_cast<std::uint8_t>(BuildingStateMask::Damaged) |
+      static_cast<std::uint8_t>(BuildingStateMask::Destroyed));
+
+  add_scorch_patch(
+      desc,
+      ScorchPatch{.center = dressing.center,
+                  .radius = std::max(dressing.extent.x(), dressing.extent.z()) * 0.95F,
+                  .ground_y = dressing.ground_y,
+                  .count = 4,
+                  .seed = dressing.seed + 601,
+                  .states = both});
+
+  add_rubble_field(desc,
+                   RubbleField{.center = dressing.center,
+                               .extent = apron,
+                               .stone = dressing.stone,
+                               .stone_dark = dressing.stone_dark,
+                               .ground_y = dressing.apron_y,
+                               .chunk_scale = dressing.scale * 0.85F,
+                               .ring_bias = 0.78F,
+                               .count = 8,
+                               .seed = dressing.seed + 17,
+                               .states = BuildingStateMask::Damaged});
+
+  add_rubble_field(desc,
+                   RubbleField{.center = dressing.center,
+                               .extent = dressing.extent,
+                               .stone = dressing.stone,
+                               .stone_dark = dressing.stone_dark,
+                               .ground_y = dressing.ground_y,
+                               .chunk_scale = dressing.scale * 1.35F,
+                               .ring_bias = 0.35F,
+                               .count = 18,
+                               .seed = dressing.seed + 233,
+                               .states = BuildingStateMask::Destroyed});
+
+  add_charred_beams(desc,
+                    CharredBeams{.center = dressing.center,
+                                 .extent = dressing.extent * 0.58F,
+                                 .timber = dressing.timber,
+                                 .ground_y = dressing.ground_y,
+                                 .length = 0.85F * dressing.scale,
+                                 .radius = 0.052F * dressing.scale,
+                                 .count = 5,
+                                 .seed = dressing.seed + 419,
+                                 .states = BuildingStateMask::Destroyed});
+
+  if (!dressing.collapsed_roof) {
+    return;
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    const int seed = dressing.seed + 811 + (i * 37);
+    const float x = dressing.center.x() + (signed_hash(seed, 51) * dressing.extent.x());
+    const float z = dressing.center.z() + (signed_hash(seed, 52) * dressing.extent.z());
+    const float half = (0.18F + (hash_at(seed, 53) * 0.20F)) * dressing.scale;
+    const QVector3D slab =
+        clamp01(mix(dressing.stone_dark, dressing.timber, hash_at(seed, 54)));
+
+    desc.add_rotated_box(QVector3D(x, dressing.ground_y + (half * 0.32F), z),
+                         QVector3D(half, 0.028F * dressing.scale, half * 0.72F),
+                         QVector3D(signed_hash(seed, 55) * 34.0F,
+                                   hash_at(seed, 56) * 90.0F,
+                                   signed_hash(seed, 57) * 30.0F),
+                         slab,
+                         BuildingStateMask::Destroyed,
+                         BuildingLODMask::Full);
+  }
+}
+
+} // namespace Render::GL

--- a/render/entity/building_decay.h
+++ b/render/entity/building_decay.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <QVector3D>
+
+#include <cstdint>
+
+#include "building_archetype_desc.h"
+#include "building_state.h"
+
+namespace Render::GL {
+
+struct BuildingDecayProfile {
+  float desaturation{0.0F};
+  float darkening{1.0F};
+  float soot{0.0F};
+  float moss{0.0F};
+  float dust{0.0F};
+  float variation{0.0F};
+};
+
+auto building_decay_profile(BuildingState state) -> BuildingDecayProfile;
+
+auto decayed_color(const QVector3D& base, BuildingState state, int seed) -> QVector3D;
+
+auto decay_hash(int seed) -> float;
+
+auto part_supports_state(BuildingStateMask mask, BuildingState state) -> bool;
+
+struct RubbleField {
+  QVector3D center{0.0F, 0.0F, 0.0F};
+  QVector3D extent{1.0F, 0.0F, 1.0F};
+  QVector3D stone{0.60F, 0.57F, 0.51F};
+  QVector3D stone_dark{0.38F, 0.35F, 0.31F};
+  float ground_y{0.0F};
+  float chunk_scale{1.0F};
+  float ring_bias{0.0F};
+  int count{9};
+  int seed{0};
+  BuildingStateMask states{BuildingStateMask::Destroyed};
+  BuildingLODMask lod{BuildingLODMask::All};
+};
+
+void add_rubble_field(BuildingArchetypeDesc& desc, const RubbleField& field);
+
+struct CharredBeams {
+  QVector3D center{0.0F, 0.0F, 0.0F};
+  QVector3D extent{1.0F, 0.0F, 1.0F};
+  QVector3D timber{0.16F, 0.12F, 0.09F};
+  float ground_y{0.0F};
+  float length{0.9F};
+  float radius{0.045F};
+  int count{4};
+  int seed{0};
+  BuildingStateMask states{BuildingStateMask::Destroyed};
+  BuildingLODMask lod{BuildingLODMask::Full};
+};
+
+void add_charred_beams(BuildingArchetypeDesc& desc, const CharredBeams& beams);
+
+struct ScorchPatch {
+  QVector3D center{0.0F, 0.0F, 0.0F};
+  float radius{0.8F};
+  float ground_y{0.0F};
+  int count{5};
+  int seed{0};
+  QVector3D soot{0.11F, 0.10F, 0.09F};
+  BuildingStateMask states{BuildingStateMask::Destroyed};
+  BuildingLODMask lod{BuildingLODMask::Full};
+};
+
+void add_scorch_patch(BuildingArchetypeDesc& desc, const ScorchPatch& patch);
+
+struct CrackVeins {
+  QVector3D origin{0.0F, 0.0F, 0.0F};
+  QVector3D span{1.0F, 1.0F, 0.0F};
+  QVector3D color{0.20F, 0.18F, 0.16F};
+  float width{0.014F};
+  int count{4};
+  int seed{0};
+  BuildingStateMask states{BuildingStateMask::Damaged | BuildingStateMask::Destroyed};
+  BuildingLODMask lod{BuildingLODMask::Full};
+};
+
+void add_crack_veins(BuildingArchetypeDesc& desc, const CrackVeins& veins);
+
+struct RuinDressing {
+  QVector3D center{0.0F, 0.0F, 0.0F};
+  QVector3D extent{1.0F, 0.0F, 1.0F};
+  QVector3D apron_extent{0.0F, 0.0F, 0.0F};
+  QVector3D stone{0.58F, 0.55F, 0.49F};
+  QVector3D stone_dark{0.36F, 0.33F, 0.29F};
+  QVector3D timber{0.17F, 0.12F, 0.08F};
+  float ground_y{0.0F};
+  float apron_y{0.02F};
+  float scale{1.0F};
+  int seed{0};
+  bool collapsed_roof{true};
+};
+
+void add_ruin_dressing(BuildingArchetypeDesc& desc, const RuinDressing& dressing);
+
+struct BrokenRim {
+  QVector3D center{0.0F, 0.0F, 0.0F};
+  QVector3D color{0.55F, 0.52F, 0.47F};
+  float radius{1.0F};
+  float chunk_half{0.10F};
+  float rise{0.16F};
+  int count{7};
+  int seed{0};
+  BuildingStateMask states{BuildingStateMask::Destroyed};
+  BuildingLODMask lod{BuildingLODMask::All};
+};
+
+void add_broken_rim(BuildingArchetypeDesc& desc, const BrokenRim& rim);
+
+} // namespace Render::GL

--- a/render/entity/building_ornament_emit.h
+++ b/render/entity/building_ornament_emit.h
@@ -7,6 +7,8 @@
 #include "../gl/primitives.h"
 #include "../submitter.h"
 #include "building_archetype_desc.h"
+#include "building_decay.h"
+#include "building_state.h"
 
 namespace Render::GL {
 
@@ -17,7 +19,8 @@ inline void emit_building_ornament(const BuildingArchetypeDesc& desc,
                                    Texture* white,
                                    bool detailed,
                                    const QVector3D* palette = nullptr,
-                                   std::size_t palette_size = 0) {
+                                   std::size_t palette_size = 0,
+                                   BuildingState filter_state = BuildingState::Normal) {
   Mesh* const cube = unit_cube != nullptr ? unit_cube : get_unit_cube();
   if (cube == nullptr) {
     return;
@@ -38,6 +41,9 @@ inline void emit_building_ornament(const BuildingArchetypeDesc& desc,
 
   for (const auto& part : desc.parts()) {
     if (!detailed && (part.lod & BuildingLODMask::Minimal) == BuildingLODMask::None) {
+      continue;
+    }
+    if (!part_supports_state(part.states, filter_state)) {
       continue;
     }
 

--- a/render/entity/building_render_common.cpp
+++ b/render/entity/building_render_common.cpp
@@ -204,7 +204,7 @@ void submit_building_instance(ISubmitter& out,
       damage_id = 10;
       break;
     case BuildingState::Destroyed:
-      damage_id = 11;
+      damage_id = 20;
       break;
     case BuildingState::Normal:
     default:

--- a/render/entity/nations/carthage/barracks_renderer.cpp
+++ b/render/entity/nations/carthage/barracks_renderer.cpp
@@ -20,6 +20,7 @@
 #include "../../barracks_renderer_common.h"
 #include "../../barracks_stockpile.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornament_emit.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
@@ -119,6 +120,22 @@ void draw_gate(const DrawContext& p,
                BuildingState state,
                bool detailed);
 
+auto barracks_ruin_desc(const CarthagePalette& c) -> const BuildingArchetypeDesc& {
+  static const BuildingArchetypeDesc k_desc = [&] {
+    BuildingArchetypeDesc desc("carthage_barracks_ruin");
+    add_ruin_dressing(desc,
+                      RuinDressing{.extent = QVector3D(1.46F, 0.0F, 1.28F),
+                                   .stone = c.stone_base,
+                                   .stone_dark = c.stone_dark,
+                                   .timber = c.wood_dark,
+                                   .ground_y = 0.16F,
+                                   .scale = 1.25F,
+                                   .seed = 487});
+    return desc;
+  }();
+  return k_desc;
+}
+
 auto build_barracks_archetype(BuildingState state,
                               Mesh* unit,
                               Texture* white) -> RenderArchetype {
@@ -132,6 +149,15 @@ auto build_barracks_archetype(BuildingState state,
     draw_courtyard(local_ctx, recorder, unit, white, palette, state, detailed);
     draw_carthage_roof(local_ctx, recorder, unit, white, palette, state, detailed);
     draw_gate(local_ctx, recorder, unit, white, palette, state, detailed);
+    emit_building_ornament(barracks_ruin_desc(palette),
+                           local_ctx.model,
+                           recorder,
+                           unit,
+                           white,
+                           detailed,
+                           nullptr,
+                           0,
+                           state);
   };
 
   TemplateRecorder full_recorder;
@@ -143,7 +169,8 @@ auto build_barracks_archetype(BuildingState state,
   return build_building_archetype_from_recorded_lods("carthage_barracks",
                                                      full_recorder.take_commands(),
                                                      minimal_recorder.take_commands(),
-                                                     70.0F);
+                                                     70.0F,
+                                                     state);
 }
 
 auto barracks_archetype(BuildingState state,

--- a/render/entity/nations/carthage/defense_tower_renderer.cpp
+++ b/render/entity/nations/carthage/defense_tower_renderer.cpp
@@ -13,6 +13,7 @@
 #include "../../../submitter.h"
 #include "../../barracks_flag_renderer.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../defense_tower_renderer_common.h"
@@ -279,6 +280,25 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
                            c.bronze,
                            c.ember);
   }
+
+  add_broken_rim(desc,
+                 BrokenRim{.center = QVector3D(0.0F, core_top - 0.16F, 0.0F),
+                           .color = c.stone_dark,
+                           .radius = 0.66F,
+                           .chunk_half = 0.14F,
+                           .rise = 0.13F,
+                           .count = 7,
+                           .seed = 397});
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(0.98F, 0.0F, 0.98F),
+                                 .apron_extent = QVector3D(1.46F, 0.0F, 1.46F),
+                                 .stone = c.stone_base,
+                                 .stone_dark = c.stone_dark,
+                                 .timber = c.wood_dark,
+                                 .ground_y = 0.34F,
+                                 .scale = 0.95F,
+                                 .seed = 397});
 
   return build_building_archetype(desc, state);
 }

--- a/render/entity/nations/carthage/home_renderer.cpp
+++ b/render/entity/nations/carthage/home_renderer.cpp
@@ -8,6 +8,7 @@
 #include "../../../../game/core/component.h"
 #include "../../../submitter.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../building_state.h"
@@ -337,6 +338,15 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
                          c.wood_dark,
                          c.bronze,
                          c.ember);
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(0.94F, 0.0F, 0.94F),
+                                 .stone = c.stone_base,
+                                 .stone_dark = c.stone_dark,
+                                 .timber = c.stone_dark * 0.5F,
+                                 .ground_y = 0.2F,
+                                 .scale = 1.0F,
+                                 .seed = 137});
 
   return build_building_archetype(desc, state);
 }

--- a/render/entity/nations/carthage/marketplace_renderer.cpp
+++ b/render/entity/nations/carthage/marketplace_renderer.cpp
@@ -15,6 +15,7 @@
 #include "../../../submitter.h"
 #include "../../../template_cache.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../building_state.h"
@@ -428,6 +429,15 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                          c.wood_dark,
                          c.cloth_gold,
                          c.ember);
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(1.12F, 0.0F, 1.12F),
+                                 .stone = c.sandstone,
+                                 .stone_dark = c.sandstone_dark,
+                                 .timber = c.sandstone_dark * 0.5F,
+                                 .ground_y = 0.14F,
+                                 .scale = 1.0F,
+                                 .seed = 223});
 
   return build_building_archetype(desc, state);
 }

--- a/render/entity/nations/carthage/temple_renderer.cpp
+++ b/render/entity/nations/carthage/temple_renderer.cpp
@@ -8,6 +8,7 @@
 
 #include "../../../render_archetype.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../building_state.h"
@@ -607,6 +608,15 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
   if (state == BuildingState::Destroyed) {
     add_carthage_temple_ruin(desc, c, podium_y, wall_h);
   }
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(1.18F, 0.0F, 0.98F),
+                                 .stone = c.sandstone,
+                                 .stone_dark = c.basalt,
+                                 .timber = c.basalt * 0.7F,
+                                 .ground_y = 0.28F,
+                                 .scale = 1.15F,
+                                 .seed = 311});
 
   return build_building_archetype(desc, state);
 }

--- a/render/entity/nations/carthage/wall_renderer.cpp
+++ b/render/entity/nations/carthage/wall_renderer.cpp
@@ -33,14 +33,14 @@ const WallGeometry k_wall_geometry{.earthwork_base = true,
                                    .rail_radius = 0.055F,
                                    .berm_half_width = 0.28F,
                                    .berm_height = 0.20F};
-auto wall_archetypes() -> const std::array<RenderArchetype, 6>& {
-  static const std::array<RenderArchetype, 6> archetypes = build_wall_archetype_set(
+auto wall_archetypes() -> const WallArchetypeSet& {
+  static const WallArchetypeSet archetypes = build_wall_archetype_set(
       "carthage_wall_variant", k_wall_palette, k_wall_geometry);
   return archetypes;
 }
 
-auto gate_archetype() -> const RenderArchetype& {
-  static const RenderArchetype archetype = build_wall_gate_archetype(
+auto gate_archetype() -> const BuildingArchetypeSet& {
+  static const BuildingArchetypeSet archetype = build_wall_gate_archetype(
       "carthage_wall_variant", k_wall_palette, k_wall_geometry);
   return archetype;
 }

--- a/render/entity/nations/roman/barracks_renderer.cpp
+++ b/render/entity/nations/roman/barracks_renderer.cpp
@@ -23,6 +23,7 @@
 #include "../../barracks_renderer_common.h"
 #include "../../barracks_stockpile.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornament_emit.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
@@ -114,6 +115,22 @@ void draw_roofline(const DrawContext& p,
                    BuildingState state,
                    bool detailed);
 
+auto barracks_ruin_desc(const RomanPalette& c) -> const BuildingArchetypeDesc& {
+  static const BuildingArchetypeDesc k_desc = [&] {
+    BuildingArchetypeDesc desc("roman_barracks_ruin");
+    add_ruin_dressing(desc,
+                      RuinDressing{.extent = QVector3D(1.46F, 0.0F, 1.28F),
+                                   .stone = c.limestone_shade,
+                                   .stone_dark = c.limestone_dark,
+                                   .timber = c.cedar_dark * 0.6F,
+                                   .ground_y = 0.16F,
+                                   .scale = 1.25F,
+                                   .seed = 443});
+    return desc;
+  }();
+  return k_desc;
+}
+
 auto build_barracks_archetype(BuildingState state,
                               Mesh* unit,
                               Texture* white) -> RenderArchetype {
@@ -127,6 +144,15 @@ auto build_barracks_archetype(BuildingState state,
     draw_colonnade(local_ctx, recorder, unit, white, palette, state, detailed);
     draw_terrace(local_ctx, recorder, unit, white, palette, state, detailed);
     draw_roofline(local_ctx, recorder, unit, white, palette, state, detailed);
+    emit_building_ornament(barracks_ruin_desc(palette),
+                           local_ctx.model,
+                           recorder,
+                           unit,
+                           white,
+                           detailed,
+                           nullptr,
+                           0,
+                           state);
   };
 
   TemplateRecorder full_recorder;
@@ -138,7 +164,8 @@ auto build_barracks_archetype(BuildingState state,
   return build_building_archetype_from_recorded_lods("roman_barracks",
                                                      full_recorder.take_commands(),
                                                      minimal_recorder.take_commands(),
-                                                     70.0F);
+                                                     70.0F,
+                                                     state);
 }
 
 auto barracks_archetype(BuildingState state,

--- a/render/entity/nations/roman/defense_tower_renderer.cpp
+++ b/render/entity/nations/roman/defense_tower_renderer.cpp
@@ -13,6 +13,7 @@
 #include "../../../submitter.h"
 #include "../../barracks_flag_renderer.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../defense_tower_renderer_common.h"
@@ -277,6 +278,25 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
                             c.gold,
                             c.terracotta_dark);
   }
+
+  add_broken_rim(desc,
+                 BrokenRim{.center = QVector3D(0.0F, shaft_top - 0.17F, 0.0F),
+                           .color = c.limestone_dark,
+                           .radius = shaft_radius * 0.94F,
+                           .chunk_half = 0.15F,
+                           .rise = 0.13F,
+                           .count = 8,
+                           .seed = 353});
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(0.98F, 0.0F, 0.98F),
+                                 .apron_extent = QVector3D(1.46F, 0.0F, 1.46F),
+                                 .stone = c.limestone_shade,
+                                 .stone_dark = c.limestone_dark,
+                                 .timber = c.limestone_dark * 0.5F,
+                                 .ground_y = 0.34F,
+                                 .scale = 0.95F,
+                                 .seed = 353});
 
   return build_building_archetype(desc, state);
 }

--- a/render/entity/nations/roman/home_renderer.cpp
+++ b/render/entity/nations/roman/home_renderer.cpp
@@ -8,6 +8,7 @@
 #include "../../../../game/core/component.h"
 #include "../../../submitter.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../building_state.h"
@@ -336,6 +337,15 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
                           0.62F,
                           c.gold,
                           c.terracotta_dark);
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(0.98F, 0.0F, 0.98F),
+                                 .stone = c.limestone_shade,
+                                 .stone_dark = c.limestone_dark,
+                                 .timber = c.terracotta_dark * 0.45F,
+                                 .ground_y = 0.16F,
+                                 .scale = 1.0F,
+                                 .seed = 101});
 
   return build_building_archetype(desc, state);
 }

--- a/render/entity/nations/roman/marketplace_renderer.cpp
+++ b/render/entity/nations/roman/marketplace_renderer.cpp
@@ -15,6 +15,7 @@
 #include "../../../submitter.h"
 #include "../../../template_cache.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../building_state.h"
@@ -430,6 +431,15 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                           c.terracotta_dark);
   add_roman_roof_standard(
       desc, QVector3D(0.72F, hall_roof_y + 0.10F, 0.0F), 0.58F, c.gold, c.cloth_red);
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(1.16F, 0.0F, 1.16F),
+                                 .stone = c.limestone_shade,
+                                 .stone_dark = c.limestone_dark,
+                                 .timber = c.cedar_dark,
+                                 .ground_y = 0.16F,
+                                 .scale = 1.0F,
+                                 .seed = 181});
 
   return build_building_archetype(desc, state);
 }

--- a/render/entity/nations/roman/temple_renderer.cpp
+++ b/render/entity/nations/roman/temple_renderer.cpp
@@ -8,6 +8,7 @@
 
 #include "../../../render_archetype.h"
 #include "../../building_archetype_desc.h"
+#include "../../building_decay.h"
 #include "../../building_ornaments.h"
 #include "../../building_render_common.h"
 #include "../../building_state.h"
@@ -617,6 +618,15 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
   if (ruined) {
     add_roman_temple_ruin(desc, c, podium_y, cella_h);
   }
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(1.18F, 0.0F, 0.92F),
+                                 .stone = c.limestone,
+                                 .stone_dark = c.limestone_dark,
+                                 .timber = c.limestone_dark * 0.5F,
+                                 .ground_y = 0.29F,
+                                 .scale = 1.15F,
+                                 .seed = 269});
 
   return build_building_archetype(desc, state);
 }

--- a/render/entity/nations/roman/wall_renderer.cpp
+++ b/render/entity/nations/roman/wall_renderer.cpp
@@ -32,14 +32,14 @@ const WallGeometry k_wall_geometry{.earthwork_base = true,
                                    .rail_radius = 0.060F,
                                    .berm_half_width = 0.30F,
                                    .berm_height = 0.22F};
-auto wall_archetypes() -> const std::array<RenderArchetype, 6>& {
-  static const std::array<RenderArchetype, 6> archetypes =
+auto wall_archetypes() -> const WallArchetypeSet& {
+  static const WallArchetypeSet archetypes =
       build_wall_archetype_set("roman_wall_variant", k_wall_palette, k_wall_geometry);
   return archetypes;
 }
 
-auto gate_archetype() -> const RenderArchetype& {
-  static const RenderArchetype archetype =
+auto gate_archetype() -> const BuildingArchetypeSet& {
+  static const BuildingArchetypeSet archetype =
       build_wall_gate_archetype("roman_wall_variant", k_wall_palette, k_wall_geometry);
   return archetype;
 }

--- a/render/entity/nations/sepulcher/barracks_renderer.cpp
+++ b/render/entity/nations/sepulcher/barracks_renderer.cpp
@@ -7,7 +7,9 @@
 #include "../../../gl/resources.h"
 #include "../../../submitter.h"
 #include "../../barracks_flag_renderer.h"
+#include "../../building_decay.h"
 #include "../../building_render_common.h"
+#include "../../building_state.h"
 #include "../../registry.h"
 #include "game/core/component.h"
 
@@ -28,35 +30,39 @@ void draw_grave_banner(const DrawContext& p,
                        const QVector3D& team,
                        const BarracksFlagRenderer::ClothBannerResources* cloth) {
   const SepulcherPalette palette;
+  const BuildingState state = resolve_building_state(p);
 
   const QVector3D team_trim = team * 0.55F + palette.grave_iron * 0.45F;
+  const float wear = (state == BuildingState::Damaged)     ? 0.82F
+                     : (state == BuildingState::Destroyed) ? 0.55F
+                                                           : 1.0F;
 
   BarracksFlagRenderer::draw_hanging_banner(
       p,
       out,
       unit,
       white,
-      team,
-      team_trim,
+      decayed_color(team, state, 1),
+      decayed_color(team_trim, state, 2),
       {.pole_base = QVector3D(-2.10F, 0.0F, -1.70F),
-       .pole_height = 3.2F,
+       .pole_height = 3.2F * wear,
        .pole_radius = 0.055F,
-       .banner_width = 0.95F,
-       .banner_height = 1.15F,
+       .banner_width = 0.95F * wear,
+       .banner_height = 1.15F * wear,
        .connector_drop_ratio = 0.5F,
-       .pole_color = palette.grave_iron,
-       .beam_color = palette.bone,
-       .connector_color = palette.grave_iron_light,
+       .pole_color = decayed_color(palette.grave_iron, state, 3),
+       .beam_color = decayed_color(palette.bone, state, 4),
+       .connector_color = decayed_color(palette.grave_iron_light, state, 5),
 
-       .ornament_offset = QVector3D(0.0F, 3.34F, 0.0F),
+       .ornament_offset = QVector3D(0.0F, 3.34F * wear, 0.0F),
        .ornament_size = QVector3D(0.05F, 0.30F, 0.05F),
-       .ornament_color = palette.bone,
-       .ring_count = 3,
+       .ornament_color = decayed_color(palette.bone, state, 6),
+       .ring_count = (state == BuildingState::Destroyed) ? 1 : 3,
        .ring_y_start = 0.6F,
-       .ring_spacing = 0.72F,
+       .ring_spacing = 0.72F * wear,
        .ring_height = 0.03F,
        .ring_radius_scale = 1.8F,
-       .ring_color = palette.bone},
+       .ring_color = decayed_color(palette.bone, state, 7)},
       cloth);
 }
 

--- a/render/entity/wall_gate_renderer_common.cpp
+++ b/render/entity/wall_gate_renderer_common.cpp
@@ -4,12 +4,14 @@
 #include <QVector3D>
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 
 #include "../../game/core/component.h"
 #include "../../game/core/entity.h"
 #include "../gl/resources.h"
 #include "building_archetype_desc.h"
+#include "building_decay.h"
 #include "building_render_common.h"
 
 namespace Render::GL {
@@ -23,6 +25,8 @@ constexpr float k_leaf_thickness = 0.075F;
 constexpr float k_leaf_swing_degrees = 100.0F;
 constexpr float k_leaf_height_ratio = 0.82F;
 constexpr float k_detail_distance_sq = 900.0F;
+
+constexpr auto k_mask_intact = k_building_state_mask_intact;
 
 auto leaf_height(const WallGeometry& geometry) -> float {
   return geometry.stake_height * k_leaf_height_ratio;
@@ -40,19 +44,37 @@ void add_jamb(BuildingArchetypeDesc& desc,
   const float radius = geometry.post_radius * 1.05F;
   const float top = geometry.stake_height + geometry.post_extra_height + 0.18F;
 
-  desc.add_cylinder(
-      QVector3D(x, 0.02F, z), QVector3D(x, top, z), radius, palette.wood_mid);
+  const float lean =
+      (decay_hash(static_cast<int>((x * 31.0F) + (z * 7.0F))) - 0.5F) * 0.16F;
+
+  desc.add_cylinder(QVector3D(x, 0.02F, z),
+                    QVector3D(x, top, z),
+                    radius,
+                    palette.wood_mid,
+                    BuildingStateMask::Normal);
+  desc.add_cylinder(QVector3D(x, 0.02F, z),
+                    QVector3D(x + lean, top * 0.94F, z + (lean * 0.5F)),
+                    radius,
+                    palette.wood_mid,
+                    BuildingStateMask::Damaged);
+  desc.add_cylinder(QVector3D(x, 0.02F, z),
+                    QVector3D(x + (lean * 2.6F), top * 0.42F, z + (lean * 1.4F)),
+                    radius * 0.96F,
+                    palette.wood_dark,
+                    BuildingStateMask::Destroyed);
   desc.add_cone(QVector3D(x, top - 0.01F, z),
                 QVector3D(x, top + geometry.tip_height, z),
                 radius * 1.02F,
-                palette.wood_dark);
+                palette.wood_dark,
+                BuildingStateMask::Normal);
 
   for (const float band : {geometry.lower_rail_y, geometry.upper_rail_y}) {
     desc.add_cylinder(QVector3D(x, band - 0.05F, z),
                       QVector3D(x, band + 0.05F, z),
                       radius * 1.12F,
                       geometry.metal_bands ? palette.masonry_accent : palette.rope,
-                      BuildingStateMask::All,
+                      band > geometry.lower_rail_y ? BuildingStateMask::Normal
+                                                   : k_mask_intact,
                       BuildingLODMask::Full);
   }
 }
@@ -71,16 +93,36 @@ void add_piers(BuildingArchetypeDesc& desc,
     for (int i = 0; i < k_stakes_per_pier; ++i) {
       const float x = side * (pier_inner + (spacing * (static_cast<float>(i) + 0.5F)));
       const float height = geometry.stake_height * (i % 2 == 0 ? 1.0F : 0.94F);
+      const float roll = decay_hash((i * 13) + static_cast<int>(side * 5.0F) + 2);
+      const bool snaps = roll < 0.45F;
+      const BuildingStateMask upright =
+          snaps ? BuildingStateMask::Normal : k_mask_intact;
+
       desc.add_cylinder(QVector3D(x, 0.0F, 0.0F),
                         QVector3D(x, height, 0.0F),
                         stake_radius,
-                        (i % 2 == 0) ? palette.wood_mid : palette.wood_light);
+                        (i % 2 == 0) ? palette.wood_mid : palette.wood_light,
+                        upright);
       desc.add_cone(QVector3D(x, height - 0.01F, 0.0F),
                     QVector3D(x, height + geometry.tip_height, 0.0F),
                     stake_radius * 1.02F,
                     palette.wood_dark,
-                    BuildingStateMask::All,
+                    upright,
                     BuildingLODMask::Full);
+      if (snaps) {
+        desc.add_cylinder(QVector3D(x, 0.0F, 0.0F),
+                          QVector3D(x, height * (0.35F + (roll * 0.6F)), 0.0F),
+                          stake_radius,
+                          palette.wood_dark,
+                          BuildingStateMask::Damaged);
+      }
+      if (roll > 0.72F) {
+        desc.add_cylinder(QVector3D(x, 0.0F, 0.0F),
+                          QVector3D(x, height * (0.2F + (roll * 0.25F)), 0.0F),
+                          stake_radius * 0.95F,
+                          palette.wood_dark,
+                          BuildingStateMask::Destroyed);
+      }
     }
 
     const float mid = side * (pier_inner + (span * 0.5F));
@@ -88,7 +130,8 @@ void add_piers(BuildingArchetypeDesc& desc,
       desc.add_box(QVector3D(mid, rail, 0.0F),
                    QVector3D(span * 0.5F, 0.05F, stake_radius * 1.25F),
                    geometry.metal_bands ? palette.masonry_accent : palette.rope,
-                   BuildingStateMask::All,
+                   rail > geometry.lower_rail_y ? BuildingStateMask::Normal
+                                                : k_mask_intact,
                    BuildingLODMask::Full);
     }
 
@@ -104,7 +147,7 @@ void add_piers(BuildingArchetypeDesc& desc,
 
 auto build_wall_gate_archetype(std::string_view name_prefix,
                                const WallPalette& palette,
-                               const WallGeometry& geometry) -> RenderArchetype {
+                               const WallGeometry& geometry) -> BuildingArchetypeSet {
   BuildingArchetypeDesc desc(std::string(name_prefix) + "_gate");
 
   if (geometry.earthwork_base) {
@@ -128,32 +171,80 @@ auto build_wall_gate_archetype(std::string_view name_prefix,
   for (const float depth : {-k_jamb_depth, k_jamb_depth}) {
     desc.add_box(QVector3D(0.0F, lintel_y, depth),
                  QVector3D(k_jamb_offset + 0.18F, 0.095F, 0.08F),
-                 palette.wood_dark);
+                 palette.wood_dark,
+                 k_mask_intact);
   }
 
   desc.add_box(QVector3D(0.0F, lintel_y + 0.26F, 0.0F),
                QVector3D(k_jamb_offset + 0.26F, 0.085F, k_jamb_depth + 0.14F),
-               palette.wood_light);
+               palette.wood_light,
+               BuildingStateMask::Normal);
 
   for (int i = -2; i <= 2; ++i) {
     desc.add_box(QVector3D(static_cast<float>(i) * 0.74F, lintel_y + 0.40F, 0.0F),
                  QVector3D(0.22F, 0.06F, k_jamb_depth + 0.07F),
                  (i % 2 == 0) ? palette.wood_mid : palette.wood_light,
-                 BuildingStateMask::All,
+                 BuildingStateMask::Normal,
                  BuildingLODMask::Full);
   }
 
+  desc.add_rotated_box(QVector3D(0.35F, 0.10F, k_jamb_depth * 1.6F),
+                       QVector3D(k_jamb_offset * 0.9F, 0.075F, 0.16F),
+                       QVector3D(0.0F, 14.0F, 6.0F),
+                       palette.wood_dark,
+                       BuildingStateMask::Destroyed);
+
   add_piers(desc, palette, geometry);
 
-  return build_building_archetype(desc, BuildingState::Normal);
+  add_rubble_field(
+      desc,
+      RubbleField{
+          .center = QVector3D(0.0F, 0.0F, 0.0F),
+          .extent = QVector3D(k_structure_half_span * 0.85F, 0.0F, k_jamb_depth * 1.4F),
+          .stone = palette.rubble,
+          .stone_dark = palette.earth_dark,
+          .count = 6,
+          .seed = 71,
+          .states = BuildingStateMask::Damaged});
+  add_rubble_field(
+      desc,
+      RubbleField{.center = QVector3D(0.0F, 0.0F, 0.0F),
+                  .extent = QVector3D(k_structure_half_span, 0.0F, k_jamb_depth * 1.9F),
+                  .stone = palette.rubble,
+                  .stone_dark = palette.earth_dark,
+                  .chunk_scale = 1.2F,
+                  .count = 13,
+                  .seed = 311,
+                  .states = BuildingStateMask::Destroyed});
+  add_charred_beams(desc,
+                    CharredBeams{.center = QVector3D(0.0F, 0.0F, 0.0F),
+                                 .extent = QVector3D(k_jamb_offset, 0.0F, 0.35F),
+                                 .timber = palette.wood_dark * 0.45F,
+                                 .length = 0.8F,
+                                 .count = 4,
+                                 .seed = 209,
+                                 .states = BuildingStateMask::Destroyed});
+  add_scorch_patch(
+      desc,
+      ScorchPatch{.center = QVector3D(0.0F, 0.0F, 0.0F),
+                  .radius = k_jamb_offset * 1.3F,
+                  .count = 5,
+                  .seed = 407,
+                  .states = static_cast<BuildingStateMask>(
+                      static_cast<std::uint8_t>(BuildingStateMask::Damaged) |
+                      static_cast<std::uint8_t>(BuildingStateMask::Destroyed))});
+
+  return build_stateful_building_archetype_set(
+      [&](BuildingState state) { return build_building_archetype(desc, state); });
 }
 
 void submit_wall_gate(ISubmitter& out,
                       const DrawContext& ctx,
-                      const RenderArchetype& frame,
+                      const BuildingArchetypeSet& frame,
                       const WallPalette& palette,
                       const WallGeometry& geometry) {
-  submit_building_instance(out, ctx, frame);
+  const BuildingState state = resolve_building_state(ctx);
+  submit_building_instance(out, ctx, frame.for_state(state));
 
   Mesh* mesh = (ctx.resources != nullptr) ? ctx.resources->unit() : nullptr;
   Texture* white = (ctx.resources != nullptr) ? ctx.resources->white() : nullptr;
@@ -165,14 +256,24 @@ void submit_wall_gate(ISubmitter& out,
         (gate != nullptr) ? std::clamp(gate->open_amount, 0.0F, 1.0F) : 0.0F;
     const float swing_degrees = open_amount * k_leaf_swing_degrees;
 
-    const float height = leaf_height(geometry);
+    const float leaf_scale = (state == BuildingState::Damaged)     ? 0.86F
+                             : (state == BuildingState::Destroyed) ? 0.55F
+                                                                   : 1.0F;
+    const float height = leaf_height(geometry) * leaf_scale;
     const float length = k_jamb_offset;
     const bool detailed = ctx.distance_sq <= k_detail_distance_sq;
 
     for (const float side : {-1.0F, 1.0F}) {
+      if (state == BuildingState::Destroyed && side < 0.0F) {
+        continue;
+      }
+
       QMatrix4x4 hinge = ctx.model;
       hinge.translate(QVector3D(side * k_jamb_offset, 0.0F, 0.0F));
       hinge.rotate(-side * swing_degrees, 0.0F, 1.0F, 0.0F);
+      if (state == BuildingState::Destroyed) {
+        hinge.rotate(-14.0F, 0.0F, 0.0F, 1.0F);
+      }
 
       const float center_x = -side * length * 0.5F;
 
@@ -182,7 +283,7 @@ void submit_wall_gate(ISubmitter& out,
                           hinge,
                           QVector3D(center_x, (height * 0.5F) + 0.03F, 0.0F),
                           QVector3D(length * 0.5F, height * 0.5F, k_leaf_thickness),
-                          palette.wood_mid);
+                          decayed_color(palette.wood_mid, state, 5));
 
       if (!detailed) {
         continue;
@@ -195,8 +296,10 @@ void submit_wall_gate(ISubmitter& out,
                             hinge,
                             QVector3D(center_x, (height * band_ratio) + 0.03F, 0.0F),
                             QVector3D(length * 0.5F, 0.055F, k_leaf_thickness + 0.022F),
-                            geometry.metal_bands ? palette.masonry_accent
-                                                 : palette.wood_dark);
+                            decayed_color(geometry.metal_bands ? palette.masonry_accent
+                                                               : palette.wood_dark,
+                                          state,
+                                          7));
       }
 
       submit_building_box(
@@ -206,7 +309,7 @@ void submit_wall_gate(ISubmitter& out,
           hinge,
           QVector3D(-side * (length - 0.10F), (height * 0.5F) + 0.03F, 0.0F),
           QVector3D(0.055F, height * 0.42F, k_leaf_thickness + 0.03F),
-          palette.wood_dark);
+          decayed_color(palette.wood_dark, state, 9));
     }
   }
 

--- a/render/entity/wall_gate_renderer_common.h
+++ b/render/entity/wall_gate_renderer_common.h
@@ -4,17 +4,18 @@
 
 #include "../render_archetype.h"
 #include "../submitter.h"
+#include "building_archetype_desc.h"
 #include "wall_renderer_common.h"
 
 namespace Render::GL {
 
 auto build_wall_gate_archetype(std::string_view name_prefix,
                                const WallPalette& palette,
-                               const WallGeometry& geometry) -> RenderArchetype;
+                               const WallGeometry& geometry) -> BuildingArchetypeSet;
 
 void submit_wall_gate(ISubmitter& out,
                       const DrawContext& ctx,
-                      const RenderArchetype& frame,
+                      const BuildingArchetypeSet& frame,
                       const WallPalette& palette,
                       const WallGeometry& geometry);
 

--- a/render/entity/wall_renderer_common.cpp
+++ b/render/entity/wall_renderer_common.cpp
@@ -6,8 +6,19 @@
 #include <cstdint>
 #include <string>
 
+#include "building_decay.h"
+
 namespace Render::GL {
 namespace {
+
+constexpr auto k_mask_intact = k_building_state_mask_intact;
+constexpr auto k_mask_broken = static_cast<BuildingStateMask>(
+    static_cast<std::uint8_t>(BuildingStateMask::Damaged) |
+    static_cast<std::uint8_t>(BuildingStateMask::Destroyed));
+
+auto span_seed(std::size_t dir, int index) -> int {
+  return (static_cast<int>(dir) * 101) + (index * 7) + 3;
+}
 
 constexpr std::uint8_t k_connection_north = 1U << 0U;
 constexpr std::uint8_t k_connection_east = 1U << 1U;
@@ -181,15 +192,81 @@ void add_stake_bindings(BuildingArchetypeDesc& desc,
                         const WallGeometry& geometry,
                         std::size_t dir,
                         float along,
-                        float radius) {
+                        float radius,
+                        BuildingStateMask states) {
   const float lateral_half = rail_offset(geometry) + (geometry.rail_radius * 0.9F);
   for (const float height : {geometry.lower_rail_y, geometry.upper_rail_y}) {
     desc.add_box(point_at(dir, along, 0.0F, height),
                  extents_at(dir, radius * 0.95F, 0.042F, lateral_half),
                  binding_color(palette, geometry),
-                 BuildingStateMask::All,
+                 states,
                  BuildingLODMask::Full);
   }
+}
+
+void add_snapped_stake(BuildingArchetypeDesc& desc,
+                       const WallPalette& palette,
+                       std::size_t dir,
+                       float along,
+                       float lean,
+                       float radius,
+                       float top,
+                       BuildingStateMask states) {
+  desc.add_cylinder(point_at(dir, along, 0.0F, 0.02F),
+                    point_at(dir, along, lean, top),
+                    radius,
+                    palette.wood_mid,
+                    states);
+  desc.add_cone(point_at(dir, along, lean, top + 0.07F),
+                point_at(dir, along, lean, top - 0.02F),
+                radius * 1.04F,
+                palette.wood_dark * 0.75F,
+                states,
+                BuildingLODMask::Full);
+}
+
+void add_span_debris(BuildingArchetypeDesc& desc,
+                     const WallPalette& palette,
+                     std::size_t dir,
+                     float length,
+                     float lateral_half) {
+  const float along_half = length * 0.5F;
+  const QVector3D center = point_at(dir, along_half, 0.0F, 0.0F);
+  const QVector3D extent = extents_at(dir, along_half * 0.86F, 0.0F, lateral_half);
+
+  add_rubble_field(desc,
+                   RubbleField{.center = center,
+                               .extent = extent,
+                               .stone = palette.rubble,
+                               .stone_dark = palette.earth_dark,
+                               .chunk_scale = 0.85F,
+                               .count = 5,
+                               .seed = static_cast<int>(dir) * 23,
+                               .states = BuildingStateMask::Damaged});
+  add_rubble_field(desc,
+                   RubbleField{.center = center,
+                               .extent = extent * 1.15F,
+                               .stone = palette.rubble,
+                               .stone_dark = palette.earth_dark,
+                               .chunk_scale = 1.15F,
+                               .count = 11,
+                               .seed = (static_cast<int>(dir) * 23) + 500,
+                               .states = BuildingStateMask::Destroyed});
+  add_charred_beams(desc,
+                    CharredBeams{.center = center,
+                                 .extent = extent,
+                                 .timber = palette.wood_dark * 0.45F,
+                                 .length = 0.55F,
+                                 .radius = 0.05F,
+                                 .count = 3,
+                                 .seed = (static_cast<int>(dir) * 29) + 90,
+                                 .states = BuildingStateMask::Destroyed});
+  add_scorch_patch(desc,
+                   ScorchPatch{.center = center,
+                               .radius = along_half * 0.7F,
+                               .count = 4,
+                               .seed = (static_cast<int>(dir) * 37) + 130,
+                               .states = k_mask_broken});
 }
 
 void add_span_stakes(BuildingArchetypeDesc& desc,
@@ -208,15 +285,44 @@ void add_span_stakes(BuildingArchetypeDesc& desc,
     const float top = geometry.stake_height + stake_height_variation(geometry, i);
     const float lean = stake_lean(geometry, i);
 
+    const float roll = decay_hash(span_seed(dir, i));
+    const bool snaps_when_damaged = roll < 0.45F;
+    const bool stands_when_destroyed = roll > 0.78F;
+    const BuildingStateMask upright_states =
+        snaps_when_damaged ? BuildingStateMask::Normal : k_mask_intact;
+
     desc.add_cylinder(point_at(dir, along, 0.0F, 0.02F),
                       point_at(dir, along, lean, top),
                       radius,
-                      alternating_stake_color(palette, i));
+                      alternating_stake_color(palette, i),
+                      upright_states);
     desc.add_cone(point_at(dir, along, lean, top - 0.01F),
                   point_at(dir, along, lean, top + geometry.tip_height),
                   radius * 1.05F,
-                  palette.wood_dark);
-    add_stake_bindings(desc, palette, geometry, dir, along, radius);
+                  palette.wood_dark,
+                  upright_states);
+    add_stake_bindings(desc, palette, geometry, dir, along, radius, upright_states);
+
+    if (snaps_when_damaged) {
+      add_snapped_stake(desc,
+                        palette,
+                        dir,
+                        along,
+                        lean,
+                        radius,
+                        top * (0.38F + (roll * 0.50F)),
+                        BuildingStateMask::Damaged);
+    }
+    if (stands_when_destroyed) {
+      add_snapped_stake(desc,
+                        palette,
+                        dir,
+                        along,
+                        lean * 2.4F,
+                        radius,
+                        top * (0.09F + (roll * 0.17F)),
+                        BuildingStateMask::Destroyed);
+    }
   }
 
   if (!capped) {
@@ -229,11 +335,21 @@ void add_span_stakes(BuildingArchetypeDesc& desc,
   desc.add_cylinder(point_at(dir, along, 0.0F, 0.02F),
                     point_at(dir, along, 0.0F, top),
                     radius,
-                    palette.wood_mid);
+                    palette.wood_mid,
+                    k_mask_intact);
   desc.add_cone(point_at(dir, along, 0.0F, top - 0.01F),
                 point_at(dir, along, 0.0F, top + geometry.tip_height),
                 radius * 1.02F,
-                palette.wood_dark);
+                palette.wood_dark,
+                BuildingStateMask::Normal);
+  add_snapped_stake(desc,
+                    palette,
+                    dir,
+                    along,
+                    0.05F,
+                    radius,
+                    top * 0.20F,
+                    BuildingStateMask::Destroyed);
 }
 
 void add_rails(BuildingArchetypeDesc& desc,
@@ -263,11 +379,20 @@ void add_rails(BuildingArchetypeDesc& desc,
 
       const float lateral = static_cast<float>(side) * offset;
       for (const float height : {geometry.lower_rail_y, geometry.upper_rail_y}) {
+        const bool upper = height > geometry.lower_rail_y;
         desc.add_cylinder(point_at(axis.positive, low, lateral, height),
                           point_at(axis.positive, high, lateral, height),
                           geometry.rail_radius,
-                          palette.wood_dark);
+                          palette.wood_dark,
+                          upper ? BuildingStateMask::Normal : k_mask_intact);
       }
+
+      desc.add_cylinder(
+          point_at(axis.positive, low * 0.72F, lateral * 1.7F, geometry.rail_radius),
+          point_at(axis.positive, high * 0.64F, lateral * 2.3F, geometry.rail_radius),
+          geometry.rail_radius * 0.92F,
+          palette.wood_dark * 0.62F,
+          BuildingStateMask::Destroyed);
     }
   }
 }
@@ -288,14 +413,14 @@ void add_span_braces(BuildingArchetypeDesc& desc,
                       point_at(dir, far_end, offset, geometry.upper_rail_y),
                       radius,
                       palette.wood_dark,
-                      BuildingStateMask::All,
+                      k_mask_intact,
                       BuildingLODMask::Full);
     if (geometry.cross_braced) {
       desc.add_cylinder(point_at(dir, far_end, offset, 0.32F),
                         point_at(dir, near_end, offset, geometry.upper_rail_y),
                         radius,
                         palette.wood_mid,
-                        BuildingStateMask::All,
+                        BuildingStateMask::Normal,
                         BuildingLODMask::Full);
     }
   }
@@ -308,18 +433,26 @@ void add_junction_post(BuildingArchetypeDesc& desc,
   desc.add_cylinder(QVector3D(0.0F, 0.02F, 0.0F),
                     QVector3D(0.0F, top, 0.0F),
                     geometry.post_radius,
-                    palette.wood_mid);
+                    palette.wood_mid,
+                    k_mask_intact);
   desc.add_cone(QVector3D(0.0F, top - 0.01F, 0.0F),
                 QVector3D(0.0F, top + (geometry.tip_height * 1.1F), 0.0F),
                 geometry.post_radius * 1.02F,
-                palette.wood_dark);
+                palette.wood_dark,
+                BuildingStateMask::Normal);
+
+  desc.add_cylinder(QVector3D(0.0F, 0.02F, 0.0F),
+                    QVector3D(0.04F, top * 0.24F, -0.03F),
+                    geometry.post_radius * 0.94F,
+                    palette.wood_dark,
+                    BuildingStateMask::Destroyed);
 
   for (const float height : {geometry.lower_rail_y, geometry.upper_rail_y}) {
     desc.add_cylinder(QVector3D(0.0F, height - 0.05F, 0.0F),
                       QVector3D(0.0F, height + 0.05F, 0.0F),
                       geometry.post_radius * 1.08F,
                       binding_color(palette, geometry),
-                      BuildingStateMask::All,
+                      k_mask_intact,
                       BuildingLODMask::Full);
   }
 }
@@ -376,17 +509,24 @@ void add_masonry(BuildingArchetypeDesc& desc,
   const float center_y = half_height + 0.06F;
   const float coping_y = center_y + half_height + 0.07F;
 
+  const float ruin_scale = 0.58F;
   desc.add_box(QVector3D(0.0F, center_y + 0.06F, 0.0F),
                QVector3D(half_width, half_height + 0.06F, half_width),
-               palette.wood_dark);
+               palette.wood_dark,
+               k_mask_intact);
+  desc.add_box(QVector3D(0.0F, (center_y + 0.06F) * ruin_scale, 0.0F),
+               QVector3D(half_width, (half_height + 0.06F) * ruin_scale, half_width),
+               palette.wood_dark,
+               BuildingStateMask::Destroyed);
   desc.add_box(QVector3D(0.0F, coping_y + 0.12F, 0.0F),
                QVector3D(half_width + 0.05F, 0.07F, half_width + 0.05F),
-               palette.masonry_accent);
+               palette.masonry_accent,
+               BuildingStateMask::Normal);
   if (palette.horned_masonry) {
     desc.add_box(QVector3D(0.0F, coping_y + 0.36F, 0.0F),
                  QVector3D(0.11F, 0.17F, 0.11F),
                  palette.wood_dark,
-                 BuildingStateMask::All,
+                 BuildingStateMask::Normal,
                  BuildingLODMask::Full);
   }
 
@@ -405,20 +545,38 @@ void add_masonry(BuildingArchetypeDesc& desc,
     const float along_center = half_width + along_half;
     desc.add_box(point_at(dir, along_center, 0.0F, center_y),
                  extents_at(dir, along_half, half_height, half_width * 0.82F),
-                 palette.wood_mid);
+                 palette.wood_mid,
+                 k_mask_intact);
+    desc.add_box(
+        point_at(dir, along_center, 0.0F, center_y * ruin_scale),
+        extents_at(dir, along_half, half_height * ruin_scale, half_width * 0.82F),
+        palette.wood_mid,
+        BuildingStateMask::Destroyed);
     desc.add_box(point_at(dir, along_center, 0.0F, coping_y),
                  extents_at(dir, along_half, 0.07F, half_width * 0.94F),
-                 palette.masonry_accent);
+                 palette.masonry_accent,
+                 k_mask_intact);
 
     for (int i = 0; i < k_merlons; ++i) {
       const float t = (static_cast<float>(i) + 0.5F) / static_cast<float>(k_merlons);
       const float along = half_width + ((length - half_width) * t);
+      const float roll = decay_hash(span_seed(dir, i) + 41);
+      const bool survives_damage = roll > 0.45F;
       desc.add_box(point_at(dir, along, 0.0F, coping_y + 0.19F),
                    extents_at(dir, 0.09F, 0.13F, half_width * 0.86F),
                    (i % 2 == 0) ? palette.masonry_accent : palette.wood_light,
-                   BuildingStateMask::All,
+                   survives_damage ? k_mask_intact : BuildingStateMask::Normal,
                    BuildingLODMask::Full);
+      if (!survives_damage) {
+        desc.add_box(point_at(dir, along, 0.0F, coping_y + 0.10F),
+                     extents_at(dir, 0.085F, 0.04F, half_width * 0.80F),
+                     palette.rubble,
+                     BuildingStateMask::Damaged,
+                     BuildingLODMask::Full);
+      }
     }
+
+    add_span_debris(desc, palette, dir, length, half_width);
   }
 }
 
@@ -441,6 +599,7 @@ void add_palisade(BuildingArchetypeDesc& desc,
     add_span_stakes(
         desc, palette, geometry, dir, length, layout[dir] == SpanKind::Open);
     add_span_braces(desc, palette, geometry, dir, rail_reach(layout, dir, geometry));
+    add_span_debris(desc, palette, dir, length, rail_offset(geometry) * 1.6F);
   }
 }
 
@@ -448,11 +607,10 @@ void add_palisade(BuildingArchetypeDesc& desc,
 
 auto build_wall_archetype_set(std::string_view name_prefix,
                               const WallPalette& palette,
-                              const WallGeometry& geometry)
-    -> std::array<RenderArchetype, 6> {
-  std::array<RenderArchetype, 6> out{};
+                              const WallGeometry& geometry) -> WallArchetypeSet {
+  WallArchetypeSet out{};
 
-  for (int i = 0; i < static_cast<int>(out.size()); ++i) {
+  for (int i = 0; i < static_cast<int>(out.variants.size()); ++i) {
     const auto variant = static_cast<WallVariant>(i);
     const auto layout = layout_for(variant);
     BuildingArchetypeDesc desc(std::string(name_prefix) + "_" + std::to_string(i));
@@ -463,8 +621,8 @@ auto build_wall_archetype_set(std::string_view name_prefix,
       add_palisade(desc, palette, geometry, layout);
     }
 
-    out[static_cast<std::size_t>(i)] =
-        build_building_archetype(desc, BuildingState::Normal);
+    out.variants[static_cast<std::size_t>(i)] = build_stateful_building_archetype_set(
+        [&](BuildingState state) { return build_building_archetype(desc, state); });
   }
 
   return out;
@@ -486,9 +644,12 @@ auto wall_renderer_variants()
 
 void submit_wall_segment_variant(ISubmitter& out,
                                  const DrawContext& ctx,
-                                 const std::array<RenderArchetype, 6>& archetypes,
+                                 const WallArchetypeSet& archetypes,
                                  WallVariant variant) {
-  submit_building_instance(out, ctx, archetypes[wall_archetype_index(variant)]);
+  submit_building_instance(out,
+                           ctx,
+                           archetypes.variants[wall_archetype_index(variant)].for_state(
+                               resolve_building_state(ctx)));
   draw_building_selection_overlay(out, ctx, BuildingSelectionStyle{2.0F, 2.0F});
 }
 

--- a/render/entity/wall_renderer_common.h
+++ b/render/entity/wall_renderer_common.h
@@ -56,15 +56,18 @@ struct WallGeometry {
   float masonry_height{1.34F};
 };
 
+struct WallArchetypeSet {
+  std::array<BuildingArchetypeSet, 6> variants;
+};
+
 auto build_wall_archetype_set(std::string_view name_prefix,
                               const WallPalette& palette,
-                              const WallGeometry& geometry)
-    -> std::array<RenderArchetype, 6>;
+                              const WallGeometry& geometry) -> WallArchetypeSet;
 auto wall_renderer_variants()
     -> const std::array<std::pair<std::string_view, WallVariant>, 7>&;
 void submit_wall_segment_variant(ISubmitter& out,
                                  const DrawContext& ctx,
-                                 const std::array<RenderArchetype, 6>& archetypes,
+                                 const WallArchetypeSet& archetypes,
                                  WallVariant variant);
 
 } // namespace Render::GL

--- a/render/equipment/register_equipment_armor.cpp
+++ b/render/equipment/register_equipment_armor.cpp
@@ -3,7 +3,6 @@
 #include "armor/armor_light_carthage.h"
 #include "armor/carthage_shoulder_cover.h"
 #include "armor/cloak_renderer.h"
-#include "armor/commander_regalia.h"
 #include "armor/roman_armor.h"
 #include "armor/roman_greaves.h"
 #include "armor/roman_shoulder_cover.h"
@@ -124,27 +123,10 @@ auto commander_cloak_config(CommanderCloakStyle style) -> const CloakConfig& {
 template <CommanderCloakStyle Style>
 auto build_commander_cloak(std::uint8_t base_role_byte)
     -> std::vector<StaticAttachmentSpec> {
-  constexpr auto regalia_style = [] {
-    if constexpr (Style == CommanderCloakStyle::Fabius) {
-      return CommanderRegaliaStyle::Fabius;
-    } else if constexpr (Style == CommanderCloakStyle::Scipio) {
-      return CommanderRegaliaStyle::Scipio;
-    } else if constexpr (Style == CommanderCloakStyle::Marcellus) {
-      return CommanderRegaliaStyle::Marcellus;
-    } else if constexpr (Style == CommanderCloakStyle::Hanno) {
-      return CommanderRegaliaStyle::Hanno;
-    } else if constexpr (Style == CommanderCloakStyle::Hasdrubal) {
-      return CommanderRegaliaStyle::Hasdrubal;
-    } else {
-      return CommanderRegaliaStyle::Hannibal;
-    }
-  }();
   return {Render::GL::cloak_make_static_attachment(commander_cloak_config(Style),
                                                    Render::GL::shared_cloak_meshes(),
                                                    humanoid_chest_bone(),
-                                                   base_role_byte),
-          Render::GL::commander_regalia_make_static_attachment(
-              regalia_style, humanoid_chest_bone(), base_role_byte)};
+                                                   base_role_byte)};
 }
 
 template <CommanderCloakStyle Style>

--- a/render/gl/backend.cpp
+++ b/render/gl/backend.cpp
@@ -50,6 +50,7 @@
 #include "backend/water_pipeline.h"
 #include "buffer.h"
 #include "decoration_gpu.h"
+#include "directional_shadow_block.h"
 #include "gl/resources.h"
 #include "gl_debug_log.h"
 #include "mesh.h"
@@ -172,7 +173,8 @@ auto Backend::initialize() -> bool {
   qInfo() << "Backend: Frame UBO created at binding 0";
   glGenBuffers(1, &m_environment_lighting_ubo);
   glBindBuffer(GL_UNIFORM_BUFFER, m_environment_lighting_ubo);
-  constexpr GLsizeiptr environment_ubo_size = sizeof(float) * 28;
+  constexpr GLsizeiptr environment_ubo_size =
+      sizeof(float) * EnvironmentLightingState::k_packed_float_count;
   glBufferData(GL_UNIFORM_BUFFER, environment_ubo_size, nullptr, GL_DYNAMIC_DRAW);
   glBindBufferBase(GL_UNIFORM_BUFFER,
                    k_environment_lighting_binding_point,
@@ -182,7 +184,7 @@ auto Backend::initialize() -> bool {
   glGenBuffers(1, &m_local_lighting_ubo);
   glBindBuffer(GL_UNIFORM_BUFFER, m_local_lighting_ubo);
   constexpr GLsizeiptr local_lighting_ubo_size =
-      sizeof(float) * ((Render::k_max_local_lights * 8) + 4);
+      sizeof(float) * Render::LocalLightingBlock::k_float_count;
   glBufferData(GL_UNIFORM_BUFFER, local_lighting_ubo_size, nullptr, GL_DYNAMIC_DRAW);
   glBindBufferBase(
       GL_UNIFORM_BUFFER, k_local_lighting_binding_point, m_local_lighting_ubo);
@@ -190,7 +192,10 @@ auto Backend::initialize() -> bool {
   qInfo() << "Backend: Local lighting UBO created at binding 2";
   glGenBuffers(1, &m_directional_shadow_ubo);
   glBindBuffer(GL_UNIFORM_BUFFER, m_directional_shadow_ubo);
-  glBufferData(GL_UNIFORM_BUFFER, sizeof(float) * 80, nullptr, GL_DYNAMIC_DRAW);
+  glBufferData(GL_UNIFORM_BUFFER,
+               sizeof(float) * DirectionalShadowBlock::k_float_count,
+               nullptr,
+               GL_DYNAMIC_DRAW);
   glBindBufferBase(
       GL_UNIFORM_BUFFER, k_directional_shadow_binding_point, m_directional_shadow_ubo);
   glBindBuffer(GL_UNIFORM_BUFFER, 0);
@@ -445,39 +450,35 @@ void Backend::render_directional_shadows(const DrawQueue& queue, const Camera& c
                        m_directional_shadow_depth_shader != nullptr &&
                        m_directional_shadow_rigged_shader != nullptr;
 
-  std::array<float, 80> packed{};
-  if (!enabled) {
-    packed[68] = 0.0F;
-    if (m_directional_shadow_ubo != 0) {
-      glBindBuffer(GL_UNIFORM_BUFFER, m_directional_shadow_ubo);
-      glBufferSubData(
-          GL_UNIFORM_BUFFER, 0, sizeof(float) * packed.size(), packed.data());
-      glBindBufferBase(GL_UNIFORM_BUFFER,
-                       k_directional_shadow_binding_point,
-                       m_directional_shadow_ubo);
-      glBindBuffer(GL_UNIFORM_BUFFER, 0);
+  const auto upload_shadow_block = [this](const DirectionalShadowBlock& block) {
+    if (m_directional_shadow_ubo == 0) {
+      return;
     }
+    const auto packed = block.packed_std140();
+    glBindBuffer(GL_UNIFORM_BUFFER, m_directional_shadow_ubo);
+    glBufferSubData(GL_UNIFORM_BUFFER,
+                    0,
+                    static_cast<GLsizeiptr>(sizeof(float) * packed.size()),
+                    packed.data());
+    glBindBufferBase(GL_UNIFORM_BUFFER,
+                     k_directional_shadow_binding_point,
+                     m_directional_shadow_ubo);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
+  };
+
+  if (!enabled) {
+    upload_shadow_block(DirectionalShadowBlock{});
     return;
   }
 
-  const int cascade_count = std::clamp(settings.cascade_count, 1, 4);
+  const int cascade_count =
+      std::clamp(settings.cascade_count, 1, k_max_shadow_cascades);
   ensure_directional_shadow_resources(settings.resolution, cascade_count);
   if (m_directional_shadow_fbo == 0 || m_directional_shadow_texture == 0) {
     return;
   }
 
-  if (m_directional_shadow_ubo != 0) {
-    const std::array<float, 80> disabled_shadow_sampling{};
-    glBindBuffer(GL_UNIFORM_BUFFER, m_directional_shadow_ubo);
-    glBufferSubData(GL_UNIFORM_BUFFER,
-                    0,
-                    sizeof(float) * disabled_shadow_sampling.size(),
-                    disabled_shadow_sampling.data());
-    glBindBufferBase(GL_UNIFORM_BUFFER,
-                     k_directional_shadow_binding_point,
-                     m_directional_shadow_ubo);
-    glBindBuffer(GL_UNIFORM_BUFFER, 0);
-  }
+  upload_shadow_block(DirectionalShadowBlock{});
 
   const float near_distance = std::max(cam.get_near(), 0.05F);
   const float far_distance =
@@ -648,8 +649,7 @@ void Backend::render_directional_shadows(const DrawQueue& queue, const Camera& c
                   1U, m_rigged_character_pipeline->max_instances_per_batch())
             : 1U;
     for (const PreparedBatch& prepared : queue.prepared_batches()) {
-      if (prepared.count == 0U ||
-          queue.get_sorted(prepared.start).index() != RiggedCreatureCmdIndex) {
+      if (prepared.count == 0U || prepared.type != DrawCmdType::RiggedCreature) {
         continue;
       }
       visible_rigged.clear();
@@ -765,33 +765,34 @@ void Backend::render_directional_shadows(const DrawQueue& queue, const Camera& c
              previous_viewport[2],
              previous_viewport[3]);
 
-  for (int cascade = 0; cascade < 4; ++cascade) {
-    std::copy_n(m_directional_shadow_matrices[cascade].constData(),
-                16,
-                packed.data() + cascade * 16);
-    packed[64 + cascade] = m_directional_shadow_splits[cascade];
+  DirectionalShadowBlock block;
+  for (int cascade = 0; cascade < k_max_shadow_cascades; ++cascade) {
+    const auto slot = static_cast<std::size_t>(cascade);
+    block.light_view_projection[slot] = m_directional_shadow_matrices[slot];
+    block.split_distances[slot] = m_directional_shadow_splits[slot];
   }
-  packed[68] = 1.0F;
-  packed[69] = static_cast<float>(cascade_count);
-  packed[70] = 1.0F / static_cast<float>(m_directional_shadow_resolution);
+  block.enabled = 1.0F;
+  block.cascade_count = static_cast<float>(cascade_count);
+  block.shadow_map_texel_size =
+      1.0F / static_cast<float>(m_directional_shadow_resolution);
   const int weather_softening = m_environment_lighting.shadow_softness > 0.65F ? 1 : 0;
-  packed[71] =
+  block.pcf_radius =
       static_cast<float>(std::clamp(settings.pcf_radius + weather_softening, 1, 3));
+  block.camera_position = cam.get_position();
+  block.depth_bias = settings.depth_bias;
+  block.normal_bias = settings.normal_bias;
+  block.cascade_blend = settings.cascade_blend;
 
-  std::array<float, 80> complete{};
-  std::copy(packed.begin(), packed.end(), complete.begin());
-  complete[72] = cam.get_position().x();
-  complete[73] = cam.get_position().y();
-  complete[74] = cam.get_position().z();
-  complete[75] = 1.0F;
-  complete[76] = settings.depth_bias;
-  complete[77] = settings.normal_bias;
-  complete[78] = settings.cascade_blend;
+  const auto complete = block.packed_std140();
   glBindBuffer(GL_UNIFORM_BUFFER, m_directional_shadow_ubo);
-  glBufferData(
-      GL_UNIFORM_BUFFER, sizeof(float) * complete.size(), nullptr, GL_DYNAMIC_DRAW);
-  glBufferSubData(
-      GL_UNIFORM_BUFFER, 0, sizeof(float) * complete.size(), complete.data());
+  glBufferData(GL_UNIFORM_BUFFER,
+               static_cast<GLsizeiptr>(sizeof(float) * complete.size()),
+               nullptr,
+               GL_DYNAMIC_DRAW);
+  glBufferSubData(GL_UNIFORM_BUFFER,
+                  0,
+                  static_cast<GLsizeiptr>(sizeof(float) * complete.size()),
+                  complete.data());
   glBindBufferBase(
       GL_UNIFORM_BUFFER, k_directional_shadow_binding_point, m_directional_shadow_ubo);
   glBindBuffer(GL_UNIFORM_BUFFER, 0);
@@ -859,25 +860,7 @@ void Backend::execute(const DrawQueue& queue, const Camera& cam) {
         candidates.end(), submitted_lights.begin(), submitted_lights.end());
     const auto selected =
         m_local_light_fader.update(candidates, cam.get_position(), m_animation_time);
-    std::array<float, (Render::k_max_local_lights * 8) + 4> packed{};
-    std::size_t active_count = 0;
-    for (const auto& light : selected) {
-      if (light.intensity <= 0.0F || light.radius <= 0.0F) {
-        continue;
-      }
-      packed[(active_count * 4) + 0] = light.position.x();
-      packed[(active_count * 4) + 1] = light.position.y();
-      packed[(active_count * 4) + 2] = light.position.z();
-      packed[(active_count * 4) + 3] = light.radius;
-      const std::size_t color_offset =
-          (Render::k_max_local_lights * 4) + (active_count * 4);
-      packed[color_offset + 0] = light.color.x();
-      packed[color_offset + 1] = light.color.y();
-      packed[color_offset + 2] = light.color.z();
-      packed[color_offset + 3] = light.intensity;
-      ++active_count;
-    }
-    packed[Render::k_max_local_lights * 8] = static_cast<float>(active_count);
+    const auto packed = Render::pack_local_lights_std140(selected);
     glBindBuffer(GL_UNIFORM_BUFFER, m_local_lighting_ubo);
     glBufferSubData(GL_UNIFORM_BUFFER,
                     0,
@@ -938,7 +921,7 @@ void Backend::execute(const DrawQueue& queue, const Camera& cam) {
     const auto now = std::chrono::steady_clock::now();
     if (now - last_report >= std::chrono::seconds(1)) {
       last_report = now;
-      std::array<std::size_t, 16> per_type{};
+      std::array<std::size_t, k_draw_cmd_type_count> per_type{};
       std::size_t scatter_instances = 0;
       std::size_t rig_gpu_palette = 0;
       std::size_t rig_cpu_palette = 0;
@@ -1080,40 +1063,38 @@ void Backend::execute(const DrawQueue& queue, const Camera& cam) {
     const std::size_t i = prepared.start;
     const std::size_t batch_end = prepared.end();
     const auto& cmd = queue.get_sorted(i);
-    if (cmd.index() == RiggedCreatureCmdIndex) {
+    if (prepared.type == DrawCmdType::RiggedCreature) {
       frame_rigged_commands += prepared.count;
     }
-    switch (cmd.index()) {
-    case CylinderCmdIndex:
-    case FogBatchCmdIndex:
+    switch (draw_cmd_type(cmd)) {
+    case DrawCmdType::Cylinder:
+    case DrawCmdType::FogBatch:
       execute_cylinder_commands(prepared, context);
       break;
-    case TerrainScatterCmdIndex:
+    case DrawCmdType::TerrainScatter:
       execute_scatter_commands(prepared, context);
       break;
-    case TerrainSurfaceCmdIndex:
+    case DrawCmdType::TerrainSurface:
       execute_terrain_commands(prepared, context);
       break;
-    case TerrainFeatureCmdIndex:
+    case DrawCmdType::TerrainFeature:
       execute_water_linear_commands(prepared, context);
       break;
-    case MeshCmdIndex:
-    case DrawPartCmdIndex:
+    case DrawCmdType::Mesh:
+    case DrawCmdType::DrawPart:
       execute_mesh_commands(prepared, context);
       break;
-    case RainBatchCmdIndex:
-    case GridCmdIndex:
-    case GroundMarkerCmdIndex:
-    case SelectionSmokeCmdIndex:
-    case PrimitiveBatchCmdIndex:
-    case EffectBatchCmdIndex:
-    case ModeIndicatorCmdIndex:
+    case DrawCmdType::RainBatch:
+    case DrawCmdType::Grid:
+    case DrawCmdType::GroundMarker:
+    case DrawCmdType::SelectionSmoke:
+    case DrawCmdType::PrimitiveBatch:
+    case DrawCmdType::EffectBatch:
+    case DrawCmdType::ModeIndicator:
       execute_effects_commands(prepared, context);
       break;
-    case RiggedCreatureCmdIndex:
+    case DrawCmdType::RiggedCreature:
       execute_rigged_commands(prepared, context);
-      break;
-    default:
       break;
     }
 

--- a/render/gl/backend.h
+++ b/render/gl/backend.h
@@ -17,6 +17,7 @@
 #include "../i_render_backend.h"
 #include "../local_lighting.h"
 #include "../world_chunk.h"
+#include "directional_shadow_block.h"
 #include "persistent_buffer.h"
 #include "resources.h"
 #include "scene/camera.h"
@@ -299,8 +300,8 @@ private:
   std::size_t m_rigged_drawn_this_frame = 0;
   PlaybackStats m_last_playback_stats{};
 
-  std::array<QMatrix4x4, 4> m_directional_shadow_matrices{};
-  std::array<float, 4> m_directional_shadow_splits{};
+  std::array<QMatrix4x4, k_max_shadow_cascades> m_directional_shadow_matrices{};
+  std::array<float, k_max_shadow_cascades> m_directional_shadow_splits{};
   Shader* m_directional_shadow_depth_shader = nullptr;
   Shader* m_directional_shadow_rigged_shader = nullptr;
 

--- a/render/gl/directional_shadow_block.h
+++ b/render/gl/directional_shadow_block.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <QMatrix4x4>
+#include <QVector3D>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+
+namespace Render::GL {
+
+inline constexpr int k_max_shadow_cascades = 4;
+
+struct DirectionalShadowBlock {
+  static constexpr std::size_t k_mat4_floats = 16;
+  static constexpr std::size_t k_vec4_floats = 4;
+  static constexpr std::size_t k_float_count =
+      (k_mat4_floats * static_cast<std::size_t>(k_max_shadow_cascades)) +
+      (k_vec4_floats * 4);
+
+  using Packed = std::array<float, k_float_count>;
+
+  std::array<QMatrix4x4, k_max_shadow_cascades> light_view_projection{};
+  std::array<float, k_max_shadow_cascades> split_distances{};
+
+  float enabled = 0.0F;
+  float cascade_count = 0.0F;
+  float shadow_map_texel_size = 0.0F;
+  float pcf_radius = 0.0F;
+
+  QVector3D camera_position;
+
+  float depth_bias = 0.0F;
+  float normal_bias = 0.0F;
+  float cascade_blend = 0.0F;
+
+  [[nodiscard]] auto packed_std140() const noexcept -> Packed {
+    Packed packed{};
+    std::size_t cursor = 0;
+
+    for (const auto& matrix : light_view_projection) {
+      std::copy_n(matrix.constData(), k_mat4_floats, packed.data() + cursor);
+      cursor += k_mat4_floats;
+    }
+
+    for (const float split : split_distances) {
+      packed[cursor++] = split;
+    }
+
+    packed[cursor++] = enabled;
+    packed[cursor++] = cascade_count;
+    packed[cursor++] = shadow_map_texel_size;
+    packed[cursor++] = pcf_radius;
+
+    packed[cursor++] = camera_position.x();
+    packed[cursor++] = camera_position.y();
+    packed[cursor++] = camera_position.z();
+    packed[cursor++] = 1.0F;
+
+    packed[cursor++] = depth_bias;
+    packed[cursor++] = normal_bias;
+    packed[cursor++] = cascade_blend;
+    packed[cursor++] = 0.0F;
+
+    return packed;
+  }
+};
+
+static_assert(DirectionalShadowBlock::k_float_count == 80,
+              "DirectionalShadows in assets/shaders/include/directional_shadows.glsl "
+              "declares mat4[4] + 4 vec4");
+
+} // namespace Render::GL

--- a/render/local_lighting.h
+++ b/render/local_lighting.h
@@ -73,6 +73,50 @@ struct LocalLight {
   return result;
 }
 
+struct LocalLightingBlock {
+  static constexpr std::size_t k_vec4_floats = 4;
+  static constexpr std::size_t k_float_count =
+      (k_max_local_lights * k_vec4_floats * 2) + k_vec4_floats;
+
+  using Packed = std::array<float, k_float_count>;
+
+  static constexpr std::size_t k_position_radius_offset = 0;
+  static constexpr std::size_t k_color_intensity_offset =
+      k_max_local_lights * k_vec4_floats;
+  static constexpr std::size_t k_meta_offset = k_max_local_lights * k_vec4_floats * 2;
+};
+
+[[nodiscard]] inline auto
+pack_local_lights_std140(const std::array<LocalLight, k_max_local_lights>& lights)
+    -> LocalLightingBlock::Packed {
+  LocalLightingBlock::Packed packed{};
+  std::size_t active_count = 0;
+
+  for (const auto& light : lights) {
+    if (light.intensity <= 0.0F || light.radius <= 0.0F) {
+      continue;
+    }
+    const std::size_t slot = active_count * LocalLightingBlock::k_vec4_floats;
+    const std::size_t position_offset =
+        LocalLightingBlock::k_position_radius_offset + slot;
+    packed[position_offset + 0] = light.position.x();
+    packed[position_offset + 1] = light.position.y();
+    packed[position_offset + 2] = light.position.z();
+    packed[position_offset + 3] = light.radius;
+
+    const std::size_t color_offset =
+        LocalLightingBlock::k_color_intensity_offset + slot;
+    packed[color_offset + 0] = light.color.x();
+    packed[color_offset + 1] = light.color.y();
+    packed[color_offset + 2] = light.color.z();
+    packed[color_offset + 3] = light.intensity;
+    ++active_count;
+  }
+
+  packed[LocalLightingBlock::k_meta_offset] = static_cast<float>(active_count);
+  return packed;
+}
+
 inline constexpr float k_local_light_fade_seconds = 0.35F;
 inline constexpr float k_local_light_match_distance = 0.75F;
 

--- a/render/sources_entity.cmake
+++ b/render/sources_entity.cmake
@@ -45,6 +45,7 @@ set(RENDER_ENTITY_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/commander_aura_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/combat_dust_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/building_archetype_desc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/entity/building_decay.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/building_render_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/wall_renderer_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/wall_gate_renderer_common.cpp

--- a/render/submitter.h
+++ b/render/submitter.h
@@ -652,7 +652,10 @@ public:
 
 private:
   [[nodiscard]] auto pick(int incoming_id) const noexcept -> int {
-    return (m_damage_id != 0 && incoming_id == 0) ? m_damage_id : incoming_id;
+    if (m_damage_id == 0 || incoming_id < 0 || incoming_id >= 10) {
+      return incoming_id;
+    }
+    return incoming_id + m_damage_id;
   }
 
   int m_damage_id;

--- a/scene/environment_lighting.h
+++ b/scene/environment_lighting.h
@@ -5,10 +5,13 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 
 namespace Render {
 
 struct EnvironmentLightingState {
+  static constexpr std::size_t k_packed_float_count = 28;
+
   QVector3D primary_direction{0.35F, 0.85F, 0.42F};
   QVector3D primary_color{1.0F, 0.95F, 0.86F};
   float primary_intensity = 1.0F;
@@ -44,7 +47,8 @@ struct EnvironmentLightingState {
     return result;
   }
 
-  [[nodiscard]] auto packed_std140() const noexcept -> std::array<float, 28> {
+  [[nodiscard]] auto
+  packed_std140() const noexcept -> std::array<float, k_packed_float_count> {
     const EnvironmentLightingState value = sanitized();
     return {
         value.primary_direction.x(),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -315,6 +315,7 @@ add_executable(
     core/mission_definition_view_test.cpp
     core/mission_events_test.cpp
     core/mission_wave_director_test.cpp
+    core/campaign_wave_assault_test.cpp
     core/production_manager_test.cpp
     core/selection_query_service_test.cpp
     core/rts_action_model_test.cpp

--- a/tests/core/campaign_wave_assault_test.cpp
+++ b/tests/core/campaign_wave_assault_test.cpp
@@ -1,0 +1,284 @@
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+#include "app/core/campaign_manager.h"
+#include "app/core/entity_cache.h"
+#include "app/core/mission_definition_view.h"
+#include "app/core/mission_setup_coordinator.h"
+#include "app/core/skirmish_loader.h"
+#include "core/component.h"
+#include "core/world.h"
+#include "game/map/campaign_definition.h"
+#include "game/map/campaign_loader.h"
+#include "game/map/terrain_service.h"
+#include "game/map/visibility_service.h"
+#include "game/systems/game_state_serializer.h"
+#include "game/systems/global_stats_registry.h"
+#include "game/systems/nation_registry.h"
+#include "game/systems/owner_registry.h"
+#include "game/systems/runtime_system_registry.h"
+#include "render/scene_renderer.h"
+#include "scene/camera.h"
+
+namespace {
+
+using Engine::Core::EntityID;
+using Engine::Core::TransformComponent;
+using Engine::Core::UnitComponent;
+
+constexpr char k_campaign[] = "second_punic_war";
+constexpr char k_campaign_path[] = "assets/campaigns/second_punic_war.json";
+constexpr int k_local_owner = 1;
+constexpr float k_tick = 1.0F / 60.0F;
+
+class CampaignWaveAssaultTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    auto& nations = Game::Systems::NationRegistry::instance();
+    nations.clear();
+    nations.initialize_defaults();
+    Game::Systems::OwnerRegistry::instance().clear();
+    Game::Systems::GlobalStatsRegistry::instance().clear();
+  }
+
+  void TearDown() override {
+    Game::Map::TerrainService::instance().clear();
+    Game::Map::VisibilityService::instance().reset();
+    Game::Systems::GlobalStatsRegistry::instance().clear();
+    Game::Systems::NationRegistry::instance().clear();
+    Game::Systems::OwnerRegistry::instance().clear();
+  }
+};
+
+auto position_of(Engine::Core::World& world, EntityID id) -> QVector3D {
+  auto* entity = world.get_entity(id);
+  if (entity == nullptr) {
+    return {};
+  }
+  const auto* transform = entity->get_component<TransformComponent>();
+  return transform == nullptr
+             ? QVector3D()
+             : QVector3D(transform->position.x, 0.0F, transform->position.z);
+}
+
+auto closest_living(Engine::Core::World& world,
+                    const std::vector<EntityID>& units,
+                    const QVector3D& point) -> float {
+  float best = std::numeric_limits<float>::max();
+  for (const auto id : units) {
+    if (world.get_entity(id) == nullptr) {
+      continue;
+    }
+    best = std::min(best, (position_of(world, id) - point).length());
+  }
+  return best;
+}
+
+struct WaveMarch {
+  float spawn_distance = 0.0F;
+  float closest_approach = 0.0F;
+  float furthest_from_camp = 0.0F;
+  bool met_a_defender = false;
+  bool wiped_out = false;
+};
+
+class MissionUnderTest {
+public:
+  auto load(const QString& mission_id) -> bool {
+    m_world.set_presentation_enabled(false);
+    Game::Systems::register_runtime_systems(m_world);
+
+    int selected_player_id = k_local_owner;
+    m_campaign.start_campaign_mission(
+        QStringLiteral("%1/%2").arg(QLatin1String(k_campaign), mission_id),
+        selected_player_id);
+    if (!m_campaign.current_mission_definition().has_value()) {
+      return false;
+    }
+    const auto& mission = *m_campaign.current_mission_definition();
+
+    App::Core::SkirmishLoader loader(m_world, m_renderer, m_camera);
+    const auto load_result = loader.start(mission.map_path,
+                                          build_campaign_player_configs(mission),
+                                          k_local_owner,
+                                          false,
+                                          selected_player_id);
+    if (!load_result.ok) {
+      m_error = load_result.error_message;
+      return false;
+    }
+
+    m_level.map_path = mission.map_path;
+    m_level.grid_width = load_result.grid_width;
+    m_level.grid_height = load_result.grid_height;
+    m_level.tile_size = load_result.tile_size;
+
+    const auto effects =
+        m_coordinator.apply_mission_setup({.world = m_world,
+                                           .campaign = m_campaign,
+                                           .level = m_level,
+                                           .selected_player_id = selected_player_id,
+                                           .local_owner_id = k_local_owner,
+                                           .pending_waves = m_pending_waves,
+                                           .entity_cache = m_entity_cache});
+    (void)effects;
+    return true;
+  }
+
+  [[nodiscard]] auto error() const -> QString { return m_error; }
+  [[nodiscard]] auto
+  waves() const -> const std::vector<App::Core::PendingMissionWave>& {
+    return m_pending_waves;
+  }
+
+  auto march(const App::Core::PendingMissionWave& wave, int seconds) -> WaveMarch {
+    WaveMarch result;
+    const QVector3D camp = wave.defense_reference_world_position;
+    result.spawn_distance = (wave.entry_world_position - camp).length();
+
+    const auto effects =
+        m_coordinator.spawn_wave({.world = m_world,
+                                  .level = m_level,
+                                  .campaign_mission_elapsed = wave.trigger_time},
+                                 wave);
+    m_spawned = effects.spawned_entity_ids;
+    if (m_spawned.empty()) {
+      return result;
+    }
+
+    result.closest_approach = closest_living(m_world, m_spawned, camp);
+    result.furthest_from_camp = result.closest_approach;
+
+    for (int second = 0; second < seconds; ++second) {
+      for (int step = 0; step < 60; ++step) {
+        m_world.update(k_tick);
+      }
+
+      const float distance = closest_living(m_world, m_spawned, camp);
+      if (distance == std::numeric_limits<float>::max()) {
+        result.wiped_out = true;
+        break;
+      }
+      result.closest_approach = std::min(result.closest_approach, distance);
+      result.furthest_from_camp = std::max(result.furthest_from_camp, distance);
+      result.met_a_defender = result.met_a_defender || fighting_a_defender();
+    }
+
+    return result;
+  }
+
+  [[nodiscard]] auto spawned() const -> const std::vector<EntityID>& {
+    return m_spawned;
+  }
+
+private:
+  [[nodiscard]] auto fighting_a_defender() -> bool {
+    for (const auto id : m_spawned) {
+      auto* entity = m_world.get_entity(id);
+      if (entity == nullptr) {
+        continue;
+      }
+      const auto* attack = entity->get_component<Engine::Core::AttackTargetComponent>();
+      if (attack == nullptr) {
+        continue;
+      }
+      auto* target = m_world.get_entity(attack->target_id);
+      const auto* target_unit =
+          target == nullptr ? nullptr : target->get_component<UnitComponent>();
+      if (target_unit != nullptr && target_unit->owner_id == k_local_owner &&
+          !target->has_component<Engine::Core::BuildingComponent>()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Engine::Core::World m_world;
+  Render::GL::Renderer m_renderer{Render::ShaderQuality::None};
+  Render::GL::Camera m_camera;
+  CampaignManager m_campaign;
+  App::Core::MissionSetupCoordinator m_coordinator;
+  Game::Systems::LevelSnapshot m_level;
+  EntityCache m_entity_cache;
+  std::vector<App::Core::PendingMissionWave> m_pending_waves;
+  std::vector<EntityID> m_spawned;
+  QString m_error;
+};
+
+auto campaign_mission_ids() -> std::vector<QString> {
+  Game::Campaign::CampaignDefinition campaign;
+  QString error;
+  if (!Game::Campaign::CampaignLoader::load_from_json_file(
+          QString::fromLatin1(k_campaign_path), campaign, &error)) {
+    return {};
+  }
+  auto missions = campaign.missions;
+  std::stable_sort(missions.begin(),
+                   missions.end(),
+                   [](const Game::Campaign::CampaignMission& lhs,
+                      const Game::Campaign::CampaignMission& rhs) {
+                     return lhs.order_index < rhs.order_index;
+                   });
+  std::vector<QString> ids;
+  ids.reserve(missions.size());
+  for (const auto& mission : missions) {
+    ids.push_back(mission.mission_id);
+  }
+  return ids;
+}
+
+} // namespace
+
+TEST_F(CampaignWaveAssaultTest, FirstMissionWaveChargesThePlayerCamp) {
+  const auto ids = campaign_mission_ids();
+  ASSERT_FALSE(ids.empty()) << "the campaign must list its missions";
+
+  MissionUnderTest mission;
+  ASSERT_TRUE(mission.load(ids.front())) << mission.error().toStdString();
+  ASSERT_FALSE(mission.waves().empty()) << "the first mission authors an assault wave";
+
+  const auto& wave = mission.waves().front();
+  const auto march = mission.march(wave, 60);
+  ASSERT_FALSE(mission.spawned().empty()) << "the wave spawned nothing";
+  ASSERT_GT(march.spawn_distance, 20.0F)
+      << "the wave is supposed to start away from the camp it marches on";
+
+  EXPECT_LT(march.closest_approach, march.spawn_distance * 0.5F)
+      << "the wave never closed on the camp: spawned " << march.spawn_distance
+      << " away, got no nearer than " << march.closest_approach;
+  EXPECT_LT(march.furthest_from_camp, march.spawn_distance + 5.0F)
+      << "the wave wandered away from the camp instead of marching on it";
+  EXPECT_TRUE(march.met_a_defender)
+      << "the wave never reached the troops holding the camp";
+}
+
+TEST_F(CampaignWaveAssaultTest, EveryCampaignMissionWaveClosesOnThePlayerCamp) {
+  const auto ids = campaign_mission_ids();
+  ASSERT_FALSE(ids.empty()) << "the campaign must list its missions";
+
+  for (const auto& mission_id : ids) {
+    SCOPED_TRACE(mission_id.toStdString());
+
+    MissionUnderTest mission;
+    ASSERT_TRUE(mission.load(mission_id)) << mission.error().toStdString();
+    if (mission.waves().empty()) {
+      continue;
+    }
+
+    const auto& wave = mission.waves().front();
+    const auto march = mission.march(wave, 30);
+    ASSERT_FALSE(mission.spawned().empty()) << "the wave spawned nothing";
+    ASSERT_GT(march.spawn_distance, 1.0F);
+
+    constexpr float k_min_ground_gained = 25.0F;
+    EXPECT_TRUE(march.closest_approach <= march.spawn_distance - k_min_ground_gained ||
+                march.met_a_defender)
+        << "the wave neither closed on the camp nor found the player: spawned "
+        << march.spawn_distance << " away, got no nearer than "
+        << march.closest_approach;
+    EXPECT_LT(march.furthest_from_camp, march.spawn_distance + 10.0F)
+        << "the wave drifted away from the camp instead of marching on it";
+  }
+}

--- a/tests/headless/mission_wave_assault_test.cpp
+++ b/tests/headless/mission_wave_assault_test.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "game/core/component.h"
+#include "game/core/ownership_constants.h"
 #include "game/core/world.h"
 #include "game/map/map_definition.h"
 #include "game/map/terrain_service.h"
@@ -268,6 +269,93 @@ TEST_F(MissionWaveAssaultTest, WaveUnitsAttackTheRampartInTheirWay) {
   EXPECT_GT(attacking_the_rampart, 0)
       << "no wave unit was working on the rampart between it and the camp";
   EXPECT_GT(damage_dealt, 0) << "the wave stood at the wall without ever striking it";
+}
+
+TEST_F(MissionWaveAssaultTest, WaveReachesACampBehindAFlankableRampart) {
+  auto& session = make_match();
+
+  const QVector3D camp = world_of(k_camp_grid_x, k_gate_grid_z);
+  spawn(session, Game::Units::SpawnType::Barracks, k_player, camp);
+
+  constexpr int k_pitch = Game::Systems::WallNetworkService::k_segment_spacing;
+  for (int grid_z = k_gate_grid_z - 8; grid_z <= k_gate_grid_z + 8; grid_z += k_pitch) {
+    spawn(session,
+          Game::Units::SpawnType::WallSegment,
+          k_player,
+          world_of(k_ring_east_x, grid_z));
+  }
+  Game::Systems::WallNetworkService::refresh_world(session.world());
+
+  make_defensive(session);
+  const auto wave = spawn_wave(session, 3);
+  ASSERT_EQ(wave.size(), 3U);
+
+  const float start = closest_wave_distance_to(session, wave, camp);
+  run_for(session, 90.0);
+  const float end = closest_wave_distance_to(session, wave, camp);
+
+  EXPECT_LT(end, start * 0.5F)
+      << "the wave never closed on a camp it had a route into: start " << start
+      << " end " << end;
+}
+
+TEST_F(MissionWaveAssaultTest, WaveWalksPastNeutralPropertyOnTheWayIn) {
+  auto& session = make_match();
+
+  const QVector3D camp = world_of(k_camp_grid_x, k_gate_grid_z);
+  spawn(session, Game::Units::SpawnType::Barracks, k_player, camp);
+
+  const EntityID temple =
+      spawn(session,
+            Game::Units::SpawnType::Temple,
+            Game::Core::NEUTRAL_OWNER_ID,
+            world_of((k_camp_grid_x + k_wave_grid_x) / 2, k_gate_grid_z - 2));
+  ASSERT_NE(temple, 0U);
+
+  make_defensive(session);
+  const auto wave = spawn_wave(session, 3);
+  ASSERT_EQ(wave.size(), 3U);
+
+  const float start = closest_wave_distance_to(session, wave, camp);
+  run_for(session, 90.0);
+
+  EXPECT_LT(closest_wave_distance_to(session, wave, camp), start * 0.5F)
+      << "the wave stopped for a neutral building instead of marching on the camp";
+
+  auto* temple_entity = session.world().get_entity(temple);
+  ASSERT_NE(temple_entity, nullptr);
+  const auto* temple_unit = temple_entity->get_component<UnitComponent>();
+  ASSERT_NE(temple_unit, nullptr);
+  EXPECT_EQ(temple_unit->health, temple_unit->max_health)
+      << "the wave spent itself on scenery nobody owns";
+}
+
+TEST_F(MissionWaveAssaultTest, WoundedWaveUnitsPressOnInsteadOfRunningHome) {
+  auto& session = make_match();
+
+  const QVector3D camp = world_of(k_camp_grid_x, k_gate_grid_z);
+  spawn(session, Game::Units::SpawnType::Barracks, k_player, camp);
+
+  const QVector3D ai_home = world_of(k_map_size - 4, k_map_size - 4);
+  spawn(session, Game::Units::SpawnType::Barracks, k_wave_ai, ai_home);
+
+  make_defensive(session);
+  const auto wave = spawn_wave(session, 3);
+  ASSERT_EQ(wave.size(), 3U);
+
+  for (const auto id : wave) {
+    auto* unit = session.world().get_entity(id)->get_component<UnitComponent>();
+    unit->health = std::max(1, unit->max_health / 10);
+  }
+
+  const float start_to_camp = closest_wave_distance_to(session, wave, camp);
+  const float start_to_home = closest_wave_distance_to(session, wave, ai_home);
+  run_for(session, 60.0);
+
+  EXPECT_LT(closest_wave_distance_to(session, wave, camp), start_to_camp * 0.5F)
+      << "a bloodied wave must keep coming, not turn around";
+  EXPECT_GT(closest_wave_distance_to(session, wave, ai_home), start_to_home)
+      << "the wave retreated toward its own base";
 }
 
 } // namespace

--- a/tests/render/building_archetype_desc_test.cpp
+++ b/tests/render/building_archetype_desc_test.cpp
@@ -1,12 +1,14 @@
 #include <QMatrix4x4>
 #include <QVector3D>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <gtest/gtest.h>
 #include <vector>
 
 #include "render/entity/building_archetype_desc.h"
+#include "render/entity/building_decay.h"
 #include "render/entity/building_ornaments.h"
 #include "render/gl/primitives.h"
 #include "render/render_archetype.h"
@@ -129,9 +131,65 @@ TEST(BuildingArchetypeDesc, ArchetypeSetSelectsStateVariant) {
   EXPECT_EQ(set.for_state(BuildingState::Normal).lods[0].draws[0].color,
             QVector3D(1.0F, 0.0F, 0.0F));
   EXPECT_EQ(set.for_state(BuildingState::Damaged).lods[0].draws[0].color,
-            QVector3D(0.0F, 1.0F, 0.0F));
+            decayed_color(QVector3D(0.0F, 1.0F, 0.0F), BuildingState::Damaged, 1));
   EXPECT_EQ(set.for_state(BuildingState::Destroyed).lods[0].draws[0].color,
-            QVector3D(0.0F, 0.0F, 1.0F));
+            decayed_color(QVector3D(0.0F, 0.0F, 1.0F), BuildingState::Destroyed, 1));
+}
+
+TEST(BuildingArchetypeDesc, HealthyStateKeepsAuthoredColors) {
+  using namespace Render::GL;
+
+  BuildingArchetypeDesc desc("healthy_color_test");
+  const QVector3D authored(0.82F, 0.44F, 0.19F);
+  desc.add_box(QVector3D(0.0F, 0.0F, 0.0F), QVector3D(1.0F, 1.0F, 1.0F), authored);
+
+  const RenderArchetype archetype =
+      build_building_archetype(desc, BuildingState::Normal);
+
+  ASSERT_EQ(archetype.lods[0].draws.size(), 1U);
+  EXPECT_EQ(archetype.lods[0].draws[0].color, authored);
+}
+
+TEST(BuildingArchetypeDesc, DecayDarkensAndDesaturatesEveryState) {
+  using namespace Render::GL;
+
+  const QVector3D authored(0.90F, 0.86F, 0.80F);
+  const QVector3D damaged = decayed_color(authored, BuildingState::Damaged, 3);
+  const QVector3D destroyed = decayed_color(authored, BuildingState::Destroyed, 3);
+
+  const auto luma = [](const QVector3D& c) {
+    return (0.299F * c.x()) + (0.587F * c.y()) + (0.114F * c.z());
+  };
+  const auto chroma = [](const QVector3D& c) {
+    return std::max({c.x(), c.y(), c.z()}) - std::min({c.x(), c.y(), c.z()});
+  };
+
+  EXPECT_LT(luma(damaged), luma(authored));
+  EXPECT_LT(luma(destroyed), luma(damaged));
+  EXPECT_LE(chroma(destroyed), chroma(authored) + 1e-4F);
+}
+
+TEST(BuildingArchetypeDesc, RuinDressingOnlyAppearsOnDamagedStates) {
+  using namespace Render::GL;
+
+  BuildingArchetypeDesc desc("ruin_dressing_test");
+  desc.add_box(QVector3D(0.0F, 0.5F, 0.0F),
+               QVector3D(1.0F, 0.5F, 1.0F),
+               QVector3D(0.8F, 0.8F, 0.8F));
+  const std::size_t authored_parts = desc.parts().size();
+
+  add_ruin_dressing(desc, RuinDressing{.extent = QVector3D(1.0F, 0.0F, 1.0F)});
+  EXPECT_GT(desc.parts().size(), authored_parts);
+
+  const RenderArchetype normal = build_building_archetype(desc, BuildingState::Normal);
+  const RenderArchetype damaged =
+      build_building_archetype(desc, BuildingState::Damaged);
+  const RenderArchetype destroyed =
+      build_building_archetype(desc, BuildingState::Destroyed);
+
+  EXPECT_EQ(normal.lods[0].draws.size(), authored_parts);
+  EXPECT_GT(damaged.lods[0].draws.size(), normal.lods[0].draws.size());
+  EXPECT_GT(destroyed.lods[0].draws.size(), damaged.lods[0].draws.size());
 }
 
 TEST(BuildingArchetypeDesc, FiltersBuildingLODMask) {

--- a/tests/render/building_render_common_test.cpp
+++ b/tests/render/building_render_common_test.cpp
@@ -9,6 +9,7 @@
 #include "game/core/entity.h"
 #include "render/entity/building_render_common.h"
 #include "render/entity/registry.h"
+#include "render/entity/wall_renderer_common.h"
 #include "render/submitter.h"
 
 namespace {
@@ -17,6 +18,7 @@ struct RecordedMesh {
   Render::GL::Mesh* mesh{nullptr};
   QMatrix4x4 model;
   QVector3D color{1.0F, 1.0F, 1.0F};
+  int material_id{0};
 };
 
 class RecordingSubmitter final : public Render::GL::ISubmitter {
@@ -28,8 +30,8 @@ public:
             const QVector3D& color,
             Render::GL::Texture*,
             float,
-            int) override {
-    meshes.push_back({mesh, model, color});
+            int material_id) override {
+    meshes.push_back({mesh, model, color, material_id});
   }
 
   void cylinder(
@@ -97,6 +99,44 @@ TEST(BuildingRenderCommon, ResolvesBuildingStateFromUnitHealth) {
 
   unit->health = 10;
   EXPECT_EQ(resolve_building_state(ctx), BuildingState::Destroyed);
+}
+
+TEST(BuildingRenderCommon, DamageMaterialTierPreservesSurfaceMaterial) {
+  using namespace Render::GL;
+
+  for (const int damage_tier : {10, 20}) {
+    RecordingSubmitter recorder;
+    DamageStateSubmitter damaged(recorder, damage_tier);
+    for (const int surface : {0, 1, 2, 3, 4}) {
+      damaged.mesh(nullptr, QMatrix4x4{}, QVector3D{}, nullptr, 1.0F, surface);
+    }
+
+    ASSERT_EQ(recorder.meshes.size(), 5U);
+    for (std::size_t i = 0; i < recorder.meshes.size(); ++i) {
+      EXPECT_EQ(recorder.meshes[i].material_id % 10, static_cast<int>(i));
+      EXPECT_EQ(recorder.meshes[i].material_id / 10, damage_tier / 10);
+    }
+  }
+}
+
+TEST(BuildingRenderCommon, WallArchetypeSetDiffersPerState) {
+  using namespace Render::GL;
+
+  const WallArchetypeSet set =
+      build_wall_archetype_set("test_wall", WallPalette{}, WallGeometry{});
+
+  for (const auto& variant : set.variants) {
+    const std::size_t normal =
+        variant.for_state(BuildingState::Normal).lods[0].draws.size();
+    const std::size_t damaged =
+        variant.for_state(BuildingState::Damaged).lods[0].draws.size();
+    const std::size_t destroyed =
+        variant.for_state(BuildingState::Destroyed).lods[0].draws.size();
+
+    EXPECT_GT(normal, 0U);
+    EXPECT_NE(normal, damaged);
+    EXPECT_NE(damaged, destroyed);
+  }
 }
 
 TEST(BuildingRenderCommon, RegisteredVariantDispatcherRoutesByNation) {

--- a/tests/render/draw_queue_sort_order_test.cpp
+++ b/tests/render/draw_queue_sort_order_test.cpp
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <type_traits>
+#include <variant>
 
 #include "render/draw_queue.h"
 #include "render/frame_budget.h"
@@ -354,3 +356,51 @@ TEST(FrameBudgetConfig, PartialRenderDefaultsOff) {
 }
 
 } // namespace
+
+TEST(DrawQueueCommandTypes, IndexConstantsFollowTheVariantAlternatives) {
+  using Render::GL::DrawCmd;
+  using Render::GL::DrawCmdType;
+
+  static_assert(
+      std::is_same_v<std::variant_alternative_t<MeshCmdIndex, DrawCmd>, MeshCmd>);
+  static_assert(
+      std::is_same_v<std::variant_alternative_t<GroundMarkerCmdIndex, DrawCmd>,
+                     GroundMarkerCmd>);
+  static_assert(
+      std::is_same_v<std::variant_alternative_t<TerrainSurfaceCmdIndex, DrawCmd>,
+                     TerrainSurfaceCmd>);
+  static_assert(
+      std::is_same_v<std::variant_alternative_t<TerrainFeatureCmdIndex, DrawCmd>,
+                     TerrainFeatureCmd>);
+  static_assert(Render::GL::k_draw_cmd_type_count == std::variant_size_v<DrawCmd>);
+
+  const DrawCmd mesh{MeshCmd{}};
+  EXPECT_EQ(Render::GL::draw_cmd_type(mesh), DrawCmdType::Mesh);
+  const DrawCmd marker{GroundMarkerCmd{}};
+  EXPECT_EQ(Render::GL::draw_cmd_type(marker), DrawCmdType::GroundMarker);
+}
+
+TEST(DrawQueuePreparedBatches, BatchTypeAlwaysMatchesItsHeadCommand) {
+  DrawQueue queue;
+
+  TerrainSurfaceCmd chunk;
+  queue.submit(chunk);
+  MeshCmd mesh;
+  queue.submit(mesh);
+  MeshCmd second_mesh;
+  second_mesh.alpha = 0.4F;
+  queue.submit(second_mesh);
+  GroundMarkerCmd ring;
+  queue.submit(ring);
+  TerrainFeatureCmd feature;
+  queue.submit(feature);
+
+  queue.sort_for_batching();
+
+  ASSERT_FALSE(queue.prepared_batches().empty());
+  for (const auto& prepared : queue.prepared_batches()) {
+    EXPECT_EQ(prepared.type,
+              Render::GL::draw_cmd_type(queue.get_sorted(prepared.start)))
+        << "batch starting at " << prepared.start;
+  }
+}

--- a/tests/render/equipment_loadout_catalog_test.cpp
+++ b/tests/render/equipment_loadout_catalog_test.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <gtest/gtest.h>
+#include <string>
 
 #include "render/creature/archetype_registry.h"
 #include "render/entity/nations/equipment_loadout_catalog.h"
@@ -314,7 +315,7 @@ TEST_F(EquipmentLoadoutCatalogTest, CommanderLoadoutsResolveAllExpectedHandles) 
   }
 }
 
-TEST_F(EquipmentLoadoutCatalogTest, CommanderRegaliaUsesSixDistinctHelmetAndCloakSets) {
+TEST_F(EquipmentLoadoutCatalogTest, CommanderLoadoutsUseSixDistinctHelmetAndCloakSets) {
   struct ExpectedRegalia {
     const char* renderer_key;
     const char* helmet;
@@ -353,6 +354,36 @@ TEST_F(EquipmentLoadoutCatalogTest, CommanderRegaliaUsesSixDistinctHelmetAndCloa
       EXPECT_NE(helmet_handles[left], helmet_handles[right]);
       EXPECT_NE(cloak_handles[left], cloak_handles[right]);
     }
+  }
+}
+
+TEST_F(EquipmentLoadoutCatalogTest, CommanderCloaksExcludePrimitiveRegalia) {
+  constexpr std::array<const char*, 6> renderer_keys{
+      "troops/roman/commanders/fabius_maximus",
+      "troops/roman/commanders/scipio_africanus",
+      "troops/roman/commanders/marcellus",
+      "troops/carthage/commanders/hanno_the_great",
+      "troops/carthage/commanders/hasdrubal_barca",
+      "troops/carthage/commanders/hannibal_barca",
+  };
+
+  auto& registry = Render::Creature::ArchetypeRegistry::instance();
+  auto const* base = registry.get(Render::Creature::ArchetypeRegistry::k_humanoid_base);
+  ASSERT_NE(base, nullptr);
+
+  for (auto const* renderer_key : renderer_keys) {
+    SCOPED_TRACE(renderer_key);
+    auto const loadout = Render::GL::Nation::resolve_equipment_loadout(renderer_key);
+    ASSERT_TRUE(loadout.found);
+    ASSERT_NE(loadout.cloak_handle, k_invalid_equipment_handle);
+
+    std::array const handles{loadout.cloak_handle};
+    std::string const debug_name = std::string(renderer_key) + "/cloak_only";
+    auto const archetype = Render::GL::resolve_humanoid_equipment_archetype(
+        debug_name, Render::Creature::ArchetypeRegistry::k_humanoid_base, handles);
+    auto const* desc = registry.get(archetype);
+    ASSERT_NE(desc, nullptr);
+    EXPECT_EQ(desc->bake_attachment_count, base->bake_attachment_count + 1U);
   }
 }
 

--- a/tests/render/local_lighting_test.cpp
+++ b/tests/render/local_lighting_test.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -164,4 +165,53 @@ TEST(LocalLightingTest, EqualScoresKeepInputOrderSoLightsDoNotSwap) {
     EXPECT_FLOAT_EQ(selected[i].color.x(), static_cast<float>(i))
         << "tie at index " << i << " did not keep input order";
   }
+}
+
+TEST(LocalLightingTest, Std140PackingMatchesTheUniformBlockSlots) {
+  std::array<Render::LocalLight, Render::k_max_local_lights> lights{};
+  for (auto& light : lights) {
+    light.radius = 0.0F;
+    light.intensity = 0.0F;
+  }
+  lights[0].position = QVector3D(1.0F, 2.0F, 3.0F);
+  lights[0].color = QVector3D(0.25F, 0.5F, 0.75F);
+  lights[0].radius = 7.0F;
+  lights[0].intensity = 1.5F;
+  lights[1].position = QVector3D(-4.0F, 0.0F, 8.0F);
+  lights[1].color = QVector3D(1.0F, 0.0F, 0.0F);
+  lights[1].radius = 3.0F;
+  lights[1].intensity = 0.5F;
+
+  const auto packed = Render::pack_local_lights_std140(lights);
+  using Block = Render::LocalLightingBlock;
+
+  EXPECT_FLOAT_EQ(packed[Block::k_position_radius_offset + 0], 1.0F);
+  EXPECT_FLOAT_EQ(packed[Block::k_position_radius_offset + 1], 2.0F);
+  EXPECT_FLOAT_EQ(packed[Block::k_position_radius_offset + 2], 3.0F);
+  EXPECT_FLOAT_EQ(packed[Block::k_position_radius_offset + 3], 7.0F);
+  EXPECT_FLOAT_EQ(packed[Block::k_color_intensity_offset + 0], 0.25F);
+  EXPECT_FLOAT_EQ(packed[Block::k_color_intensity_offset + 3], 1.5F);
+  EXPECT_FLOAT_EQ(packed[Block::k_position_radius_offset + 4], -4.0F);
+  EXPECT_FLOAT_EQ(packed[Block::k_color_intensity_offset + 7], 0.5F);
+  EXPECT_FLOAT_EQ(packed[Block::k_meta_offset], 2.0F);
+}
+
+TEST(LocalLightingTest, Std140PackingSkipsDarkLightsSoSlotsStayContiguous) {
+  std::array<Render::LocalLight, Render::k_max_local_lights> lights{};
+  for (auto& light : lights) {
+    light.radius = 0.0F;
+    light.intensity = 0.0F;
+  }
+  lights[0].radius = 0.0F;
+  lights[0].intensity = 1.0F;
+  lights[1].position = QVector3D(5.0F, 0.0F, 0.0F);
+  lights[1].radius = 4.0F;
+  lights[1].intensity = 2.0F;
+
+  const auto packed = Render::pack_local_lights_std140(lights);
+  using Block = Render::LocalLightingBlock;
+
+  EXPECT_FLOAT_EQ(packed[Block::k_position_radius_offset + 0], 5.0F)
+      << "the surviving light must land in the first slot";
+  EXPECT_FLOAT_EQ(packed[Block::k_meta_offset], 1.0F);
 }

--- a/tests/render/shader_source_test.cpp
+++ b/tests/render/shader_source_test.cpp
@@ -3,10 +3,14 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <locale>
+#include <map>
 #include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include "render/gl/directional_shadow_block.h"
+#include "render/local_lighting.h"
 
 namespace {
 
@@ -81,6 +85,56 @@ void expect_literal_smoothstep_edges_are_ordered(const std::string& shader_sourc
     EXPECT_LT(edge0, edge1) << shader_name
                             << " contains reversed smoothstep edges: " << it->str();
   }
+}
+
+struct Std140Block {
+  std::vector<std::string> member_names;
+  std::size_t float_count = 0;
+};
+
+auto parse_std140_block(const std::string& glsl,
+                        const std::string& block_name,
+                        const std::map<std::string, std::size_t>& array_extents)
+    -> Std140Block {
+  Std140Block parsed;
+  const std::regex block(R"(layout\(std140\)\s+uniform\s+)" + block_name +
+                         R"(\s*\{([^}]*)\})");
+  std::smatch match;
+  if (!std::regex_search(glsl, match, block)) {
+    return parsed;
+  }
+  const std::string body = match[1].str();
+
+  const std::regex member(
+      R"((mat4|vec4|vec3|vec2|float|int)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:\[\s*([A-Za-z0-9_]+)\s*\])?\s*;)");
+  for (auto it = std::sregex_iterator(body.begin(), body.end(), member);
+       it != std::sregex_iterator();
+       ++it) {
+    const std::string type = (*it)[1].str();
+    parsed.member_names.push_back((*it)[2].str());
+
+    std::size_t elements = 1;
+    if ((*it)[3].matched) {
+      const std::string extent = (*it)[3].str();
+      const auto named = array_extents.find(extent);
+      elements = named != array_extents.end()
+                     ? named->second
+                     : static_cast<std::size_t>(std::stoul(extent));
+    }
+
+    const std::size_t slots_per_element = type == "mat4" ? 4U : 1U;
+    parsed.float_count += elements * slots_per_element * 4U;
+  }
+  return parsed;
+}
+
+auto glsl_int_constant(const std::string& glsl, const std::string& name) -> int {
+  std::smatch match;
+  const std::regex declaration(R"(const\s+int\s+)" + name + R"(\s*=\s*([0-9]+)\s*;)");
+  if (!std::regex_search(glsl, match, declaration)) {
+    return -1;
+  }
+  return std::stoi(match[1].str());
 }
 
 } // namespace
@@ -454,4 +508,56 @@ TEST(ShaderSource, RoadsKeepPackedEarthSeparateFromPaving) {
   EXPECT_NE(flat.find("vec2 aggregate_cells = worley_f("), std::string::npos);
   EXPECT_NE(flat.find("float rut_left ="), std::string::npos);
   EXPECT_NE(flat.find("u_alpha * edge_alpha"), std::string::npos);
+}
+
+TEST(ShaderSource, DirectionalShadowBlockMatchesTheUploadedStruct) {
+  const auto root = find_repo_root();
+  const auto glsl =
+      read_text(root / "assets" / "shaders" / "include" / "directional_shadows.glsl");
+  ASSERT_FALSE(glsl.empty());
+
+  const int declared_cascades = glsl_int_constant(glsl, "SOI_MAX_SHADOW_CASCADES");
+  EXPECT_EQ(declared_cascades, Render::GL::k_max_shadow_cascades);
+  ASSERT_GT(declared_cascades, 0);
+
+  const auto block = parse_std140_block(
+      glsl,
+      "DirectionalShadows",
+      {{"SOI_MAX_SHADOW_CASCADES", static_cast<std::size_t>(declared_cascades)}});
+  ASSERT_FALSE(block.member_names.empty()) << "DirectionalShadows block not found";
+
+  EXPECT_EQ(block.float_count, Render::GL::DirectionalShadowBlock::k_float_count)
+      << "the shader block and DirectionalShadowBlock no longer agree on size";
+
+  const std::vector<std::string> expected_order{"u_shadow_light_vp",
+                                                "u_shadow_split_distances",
+                                                "u_shadow_params",
+                                                "u_shadow_camera_position",
+                                                "u_shadow_bias"};
+  EXPECT_EQ(block.member_names, expected_order)
+      << "DirectionalShadowBlock::packed_std140 writes these in declaration order";
+}
+
+TEST(ShaderSource, LocalLightingBlockMatchesTheUploadedStruct) {
+  const auto root = find_repo_root();
+  const auto glsl =
+      read_text(root / "assets" / "shaders" / "include" / "local_lighting.glsl");
+  ASSERT_FALSE(glsl.empty());
+
+  const int declared_lights = glsl_int_constant(glsl, "SOI_MAX_LOCAL_LIGHTS");
+  EXPECT_EQ(static_cast<std::size_t>(declared_lights), Render::k_max_local_lights);
+  ASSERT_GT(declared_lights, 0);
+
+  const auto block = parse_std140_block(
+      glsl,
+      "LocalLighting",
+      {{"SOI_MAX_LOCAL_LIGHTS", static_cast<std::size_t>(declared_lights)}});
+  ASSERT_FALSE(block.member_names.empty()) << "LocalLighting block not found";
+
+  EXPECT_EQ(block.float_count, Render::LocalLightingBlock::k_float_count);
+
+  const std::vector<std::string> expected_order{
+      "u_local_position_radius", "u_local_color_intensity", "u_local_light_meta"};
+  EXPECT_EQ(block.member_names, expected_order)
+      << "pack_local_lights_std140 writes these in declaration order";
 }


### PR DESCRIPTION
Resolve campaign wave march targets from the player barracks first, then other non-wall buildings, and finally troops. Reuse that resolution during mission setup and restore so walls, gates, scouts, and civilians cannot pull the assault objective away from the defended camp.

Keep assault-wave units out of retreat behavior and ignore neutral-owned targets unless a barrier actually blocks the route. Track per-unit progress toward the current objective and only select a breach after the formation stalls, allowing waves to flank open ramparts while still breaking enclosed defenses.

Add state-aware building decay with deterministic desaturation, soot, moss, dust, rubble, charred beams, scorch marks, cracks, broken rims, and collapsed roof dressing. Apply damaged and destroyed archetypes across Roman and Carthaginian buildings, barracks variants, walls, and gates while preserving team-color palette parts.

Encode the damage tier alongside the base material so shader soot no longer replaces material identity. Harden the render backend with typed draw-command categories, prepared-batch type metadata, explicit std140 packers for local lighting and directional shadows, and shared packed-size constants for uniform buffers.

Expand campaign, headless AI, building archetype, material, draw queue, lighting, and shader contract coverage, and document the assault targeting and building degradation architecture.

Validation: make format passed. Builds and tests were intentionally not run.