### PR TITLE
Polish combat animation and melee transitions

### DIFF
--- a/animation/CMakeLists.txt
+++ b/animation/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
     clip_manifest.cpp
     combat_manifest.cpp
     action_manifest.cpp
+    death_pose_manifest.cpp
     elephant_gait_manifest.cpp
     attack_pose_manifest.cpp
     guard_manifest.cpp

--- a/animation/clip_manifest.h
+++ b/animation/clip_manifest.h
@@ -129,27 +129,32 @@ inline constexpr std::uint16_t k_humanoid_riding_reining_clip = 19U;
 inline constexpr std::uint16_t k_humanoid_riding_bow_shot_clip = 20U;
 inline constexpr std::uint16_t k_humanoid_riding_sword_strike_clip = 21U;
 inline constexpr std::uint16_t k_humanoid_riding_spear_thrust_clip = 22U;
+
 inline constexpr std::uint16_t k_humanoid_die_infantry_clip = 23U;
-inline constexpr std::uint16_t k_humanoid_dead_infantry_clip = 24U;
-inline constexpr std::uint16_t k_humanoid_die_mounted_clip = 25U;
-inline constexpr std::uint16_t k_humanoid_dead_mounted_clip = 26U;
-inline constexpr std::uint16_t k_humanoid_rpg_sword_slash_left_clip = 27U;
-inline constexpr std::uint16_t k_humanoid_rpg_sword_slash_right_clip = 28U;
-inline constexpr std::uint16_t k_humanoid_rpg_sword_overhead_clip = 29U;
-inline constexpr std::uint16_t k_humanoid_rpg_sword_thrust_clip = 30U;
-inline constexpr std::uint16_t k_humanoid_rpg_sword_finisher_clip = 31U;
-inline constexpr std::uint16_t k_humanoid_archer_melee_clip = 32U;
-inline constexpr std::uint16_t k_humanoid_hold_spear_attack_clip = 33U;
-inline constexpr std::uint16_t k_humanoid_hold_bow_attack_clip = 34U;
-inline constexpr std::uint16_t k_humanoid_showcase_first_clip = 35U;
-inline constexpr std::uint16_t k_humanoid_showcase_jump_clip = 35U;
-inline constexpr std::uint16_t k_humanoid_showcase_front_flip_clip = 36U;
-inline constexpr std::uint16_t k_humanoid_showcase_handstand_clip = 37U;
-inline constexpr std::uint16_t k_humanoid_showcase_side_aerial_clip = 38U;
-inline constexpr std::uint16_t k_humanoid_showcase_sword_flourish_clip = 39U;
-inline constexpr std::uint16_t k_humanoid_showcase_spear_throw_clip = 40U;
+inline constexpr std::uint16_t k_humanoid_die_infantry_face_clip = 24U;
+inline constexpr std::uint16_t k_humanoid_die_infantry_side_clip = 25U;
+inline constexpr std::uint16_t k_humanoid_dead_infantry_clip = 26U;
+inline constexpr std::uint16_t k_humanoid_dead_infantry_face_clip = 27U;
+inline constexpr std::uint16_t k_humanoid_dead_infantry_side_clip = 28U;
+inline constexpr std::uint16_t k_humanoid_die_mounted_clip = 29U;
+inline constexpr std::uint16_t k_humanoid_dead_mounted_clip = 30U;
+inline constexpr std::uint16_t k_humanoid_rpg_sword_slash_left_clip = 31U;
+inline constexpr std::uint16_t k_humanoid_rpg_sword_slash_right_clip = 32U;
+inline constexpr std::uint16_t k_humanoid_rpg_sword_overhead_clip = 33U;
+inline constexpr std::uint16_t k_humanoid_rpg_sword_thrust_clip = 34U;
+inline constexpr std::uint16_t k_humanoid_rpg_sword_finisher_clip = 35U;
+inline constexpr std::uint16_t k_humanoid_archer_melee_clip = 36U;
+inline constexpr std::uint16_t k_humanoid_hold_spear_attack_clip = 37U;
+inline constexpr std::uint16_t k_humanoid_hold_bow_attack_clip = 38U;
+inline constexpr std::uint16_t k_humanoid_showcase_first_clip = 39U;
+inline constexpr std::uint16_t k_humanoid_showcase_jump_clip = 39U;
+inline constexpr std::uint16_t k_humanoid_showcase_front_flip_clip = 40U;
+inline constexpr std::uint16_t k_humanoid_showcase_handstand_clip = 41U;
+inline constexpr std::uint16_t k_humanoid_showcase_side_aerial_clip = 42U;
+inline constexpr std::uint16_t k_humanoid_showcase_sword_flourish_clip = 43U;
+inline constexpr std::uint16_t k_humanoid_showcase_spear_throw_clip = 44U;
 inline constexpr std::uint16_t k_humanoid_showcase_clip_count = 6U;
-inline constexpr std::uint16_t k_humanoid_clip_count = 41U;
+inline constexpr std::uint16_t k_humanoid_clip_count = 45U;
 
 inline constexpr float k_humanoid_idle_breath_cycle_time = 8.0F;
 inline constexpr std::uint32_t k_humanoid_idle_breath_frames = 90U;
@@ -164,6 +169,7 @@ inline constexpr std::uint8_t k_humanoid_idle_variant_count = 6U;
 inline constexpr std::uint8_t k_humanoid_attack_sword_variant_count = 3U;
 inline constexpr std::uint8_t k_humanoid_attack_spear_variant_count = 3U;
 inline constexpr std::uint8_t k_humanoid_riding_sword_variant_count = 1U;
+inline constexpr std::uint8_t k_humanoid_infantry_death_variant_count = 3U;
 
 inline constexpr std::uint16_t k_horse_idle_clip = 0U;
 inline constexpr std::uint16_t k_horse_walk_clip = 1U;
@@ -274,6 +280,8 @@ humanoid_variant_count_table() noexcept -> std::array<std::uint8_t, state_count(
   t[state_index(StateId::Idle)] = k_humanoid_idle_variant_count;
   t[state_index(StateId::AttackSword)] = k_humanoid_attack_sword_variant_count;
   t[state_index(StateId::AttackSpear)] = k_humanoid_attack_spear_variant_count;
+  t[state_index(StateId::Die)] = k_humanoid_infantry_death_variant_count;
+  t[state_index(StateId::Dead)] = k_humanoid_infantry_death_variant_count;
   return t;
 }
 

--- a/animation/combat_manifest.cpp
+++ b/animation/combat_manifest.cpp
@@ -290,7 +290,10 @@ auto build_resolved_state(const CombatPersistentState& persistent,
     resolved.phase = transaction_phase_from_attack_phase(resolved.attack_phase);
     resolved.phase_progress = transaction_phase_progress_from_attack_phase(
         resolved.attack_phase, resolved.phase);
-    resolved.exit_blend_progress = 0.0F;
+
+    resolved.exit_blend_progress = resolved.phase == CombatTransactionPhase::ExitBlend
+                                       ? resolved.phase_progress
+                                       : 0.0F;
     resolved.is_melee = raw.is_melee;
     resolved.attack_family = raw.attack_family;
     resolved.finisher_attack = raw.finisher_attack;

--- a/animation/death_pose_manifest.cpp
+++ b/animation/death_pose_manifest.cpp
@@ -1,0 +1,564 @@
+#include "death_pose_manifest.h"
+
+#include <algorithm>
+#include <array>
+#include <span>
+
+namespace Animation {
+
+namespace {
+
+using PoseFk::LimbAim;
+using PoseFk::Mat3;
+
+struct DeathKey {
+  float t{0.0F};
+  float root_x{0.0F};
+  float root_y{0.975F};
+  float root_z{0.0F};
+  float body_pitch{0.0F};
+  float body_roll{0.0F};
+  float body_yaw{0.0F};
+  float spine_pitch{0.0F};
+  float spine_roll{0.0F};
+  float spine_yaw{0.0F};
+  float head_pitch{0.0F};
+  float head_roll{0.0F};
+  float foot_pitch_l{0.0F};
+  float foot_pitch_r{0.0F};
+  LimbAim arm_l{4.0F, 7.0F, 0.0F, 14.0F};
+  LimbAim arm_r{4.0F, 7.0F, 0.0F, 14.0F};
+  LimbAim leg_l{0.0F, 3.0F, 0.0F, 4.0F};
+  LimbAim leg_r{0.0F, 3.0F, 0.0F, 4.0F};
+};
+
+constexpr std::array<DeathKey, 8> k_back_sprawl_keys{{
+    {.t = 0.00F},
+    {.t = 0.07F,
+     .root_y = 0.955F,
+     .root_z = -0.03F,
+     .body_pitch = -5.0F,
+     .spine_pitch = -15.0F,
+     .head_pitch = -20.0F,
+     .arm_l = {-34.0F, 40.0F, 0.0F, 22.0F},
+     .arm_r = {-30.0F, 36.0F, 0.0F, 26.0F},
+     .leg_l = {2.0F, 6.0F, 0.0F, 14.0F},
+     .leg_r = {2.0F, 5.0F, 0.0F, 14.0F}},
+    {.t = 0.20F,
+     .root_y = 0.905F,
+     .root_z = -0.13F,
+     .body_pitch = -13.0F,
+     .spine_pitch = -11.0F,
+     .head_pitch = -16.0F,
+     .arm_l = {-22.0F, 50.0F, 0.0F, 30.0F},
+     .arm_r = {-18.0F, 46.0F, 0.0F, 34.0F},
+     .leg_l = {20.0F, 7.0F, 0.0F, 51.0F},
+     .leg_r = {2.0F, 5.0F, 0.0F, 51.0F}},
+    {.t = 0.42F,
+     .root_y = 0.600F,
+     .root_z = -0.24F,
+     .body_pitch = -20.0F,
+     .spine_pitch = -2.0F,
+     .head_pitch = 2.0F,
+     .arm_l = {-26.0F, 56.0F, 0.0F, 30.0F},
+     .arm_r = {-22.0F, 52.0F, 0.0F, 34.0F},
+     .leg_l = {39.0F, 9.0F, 0.0F, 112.0F},
+     .leg_r = {35.0F, 6.0F, 0.0F, 106.0F}},
+    {.t = 0.62F,
+     .root_y = 0.300F,
+     .root_z = -0.34F,
+     .body_pitch = -44.0F,
+     .spine_pitch = 8.0F,
+     .head_pitch = 14.0F,
+     .arm_l = {-18.0F, 58.0F, 0.0F, 26.0F},
+     .arm_r = {-14.0F, 50.0F, 0.0F, 34.0F},
+     .leg_l = {70.0F, 11.0F, 0.0F, 119.0F},
+     .leg_r = {69.0F, 7.0F, 0.0F, 125.0F}},
+    {.t = 0.78F,
+     .root_y = 0.175F,
+     .root_z = -0.44F,
+     .body_pitch = -82.0F,
+     .spine_pitch = 4.0F,
+     .head_pitch = 8.0F,
+     .foot_pitch_l = -18.0F,
+     .foot_pitch_r = -14.0F,
+     .arm_l = {-8.0F, 54.0F, 0.0F, 20.0F},
+     .arm_r = {-6.0F, 44.0F, 0.0F, 32.0F},
+     .leg_l = {23.0F, 12.0F, 0.0F, 52.0F},
+     .leg_r = {29.0F, 8.0F, 0.0F, 62.0F}},
+    {.t = 0.88F,
+     .root_y = 0.178F,
+     .root_z = -0.50F,
+     .body_pitch = -96.0F,
+     .spine_pitch = -4.0F,
+     .head_pitch = 2.0F,
+     .head_roll = 4.0F,
+     .foot_pitch_l = -26.0F,
+     .foot_pitch_r = -22.0F,
+     .arm_l = {-16.0F, 56.0F, 0.0F, 12.0F},
+     .arm_r = {-14.0F, 38.0F, 0.0F, 30.0F},
+     .leg_l = {-5.0F, 12.0F, 0.0F, 24.0F},
+     .leg_r = {5.0F, 8.0F, 0.0F, 47.0F}},
+    {.t = 1.00F,
+     .root_y = 0.158F,
+     .root_z = -0.52F,
+     .body_pitch = -92.0F,
+     .body_roll = 5.0F,
+     .spine_roll = 4.0F,
+     .head_pitch = 2.0F,
+     .head_roll = 10.0F,
+     .foot_pitch_l = -30.0F,
+     .foot_pitch_r = -24.0F,
+     .arm_l = {-9.0F, 52.0F, 0.0F, 14.0F},
+     .arm_r = {-7.0F, 26.0F, 0.0F, 42.0F},
+     .leg_l = {-8.0F, 9.0F, 0.0F, 3.0F},
+     .leg_r = {10.0F, 4.0F, 0.0F, 41.0F}},
+}};
+
+constexpr std::array<DeathKey, 8> k_face_plant_keys{{
+    {.t = 0.00F},
+    {.t = 0.08F,
+     .root_y = 0.955F,
+     .root_z = 0.04F,
+     .body_pitch = 6.0F,
+     .spine_pitch = 14.0F,
+     .head_pitch = 16.0F,
+     .arm_l = {26.0F, 14.0F, 0.0F, 30.0F},
+     .arm_r = {22.0F, 12.0F, 0.0F, 34.0F},
+     .leg_l = {2.0F, 4.0F, 0.0F, 8.0F},
+     .leg_r = {2.0F, 4.0F, 0.0F, 8.0F}},
+    {.t = 0.22F,
+     .root_y = 0.860F,
+     .root_z = 0.10F,
+     .body_pitch = 20.0F,
+     .spine_pitch = 18.0F,
+     .head_pitch = 12.0F,
+     .arm_l = {46.0F, 18.0F, 0.0F, 40.0F},
+     .arm_r = {42.0F, 16.0F, 0.0F, 44.0F},
+     .leg_l = {20.0F, 5.0F, 0.0F, 46.0F},
+     .leg_r = {16.0F, 5.0F, 0.0F, 42.0F}},
+    {.t = 0.42F,
+     .root_y = 0.580F,
+     .root_z = 0.10F,
+     .body_pitch = 34.0F,
+     .spine_pitch = 12.0F,
+     .head_pitch = 10.0F,
+     .foot_pitch_l = 20.0F,
+     .foot_pitch_r = 18.0F,
+     .arm_l = {60.0F, 22.0F, 0.0F, 32.0F},
+     .arm_r = {56.0F, 20.0F, 0.0F, 36.0F},
+     .leg_l = {35.0F, 7.0F, 0.0F, 97.0F},
+     .leg_r = {42.0F, 6.0F, 0.0F, 106.0F}},
+    {.t = 0.62F,
+     .root_y = 0.470F,
+     .root_z = 0.24F,
+     .body_pitch = 62.0F,
+     .spine_pitch = 6.0F,
+     .head_pitch = 4.0F,
+     .foot_pitch_l = 22.0F,
+     .foot_pitch_r = 20.0F,
+     .arm_l = {30.0F, 26.0F, 0.0F, 24.0F},
+     .arm_r = {26.0F, 24.0F, 0.0F, 28.0F},
+     .leg_l = {24.0F, 8.0F, 0.0F, 64.0F},
+     .leg_r = {24.0F, 7.0F, 0.0F, 70.0F}},
+    {.t = 0.80F,
+     .root_y = 0.170F,
+     .root_z = 0.40F,
+     .body_pitch = 88.0F,
+     .spine_pitch = -2.0F,
+     .head_pitch = -6.0F,
+     .foot_pitch_l = 16.0F,
+     .foot_pitch_r = 12.0F,
+     .arm_l = {14.0F, 46.0F, 0.0F, 6.0F},
+     .arm_r = {12.0F, 30.0F, 0.0F, 6.0F},
+     .leg_l = {6.0F, 8.0F, 0.0F, 2.0F},
+     .leg_r = {4.0F, 5.0F, 0.0F, 2.0F}},
+    {.t = 0.90F,
+     .root_y = 0.155F,
+     .root_z = 0.44F,
+     .body_pitch = 95.0F,
+     .spine_pitch = -5.0F,
+     .head_pitch = -12.0F,
+     .head_roll = 10.0F,
+     .foot_pitch_l = 22.0F,
+     .foot_pitch_r = 18.0F,
+     .arm_l = {12.0F, 38.0F, 0.0F, 4.0F},
+     .arm_r = {10.0F, 22.0F, 0.0F, 6.0F},
+     .leg_l = {11.0F, 8.0F, 0.0F, 2.0F},
+     .leg_r = {9.0F, 5.0F, 0.0F, 2.0F}},
+    {.t = 1.00F,
+     .root_y = 0.150F,
+     .root_z = 0.43F,
+     .body_pitch = 90.0F,
+     .body_roll = -4.0F,
+     .spine_roll = -4.0F,
+     .head_pitch = -4.0F,
+     .head_roll = 14.0F,
+     .foot_pitch_l = 24.0F,
+     .foot_pitch_r = 20.0F,
+     .arm_l = {11.0F, 26.0F, 0.0F, 6.0F},
+     .arm_r = {9.0F, 34.0F, 0.0F, 10.0F},
+     .leg_l = {6.0F, 8.0F, 0.0F, 3.0F},
+     .leg_r = {4.0F, 4.0F, 0.0F, 4.0F}},
+}};
+
+constexpr std::array<DeathKey, 8> k_side_crumple_keys{{
+    {.t = 0.00F},
+    {.t = 0.08F,
+     .root_x = -0.03F,
+     .root_y = 0.955F,
+     .body_roll = 8.0F,
+     .spine_roll = 10.0F,
+     .head_pitch = -8.0F,
+     .head_roll = 14.0F,
+     .arm_l = {-10.0F, 34.0F, 0.0F, 26.0F},
+     .arm_r = {-24.0F, 30.0F, 0.0F, 30.0F},
+     .leg_l = {2.0F, 6.0F, 0.0F, 18.0F},
+     .leg_r = {2.0F, 5.0F, 0.0F, 14.0F}},
+    {.t = 0.22F,
+     .root_x = -0.11F,
+     .root_y = 0.905F,
+     .root_z = -0.06F,
+     .body_pitch = -8.0F,
+     .body_roll = 18.0F,
+     .body_yaw = 10.0F,
+     .spine_roll = 12.0F,
+     .head_roll = 12.0F,
+     .arm_l = {-6.0F, 44.0F, 0.0F, 34.0F},
+     .arm_r = {-16.0F, 34.0F, 0.0F, 40.0F},
+     .leg_l = {26.0F, 9.0F, 0.0F, 36.0F},
+     .leg_r = {4.0F, 5.0F, 0.0F, 34.0F}},
+    {.t = 0.42F,
+     .root_x = -0.22F,
+     .root_y = 0.580F,
+     .root_z = -0.16F,
+     .body_pitch = -18.0F,
+     .body_roll = 30.0F,
+     .body_yaw = 16.0F,
+     .spine_roll = 8.0F,
+     .head_roll = 10.0F,
+     .arm_l = {6.0F, 40.0F, 0.0F, 44.0F},
+     .arm_r = {-6.0F, 30.0F, 0.0F, 48.0F},
+     .leg_l = {52.0F, 10.0F, 0.0F, 76.0F},
+     .leg_r = {34.0F, 6.0F, 0.0F, 70.0F}},
+    {.t = 0.62F,
+     .root_x = -0.30F,
+     .root_y = 0.320F,
+     .root_z = -0.24F,
+     .body_pitch = -40.0F,
+     .body_roll = 40.0F,
+     .body_yaw = 18.0F,
+     .spine_roll = 6.0F,
+     .head_roll = 6.0F,
+     .arm_l = {2.0F, 30.0F, 0.0F, 46.0F},
+     .arm_r = {-4.0F, 42.0F, 0.0F, 40.0F},
+     .leg_l = {66.0F, 11.0F, 0.0F, 122.0F},
+     .leg_r = {62.0F, 7.0F, 0.0F, 128.0F}},
+    {.t = 0.80F,
+     .root_x = -0.35F,
+     .root_y = 0.190F,
+     .root_z = -0.32F,
+     .body_pitch = -74.0F,
+     .body_roll = 44.0F,
+     .body_yaw = 18.0F,
+     .head_pitch = 6.0F,
+     .head_roll = 6.0F,
+     .foot_pitch_l = -12.0F,
+     .foot_pitch_r = -10.0F,
+     .arm_l = {-4.0F, 22.0F, 0.0F, 42.0F},
+     .arm_r = {-6.0F, 46.0F, 0.0F, 30.0F},
+     .leg_l = {26.0F, 11.0F, 0.0F, 56.0F},
+     .leg_r = {20.0F, 7.0F, 0.0F, 32.0F}},
+    {.t = 0.90F,
+     .root_x = -0.37F,
+     .root_y = 0.178F,
+     .root_z = -0.36F,
+     .body_pitch = -86.0F,
+     .body_roll = 46.0F,
+     .body_yaw = 18.0F,
+     .head_pitch = 10.0F,
+     .foot_pitch_l = -16.0F,
+     .foot_pitch_r = -14.0F,
+     .arm_l = {-10.0F, 16.0F, 0.0F, 38.0F},
+     .arm_r = {-6.0F, 48.0F, 0.0F, 24.0F},
+     .leg_l = {12.0F, 11.0F, 0.0F, 44.0F},
+     .leg_r = {24.0F, 7.0F, 0.0F, 58.0F}},
+    {.t = 1.00F,
+     .root_x = -0.37F,
+     .root_y = 0.168F,
+     .root_z = -0.37F,
+     .body_pitch = -80.0F,
+     .body_roll = 46.0F,
+     .body_yaw = 18.0F,
+     .spine_roll = 6.0F,
+     .head_pitch = 12.0F,
+     .head_roll = -6.0F,
+     .foot_pitch_l = -18.0F,
+     .foot_pitch_r = -15.0F,
+     .arm_l = {-8.0F, 14.0F, 0.0F, 36.0F},
+     .arm_r = {-9.0F, 44.0F, 0.0F, 22.0F},
+     .leg_l = {14.0F, 11.0F, 0.0F, 48.0F},
+     .leg_r = {26.0F, 7.0F, 0.0F, 62.0F}},
+}};
+
+constexpr std::array<DeathKey, 7> k_mounted_unseat_keys{{
+    {.t = 0.00F},
+    {.t = 0.10F,
+     .root_x = 0.10F,
+     .root_y = 0.965F,
+     .body_roll = -12.0F,
+     .spine_roll = -14.0F,
+     .head_roll = -18.0F,
+     .arm_l = {-20.0F, 26.0F, 0.0F, 34.0F},
+     .arm_r = {-34.0F, 40.0F, 0.0F, 24.0F},
+     .leg_l = {-6.0F, 8.0F, 0.0F, 10.0F},
+     .leg_r = {-6.0F, 8.0F, 0.0F, 10.0F}},
+    {.t = 0.28F,
+     .root_x = 0.32F,
+     .root_y = 0.890F,
+     .root_z = -0.08F,
+     .body_pitch = -10.0F,
+     .body_roll = -22.0F,
+     .body_yaw = -14.0F,
+     .spine_roll = -12.0F,
+     .head_roll = -14.0F,
+     .arm_l = {-10.0F, 34.0F, 0.0F, 42.0F},
+     .arm_r = {-20.0F, 48.0F, 0.0F, 30.0F},
+     .leg_l = {22.0F, 12.0F, 0.0F, 54.0F},
+     .leg_r = {6.0F, 6.0F, 0.0F, 52.0F}},
+    {.t = 0.50F,
+     .root_x = 0.54F,
+     .root_y = 0.580F,
+     .root_z = -0.18F,
+     .body_pitch = -22.0F,
+     .body_roll = -34.0F,
+     .body_yaw = -20.0F,
+     .arm_l = {0.0F, 38.0F, 0.0F, 46.0F},
+     .arm_r = {-8.0F, 50.0F, 0.0F, 38.0F},
+     .leg_l = {26.0F, 14.0F, 0.0F, 74.0F},
+     .leg_r = {48.0F, 8.0F, 0.0F, 106.0F}},
+    {.t = 0.72F,
+     .root_x = 0.68F,
+     .root_y = 0.250F,
+     .root_z = -0.26F,
+     .body_pitch = -54.0F,
+     .body_roll = -40.0F,
+     .body_yaw = -22.0F,
+     .head_pitch = 8.0F,
+     .foot_pitch_l = -14.0F,
+     .foot_pitch_r = -12.0F,
+     .arm_l = {-4.0F, 30.0F, 0.0F, 42.0F},
+     .arm_r = {-8.0F, 46.0F, 0.0F, 32.0F},
+     .leg_l = {37.0F, 12.0F, 0.0F, 50.0F},
+     .leg_r = {42.0F, 7.0F, 0.0F, 44.0F}},
+    {.t = 0.88F,
+     .root_x = 0.75F,
+     .root_y = 0.186F,
+     .root_z = -0.30F,
+     .body_pitch = -88.0F,
+     .body_roll = -42.0F,
+     .body_yaw = -20.0F,
+     .head_pitch = 12.0F,
+     .head_roll = -8.0F,
+     .foot_pitch_l = -20.0F,
+     .foot_pitch_r = -18.0F,
+     .arm_l = {-6.0F, 20.0F, 0.0F, 32.0F},
+     .arm_r = {-14.0F, 42.0F, 0.0F, 26.0F},
+     .leg_l = {14.0F, 12.0F, 0.0F, 30.0F},
+     .leg_r = {-10.0F, 6.0F, 0.0F, 3.0F}},
+    {.t = 1.00F,
+     .root_x = 0.76F,
+     .root_y = 0.172F,
+     .root_z = -0.30F,
+     .body_pitch = -82.0F,
+     .body_roll = -40.0F,
+     .body_yaw = -18.0F,
+     .spine_roll = -6.0F,
+     .head_pitch = 10.0F,
+     .head_roll = -12.0F,
+     .foot_pitch_l = -22.0F,
+     .foot_pitch_r = -18.0F,
+     .arm_l = {-9.0F, 18.0F, 0.0F, 34.0F},
+     .arm_r = {-8.0F, 40.0F, 0.0F, 24.0F},
+     .leg_l = {15.0F, 11.0F, 0.0F, 25.0F},
+     .leg_r = {-4.0F, 6.0F, 0.0F, 1.0F}},
+}};
+
+[[nodiscard]] auto
+keys_for(HumanoidDeathCollapse collapse) noexcept -> std::span<const DeathKey> {
+  switch (collapse) {
+  case HumanoidDeathCollapse::BackSprawl:
+    return k_back_sprawl_keys;
+  case HumanoidDeathCollapse::FacePlant:
+    return k_face_plant_keys;
+  case HumanoidDeathCollapse::SideCrumple:
+    return k_side_crumple_keys;
+  case HumanoidDeathCollapse::MountedUnseat:
+    return k_mounted_unseat_keys;
+  case HumanoidDeathCollapse::None:
+  case HumanoidDeathCollapse::Count:
+    break;
+  }
+  return {};
+}
+
+[[nodiscard]] auto mix(float a, float b, float t) noexcept -> float {
+  return a + ((b - a) * t);
+}
+
+[[nodiscard]] auto
+blend_key(const DeathKey& a, const DeathKey& b, float t) noexcept -> DeathKey {
+  DeathKey out{};
+  out.t = mix(a.t, b.t, t);
+  out.root_x = mix(a.root_x, b.root_x, t);
+  out.root_y = mix(a.root_y, b.root_y, t);
+  out.root_z = mix(a.root_z, b.root_z, t);
+  out.body_pitch = mix(a.body_pitch, b.body_pitch, t);
+  out.body_roll = mix(a.body_roll, b.body_roll, t);
+  out.body_yaw = mix(a.body_yaw, b.body_yaw, t);
+  out.spine_pitch = mix(a.spine_pitch, b.spine_pitch, t);
+  out.spine_roll = mix(a.spine_roll, b.spine_roll, t);
+  out.spine_yaw = mix(a.spine_yaw, b.spine_yaw, t);
+  out.head_pitch = mix(a.head_pitch, b.head_pitch, t);
+  out.head_roll = mix(a.head_roll, b.head_roll, t);
+  out.foot_pitch_l = mix(a.foot_pitch_l, b.foot_pitch_l, t);
+  out.foot_pitch_r = mix(a.foot_pitch_r, b.foot_pitch_r, t);
+  out.arm_l = PoseFk::blend_limb(a.arm_l, b.arm_l, t);
+  out.arm_r = PoseFk::blend_limb(a.arm_r, b.arm_r, t);
+  out.leg_l = PoseFk::blend_limb(a.leg_l, b.leg_l, t);
+  out.leg_r = PoseFk::blend_limb(a.leg_r, b.leg_r, t);
+  return out;
+}
+
+[[nodiscard]] auto
+segment_ease(const DeathKey& a, const DeathKey& b, float t) noexcept -> float {
+  float const drop = a.root_y - b.root_y;
+  if (drop > 0.08F) {
+    return t * t;
+  }
+  return PoseFk::smoothstep(t);
+}
+
+[[nodiscard]] auto sample_key(std::span<const DeathKey> keys,
+                              float phase) noexcept -> DeathKey {
+  phase = std::clamp(phase, 0.0F, 1.0F);
+  if (keys.empty()) {
+    return {};
+  }
+  if (phase <= keys.front().t) {
+    return keys.front();
+  }
+  for (std::size_t i = 0; i + 1 < keys.size(); ++i) {
+    const DeathKey& a = keys[i];
+    const DeathKey& b = keys[i + 1];
+    if (phase <= b.t) {
+      float const span = std::max(1.0e-5F, b.t - a.t);
+      return blend_key(a, b, segment_ease(a, b, (phase - a.t) / span));
+    }
+  }
+  return keys.back();
+}
+
+} // namespace
+
+auto humanoid_death_collapse_name(HumanoidDeathCollapse collapse) noexcept
+    -> std::string_view {
+  switch (collapse) {
+  case HumanoidDeathCollapse::BackSprawl:
+    return "back_sprawl";
+  case HumanoidDeathCollapse::FacePlant:
+    return "face_plant";
+  case HumanoidDeathCollapse::SideCrumple:
+    return "side_crumple";
+  case HumanoidDeathCollapse::MountedUnseat:
+    return "mounted_unseat";
+  case HumanoidDeathCollapse::None:
+  case HumanoidDeathCollapse::Count:
+    break;
+  }
+  return "none";
+}
+
+auto resolve_humanoid_death_pose(const HumanoidDeathPoseInputs& inputs) noexcept
+    -> HumanoidDeathPoseSample {
+  auto const keys = keys_for(inputs.collapse);
+  if (keys.empty()) {
+    return {};
+  }
+  DeathKey const key = sample_key(keys, inputs.phase);
+  PoseFk::HumanoidRigMetrics const& rig = inputs.rig;
+
+  using PoseFk::add;
+  using PoseFk::multiply;
+  using PoseFk::radians;
+  using PoseFk::rot_x;
+  using PoseFk::rot_y;
+  using PoseFk::rot_z;
+  using PoseFk::scaled;
+  using PoseFk::sub;
+  using PoseFk::transform;
+
+  Mat3 const spine =
+      multiply(rot_x(radians(key.spine_pitch)),
+               multiply(rot_z(radians(key.spine_roll)), rot_y(radians(key.spine_yaw))));
+
+  PoseVec3 const pelvis{0.0F, rig.pelvis_y, 0.0F};
+  PoseVec3 const neck = add(pelvis, transform(spine, {0.0F, rig.neck_rise, 0.0F}));
+  PoseVec3 const shoulder_center =
+      add(pelvis, transform(spine, {0.0F, rig.shoulder_rise, 0.0F}));
+  PoseVec3 const shoulder_l =
+      add(shoulder_center, transform(spine, {-rig.shoulder_half_width, 0.0F, 0.0F}));
+  PoseVec3 const shoulder_r =
+      add(shoulder_center, transform(spine, {rig.shoulder_half_width, 0.0F, 0.0F}));
+  Mat3 const skull = multiply(
+      spine, multiply(rot_x(radians(key.head_pitch)), rot_z(radians(key.head_roll))));
+  PoseVec3 const head = add(neck, transform(skull, {0.0F, rig.head_rise, 0.0F}));
+
+  auto const arm_l = PoseFk::limb_segments(key.arm_l, -1.0F, 1.0F, spine);
+  auto const arm_r = PoseFk::limb_segments(key.arm_r, 1.0F, 1.0F, spine);
+  PoseVec3 const elbow_l = add(shoulder_l, scaled(arm_l.upper, rig.upper_arm_len));
+  PoseVec3 const hand_l = add(elbow_l, scaled(arm_l.lower, rig.fore_arm_len));
+  PoseVec3 const elbow_r = add(shoulder_r, scaled(arm_r.upper, rig.upper_arm_len));
+  PoseVec3 const hand_r = add(elbow_r, scaled(arm_r.lower, rig.fore_arm_len));
+
+  Mat3 const upright = PoseFk::identity();
+  PoseVec3 const hip_l = add(pelvis, {-rig.hip_half_width, -rig.hip_drop, 0.0F});
+  PoseVec3 const hip_r = add(pelvis, {rig.hip_half_width, -rig.hip_drop, 0.0F});
+  auto const leg_l = PoseFk::limb_segments(key.leg_l, -1.0F, -1.0F, upright);
+  auto const leg_r = PoseFk::limb_segments(key.leg_r, 1.0F, -1.0F, upright);
+  PoseVec3 const knee_l = add(hip_l, scaled(leg_l.upper, rig.upper_leg_len));
+  PoseVec3 const foot_l = add(knee_l, scaled(leg_l.lower, rig.lower_leg_len));
+  PoseVec3 const knee_r = add(hip_r, scaled(leg_r.upper, rig.upper_leg_len));
+  PoseVec3 const foot_r = add(knee_r, scaled(leg_r.lower, rig.lower_leg_len));
+
+  Mat3 const body =
+      multiply(rot_x(radians(key.body_pitch)),
+               multiply(rot_z(radians(key.body_roll)), rot_y(radians(key.body_yaw))));
+  PoseVec3 const root{key.root_x, key.root_y, key.root_z};
+  float const height = std::max(0.1F, inputs.height_scale);
+
+  auto place = [&](PoseVec3 p) {
+    return scaled(add(transform(body, sub(p, pelvis)), root), height);
+  };
+
+  HumanoidDeathPoseSample sample{};
+  sample.active = true;
+  sample.pelvis = place(pelvis);
+  sample.neck_base = place(neck);
+  sample.head = place(head);
+  sample.shoulder_l = place(shoulder_l);
+  sample.shoulder_r = place(shoulder_r);
+  sample.elbow_l = place(elbow_l);
+  sample.elbow_r = place(elbow_r);
+  sample.hand_l = place(hand_l);
+  sample.hand_r = place(hand_r);
+  sample.knee_l = place(knee_l);
+  sample.knee_r = place(knee_r);
+  sample.foot_l = place(foot_l);
+  sample.foot_r = place(foot_r);
+  sample.foot_pitch_l = radians(key.foot_pitch_l);
+  sample.foot_pitch_r = radians(key.foot_pitch_r);
+  return sample;
+}
+
+} // namespace Animation

--- a/animation/death_pose_manifest.h
+++ b/animation/death_pose_manifest.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+#include "pose_manifest.h"
+#include "rig/pose_fk.h"
+
+namespace Animation {
+
+enum class HumanoidDeathCollapse : std::uint8_t {
+  None = 0,
+
+  BackSprawl,
+
+  FacePlant,
+
+  SideCrumple,
+
+  MountedUnseat,
+  Count
+};
+
+[[nodiscard]] constexpr auto humanoid_infantry_death_collapse(
+    std::uint8_t variant) noexcept -> HumanoidDeathCollapse {
+  switch (variant % k_humanoid_infantry_death_variant_count) {
+  case 1U:
+    return HumanoidDeathCollapse::FacePlant;
+  case 2U:
+    return HumanoidDeathCollapse::SideCrumple;
+  default:
+    return HumanoidDeathCollapse::BackSprawl;
+  }
+}
+
+struct HumanoidDeathPoseInputs {
+  HumanoidDeathCollapse collapse{HumanoidDeathCollapse::None};
+
+  float phase{0.0F};
+  float height_scale{1.0F};
+  PoseFk::HumanoidRigMetrics rig{};
+};
+
+struct HumanoidDeathPoseSample {
+  bool active{false};
+  PoseVec3 pelvis{};
+  PoseVec3 neck_base{};
+  PoseVec3 head{};
+  PoseVec3 shoulder_l{};
+  PoseVec3 shoulder_r{};
+  PoseVec3 elbow_l{};
+  PoseVec3 elbow_r{};
+  PoseVec3 hand_l{};
+  PoseVec3 hand_r{};
+  PoseVec3 knee_l{};
+  PoseVec3 knee_r{};
+  PoseVec3 foot_l{};
+  PoseVec3 foot_r{};
+  float foot_pitch_l{0.0F};
+  float foot_pitch_r{0.0F};
+};
+
+[[nodiscard]] auto humanoid_death_collapse_name(HumanoidDeathCollapse collapse) noexcept
+    -> std::string_view;
+
+[[nodiscard]] constexpr auto
+humanoid_death_collapse_duration(HumanoidDeathCollapse collapse) noexcept -> float {
+  switch (collapse) {
+  case HumanoidDeathCollapse::BackSprawl:
+    return 1.15F;
+  case HumanoidDeathCollapse::FacePlant:
+    return 1.00F;
+  case HumanoidDeathCollapse::SideCrumple:
+    return 1.10F;
+  case HumanoidDeathCollapse::MountedUnseat:
+    return 1.25F;
+  case HumanoidDeathCollapse::None:
+  case HumanoidDeathCollapse::Count:
+    break;
+  }
+  return 1.0F;
+}
+
+inline constexpr float k_humanoid_death_bake_fps = 30.0F;
+
+[[nodiscard]] constexpr auto humanoid_death_collapse_frames(
+    HumanoidDeathCollapse collapse) noexcept -> std::uint32_t {
+  return static_cast<std::uint32_t>(
+      (humanoid_death_collapse_duration(collapse) * k_humanoid_death_bake_fps) + 0.5F);
+}
+
+[[nodiscard]] auto resolve_humanoid_death_pose(
+    const HumanoidDeathPoseInputs& inputs) noexcept -> HumanoidDeathPoseSample;
+
+} // namespace Animation

--- a/animation/locomotion_manifest.cpp
+++ b/animation/locomotion_manifest.cpp
@@ -98,6 +98,8 @@ signed_travel_alignment(float entity_forward_x,
 constexpr float k_reverse_gait_enter_alignment = -0.30F;
 constexpr float k_reverse_gait_exit_alignment = -0.05F;
 
+constexpr float k_locomotion_residual_blend = 0.02F;
+
 struct LocomotionTargets {
   float normalized_speed{0.0F};
   float locomotion_blend{0.0F};
@@ -247,6 +249,16 @@ struct LocomotionPoseProfile {
   return t * t * (3.0F - 2.0F * t);
 }
 
+constexpr float k_swing_tangent_ratio = 0.75F;
+
+[[nodiscard]] auto swing_travel(float t, float planted_fraction) noexcept -> float {
+  float const stance_slope = -k_swing_tangent_ratio * (1.0F - planted_fraction) /
+                             std::max(0.05F, planted_fraction);
+  float const t2 = t * t;
+  float const t3 = t2 * t;
+  return (stance_slope * ((2.0F * t3) - (3.0F * t2) + t)) + ((3.0F * t2) - (2.0F * t3));
+}
+
 [[nodiscard]] auto
 smooth_pulse(float t, float start, float peak, float end) noexcept -> float {
   if (t <= start || t >= end) {
@@ -315,7 +327,7 @@ smooth_pulse(float t, float start, float peak, float end) noexcept -> float {
                                    std::max(1.0e-4F, 1.0F - planted_fraction),
                                0.0F,
                                1.0F);
-    float const travel = 0.68F * smoothstep(t) + 0.32F * std::sqrt(t);
+    float const travel = swing_travel(t, planted_fraction);
     float const lift_curve = std::sin(t * std::numbers::pi_v<float>);
     float const landing_soften = smooth_pulse(t, 0.72F, 0.90F, 1.0F);
     z_pos = -foot_stride_length * 0.50F + (foot_stride_length * 1.00F) * travel;
@@ -471,24 +483,45 @@ auto resolve_humanoid_locomotion_sample(const HumanoidLocomotionInputs& inputs) 
                                              inputs.tuning.turn_blend_tau);
   }
 
+  bool const has_locomotion = is_moving(inputs.movement_state);
+
+  sample.locomotion_presence = has_locomotion ? 1.0F : 0.0F;
+  sample.run_presence =
+      (has_locomotion && inputs.motion_state == HumanoidMotionState::Run) ? 1.0F : 0.0F;
+  if (previous.initialized) {
+    sample.locomotion_presence = smooth_towards(previous.locomotion_presence,
+                                                sample.locomotion_presence,
+                                                delta_time,
+                                                inputs.tuning.locomotion_blend_tau);
+    sample.run_presence = smooth_towards(previous.run_presence,
+                                         sample.run_presence,
+                                         delta_time,
+                                         inputs.tuning.run_blend_tau);
+  }
+
+  bool const residual_gait = !has_locomotion && previous.initialized &&
+                             sample.locomotion_presence > k_locomotion_residual_blend;
+  bool const gait_running = has_locomotion || residual_gait;
+
   sample.reverse_gait = previous.initialized ? previous.reverse_gait : false;
-  if (is_moving(inputs.movement_state)) {
+  if (has_locomotion) {
     if (sample.travel_alignment <= k_reverse_gait_enter_alignment) {
       sample.reverse_gait = true;
     } else if (sample.travel_alignment >= k_reverse_gait_exit_alignment) {
       sample.reverse_gait = false;
     }
-  } else {
+  } else if (!residual_gait) {
     sample.reverse_gait = false;
   }
 
-  if (previous.initialized && is_moving(inputs.movement_state)) {
+  if (previous.initialized && gait_running) {
     float const previous_cycle_time =
         (previous.cycle_time > 1.0e-4F) ? previous.cycle_time : targets.cycle_time;
-    sample.cycle_time = smooth_towards(previous_cycle_time,
-                                       targets.cycle_time,
-                                       delta_time,
-                                       inputs.tuning.cadence_blend_tau);
+    sample.cycle_time = has_locomotion ? smooth_towards(previous_cycle_time,
+                                                        targets.cycle_time,
+                                                        delta_time,
+                                                        inputs.tuning.cadence_blend_tau)
+                                       : previous_cycle_time;
     float const phase_direction = sample.reverse_gait ? -1.0F : 1.0F;
     sample.cycle_phase =
         wrap_locomotion_phase(previous.phase + phase_direction * delta_time /
@@ -523,10 +556,9 @@ auto resolve_humanoid_locomotion_sample(const HumanoidLocomotionInputs& inputs) 
                                          inputs.tuning.acceleration_blend_tau);
   }
 
-  sample.stride_distance =
-      is_moving(inputs.movement_state)
-          ? sample.speed * sample.cycle_time * std::max(0.0F, sample.locomotion_blend)
-          : 0.0F;
+  sample.stride_distance = gait_running ? sample.speed * sample.cycle_time *
+                                              std::max(0.0F, sample.locomotion_blend)
+                                        : 0.0F;
 
   sample.persistent = previous;
   if (inputs.has_persistent_state && inputs.allow_persistent_update) {
@@ -543,6 +575,8 @@ auto resolve_humanoid_locomotion_sample(const HumanoidLocomotionInputs& inputs) 
     sample.persistent.reverse_gait = sample.reverse_gait;
     sample.persistent.locomotion_blend = sample.locomotion_blend;
     sample.persistent.run_blend = sample.run_blend;
+    sample.persistent.locomotion_presence = sample.locomotion_presence;
+    sample.persistent.run_presence = sample.run_presence;
     sample.persistent.state = sample.state;
   }
 

--- a/animation/locomotion_manifest.h
+++ b/animation/locomotion_manifest.h
@@ -36,6 +36,9 @@ struct HumanoidLocomotionPersistentState {
   float filtered_travel_alignment{1.0F};
   float locomotion_blend{0.0F};
   float run_blend{0.0F};
+
+  float locomotion_presence{0.0F};
+  float run_presence{0.0F};
   bool reverse_gait{false};
   HumanoidMotionState state{HumanoidMotionState::Idle};
 };
@@ -65,6 +68,8 @@ struct HumanoidLocomotionSample {
   float stride_distance{0.0F};
   float locomotion_blend{0.0F};
   float run_blend{0.0F};
+  float locomotion_presence{0.0F};
+  float run_presence{0.0F};
   float turn_amount{0.0F};
 
   float travel_alignment{1.0F};

--- a/animation/rig/pose_fk.h
+++ b/animation/rig/pose_fk.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <numbers>
+
+#include "../pose_manifest.h"
+
+namespace Animation::PoseFk {
+
+struct Mat3 {
+  std::array<float, 9> m{1.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 1.0F};
+};
+
+[[nodiscard]] inline auto identity() noexcept -> Mat3 {
+  return Mat3{};
+}
+
+[[nodiscard]] inline auto rot_x(float radians) noexcept -> Mat3 {
+  float const c = std::cos(radians);
+  float const s = std::sin(radians);
+  return Mat3{{1.0F, 0.0F, 0.0F, 0.0F, c, -s, 0.0F, s, c}};
+}
+
+[[nodiscard]] inline auto rot_y(float radians) noexcept -> Mat3 {
+  float const c = std::cos(radians);
+  float const s = std::sin(radians);
+  return Mat3{{c, 0.0F, s, 0.0F, 1.0F, 0.0F, -s, 0.0F, c}};
+}
+
+[[nodiscard]] inline auto rot_z(float radians) noexcept -> Mat3 {
+  float const c = std::cos(radians);
+  float const s = std::sin(radians);
+  return Mat3{{c, -s, 0.0F, s, c, 0.0F, 0.0F, 0.0F, 1.0F}};
+}
+
+[[nodiscard]] inline auto multiply(const Mat3& a, const Mat3& b) noexcept -> Mat3 {
+  Mat3 out{};
+  for (int row = 0; row < 3; ++row) {
+    for (int col = 0; col < 3; ++col) {
+      float sum = 0.0F;
+      for (int k = 0; k < 3; ++k) {
+        sum += a.m[(row * 3) + k] * b.m[(k * 3) + col];
+      }
+      out.m[(row * 3) + col] = sum;
+    }
+  }
+  return out;
+}
+
+[[nodiscard]] inline auto transform(const Mat3& a, PoseVec3 v) noexcept -> PoseVec3 {
+  return {a.m[0] * v.x + a.m[1] * v.y + a.m[2] * v.z,
+          a.m[3] * v.x + a.m[4] * v.y + a.m[5] * v.z,
+          a.m[6] * v.x + a.m[7] * v.y + a.m[8] * v.z};
+}
+
+[[nodiscard]] inline auto add(PoseVec3 a, PoseVec3 b) noexcept -> PoseVec3 {
+  return {a.x + b.x, a.y + b.y, a.z + b.z};
+}
+
+[[nodiscard]] inline auto sub(PoseVec3 a, PoseVec3 b) noexcept -> PoseVec3 {
+  return {a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+[[nodiscard]] inline auto scaled(PoseVec3 a, float k) noexcept -> PoseVec3 {
+  return {a.x * k, a.y * k, a.z * k};
+}
+
+[[nodiscard]] inline auto radians(float degrees) noexcept -> float {
+  return degrees * (std::numbers::pi_v<float> / 180.0F);
+}
+
+[[nodiscard]] inline auto smoothstep(float t) noexcept -> float {
+  t = std::clamp(t, 0.0F, 1.0F);
+  return t * t * (3.0F - (2.0F * t));
+}
+
+[[nodiscard]] inline auto ramp(float phase, float start, float span) noexcept -> float {
+  return smoothstep((phase - start) / std::max(1.0e-4F, span));
+}
+
+struct LimbAim {
+  float pitch{0.0F};
+  float splay{0.0F};
+  float yaw{0.0F};
+  float bend{0.0F};
+};
+
+struct LimbSegments {
+  PoseVec3 upper{};
+  PoseVec3 lower{};
+};
+
+[[nodiscard]] inline auto limb_segments(const LimbAim& aim,
+                                        float side_sign,
+                                        float bend_sign,
+                                        const Mat3& pre) noexcept -> LimbSegments {
+  constexpr PoseVec3 k_down{0.0F, -1.0F, 0.0F};
+  Mat3 const base = multiply(
+      pre, multiply(rot_y(radians(aim.yaw)), rot_z(radians(aim.splay) * side_sign)));
+  LimbSegments out{};
+  out.upper = transform(multiply(base, rot_x(-radians(aim.pitch))), k_down);
+  out.lower = transform(
+      multiply(base, rot_x(-radians(aim.pitch + (bend_sign * aim.bend)))), k_down);
+  return out;
+}
+
+[[nodiscard]] inline auto
+blend_limb(const LimbAim& a, const LimbAim& b, float t) noexcept -> LimbAim {
+  return {a.pitch + ((b.pitch - a.pitch) * t),
+          a.splay + ((b.splay - a.splay) * t),
+          a.yaw + ((b.yaw - a.yaw) * t),
+          a.bend + ((b.bend - a.bend) * t)};
+}
+
+struct HumanoidRigMetrics {
+  float pelvis_y{0.975F};
+  float neck_rise{0.540F};
+  float head_rise{0.140F};
+  float shoulder_rise{0.450F};
+  float shoulder_half_width{0.252F};
+  float hip_half_width{0.100F};
+  float hip_drop{0.020F};
+  float upper_arm_len{0.320F};
+  float fore_arm_len{0.270F};
+  float upper_leg_len{0.500F};
+  float lower_leg_len{0.470F};
+};
+
+} // namespace Animation::PoseFk

--- a/animation/selection_manifest.cpp
+++ b/animation/selection_manifest.cpp
@@ -1,6 +1,7 @@
 #include "selection_manifest.h"
 
 #include <algorithm>
+#include <array>
 #include <utility>
 
 namespace Animation {
@@ -169,23 +170,58 @@ auto resolve_combat_playback_layer_policy(
     return policy;
   }
 
-  if (inputs.phase == CombatTransactionPhase::Enter ||
-      inputs.phase == CombatTransactionPhase::Anticipation) {
-    if (inputs.selection_state_differs_from_base) {
+  float const stance_weight = 1.0F - policy.combat_weight;
+  if (inputs.selection_state_differs_from_base) {
+    if (stance_weight > k_combat_stance_blend_epsilon) {
       policy.full_body_source = PlaybackLayerSource::Base;
-      policy.full_body_weight = 1.0F - policy.combat_weight;
+      policy.full_body_weight = stance_weight;
     }
-  } else if (inputs.phase == CombatTransactionPhase::ExitBlend) {
-    if (inputs.selection_state_differs_from_base) {
-      policy.full_body_source = PlaybackLayerSource::Base;
-      policy.full_body_weight = 1.0F - policy.combat_weight;
-    } else if (inputs.action_state_differs_from_selection) {
-      policy.full_body_source = PlaybackLayerSource::Action;
-      policy.full_body_weight = policy.combat_weight;
-    }
+  } else if (inputs.phase == CombatTransactionPhase::ExitBlend &&
+             inputs.action_state_differs_from_selection) {
+    policy.full_body_source = PlaybackLayerSource::Action;
+    policy.full_body_weight = policy.combat_weight;
   }
 
   return policy;
+}
+
+auto resolve_locomotion_crossfade(const LocomotionCrossfadeInputs& inputs) noexcept
+    -> LocomotionCrossfade {
+  float const locomotion = std::clamp(inputs.locomotion_presence, 0.0F, 1.0F);
+  float const run = std::clamp(inputs.run_presence, 0.0F, 1.0F);
+
+  struct Candidate {
+    StateId state;
+    float weight;
+  };
+  std::array<Candidate, 3> const candidates{{
+      {StateId::Idle, 1.0F - locomotion},
+      {StateId::Walk, locomotion * (1.0F - run)},
+      {StateId::Run, locomotion * run},
+  }};
+
+  LocomotionCrossfade crossfade{};
+  crossfade.primary = inputs.resolved;
+  crossfade.secondary = inputs.resolved;
+
+  float primary_weight = 0.0F;
+  float secondary_weight = -1.0F;
+  for (auto const& candidate : candidates) {
+    if (candidate.state == crossfade.primary) {
+      primary_weight = candidate.weight;
+    } else if (candidate.weight > secondary_weight) {
+      secondary_weight = candidate.weight;
+      crossfade.secondary = candidate.state;
+    }
+  }
+
+  float const pair_total = primary_weight + std::max(0.0F, secondary_weight);
+  if (pair_total <= 1.0e-4F || crossfade.secondary == crossfade.primary) {
+    return crossfade;
+  }
+  crossfade.secondary_weight = std::max(0.0F, secondary_weight) / pair_total;
+  crossfade.active = crossfade.secondary_weight > k_locomotion_crossfade_epsilon;
+  return crossfade;
 }
 
 } // namespace Animation

--- a/animation/selection_manifest.h
+++ b/animation/selection_manifest.h
@@ -82,6 +82,28 @@ struct CombatPlaybackLayerPolicy {
   float combat_weight{0.0F};
 };
 
+struct LocomotionCrossfadeInputs {
+
+  StateId resolved{StateId::Idle};
+
+  float locomotion_presence{0.0F};
+  float run_presence{0.0F};
+};
+
+struct LocomotionCrossfade {
+  bool active{false};
+  StateId primary{StateId::Idle};
+  StateId secondary{StateId::Idle};
+  float secondary_weight{0.0F};
+};
+
+inline constexpr float k_locomotion_crossfade_epsilon = 0.012F;
+
+inline constexpr float k_combat_stance_blend_epsilon = 0.06F;
+
+[[nodiscard]] auto resolve_locomotion_crossfade(
+    const LocomotionCrossfadeInputs& inputs) noexcept -> LocomotionCrossfade;
+
 [[nodiscard]] auto
 seeded_visual_variant_index(std::uint32_t seed,
                             std::uint8_t stride) noexcept -> std::uint8_t;

--- a/animation/showcase_pose_manifest.cpp
+++ b/animation/showcase_pose_manifest.cpp
@@ -6,87 +6,28 @@
 #include <numbers>
 #include <span>
 
+#include "rig/pose_fk.h"
+
 namespace Animation {
 
 namespace {
 
-struct Mat3 {
-  std::array<float, 9> m{1.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 1.0F};
-};
-
-[[nodiscard]] auto identity() noexcept -> Mat3 {
-  return Mat3{};
-}
-
-[[nodiscard]] auto rot_x(float radians) noexcept -> Mat3 {
-  float const c = std::cos(radians);
-  float const s = std::sin(radians);
-  return Mat3{{1.0F, 0.0F, 0.0F, 0.0F, c, -s, 0.0F, s, c}};
-}
-
-[[nodiscard]] auto rot_y(float radians) noexcept -> Mat3 {
-  float const c = std::cos(radians);
-  float const s = std::sin(radians);
-  return Mat3{{c, 0.0F, s, 0.0F, 1.0F, 0.0F, -s, 0.0F, c}};
-}
-
-[[nodiscard]] auto rot_z(float radians) noexcept -> Mat3 {
-  float const c = std::cos(radians);
-  float const s = std::sin(radians);
-  return Mat3{{c, -s, 0.0F, s, c, 0.0F, 0.0F, 0.0F, 1.0F}};
-}
-
-[[nodiscard]] auto multiply(const Mat3& a, const Mat3& b) noexcept -> Mat3 {
-  Mat3 out{};
-  for (int row = 0; row < 3; ++row) {
-    for (int col = 0; col < 3; ++col) {
-      float sum = 0.0F;
-      for (int k = 0; k < 3; ++k) {
-        sum += a.m[(row * 3) + k] * b.m[(k * 3) + col];
-      }
-      out.m[(row * 3) + col] = sum;
-    }
-  }
-  return out;
-}
-
-[[nodiscard]] auto transform(const Mat3& a, PoseVec3 v) noexcept -> PoseVec3 {
-  return {a.m[0] * v.x + a.m[1] * v.y + a.m[2] * v.z,
-          a.m[3] * v.x + a.m[4] * v.y + a.m[5] * v.z,
-          a.m[6] * v.x + a.m[7] * v.y + a.m[8] * v.z};
-}
-
-[[nodiscard]] auto add(PoseVec3 a, PoseVec3 b) noexcept -> PoseVec3 {
-  return {a.x + b.x, a.y + b.y, a.z + b.z};
-}
-
-[[nodiscard]] auto sub(PoseVec3 a, PoseVec3 b) noexcept -> PoseVec3 {
-  return {a.x - b.x, a.y - b.y, a.z - b.z};
-}
-
-[[nodiscard]] auto scaled(PoseVec3 a, float k) noexcept -> PoseVec3 {
-  return {a.x * k, a.y * k, a.z * k};
-}
-
-[[nodiscard]] auto radians(float degrees) noexcept -> float {
-  return degrees * (std::numbers::pi_v<float> / 180.0F);
-}
-
-[[nodiscard]] auto smoothstep(float t) noexcept -> float {
-  t = std::clamp(t, 0.0F, 1.0F);
-  return t * t * (3.0F - (2.0F * t));
-}
-
-[[nodiscard]] auto ramp(float phase, float start, float span) noexcept -> float {
-  return smoothstep((phase - start) / std::max(1.0e-4F, span));
-}
-
-struct ShowcaseLimbAim {
-  float pitch{0.0F};
-  float splay{0.0F};
-  float yaw{0.0F};
-  float bend{0.0F};
-};
+using PoseFk::add;
+using PoseFk::identity;
+using PoseFk::limb_segments;
+using PoseFk::LimbSegments;
+using PoseFk::Mat3;
+using PoseFk::multiply;
+using PoseFk::radians;
+using PoseFk::ramp;
+using PoseFk::rot_x;
+using PoseFk::rot_y;
+using PoseFk::rot_z;
+using PoseFk::scaled;
+using PoseFk::smoothstep;
+using PoseFk::sub;
+using PoseFk::transform;
+using ShowcaseLimbAim = PoseFk::LimbAim;
 
 struct ShowcaseKey {
   float t{0.0F};
@@ -1158,25 +1099,6 @@ blend_key(const ShowcaseKey& a, const ShowcaseKey& b, float u) noexcept -> Showc
     }
   }
   return keys.back();
-}
-
-struct LimbSegments {
-  PoseVec3 upper{};
-  PoseVec3 lower{};
-};
-
-[[nodiscard]] auto limb_segments(const ShowcaseLimbAim& aim,
-                                 float side_sign,
-                                 float bend_sign,
-                                 const Mat3& pre) noexcept -> LimbSegments {
-  constexpr PoseVec3 k_down{0.0F, -1.0F, 0.0F};
-  Mat3 const base = multiply(
-      pre, multiply(rot_y(radians(aim.yaw)), rot_z(radians(aim.splay) * side_sign)));
-  LimbSegments out{};
-  out.upper = transform(multiply(base, rot_x(-radians(aim.pitch))), k_down);
-  out.lower = transform(
-      multiply(base, rot_x(-radians(aim.pitch + (bend_sign * aim.bend)))), k_down);
-  return out;
 }
 
 } // namespace

--- a/docs/ANIMATION_ARCHITECTURE.md
+++ b/docs/ANIMATION_ARCHITECTURE.md
@@ -173,6 +173,42 @@ Key properties that keep it smooth (Phase 6):
 - **Turn (6.4):** a signed turn amount drives lean, torso twist, stride bias and
   inside/outside foot asymmetry.
 
+### The swing has to join the stance at the stance's own speed
+
+A planted foot slides backwards relative to the hips at `-stride / planted_fraction` per
+unit phase. `swing_travel()` is therefore a Hermite whose **end tangents carry that
+slope**, not an ease that starts and finishes at rest: the foot leaves the ground still
+travelling backwards, reaches its furthest forward point shortly before touchdown, and
+retracts into the plant. Take the tangents away and the foot path has a corner at toe-off
+and another at heel strike — one visible hitch per stride, which is what the old
+`0.68·smoothstep(t) + 0.32·√t` produced (√ has an _infinite_ slope at `t = 0`).
+
+The retraction near touchdown is also the cheapest foot-lock the stylised gait gets: the
+foot is moving with the ground at the moment it lands rather than against it.
+
+### Stand, walk and run are three clips, so the switch is a crossfade
+
+Selection resolves one baked clip, so a unit that starts or stops walking would cut
+between `idle` and `walk` on the frame the movement flag flips — mid-stride, both feet in
+the wrong place. `resolve_locomotion_crossfade()` (`animation/selection_manifest.cpp`)
+instead names a primary clip and a second one to blend against, and
+`humanoid_animation_selection.cpp` hangs the second on the request's `full_body_blend`
+layer. The played state stays whatever the movement says, so nothing downstream sees a
+walking unit reported as idle.
+
+The weight is **`locomotion_presence` / `run_presence`, not `locomotion_blend`**. The
+blends carry how fast the unit is going, so driving the clip mix from them would leave
+every unit slower than the reference walk permanently diluted with the stand — a builder
+at half reference speed would look like it never commits to a step. Presence only answers
+"is there a stride at all", eased over the same `tau`, so it settles at one for a crawl
+and a sprint alike.
+
+The stride also keeps _cycling_ while it fades: `resolve_humanoid_locomotion_sample()`
+integrates the phase at the last walking cadence for as long as presence is above
+`k_locomotion_residual_blend`, instead of handing it straight back to the idle free-run.
+A walk that froze mid-step and then vanished was the single most visible hitch in
+first-person play.
+
 ### Gait amplitude and the skate budget
 
 `walk_profile()` / `run_profile()` in `animation/locomotion_manifest.cpp` hold the gait
@@ -231,8 +267,9 @@ exist because an acrobatic move is not a small perturbation of a stance — a
 handstand inverts the whole body, so the additive delta vocabulary the ambient
 idles use (`ambient_pose_manifest.cpp`) cannot express it.
 
-`animation/showcase_pose_manifest.{h,cpp}` holds the keys and the forward
-kinematics that turn them into a complete `HumanoidPose`:
+`animation/showcase_pose_manifest.{h,cpp}` holds the keys; the forward kinematics
+that turn them into a complete `HumanoidPose` live in `animation/rig/pose_fk.h`,
+shared with the death collapses (§4c):
 
 ```
  ShowcaseKey  { root, body_pitch/roll/yaw, spine_*, head_pitch, blade_*, 4 limb aims }
@@ -297,6 +334,73 @@ and drawn from the cached preparation.
 
 ---
 
+## 4c. Dying (`animation/death_pose_manifest.{h,cpp}`)
+
+A death is authored the same way a showcase move is, and for the same reason. It
+used to be a list of per-joint offsets faded in with a smoothstep, and that has
+two failure modes that a fall exposes immediately:
+
+- **Segments came apart.** The offsets moved the shoulders and the hands but not
+  the elbows, and the head further than the neck. By the end of the clip the
+  forearms were **3.27× their bind length** (`humanoid_preview --report`) and the
+  head had visibly left the neck behind.
+- **Nobody reached the ground.** The pelvis only sank 0.42 m, so the body settled
+  into a floating half-crouch with its head hanging in the air — a shape the
+  corpse then held for as long as it was on the field.
+
+The falls are now `DeathKey` sequences resolved through the same forward
+kinematics as the showcase moves, shared in `animation/rig/pose_fk.h`: bone
+lengths are exact by construction, and the settled pose is authored where a body
+actually lies.
+
+```
+ DeathKey { root, body_pitch/roll/yaw, spine_*, head_*, foot_pitch, 4 limb aims }
+        │  keys eased per segment: falling segments ease *in* only (t²), so the
+        │  body accelerates into the ground instead of arriving softly
+        ▼
+ PoseFk  spine → neck/shoulders/head, limb aims → elbows/hands/knees/feet
+        ▼
+ whole-body rotation about the pelvis, then translation to the authored root
+```
+
+### Which way a man goes down
+
+Four collapses are authored. Three are reachable by an infantry casualty and are
+baked as **clip variants**, so `resolve_bpat_clip` picks one by adding the
+`death_variant` to the base clip index — hence `die_infantry`,
+`die_infantry_face`, `die_infantry_side` are contiguous in `clip_manifest.h`, and
+so are the three `dead_infantry*` clips that hold the corpses.
+
+| collapse        | what it is                                                | chosen when                  |
+| --------------- | --------------------------------------------------------- | ---------------------------- |
+| `BackSprawl`    | trunk arches, knees fold, hips land, shoulders whip down  | struck from the front        |
+| `FacePlant`     | folds over its own knees, lands face-down                 | cut down from behind         |
+| `SideCrumple`   | legs go out sideways, comes to rest twisted onto one side | taken on the flank           |
+| `MountedUnseat` | carried clear of the saddle before gravity gets him       | rider profile, not a variant |
+
+`infantry_death_variant()` (`damage_application.cpp`) takes the dot product of
+the blow direction against the casualty's facing. It is not a die roll: a man
+shot in the chest must not land on his face. Slot zero of a volley always takes
+the fall the blow argues for; the men behind him may be substituted onto the side
+crumple, which is where identical bodies would otherwise show.
+
+The trunk roll on the side falls deliberately stops short of 90°. The rig carries
+its shoulders as two points half a metre apart on a rigid spine, so a body laid
+exactly on its side puts the lower shoulder underground — and from the game
+camera a three-quarter roll reads as "dropped" anyway.
+
+Each collapse also owns its own length
+(`humanoid_death_collapse_duration`), and that one number drives both the baked
+frame count and the runtime `DeathAnimationComponent::state_duration`. They must
+agree or the body would still be moving when the clip runs out.
+
+`tests/render/creature/death_collapse_test.cpp` guards both original defects:
+every segment holds its bind length across every sampled phase of every fall, and
+no joint is driven through the ground. Review a change with
+`humanoid_preview --clip die_infantry --view iso --report`.
+
+---
+
 ## 5. Combat: visual state machine + marker-driven damage
 
 Melee combat is animated by a small per-swing state machine and, crucially, the **HP hit
@@ -332,6 +436,43 @@ lands when the blade visually connects** — not on the trigger frame.
 
 The visual side (`combat_visual_state.cpp`) eases each phase (`eased_combat_phase_progress`)
 and applies a lane-driven weight curve (`emphasis_scale` × finisher/amplified multipliers).
+
+### The stance bleeds through the whole swing
+
+`combat_attack_visual_weight()` never reaches 1: a swing peaks at 0.95 of the attack clip
+with the stance showing through the rest. That weight has to be _applied_ everywhere it is
+below one, not only during the wind-up and the exit. Blending the stance during
+Enter/Anticipation and nowhere else put a step in the mix exactly where anticipation hands
+over to the strike — the stance went from three tenths of the pose to none of it on one
+frame, right as the blade started to move.
+
+The authored RPG timeline had a second hole in the same curve: `exit_blend_progress` was
+pinned at zero, so `ExitBlend` evaluated to a _constant_ 0.80 for the whole recovery and
+then cut to the stance when the action ended. It is now read off the authored phase, so
+the weight actually walks down to zero and `use_base_selection` takes over cleanly before
+the move finishes.
+
+### A swing is one arc, not five lunges
+
+`sample_authored_sword_pose_key()` interpolates the authored keys with Hermite/Catmull-Rom
+tangents (central differences, zero at the first and last key). Easing each _segment_
+separately with its own smoothstep — the old behaviour — drove the blade's velocity to
+zero at every key, so a cut read as a series of short lunges with a stop between each.
+
+Blade direction is **slerped**, not lerp-and-normalise. The keys either side of a cut are
+up to 135° apart, and the chord path crawls near both ends and whips through the middle;
+slerp gives the cut a constant angular rate, which is what makes the arc readable.
+
+Every RPG sword move also starts and finishes on one shared `rpg_sword_guard_key()`. It
+has to be literally the same key, not five near-copies: the moves chain into one another
+and fall back to the stance when they end, and an 8 cm hand offset between the last frame
+of one and the first frame of the next is a snap at exactly the moment the player is
+watching the blade.
+
+Finally, the swing trail in `sword_renderer.cpp` is no longer gated off for the authored
+blade. Without it an RPG cut is a thin prism crossing the screen in five frames;
+`sword_trail_window()` takes the window from the move, because each RPG attack puts its
+cut in a different slice of its own timeline.
 
 ### Arms are solved, not stretched
 

--- a/game/systems/combat_system/combat_action_processor.cpp
+++ b/game/systems/combat_system/combat_action_processor.cpp
@@ -559,7 +559,14 @@ void process_authored_combat_action(
   if (is_rts_attack_action(action_id)) {
     auto const* unit = entity.get_component<Engine::Core::UnitComponent>();
     auto const* target = entity.get_component<Engine::Core::AttackTargetComponent>();
+
+    auto const* attack = entity.get_component<Engine::Core::AttackComponent>();
+    bool const shooting_from_a_melee =
+        !is_rts_melee_action(action_id) && attack != nullptr && attack->in_melee_lock &&
+        Game::Systems::CombatRules::participates_in_rts_melee_lock(&entity);
+
     bool const interrupted = unit == nullptr || unit->health <= 0 ||
+                             shooting_from_a_melee ||
                              entity.has_component<Engine::Core::StaggerComponent>() ||
                              (target != nullptr && target->target_id != 0 &&
                               target->target_id != action->active_target_id);

--- a/game/systems/combat_system/combat_mode_processor.cpp
+++ b/game/systems/combat_system/combat_mode_processor.cpp
@@ -23,7 +23,7 @@ void update_combat_mode(Engine::Core::Entity* attacker,
   bool const in_melee_combat =
       attack_comp->in_melee_lock &&
       Game::Systems::CombatRules::participates_in_rts_melee_lock(attacker);
-  if (in_melee_combat && attack_comp->can_melee) {
+  if (in_melee_combat) {
 
     attack_comp->current_mode = Engine::Core::AttackComponent::CombatMode::Melee;
     return;

--- a/game/systems/combat_system/damage_application.cpp
+++ b/game/systems/combat_system/damage_application.cpp
@@ -22,6 +22,7 @@
 #include "../marketplace_system.h"
 #include "../order_service.h"
 #include "../wall_network_service.h"
+#include "animation/death_pose_manifest.h"
 #include "combat_types.h"
 #include "combat_utils.h"
 #include "structure_combat.h"
@@ -62,16 +63,72 @@ struct DeathSequenceTiming {
   std::uint8_t sequence_variant{0U};
 };
 
+auto infantry_death_variant(Engine::Core::Entity* target,
+                            Engine::Core::Entity* attacker,
+                            std::uint16_t slot) -> std::uint8_t {
+  using Animation::HumanoidDeathCollapse;
+
+  auto const variant_for = [](HumanoidDeathCollapse collapse) -> std::uint8_t {
+    for (std::uint8_t v = 0U; v < Animation::k_humanoid_infantry_death_variant_count;
+         ++v) {
+      if (Animation::humanoid_infantry_death_collapse(v) == collapse) {
+        return v;
+      }
+    }
+    return 0U;
+  };
+
+  auto const jitter = static_cast<std::uint32_t>(
+      (target != nullptr ? target->get_id() * 2654435761U : 0U) + (slot * 40503U));
+  bool const flanked_by_jitter = slot != 0U && (jitter >> 13U) % 3U == 0U;
+
+  auto const* target_transform =
+      target != nullptr ? target->get_component<Engine::Core::TransformComponent>()
+                        : nullptr;
+  auto const* attacker_transform =
+      attacker != nullptr ? attacker->get_component<Engine::Core::TransformComponent>()
+                          : nullptr;
+  if (target_transform == nullptr || attacker_transform == nullptr) {
+    return variant_for(flanked_by_jitter ? HumanoidDeathCollapse::SideCrumple
+                                         : HumanoidDeathCollapse::BackSprawl);
+  }
+
+  float const to_attacker_x =
+      attacker_transform->position.x - target_transform->position.x;
+  float const to_attacker_z =
+      attacker_transform->position.z - target_transform->position.z;
+  float const length_sq =
+      (to_attacker_x * to_attacker_x) + (to_attacker_z * to_attacker_z);
+  if (length_sq < 1.0e-4F) {
+    return variant_for(HumanoidDeathCollapse::BackSprawl);
+  }
+
+  float const yaw = target_transform->rotation.y * std::numbers::pi_v<float> / 180.0F;
+  float const facing_dot =
+      ((std::sin(yaw) * to_attacker_x) + (std::cos(yaw) * to_attacker_z)) /
+      std::sqrt(length_sq);
+
+  if (facing_dot > 0.42F) {
+    return variant_for(flanked_by_jitter ? HumanoidDeathCollapse::SideCrumple
+                                         : HumanoidDeathCollapse::BackSprawl);
+  }
+  if (facing_dot < -0.42F) {
+    return variant_for(flanked_by_jitter ? HumanoidDeathCollapse::SideCrumple
+                                         : HumanoidDeathCollapse::FacePlant);
+  }
+  return variant_for(HumanoidDeathCollapse::SideCrumple);
+}
+
 auto resolve_death_variant(Engine::Core::Entity* target,
                            Engine::Core::Entity* attacker,
-                           Engine::Core::DeathSequenceProfile profile) -> std::uint8_t {
-  (void)target;
-  (void)attacker;
+                           Engine::Core::DeathSequenceProfile profile,
+                           std::uint16_t slot = 0U) -> std::uint8_t {
   switch (profile) {
+  case Engine::Core::DeathSequenceProfile::Infantry:
+    return infantry_death_variant(target, attacker, slot);
   case Engine::Core::DeathSequenceProfile::MountedRider:
   case Engine::Core::DeathSequenceProfile::Elephant:
   case Engine::Core::DeathSequenceProfile::Horse:
-  case Engine::Core::DeathSequenceProfile::Infantry:
   default:
     return 0U;
   }
@@ -83,7 +140,8 @@ auto resolve_death_timing(Engine::Core::DeathSequenceProfile profile,
   timing.sequence_variant = variant;
   switch (profile) {
   case Engine::Core::DeathSequenceProfile::MountedRider:
-    timing.state_duration = 1.15F;
+    timing.state_duration = Animation::humanoid_death_collapse_duration(
+        Animation::HumanoidDeathCollapse::MountedUnseat);
     timing.dead_hold_duration = 0.95F;
     break;
   case Engine::Core::DeathSequenceProfile::Horse:
@@ -97,6 +155,9 @@ auto resolve_death_timing(Engine::Core::DeathSequenceProfile profile,
     break;
   case Engine::Core::DeathSequenceProfile::Infantry:
   default:
+
+    timing.state_duration = Animation::humanoid_death_collapse_duration(
+        Animation::humanoid_infantry_death_collapse(variant));
     break;
   }
   return timing;
@@ -257,8 +318,6 @@ auto begin_soldier_casualties(Engine::Core::Entity* target,
     return 0;
   }
 
-  auto const variant = resolve_death_variant(target, attacker, profile);
-  auto const timing = resolve_death_timing(profile, variant);
   auto const* presentation =
       target->get_component<Engine::Core::FormationPresentationComponent>();
   auto presentation_for_slot =
@@ -320,6 +379,9 @@ auto begin_soldier_casualties(Engine::Core::Entity* target,
       entry.local_z = soldier->local_z;
       entry.local_yaw = soldier->local_yaw;
     }
+    auto const variant = resolve_death_variant(
+        target, attacker, profile, static_cast<std::uint16_t>(slot));
+    auto const timing = resolve_death_timing(profile, variant);
     entry.profile = profile;
     entry.state = Engine::Core::DeathSequenceState::Dying;
     entry.state_time = 0.0F;

--- a/game/systems/combat_system/siege_special_processor.cpp
+++ b/game/systems/combat_system/siege_special_processor.cpp
@@ -12,6 +12,7 @@
 #include "../../core/world.h"
 #include "../../units/spawn_type.h"
 #include "../../visuals/team_colors.h"
+#include "../combat_rules.h"
 #include "../projectile_kind.h"
 #include "../projectile_system.h"
 #include "combat_random.h"
@@ -288,9 +289,17 @@ void process_loading_siege_unit(Engine::Core::World* world,
     loading = siege->add_component<Engine::Core::CatapultLoadingComponent>();
   }
 
-  if (is_motion_active(*siege) &&
+  auto const* attack = siege->get_component<Engine::Core::AttackComponent>();
+  bool const in_melee_lock =
+      attack != nullptr && attack->in_melee_lock &&
+      Game::Systems::CombatRules::participates_in_rts_melee_lock(siege);
+
+  if ((is_motion_active(*siege) || in_melee_lock) &&
       loading->state != Engine::Core::CatapultLoadingComponent::LoadingState::Idle) {
     reset_loading(*loading);
+  }
+  if (in_melee_lock) {
+    return;
   }
 
   if (loading->state == Engine::Core::CatapultLoadingComponent::LoadingState::Loading ||

--- a/game/systems/formation_combat_geometry.cpp
+++ b/game/systems/formation_combat_geometry.cpp
@@ -67,12 +67,6 @@ auto single_body_radius(const Engine::Core::Entity& entity,
                         const Engine::Core::TransformComponent::Vec3& scale) noexcept
     -> float {
   float radius = std::max(0.05F, std::max(scale.x, scale.z) * 0.5F);
-  if (auto const* unit = entity.get_component<Engine::Core::UnitComponent>()) {
-    radius = std::max(
-        radius,
-        Game::Units::TroopConfig::instance().get_selection_ring_size(unit->spawn_type) *
-            0.5F);
-  }
   if (entity.has_component<Engine::Core::ElephantComponent>()) {
     float const visual_scale =
         std::max(0.05F, std::max(std::abs(scale.x), std::abs(scale.z)));

--- a/render/creature/animation_state_components.h
+++ b/render/creature/animation_state_components.h
@@ -31,6 +31,8 @@ struct HumanoidAnimationStateComponent : public Engine::Core::Component {
   float filtered_travel_alignment{1.0F};
   float locomotion_blend{0.0F};
   float run_blend{0.0F};
+  float locomotion_presence{0.0F};
+  float run_presence{0.0F};
   bool reverse_gait{false};
   Render::GL::HumanoidMotionState locomotion_state{
       Render::GL::HumanoidMotionState::Idle};

--- a/render/creature/humanoid_clip_ids.h
+++ b/render/creature/humanoid_clip_ids.h
@@ -51,8 +51,18 @@ inline constexpr std::uint16_t k_humanoid_riding_spear_thrust_clip =
     Animation::k_humanoid_riding_spear_thrust_clip;
 inline constexpr std::uint16_t k_humanoid_die_infantry_clip =
     Animation::k_humanoid_die_infantry_clip;
+inline constexpr std::uint16_t k_humanoid_die_infantry_face_clip =
+    Animation::k_humanoid_die_infantry_face_clip;
+inline constexpr std::uint16_t k_humanoid_die_infantry_side_clip =
+    Animation::k_humanoid_die_infantry_side_clip;
 inline constexpr std::uint16_t k_humanoid_dead_infantry_clip =
     Animation::k_humanoid_dead_infantry_clip;
+inline constexpr std::uint16_t k_humanoid_dead_infantry_face_clip =
+    Animation::k_humanoid_dead_infantry_face_clip;
+inline constexpr std::uint16_t k_humanoid_dead_infantry_side_clip =
+    Animation::k_humanoid_dead_infantry_side_clip;
+inline constexpr std::uint8_t k_humanoid_infantry_death_variant_count =
+    Animation::k_humanoid_infantry_death_variant_count;
 inline constexpr std::uint16_t k_humanoid_die_mounted_clip =
     Animation::k_humanoid_die_mounted_clip;
 inline constexpr std::uint16_t k_humanoid_dead_mounted_clip =

--- a/render/creature/pipeline/humanoid_animation_selection.cpp
+++ b/render/creature/pipeline/humanoid_animation_selection.cpp
@@ -365,6 +365,73 @@ auto apply_ambient_idle_crossfade(HumanoidAnimationSelection& selection,
   return true;
 }
 
+auto locomotion_pose_intent(Render::Creature::AnimationStateId state) noexcept
+    -> Animation::PoseIntent {
+  switch (state) {
+  case Render::Creature::AnimationStateId::Walk:
+    return Animation::PoseIntent::Walk;
+  case Render::Creature::AnimationStateId::Run:
+    return Animation::PoseIntent::Run;
+  default:
+    return Animation::PoseIntent::Idle;
+  }
+}
+
+auto is_locomotion_state(Render::Creature::AnimationStateId state) noexcept -> bool {
+  return state == Render::Creature::AnimationStateId::Idle ||
+         state == Render::Creature::AnimationStateId::Walk ||
+         state == Render::Creature::AnimationStateId::Run;
+}
+
+auto apply_locomotion_crossfade(HumanoidAnimationSelection& selection,
+                                const Render::GL::HumanoidAnimationContext& anim,
+                                const UnitVisualSpec& spec,
+                                std::uint32_t seed,
+                                const Render::GL::HumanoidVariant* variant) noexcept
+    -> bool {
+
+  if (!is_locomotion_state(selection.state) || anim.inputs.is_attacking ||
+      anim.inputs.is_casting || anim.inputs.is_mounted ||
+      anim.inputs.has_showcase_clip || anim.inputs.is_in_hold_mode ||
+      anim.inputs.is_exiting_hold || anim.inputs.is_guarding ||
+      anim.inputs.is_exiting_guard || anim.inputs.is_hit_reacting ||
+      anim.inputs.is_healing || anim.inputs.is_constructing || anim.inputs.is_dying ||
+      anim.inputs.is_dead) {
+    return false;
+  }
+
+  auto const crossfade = Animation::resolve_locomotion_crossfade({
+      .resolved = selection.state,
+      .locomotion_presence = anim.gait.locomotion_presence,
+      .run_presence = anim.gait.run_presence,
+  });
+  if (!crossfade.active) {
+    return false;
+  }
+
+  auto const build = [&](Render::Creature::AnimationStateId state) {
+    return build_selection_for_pose(
+        spec,
+        anim,
+        Render::Creature::resolve_pose_for_intent(locomotion_pose_intent(state)),
+        seed,
+        variant);
+  };
+  auto const primary = build(crossfade.primary);
+  auto const secondary = build(crossfade.secondary);
+  if (!primary.clip_id.has_value() || !secondary.clip_id.has_value() ||
+      primary.clip_id == secondary.clip_id) {
+    return false;
+  }
+
+  selection = primary;
+  selection.full_body_blend =
+      playback_layer_from_selection(secondary,
+                                    crossfade.secondary_weight,
+                                    Render::Creature::PlaybackLayerMode::FullBodyBlend);
+  return true;
+}
+
 auto apply_hold_stance_crossfade(HumanoidAnimationSelection& selection,
                                  const Render::GL::HumanoidAnimationContext& anim,
                                  const UnitVisualSpec& spec,
@@ -410,6 +477,10 @@ auto resolve_humanoid_animation_selection(
     const Render::GL::HumanoidVariant* variant) noexcept -> HumanoidAnimationSelection {
   HumanoidAnimationSelection selection = build_selection_for_pose(
       spec, anim, Render::Creature::resolve_pose(anim.inputs), seed, variant);
+
+  if (apply_locomotion_crossfade(selection, anim, spec, seed, variant)) {
+    return selection;
+  }
 
   if (apply_ambient_idle_crossfade(selection, anim, spec, seed, variant)) {
     return selection;

--- a/render/equipment/weapons/sword_renderer.cpp
+++ b/render/equipment/weapons/sword_renderer.cpp
@@ -216,6 +216,28 @@ uses_authored_rpg_sword_blade(const HumanoidAnimationContext& anim) noexcept -> 
   return k_sword_blade_axis_in_grip;
 }
 
+struct SwordTrailWindow {
+  float start{0.28F};
+  float end{0.68F};
+};
+
+[[nodiscard]] auto sword_trail_window(const HumanoidAnimationContext& anim,
+                                      bool authored) noexcept -> SwordTrailWindow {
+  if (!authored) {
+    return {};
+  }
+  switch (anim.inputs.sword_attack_animation) {
+  case Animation::SwordAttackAnimation::RpgOverhead:
+    return {0.36F, 0.74F};
+  case Animation::SwordAttackAnimation::RpgThrust:
+    return {0.28F, 0.64F};
+  case Animation::SwordAttackAnimation::RpgFinisher:
+    return {0.42F, 0.82F};
+  default:
+    return {0.32F, 0.72F};
+  }
+}
+
 auto sword_archetype(const SwordRenderConfig& config) -> const RenderArchetype& {
   struct CachedArchetype {
     SwordArchetypeKey key;
@@ -645,10 +667,11 @@ void SwordRenderer::submit(const SwordRenderConfig& m_config,
                                  sword_local_pose(sword_dir),
                              palette_slots);
 
-  if (is_attacking && !use_authored_blade && attack_phase >= 0.28F &&
-      attack_phase < 0.68F) {
+  auto const trail = sword_trail_window(anim, use_authored_blade);
+  if (is_attacking && attack_phase >= trail.start && attack_phase < trail.end) {
     float const base_w = m_config.sword_width;
-    float const t = (attack_phase - 0.28F) / 0.40F;
+    float const t = clamp01((attack_phase - trail.start) /
+                            std::max(1.0e-3F, trail.end - trail.start));
 
     float const alpha = clamp01(0.60F * std::sin(t * std::numbers::pi_v<float>));
     QMatrix4x4 const sword_world =
@@ -691,8 +714,8 @@ void SwordRenderer::submit(const SwordRenderConfig& m_config,
         nullptr,
         alpha * 0.45F);
 
-    if (attack_phase >= 0.32F && attack_phase < 0.60F) {
-      float const ghost_t = (attack_phase - 0.32F) / 0.28F;
+    if (t >= 0.10F && t < 0.80F) {
+      float const ghost_t = (t - 0.10F) / 0.70F;
       float const ghost_alpha = clamp01(0.28F * (1.0F - ghost_t * ghost_t));
       QVector3D const ghost_end = blade_base + swing_dir * (0.42F + 0.22F * ghost_t);
       QVector3D const ghost_color =

--- a/render/gl/humanoid/humanoid_types.h
+++ b/render/gl/humanoid/humanoid_types.h
@@ -293,6 +293,8 @@ struct HumanoidGaitDescriptor {
   bool is_airborne{false};
   float locomotion_blend{0.0F};
   float run_blend{0.0F};
+  float locomotion_presence{0.0F};
+  float run_presence{0.0F};
   float turn_amount{0.0F};
 
   float travel_alignment{1.0F};

--- a/render/humanoid/humanoid_manifest.cpp
+++ b/render/humanoid/humanoid_manifest.cpp
@@ -23,6 +23,7 @@
 #include "../horse/horse_motion.h"
 #include "animation/bpat/bpat_format.h"
 #include "animation/clip_manifest.h"
+#include "animation/death_pose_manifest.h"
 #include "animation/showcase_pose_manifest.h"
 #include "grip_axis.h"
 #include "humanoid_full_builder.h"
@@ -50,11 +51,6 @@ enum class BakerHoldType : std::uint8_t {
   None,
   Spear,
   Bow
-};
-enum class BakerDeathType : std::uint8_t {
-  None,
-  Infantry,
-  Mounted
 };
 enum class BakerRidingType : std::uint8_t {
   None,
@@ -126,7 +122,8 @@ struct HumanoidClipSpec {
   Render::GL::HumanoidMotionState state;
   BakerAttackType attack_type{BakerAttackType::None};
   std::uint8_t attack_variant{0};
-  BakerDeathType death_type{BakerDeathType::None};
+  Animation::HumanoidDeathCollapse death_collapse{
+      Animation::HumanoidDeathCollapse::None};
   BakerRidingType riding_type{BakerRidingType::None};
   BakerHoldType hold_type{BakerHoldType::None};
   BakerAmbientIdleType ambient_idle_type{BakerAmbientIdleType::None};
@@ -151,7 +148,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -164,7 +161,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::SitDown,
@@ -177,7 +174,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::Jump,
@@ -190,7 +187,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::RaiseWeapon,
@@ -203,7 +200,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::ShiftWeight,
@@ -216,7 +213,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::PlantFlag,
@@ -229,7 +226,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Walk,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -242,7 +239,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Run,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -255,7 +252,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Hold,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::Spear,
      BakerAmbientIdleType::None,
@@ -268,7 +265,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Hold,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::Bow,
      BakerAmbientIdleType::None,
@@ -281,7 +278,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Sword,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -294,7 +291,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Sword,
      1,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -307,7 +304,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Sword,
      2,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -320,7 +317,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Spear,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -333,7 +330,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Spear,
      1,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -346,7 +343,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Spear,
      2,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -359,7 +356,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Bow,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -372,7 +369,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::Idle,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -385,7 +382,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::Charge,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -398,7 +395,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Hold,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::Reining,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -411,7 +408,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::BowShot,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -424,7 +421,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::SwordStrike,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -437,7 +434,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::SpearThrust,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -450,20 +447,75 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::Infantry,
+     Animation::HumanoidDeathCollapse::BackSprawl,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
      BakerShowcaseType::None,
-     20U,
-     24.0F,
+     Animation::humanoid_death_collapse_frames(
+         Animation::HumanoidDeathCollapse::BackSprawl),
+     Animation::k_humanoid_death_bake_fps,
+     1.0F,
+     false},
+    {"die_infantry_face",
+     Render::GL::HumanoidMotionState::Idle,
+     BakerAttackType::None,
+     0,
+     Animation::HumanoidDeathCollapse::FacePlant,
+     BakerRidingType::None,
+     BakerHoldType::None,
+     BakerAmbientIdleType::None,
+     BakerShowcaseType::None,
+     Animation::humanoid_death_collapse_frames(
+         Animation::HumanoidDeathCollapse::FacePlant),
+     Animation::k_humanoid_death_bake_fps,
+     1.0F,
+     false},
+    {"die_infantry_side",
+     Render::GL::HumanoidMotionState::Idle,
+     BakerAttackType::None,
+     0,
+     Animation::HumanoidDeathCollapse::SideCrumple,
+     BakerRidingType::None,
+     BakerHoldType::None,
+     BakerAmbientIdleType::None,
+     BakerShowcaseType::None,
+     Animation::humanoid_death_collapse_frames(
+         Animation::HumanoidDeathCollapse::SideCrumple),
+     Animation::k_humanoid_death_bake_fps,
      1.0F,
      false},
     {"dead_infantry",
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::Infantry,
+     Animation::HumanoidDeathCollapse::BackSprawl,
+     BakerRidingType::None,
+     BakerHoldType::None,
+     BakerAmbientIdleType::None,
+     BakerShowcaseType::None,
+     1U,
+     1.0F,
+     1.0F,
+     true},
+    {"dead_infantry_face",
+     Render::GL::HumanoidMotionState::Idle,
+     BakerAttackType::None,
+     0,
+     Animation::HumanoidDeathCollapse::FacePlant,
+     BakerRidingType::None,
+     BakerHoldType::None,
+     BakerAmbientIdleType::None,
+     BakerShowcaseType::None,
+     1U,
+     1.0F,
+     1.0F,
+     true},
+    {"dead_infantry_side",
+     Render::GL::HumanoidMotionState::Idle,
+     BakerAttackType::None,
+     0,
+     Animation::HumanoidDeathCollapse::SideCrumple,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -476,20 +528,21 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::Mounted,
+     Animation::HumanoidDeathCollapse::MountedUnseat,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
      BakerShowcaseType::None,
-     20U,
-     24.0F,
+     Animation::humanoid_death_collapse_frames(
+         Animation::HumanoidDeathCollapse::MountedUnseat),
+     Animation::k_humanoid_death_bake_fps,
      1.0F,
      false},
     {"dead_mounted",
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::Mounted,
+     Animation::HumanoidDeathCollapse::MountedUnseat,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -502,7 +555,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Sword,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -515,7 +568,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Sword,
      1,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -528,7 +581,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Sword,
      3,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -541,7 +594,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Sword,
      4,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -554,7 +607,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::Sword,
      5,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -567,7 +620,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::BowMelee,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -580,7 +633,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::SpearFromHold,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -593,7 +646,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Attacking,
      BakerAttackType::BowFromHold,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -607,7 +660,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -620,7 +673,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -633,7 +686,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -646,7 +699,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -659,7 +712,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -672,7 +725,7 @@ constexpr std::array<HumanoidClipSpec, k_humanoid_baker_clip_count> k_humanoid_c
      Render::GL::HumanoidMotionState::Idle,
      BakerAttackType::None,
      0,
-     BakerDeathType::None,
+     Animation::HumanoidDeathCollapse::None,
      BakerRidingType::None,
      BakerHoldType::None,
      BakerAmbientIdleType::None,
@@ -906,12 +959,20 @@ struct AuthoredSwordPoseKey {
 
 using AuthoredSwordPoseKeys = std::array<AuthoredSwordPoseKey, 6>;
 
+constexpr QVector3D k_rpg_sword_guard_right_hand{0.22F, 1.18F, 0.20F};
+constexpr QVector3D k_rpg_sword_guard_left_hand{-0.22F, 1.13F, 0.18F};
+constexpr QVector3D k_rpg_sword_guard_blade_dir{0.12F, 0.86F, 0.50F};
+
+auto rpg_sword_guard_key(float phase) -> AuthoredSwordPoseKey {
+  return {.phase = phase,
+          .right_hand = k_rpg_sword_guard_right_hand,
+          .left_hand = k_rpg_sword_guard_left_hand,
+          .blade_dir = k_rpg_sword_guard_blade_dir};
+}
+
 auto rpg_sword_pose_keys(std::uint8_t variant) -> const AuthoredSwordPoseKeys& {
   static const AuthoredSwordPoseKeys slash_left{{
-      {.phase = 0.00F,
-       .right_hand = {0.24F, 1.22F, 0.18F},
-       .left_hand = {-0.22F, 1.16F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(0.00F),
       {.phase = 0.16F,
        .right_hand = {0.46F, 1.44F, -0.26F},
        .left_hand = {-0.26F, 1.10F, 0.20F},
@@ -940,16 +1001,10 @@ auto rpg_sword_pose_keys(std::uint8_t variant) -> const AuthoredSwordPoseKeys& {
        .blade_dir = {-0.84F, -0.44F, 0.32F},
        .pelvis_delta = {0.00F, -0.04F, 0.10F},
        .shoulder_r_delta = {-0.08F, -0.08F, 0.14F}},
-      {.phase = 1.00F,
-       .right_hand = {0.22F, 1.16F, 0.24F},
-       .left_hand = {-0.22F, 1.12F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(1.00F),
   }};
   static const AuthoredSwordPoseKeys slash_right{{
-      {.phase = 0.00F,
-       .right_hand = {0.22F, 1.18F, 0.20F},
-       .left_hand = {-0.22F, 1.14F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(0.00F),
       {.phase = 0.16F,
        .right_hand = {-0.28F, 1.42F, -0.22F},
        .left_hand = {-0.26F, 1.10F, 0.20F},
@@ -980,16 +1035,10 @@ auto rpg_sword_pose_keys(std::uint8_t variant) -> const AuthoredSwordPoseKeys& {
        .blade_dir = {0.84F, -0.44F, 0.32F},
        .pelvis_delta = {0.00F, -0.04F, 0.08F},
        .shoulder_r_delta = {0.12F, -0.06F, 0.12F}},
-      {.phase = 1.00F,
-       .right_hand = {0.22F, 1.16F, 0.24F},
-       .left_hand = {-0.22F, 1.12F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(1.00F),
   }};
   static const AuthoredSwordPoseKeys overhead{{
-      {.phase = 0.00F,
-       .right_hand = {0.22F, 1.18F, 0.20F},
-       .left_hand = {-0.22F, 1.12F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(0.00F),
       {.phase = 0.18F,
        .right_hand = {0.18F, 1.58F, -0.32F},
        .left_hand = {-0.18F, 1.18F, 0.20F},
@@ -1016,16 +1065,10 @@ auto rpg_sword_pose_keys(std::uint8_t variant) -> const AuthoredSwordPoseKeys& {
        .right_hand = {-0.02F, 0.64F, 0.70F},
        .left_hand = {-0.06F, 0.90F, 0.54F},
        .blade_dir = {-0.10F, -0.78F, 0.62F}},
-      {.phase = 1.00F,
-       .right_hand = {0.22F, 1.14F, 0.24F},
-       .left_hand = {-0.22F, 1.10F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(1.00F),
   }};
   static const AuthoredSwordPoseKeys thrust{{
-      {.phase = 0.00F,
-       .right_hand = {0.20F, 1.16F, 0.18F},
-       .left_hand = {-0.22F, 1.12F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(0.00F),
       {.phase = 0.14F,
        .right_hand = {0.28F, 1.18F, -0.30F},
        .left_hand = {-0.18F, 1.08F, 0.18F},
@@ -1050,16 +1093,10 @@ auto rpg_sword_pose_keys(std::uint8_t variant) -> const AuthoredSwordPoseKeys& {
        .right_hand = {0.08F, 1.02F, 1.02F},
        .left_hand = {-0.04F, 1.00F, 0.58F},
        .blade_dir = {0.06F, 0.28F, 0.96F}},
-      {.phase = 1.00F,
-       .right_hand = {0.22F, 1.14F, 0.24F},
-       .left_hand = {-0.22F, 1.10F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(1.00F),
   }};
   static const AuthoredSwordPoseKeys finisher{{
-      {.phase = 0.00F,
-       .right_hand = {0.22F, 1.18F, 0.20F},
-       .left_hand = {-0.22F, 1.12F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(0.00F),
       {.phase = 0.18F,
        .right_hand = {0.26F, 1.68F, -0.42F},
        .left_hand = {-0.20F, 1.22F, 0.18F},
@@ -1085,10 +1122,7 @@ auto rpg_sword_pose_keys(std::uint8_t variant) -> const AuthoredSwordPoseKeys& {
        .right_hand = {-0.24F, 0.52F, 0.74F},
        .left_hand = {-0.08F, 0.82F, 0.54F},
        .blade_dir = {-0.14F, -0.86F, 0.48F}},
-      {.phase = 1.00F,
-       .right_hand = {0.22F, 1.12F, 0.24F},
-       .left_hand = {-0.22F, 1.08F, 0.18F},
-       .blade_dir = {0.12F, 0.86F, 0.50F}},
+      rpg_sword_guard_key(1.00F),
   }};
 
   switch (variant) {
@@ -1106,34 +1140,81 @@ auto rpg_sword_pose_keys(std::uint8_t variant) -> const AuthoredSwordPoseKeys& {
   }
 }
 
+auto slerp_dir(const QVector3D& from, const QVector3D& to, float t) -> QVector3D {
+  if (from.lengthSquared() < 1.0e-8F || to.lengthSquared() < 1.0e-8F) {
+    return blend_vec(from, to, t);
+  }
+  QVector3D const a = from.normalized();
+  QVector3D const b = to.normalized();
+  float const dot = std::clamp(QVector3D::dotProduct(a, b), -1.0F, 1.0F);
+  if (dot > 0.9995F) {
+    QVector3D const straight = blend_vec(a, b, t);
+    return straight.lengthSquared() > 1.0e-8F ? straight.normalized() : a;
+  }
+  QVector3D ortho = b - (a * dot);
+  if (ortho.lengthSquared() < 1.0e-8F) {
+
+    ortho = QVector3D::crossProduct(a, QVector3D(0.0F, 1.0F, 0.0F));
+    if (ortho.lengthSquared() < 1.0e-8F) {
+      ortho = QVector3D::crossProduct(a, QVector3D(1.0F, 0.0F, 0.0F));
+    }
+  }
+  ortho.normalize();
+  float const theta = std::acos(dot) * std::clamp(t, 0.0F, 1.0F);
+  return (a * std::cos(theta)) + (ortho * std::sin(theta));
+}
+
 auto sample_authored_sword_pose_key(const AuthoredSwordPoseKeys& keys,
                                     float phase) -> AuthoredSwordPoseKey {
   float const clamped = std::clamp(phase, 0.0F, 1.0F);
-  for (std::size_t i = 1; i < keys.size(); ++i) {
-    if (clamped <= keys[i].phase) {
-      auto const& from = keys[i - 1U];
-      auto const& to = keys[i];
-      float const span = std::max(0.001F, to.phase - from.phase);
-      float const raw_t = std::clamp((clamped - from.phase) / span, 0.0F, 1.0F);
-      float const t = raw_t * raw_t * (3.0F - 2.0F * raw_t);
-      return {
-          .phase = clamped,
-          .right_hand = blend_vec(from.right_hand, to.right_hand, t),
-          .left_hand = blend_vec(from.left_hand, to.left_hand, t),
-          .blade_dir = blend_vec(from.blade_dir, to.blade_dir, t).normalized(),
-          .pelvis_delta = blend_vec(from.pelvis_delta, to.pelvis_delta, t),
-          .shoulder_r_delta = blend_vec(from.shoulder_r_delta, to.shoulder_r_delta, t),
-          .shoulder_l_delta = blend_vec(from.shoulder_l_delta, to.shoulder_l_delta, t),
-          .neck_delta = blend_vec(from.neck_delta, to.neck_delta, t),
-          .head_delta = blend_vec(from.head_delta, to.head_delta, t),
-          .foot_r_delta = blend_vec(from.foot_r_delta, to.foot_r_delta, t),
-          .knee_r_delta = blend_vec(from.knee_r_delta, to.knee_r_delta, t),
-          .foot_l_delta = blend_vec(from.foot_l_delta, to.foot_l_delta, t),
-          .knee_l_delta = blend_vec(from.knee_l_delta, to.knee_l_delta, t),
-      };
-    }
+  std::size_t segment = 1U;
+  while (segment + 1U < keys.size() && clamped > keys[segment].phase) {
+    ++segment;
   }
-  return keys.back();
+  auto const& from = keys[segment - 1U];
+  auto const& to = keys[segment];
+  float const span = std::max(0.001F, to.phase - from.phase);
+  float const t = std::clamp((clamped - from.phase) / span, 0.0F, 1.0F);
+
+  using Channel = QVector3D AuthoredSwordPoseKey::*;
+  auto tangent = [&keys](std::size_t index, Channel channel) -> QVector3D {
+    if (index == 0U || index + 1U >= keys.size()) {
+      return {};
+    }
+    float const window =
+        std::max(0.001F, keys[index + 1U].phase - keys[index - 1U].phase);
+    return (keys[index + 1U].*channel - keys[index - 1U].*channel) / window;
+  };
+
+  float const t2 = t * t;
+  float const t3 = t2 * t;
+  float const h00 = (2.0F * t3) - (3.0F * t2) + 1.0F;
+  float const h10 = t3 - (2.0F * t2) + t;
+  float const h01 = (-2.0F * t3) + (3.0F * t2);
+  float const h11 = t3 - t2;
+  auto hermite = [&](Channel channel) -> QVector3D {
+    return (from.*channel * h00) + (tangent(segment - 1U, channel) * span * h10) +
+           (to.*channel * h01) + (tangent(segment, channel) * span * h11);
+  };
+
+  bool const terminal_segment = segment == 1U || segment + 1U == keys.size();
+  float const blade_t = terminal_segment ? (t * t * (3.0F - 2.0F * t)) : t;
+
+  return {
+      .phase = clamped,
+      .right_hand = hermite(&AuthoredSwordPoseKey::right_hand),
+      .left_hand = hermite(&AuthoredSwordPoseKey::left_hand),
+      .blade_dir = slerp_dir(from.blade_dir, to.blade_dir, blade_t),
+      .pelvis_delta = hermite(&AuthoredSwordPoseKey::pelvis_delta),
+      .shoulder_r_delta = hermite(&AuthoredSwordPoseKey::shoulder_r_delta),
+      .shoulder_l_delta = hermite(&AuthoredSwordPoseKey::shoulder_l_delta),
+      .neck_delta = hermite(&AuthoredSwordPoseKey::neck_delta),
+      .head_delta = hermite(&AuthoredSwordPoseKey::head_delta),
+      .foot_r_delta = hermite(&AuthoredSwordPoseKey::foot_r_delta),
+      .knee_r_delta = hermite(&AuthoredSwordPoseKey::knee_r_delta),
+      .foot_l_delta = hermite(&AuthoredSwordPoseKey::foot_l_delta),
+      .knee_l_delta = hermite(&AuthoredSwordPoseKey::knee_l_delta),
+  };
 }
 
 void apply_authored_rpg_sword_pose(Render::GL::HumanoidPoseController& ctrl,
@@ -1189,50 +1270,13 @@ void bake_hold_pose(BakeProfile profile,
   }
 }
 
-void bake_death_pose(BakerDeathType death_type,
+void bake_death_pose(Animation::HumanoidDeathCollapse collapse,
                      float blend,
                      Render::GL::HumanoidPose& pose) {
-  float const fall = std::clamp(blend, 0.0F, 1.0F);
-  float const eased = fall * fall * (3.0F - 2.0F * fall);
-  float const side_sign = (death_type == BakerDeathType::Mounted) ? -1.0F : 1.0F;
-
-  pose.pelvis_pos.setY(pose.pelvis_pos.y() - 0.42F * eased);
-  pose.pelvis_pos.setZ(pose.pelvis_pos.z() - 0.36F * eased);
-
-  pose.neck_base.setY(pose.neck_base.y() - 0.58F * eased);
-  pose.neck_base.setZ(pose.neck_base.z() - 0.52F * eased);
-  pose.head_pos.setY(pose.head_pos.y() - 0.72F * eased);
-  pose.head_pos.setZ(pose.head_pos.z() - 0.64F * eased);
-  pose.head_pos.setX(pose.head_pos.x() + side_sign * 0.12F * eased);
-
-  pose.shoulder_l.setY(pose.shoulder_l.y() - 0.45F * eased);
-  pose.shoulder_r.setY(pose.shoulder_r.y() - 0.42F * eased);
-  pose.shoulder_l.setZ(pose.shoulder_l.z() - 0.28F * eased);
-  pose.shoulder_r.setZ(pose.shoulder_r.z() - 0.22F * eased);
-  pose.shoulder_l.setX(pose.shoulder_l.x() - side_sign * 0.08F * eased);
-  pose.shoulder_r.setX(pose.shoulder_r.x() - side_sign * 0.03F * eased);
-
-  pose.hand_l.setY(pose.hand_l.y() - 0.58F * eased);
-  pose.hand_r.setY(pose.hand_r.y() - 0.52F * eased);
-  pose.hand_l.setZ(pose.hand_l.z() - 0.40F * eased);
-  pose.hand_r.setZ(pose.hand_r.z() - 0.28F * eased);
-  pose.hand_l.setX(pose.hand_l.x() - side_sign * 0.14F * eased);
-  pose.hand_r.setX(pose.hand_r.x() - side_sign * 0.06F * eased);
-
-  pose.knee_l.setY(pose.knee_l.y() - 0.26F * eased);
-  pose.knee_r.setY(pose.knee_r.y() - 0.24F * eased);
-  pose.knee_l.setZ(pose.knee_l.z() + 0.18F * eased);
-  pose.knee_r.setZ(pose.knee_r.z() + 0.08F * eased);
-  pose.foot_l.setZ(pose.foot_l.z() + 0.28F * eased);
-  pose.foot_r.setZ(pose.foot_r.z() + 0.12F * eased);
-
-  if (death_type == BakerDeathType::Mounted) {
-    pose.pelvis_pos.setX(pose.pelvis_pos.x() + side_sign * 0.22F * eased);
-    pose.neck_base.setX(pose.neck_base.x() + side_sign * 0.26F * eased);
-    pose.head_pos.setX(pose.head_pos.x() + side_sign * 0.34F * eased);
-    pose.foot_l.setX(pose.foot_l.x() + side_sign * 0.16F * eased);
-    pose.foot_r.setX(pose.foot_r.x() + side_sign * 0.12F * eased);
-  }
+  Render::GL::HumanoidAnimationContext anim_ctx{};
+  anim_ctx.gait.state = Render::GL::HumanoidMotionState::Idle;
+  Render::GL::HumanoidPoseController ctrl(pose, anim_ctx);
+  ctrl.apply_death_collapse(collapse, std::clamp(blend, 0.0F, 1.0F));
 }
 
 [[nodiscard]] auto
@@ -1296,7 +1340,8 @@ void bake_humanoid_clip_frame(BakeProfile profile,
 
   Render::GL::HumanoidPose pose{};
 
-  if (clip.death_type != BakerDeathType::None) {
+  if (clip.death_collapse != Animation::HumanoidDeathCollapse::None) {
+
     Render::GL::HumanoidGaitDescriptor gait{};
     gait.state = Render::GL::HumanoidMotionState::Idle;
     gait.cycle_time = 1.6F;
@@ -1305,8 +1350,9 @@ void bake_humanoid_clip_frame(BakeProfile profile,
     gait.normalized_speed = 0.0F;
     Render::GL::HumanoidRendererBase::compute_locomotion_pose(
         0U, 0.0F, gait, variation, pose);
+
     float const death_blend = clip.loops ? 1.0F : phase;
-    bake_death_pose(clip.death_type, death_blend, pose);
+    bake_death_pose(clip.death_collapse, death_blend, pose);
   } else if (clip.attack_type != BakerAttackType::None) {
 
     Render::GL::HumanoidGaitDescriptor hold_gait{};

--- a/render/humanoid/pose_controller.cpp
+++ b/render/humanoid/pose_controller.cpp
@@ -363,6 +363,34 @@ void HumanoidPoseController::apply_showcase_move(Animation::HumanoidShowcaseMove
   }
 }
 
+void HumanoidPoseController::apply_death_collapse(
+    Animation::HumanoidDeathCollapse collapse, float phase) {
+  auto const sample = Animation::resolve_humanoid_death_pose({
+      .collapse = collapse,
+      .phase = phase,
+      .height_scale = 1.0F,
+  });
+  if (!sample.active) {
+    return;
+  }
+  m_pose.pelvis_pos = to_qvec(sample.pelvis);
+  m_pose.neck_base = to_qvec(sample.neck_base);
+  m_pose.head_pos = to_qvec(sample.head);
+  m_pose.shoulder_l = to_qvec(sample.shoulder_l);
+  m_pose.shoulder_r = to_qvec(sample.shoulder_r);
+  m_pose.elbow_l = to_qvec(sample.elbow_l);
+  m_pose.elbow_r = to_qvec(sample.elbow_r);
+  m_pose.hand_l = to_qvec(sample.hand_l);
+  m_pose.hand_r = to_qvec(sample.hand_r);
+  m_pose.knee_l = to_qvec(sample.knee_l);
+  m_pose.knee_r = to_qvec(sample.knee_r);
+  m_pose.foot_l = to_qvec(sample.foot_l);
+  m_pose.foot_r = to_qvec(sample.foot_r);
+  m_pose.foot_pitch_l = sample.foot_pitch_l;
+  m_pose.foot_pitch_r = sample.foot_pitch_r;
+  m_pose.foot_y_offset = 0.0F;
+}
+
 void HumanoidPoseController::kneel(float depth) {
   using HP = HumanProportions;
 

--- a/render/humanoid/pose_controller.h
+++ b/render/humanoid/pose_controller.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 
+#include "animation/death_pose_manifest.h"
 #include "animation/rig/humanoid_proportions.h"
 #include "animation/showcase_pose_manifest.h"
 #include "humanoid_renderer_base.h"
@@ -25,6 +26,8 @@ public:
   void apply_ambient_idle_explicit(AmbientIdleType idle_type, float phase);
 
   void apply_showcase_move(Animation::HumanoidShowcaseMove move, float phase);
+
+  void apply_death_collapse(Animation::HumanoidDeathCollapse collapse, float phase);
 
   void kneel(float depth);
   void kneel_transition(float progress, bool standing_up);

--- a/render/humanoid/prepare_animation.cpp
+++ b/render/humanoid/prepare_animation.cpp
@@ -13,6 +13,8 @@ void reset_humanoid_locomotion_state(
   state.filtered_turn = 0.0F;
   state.locomotion_blend = 0.0F;
   state.run_blend = 0.0F;
+  state.locomotion_presence = 0.0F;
+  state.run_presence = 0.0F;
   state.locomotion_state = Animation::HumanoidMotionState::Idle;
   state.locomotion_initialized = false;
   state.combat_visual = {};
@@ -210,6 +212,8 @@ namespace {
       .filtered_travel_alignment = component.filtered_travel_alignment,
       .locomotion_blend = component.locomotion_blend,
       .run_blend = component.run_blend,
+      .locomotion_presence = component.locomotion_presence,
+      .run_presence = component.run_presence,
       .reverse_gait = component.reverse_gait,
       .state = component.locomotion_state,
   };
@@ -230,6 +234,8 @@ void write_persistent_locomotion_to_component(
   component.reverse_gait = persistent.reverse_gait;
   component.locomotion_blend = persistent.locomotion_blend;
   component.run_blend = persistent.run_blend;
+  component.locomotion_presence = persistent.locomotion_presence;
+  component.run_presence = persistent.run_presence;
   component.locomotion_state = persistent.state;
 }
 
@@ -275,6 +281,8 @@ auto build_humanoid_locomotion_state(const HumanoidLocomotionInputs& inputs)
   state.gait.stride_distance = sample.stride_distance;
   state.gait.locomotion_blend = sample.locomotion_blend;
   state.gait.run_blend = sample.run_blend;
+  state.gait.locomotion_presence = sample.locomotion_presence;
+  state.gait.run_presence = sample.run_presence;
   state.gait.turn_amount = sample.turn_amount;
   state.gait.travel_alignment = sample.travel_alignment;
   state.gait.reverse_gait = sample.reverse_gait;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -243,6 +243,7 @@ add_executable(
     render/creature/quadruped_gait_test.cpp
     ${_soi_optional_test_sources}
     render/creature/humanoid_prepare_test.cpp
+    render/creature/death_collapse_test.cpp
     render/creature/horse_prepare_test.cpp
     render/creature/elephant_prepare_test.cpp
     render/creature/quadruped_clip_set_test.cpp

--- a/tests/render/bpat/bpat_registry_test.cpp
+++ b/tests/render/bpat/bpat_registry_test.cpp
@@ -1,8 +1,10 @@
 #include <QCoreApplication>
 #include <QMatrix4x4>
 
+#include <algorithm>
 #include <array>
 #include <gtest/gtest.h>
+#include <limits>
 #include <string>
 
 #include "animation/bpat/bpat_format.h"
@@ -558,8 +560,19 @@ TEST(BpatRegistry, HumanoidRpgSwordClipsMoveAttachedSwordIntoDistinctCuts) {
   EXPECT_GT(thrust_contact.tip.z(), slash_left_contact.tip.z() + 0.18F);
   EXPECT_GT(thrust_contact.tip.z(), slash_right_contact.tip.z() + 0.18F);
   EXPECT_GT(overhead_release.tip.y(), slash_left_contact.tip.y() + 0.20F);
-  EXPECT_GT(finisher_release.tip.y(), overhead_release.tip.y() + 0.025F);
   EXPECT_LT(finisher_contact.base.y(), finisher_release.base.y() - 0.55F);
+
+  auto const highest_tip = [&](Animation::SwordAttackAnimation anim) {
+    auto const clip_id = Animation::humanoid_sword_attack_clip(anim);
+    auto const clip = blob->clip(clip_id);
+    float highest = -std::numeric_limits<float>::infinity();
+    for (std::uint32_t frame = 0; frame < clip.frame_count; ++frame) {
+      highest = std::max(highest, sample_sword(anim, frame).tip.y());
+    }
+    return highest;
+  };
+  EXPECT_GT(highest_tip(Animation::SwordAttackAnimation::RpgFinisher),
+            highest_tip(Animation::SwordAttackAnimation::RpgOverhead) + 0.025F);
 }
 
 TEST(BpatRegistry, HoldClipsBakeKneelingWeaponReadyPoses) {

--- a/tests/render/creature/death_collapse_test.cpp
+++ b/tests/render/creature/death_collapse_test.cpp
@@ -1,0 +1,168 @@
+#include <array>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <string>
+
+#include "animation/death_pose_manifest.h"
+#include "animation/rig/pose_fk.h"
+
+namespace {
+
+using Animation::HumanoidDeathCollapse;
+using Animation::HumanoidDeathPoseSample;
+using Animation::PoseVec3;
+
+constexpr std::array<HumanoidDeathCollapse, 4> k_collapses{
+    HumanoidDeathCollapse::BackSprawl,
+    HumanoidDeathCollapse::FacePlant,
+    HumanoidDeathCollapse::SideCrumple,
+    HumanoidDeathCollapse::MountedUnseat,
+};
+
+[[nodiscard]] auto distance(PoseVec3 a, PoseVec3 b) -> float {
+  float const dx = a.x - b.x;
+  float const dy = a.y - b.y;
+  float const dz = a.z - b.z;
+  return std::sqrt((dx * dx) + (dy * dy) + (dz * dz));
+}
+
+[[nodiscard]] auto sample_at(HumanoidDeathCollapse collapse,
+                             float phase) -> HumanoidDeathPoseSample {
+  return Animation::resolve_humanoid_death_pose({.collapse = collapse, .phase = phase});
+}
+
+[[nodiscard]] auto label(HumanoidDeathCollapse collapse, float phase) -> std::string {
+  return std::string(Animation::humanoid_death_collapse_name(collapse)) + " @ " +
+         std::to_string(phase);
+}
+
+constexpr int k_sample_count = 41;
+
+} // namespace
+
+TEST(DeathCollapseTest, NoFallStretchesALimbPastItsBindLength) {
+  Animation::PoseFk::HumanoidRigMetrics const rig{};
+
+  for (auto const collapse : k_collapses) {
+    for (int i = 0; i < k_sample_count; ++i) {
+      float const phase =
+          static_cast<float>(i) / static_cast<float>(k_sample_count - 1);
+      auto const pose = sample_at(collapse, phase);
+      ASSERT_TRUE(pose.active) << label(collapse, phase);
+
+      auto const segment = [&](PoseVec3 a, PoseVec3 b, float bind, const char* name) {
+        EXPECT_NEAR(distance(a, b), bind, 1.0e-3F)
+            << name << " " << label(collapse, phase);
+      };
+
+      segment(pose.shoulder_l, pose.elbow_l, rig.upper_arm_len, "upper_arm_l");
+      segment(pose.shoulder_r, pose.elbow_r, rig.upper_arm_len, "upper_arm_r");
+      segment(pose.elbow_l, pose.hand_l, rig.fore_arm_len, "fore_arm_l");
+      segment(pose.elbow_r, pose.hand_r, rig.fore_arm_len, "fore_arm_r");
+      segment(pose.knee_l, pose.foot_l, rig.lower_leg_len, "lower_leg_l");
+      segment(pose.knee_r, pose.foot_r, rig.lower_leg_len, "lower_leg_r");
+      segment(pose.neck_base, pose.head, rig.head_rise, "neck_to_head");
+      segment(pose.pelvis, pose.neck_base, rig.neck_rise, "spine");
+    }
+  }
+}
+
+TEST(DeathCollapseTest, NoFallDrivesAJointThroughTheGround) {
+  struct JointFloor {
+    const char* name;
+    PoseVec3 HumanoidDeathPoseSample::*joint;
+    float floor;
+  };
+
+  constexpr float k_allowance = 0.06F;
+  const std::array<JointFloor, 11> joints{{
+      {"pelvis", &HumanoidDeathPoseSample::pelvis, 0.10F},
+      {"neck", &HumanoidDeathPoseSample::neck_base, 0.11F},
+      {"head", &HumanoidDeathPoseSample::head, 0.09F},
+      {"elbow_l", &HumanoidDeathPoseSample::elbow_l, 0.045F},
+      {"elbow_r", &HumanoidDeathPoseSample::elbow_r, 0.045F},
+      {"hand_l", &HumanoidDeathPoseSample::hand_l, 0.03F},
+      {"hand_r", &HumanoidDeathPoseSample::hand_r, 0.03F},
+      {"knee_l", &HumanoidDeathPoseSample::knee_l, 0.06F},
+      {"knee_r", &HumanoidDeathPoseSample::knee_r, 0.06F},
+      {"foot_l", &HumanoidDeathPoseSample::foot_l, 0.0F},
+      {"foot_r", &HumanoidDeathPoseSample::foot_r, 0.0F},
+  }};
+
+  for (auto const collapse : k_collapses) {
+    for (int i = 0; i < k_sample_count; ++i) {
+      float const phase =
+          static_cast<float>(i) / static_cast<float>(k_sample_count - 1);
+      auto const pose = sample_at(collapse, phase);
+      for (auto const& joint : joints) {
+        EXPECT_GE((pose.*joint.joint).y, joint.floor - k_allowance)
+            << joint.name << " " << label(collapse, phase);
+      }
+    }
+  }
+}
+
+TEST(DeathCollapseTest, EveryFallStartsUprightAndEndsFlatOnTheGround) {
+  for (auto const collapse : k_collapses) {
+    auto const standing = sample_at(collapse, 0.0F);
+    auto const settled = sample_at(collapse, 1.0F);
+
+    EXPECT_GT(standing.head.y, 1.5F)
+        << Animation::humanoid_death_collapse_name(collapse);
+    EXPECT_GT(standing.pelvis.y, 0.9F)
+        << Animation::humanoid_death_collapse_name(collapse);
+
+    EXPECT_LT(settled.head.y, 0.30F)
+        << Animation::humanoid_death_collapse_name(collapse);
+    EXPECT_LT(settled.pelvis.y, 0.30F)
+        << Animation::humanoid_death_collapse_name(collapse);
+
+    float const trunk_rise = settled.neck_base.y - settled.pelvis.y;
+    float const trunk_len = distance(settled.neck_base, settled.pelvis);
+    EXPECT_LT(std::abs(trunk_rise / trunk_len), 0.43F)
+        << Animation::humanoid_death_collapse_name(collapse);
+  }
+}
+
+TEST(DeathCollapseTest, TheHeldCorpsePoseIsTheLastFrameOfTheFall) {
+  for (auto const collapse : k_collapses) {
+    auto const settled = sample_at(collapse, 1.0F);
+    auto const past_end = sample_at(collapse, 1.4F);
+    EXPECT_NEAR(distance(settled.head, past_end.head), 0.0F, 1.0e-5F)
+        << Animation::humanoid_death_collapse_name(collapse);
+    EXPECT_NEAR(distance(settled.pelvis, past_end.pelvis), 0.0F, 1.0e-5F)
+        << Animation::humanoid_death_collapse_name(collapse);
+  }
+}
+
+TEST(DeathCollapseTest, TheThreeInfantryFallsEndInDifferentPlaces) {
+  auto const back = sample_at(Animation::humanoid_infantry_death_collapse(0), 1.0F);
+  auto const face = sample_at(Animation::humanoid_infantry_death_collapse(1), 1.0F);
+  auto const side = sample_at(Animation::humanoid_infantry_death_collapse(2), 1.0F);
+
+  EXPECT_GT(distance(back.head, face.head), 1.0F);
+  EXPECT_GT(distance(back.head, side.head), 0.3F);
+  EXPECT_GT(distance(face.head, side.head), 1.0F);
+
+  EXPECT_LT(back.head.z, back.pelvis.z);
+  EXPECT_GT(face.head.z, face.pelvis.z);
+}
+
+TEST(DeathCollapseTest, VariantsMapOntoTheThreeInfantryFalls) {
+  EXPECT_EQ(Animation::humanoid_infantry_death_collapse(0),
+            HumanoidDeathCollapse::BackSprawl);
+  EXPECT_EQ(Animation::humanoid_infantry_death_collapse(1),
+            HumanoidDeathCollapse::FacePlant);
+  EXPECT_EQ(Animation::humanoid_infantry_death_collapse(2),
+            HumanoidDeathCollapse::SideCrumple);
+
+  for (std::uint8_t v = 0U; v < 16U; ++v) {
+    EXPECT_NE(Animation::humanoid_infantry_death_collapse(v),
+              HumanoidDeathCollapse::None);
+  }
+}
+
+TEST(DeathCollapseTest, NoCollapseIsInert) {
+  auto const none = sample_at(HumanoidDeathCollapse::None, 0.5F);
+  EXPECT_FALSE(none.active);
+}

--- a/tests/render/creature/humanoid_prepare_test.cpp
+++ b/tests/render/creature/humanoid_prepare_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include <limits>
 #include <numbers>
+#include <numeric>
 #include <unordered_set>
 #include <vector>
 
@@ -67,6 +68,7 @@
 #include "render/gl/humanoid/animation/animation_inputs.h"
 #include "render/gl/humanoid/humanoid_types.h"
 #include "render/humanoid/cache_control.h"
+#include "render/humanoid/humanoid_manifest.h"
 #include "render/humanoid/humanoid_renderer_base.h"
 #include "render/humanoid/humanoid_spec.h"
 #include "render/humanoid/pose_cache_components.h"
@@ -1246,6 +1248,142 @@ TEST(HumanoidPrepare, PersistentEntitySwordsmanWalkRequestAdvancesPhaseOverTime)
   EXPECT_EQ(first.state, Render::Creature::AnimationStateId::Walk);
   EXPECT_EQ(second.state, Render::Creature::AnimationStateId::Walk);
   EXPECT_NE(first.phase, second.phase);
+}
+
+TEST(HumanoidPrepare, StoppingAUnitBlendsTheStrideOutInsteadOfCutting) {
+  class FixedSpecRenderer final : public Render::GL::HumanoidRendererBase {
+  public:
+    explicit FixedSpecRenderer(Render::Creature::Pipeline::UnitVisualSpec spec)
+        : spec_(spec) {}
+
+    auto
+    visual_spec() const -> const Render::Creature::Pipeline::UnitVisualSpec& override {
+      return spec_;
+    }
+
+  private:
+    Render::Creature::Pipeline::UnitVisualSpec spec_{};
+  };
+
+  Render::GL::EntityRendererRegistry registry;
+  Render::GL::register_built_in_entity_renderers(registry);
+  auto const warm_renderer = registry.get("troops/roman/swordsman");
+  ASSERT_TRUE(static_cast<bool>(warm_renderer));
+  {
+    Render::GL::DrawContext warm_ctx{};
+    warm_ctx.allow_template_cache = false;
+    Engine::Core::Entity warm_entity(998);
+    auto* warm_unit =
+        warm_entity.add_component<Engine::Core::UnitComponent>(100, 100, 1.0F, 12.0F);
+    ASSERT_NE(warm_unit, nullptr);
+    warm_unit->spawn_type = Game::Units::SpawnType::Knight;
+    warm_unit->nation_id = Game::Systems::NationID::RomanRepublic;
+    warm_ctx.entity = &warm_entity;
+    CountingSubmitter warm_sink;
+    warm_renderer(warm_ctx, warm_sink);
+  }
+
+  auto const archetype_id = find_archetype_id("troops/roman/swordsman");
+  ASSERT_NE(archetype_id, Render::Creature::k_invalid_archetype);
+
+  Render::Creature::Pipeline::UnitVisualSpec spec{};
+  spec.kind = Render::Creature::Pipeline::CreatureKind::Humanoid;
+  spec.debug_name = "troops/roman/swordsman";
+  spec.owned_legacy_slots = Render::Creature::Pipeline::LegacySlotMask::AllHumanoid;
+  spec.archetype_id = archetype_id;
+  spec.creature_asset_id = Render::Creature::Pipeline::k_humanoid_sword_asset;
+  FixedSpecRenderer owner(spec);
+
+  Engine::Core::Entity entity(1);
+  auto* unit = entity.add_component<Engine::Core::UnitComponent>(100, 100, 1.0F, 12.0F);
+  auto* movement = entity.add_component<Engine::Core::MovementComponent>();
+  auto* transform = entity.add_component<Engine::Core::TransformComponent>();
+  auto* motion = entity.add_component<Engine::Core::MotionPresentationComponent>();
+  ASSERT_NE(unit, nullptr);
+  ASSERT_NE(movement, nullptr);
+  ASSERT_NE(transform, nullptr);
+  ASSERT_NE(motion, nullptr);
+  unit->spawn_type = Game::Units::SpawnType::Knight;
+  unit->nation_id = Game::Systems::NationID::RomanRepublic;
+  transform->position = {0.0F, 0.0F, 0.0F};
+  motion->initialized = true;
+  motion->snapshot_valid = true;
+  motion->direction_x = 0.0F;
+  motion->direction_z = 1.0F;
+
+  auto walk = [&]() {
+    MovementTestAccess::set_has_target(*movement, true);
+    MovementTestAccess::set_target_x(*movement, 0.0F);
+    MovementTestAccess::set_target_y(*movement, 40.0F);
+    MovementTestAccess::set_vx(*movement, 0.0F);
+    MovementTestAccess::set_vz(*movement, 2.2F);
+    motion->set_state(Engine::Core::MotionPresentationState::Walk);
+    motion->has_navigation_intent = true;
+    motion->has_movement_target = true;
+    motion->movement_target_x = 0.0F;
+    motion->movement_target_z = 40.0F;
+    motion->speed = 2.2F;
+  };
+  auto stand = [&]() {
+    MovementTestAccess::set_has_target(*movement, false);
+    MovementTestAccess::set_vx(*movement, 0.0F);
+    MovementTestAccess::set_vz(*movement, 0.0F);
+    motion->set_state(Engine::Core::MotionPresentationState::Idle);
+    motion->has_navigation_intent = false;
+    motion->has_movement_target = false;
+    motion->speed = 0.0F;
+  };
+
+  auto request_for_time = [&](float animation_time) {
+    Render::GL::DrawContext ctx{};
+    ctx.allow_template_cache = false;
+    ctx.force_humanoid_lod = true;
+    ctx.forced_humanoid_lod = Render::Creature::CreatureLOD::Full;
+    ctx.animation_time = animation_time;
+    ctx.entity = &entity;
+    auto const anim = Render::GL::sample_anim_state(ctx);
+    Render::Humanoid::HumanoidPreparation prep;
+    Render::Humanoid::prepare_humanoid_instances(owner, ctx, anim, 0U, prep);
+    EXPECT_FALSE(prep.bodies.requests().empty());
+    Render::GL::advance_pose_cache_frame();
+    return prep.bodies.requests().front();
+  };
+
+  constexpr float k_step = 1.0F / 60.0F;
+  float time = 0.0F;
+  walk();
+  Render::Creature::CreatureRenderRequest settled{};
+  for (int frame = 0; frame < 90; ++frame) {
+    time += k_step;
+    settled = request_for_time(time);
+  }
+  ASSERT_EQ(settled.state, Render::Creature::AnimationStateId::Walk);
+  EXPECT_FALSE(settled.full_body_blend.active())
+      << "a settled walk is one clip, not a blend";
+
+  stand();
+  std::vector<float> stand_weights;
+  std::vector<float> phases;
+  for (int frame = 0; frame < 12; ++frame) {
+    time += k_step;
+    auto const request = request_for_time(time);
+    if (request.full_body_blend.active() &&
+        request.full_body_blend.state == Render::Creature::AnimationStateId::Walk) {
+      stand_weights.push_back(1.0F - request.full_body_blend.weight);
+      phases.push_back(request.full_body_blend.phase);
+    } else if (request.full_body_blend.active()) {
+      stand_weights.push_back(request.full_body_blend.weight);
+      phases.push_back(request.phase);
+    }
+  }
+
+  ASSERT_GE(stand_weights.size(), 8U) << "the stride vanished instead of blending out";
+  EXPECT_LT(stand_weights.front(), 0.35F) << "the stand should not appear all at once";
+  EXPECT_GT(stand_weights.back(), stand_weights.front())
+      << "the stand should keep taking over";
+
+  ASSERT_GE(phases.size(), 8U);
+  EXPECT_NE(phases.front(), phases.back());
 }
 
 TEST(HumanoidPrepare, MultiSoldierCombatFallbackOffsetsAttackPhasePerSoldier) {
@@ -3788,6 +3926,263 @@ TEST(AnimationCoreLocomotionManifest, RunSampleIsDeterministic) {
   EXPECT_FLOAT_EQ(first.stride_distance, second.stride_distance);
   EXPECT_GT(first.cycle_time, 0.0F);
   EXPECT_GT(first.stride_distance, 0.0F);
+}
+
+namespace {
+
+auto walk_pose_inputs() -> Animation::HumanoidLocomotionPoseInputs {
+  Animation::HumanoidLocomotionPoseInputs inputs{};
+  inputs.state = Animation::HumanoidMotionState::Walk;
+  inputs.normalized_speed = 1.0F;
+  inputs.locomotion_blend = 1.0F;
+  inputs.stride_distance = 2.35F * 0.92F;
+  inputs.walk_speed_multiplier = 1.0F;
+  inputs.stance_width = 1.0F;
+  inputs.arm_swing_amplitude = 1.0F;
+  inputs.reference_walk_speed = 2.35F;
+  inputs.reference_run_speed = 5.10F;
+  inputs.ground_y = 0.0F;
+  inputs.foot_y_offset = 0.02F;
+  inputs.base_foot_l = {-0.20F, 0.02F, 0.02F};
+  inputs.base_foot_r = {0.20F, 0.02F, -0.02F};
+  return inputs;
+}
+
+auto foot_z_samples(Animation::HumanoidLocomotionPoseInputs inputs,
+                    int steps) -> std::vector<float> {
+  std::vector<float> samples;
+  samples.reserve(static_cast<std::size_t>(steps) + 1U);
+  for (int i = 0; i <= steps; ++i) {
+    inputs.cycle_phase = static_cast<float>(i) / static_cast<float>(steps);
+    samples.push_back(Animation::resolve_humanoid_locomotion_pose(inputs).foot_l.z);
+  }
+  return samples;
+}
+
+} // namespace
+
+TEST(AnimationCoreLocomotionManifest, WalkSwingLeavesTheGroundWithoutAJerk) {
+  constexpr int k_steps = 720;
+  auto const samples = foot_z_samples(walk_pose_inputs(), k_steps);
+
+  std::vector<float> deltas;
+  deltas.reserve(samples.size());
+  for (std::size_t i = 1; i < samples.size(); ++i) {
+    deltas.push_back(std::abs(samples[i] - samples[i - 1U]));
+  }
+  auto const mean_delta = std::accumulate(deltas.begin(), deltas.end(), 0.0F) /
+                          static_cast<float>(deltas.size());
+  auto const worst_delta = *std::max_element(deltas.begin(), deltas.end());
+
+  ASSERT_GT(mean_delta, 0.0F);
+  EXPECT_LT(worst_delta, mean_delta * 3.0F);
+}
+
+TEST(AnimationCoreLocomotionManifest, WalkCycleClosesOnItself) {
+  auto inputs = walk_pose_inputs();
+  constexpr float k_step = 1.0F / 720.0F;
+
+  inputs.cycle_phase = 0.0F;
+  auto const start = Animation::resolve_humanoid_locomotion_pose(inputs);
+  inputs.cycle_phase = 1.0F - k_step;
+  auto const wrap = Animation::resolve_humanoid_locomotion_pose(inputs);
+  inputs.cycle_phase = k_step;
+  auto const next = Animation::resolve_humanoid_locomotion_pose(inputs);
+
+  float const step_into_wrap = std::abs(start.foot_l.z - wrap.foot_l.z);
+  float const step_after_wrap = std::abs(next.foot_l.z - start.foot_l.z);
+  EXPECT_LT(step_into_wrap, 0.01F);
+  EXPECT_NEAR(step_into_wrap, step_after_wrap, 0.004F);
+  EXPECT_NEAR(start.foot_l.y, wrap.foot_l.y, 0.004F);
+  EXPECT_NEAR(start.foot_pitch_l, wrap.foot_pitch_l, 0.05F);
+}
+
+TEST(AnimationCoreLocomotionManifest, GaitKeepsCyclingWhileTheStrideBlendsOut) {
+  auto const walking =
+      step_locomotion(walking_inputs(), 0.0F, 1.0F, 0.0F, 1.0F, 60, 1.0F / 60.0F);
+  ASSERT_GT(walking.locomotion_blend, 0.5F);
+
+  auto inputs = walking_inputs();
+  inputs.movement_state = Animation::MovementState::Idle;
+  inputs.motion_state = Animation::HumanoidMotionState::Idle;
+  inputs.speed = 0.0F;
+  inputs.has_persistent_state = true;
+  inputs.allow_persistent_update = true;
+  inputs.previous = walking.persistent;
+  inputs.sample_time = walking.persistent.last_sample_time;
+
+  auto previous = walking;
+  float advanced = 0.0F;
+  for (int frame = 0; frame < 6; ++frame) {
+    inputs.sample_time += 1.0F / 60.0F;
+    auto const sample = Animation::resolve_humanoid_locomotion_sample(inputs);
+    float delta = sample.cycle_phase - previous.cycle_phase;
+    if (delta < -0.5F) {
+      delta += 1.0F;
+    }
+    EXPECT_GT(delta, 0.0F);
+    advanced += delta;
+    EXPECT_NEAR(sample.cycle_time, walking.cycle_time, 1.0e-4F);
+    inputs.previous = sample.persistent;
+    previous = sample;
+  }
+
+  EXPECT_NEAR(advanced, (6.0F / 60.0F) / walking.cycle_time, 0.02F);
+  EXPECT_LT(previous.locomotion_blend, walking.locomotion_blend);
+}
+
+namespace {
+
+struct SwingSample {
+  QVector3D hand;
+  QVector3D blade_axis;
+};
+
+auto bake_sword_swing(std::string_view clip_name) -> std::vector<SwingSample> {
+  auto const& manifest =
+      Render::Humanoid::humanoid_manifest(Render::Humanoid::BakeProfile::SwordReady);
+  std::size_t clip_index = manifest.clips.size();
+  for (std::size_t i = 0; i < manifest.clips.size(); ++i) {
+    if (manifest.clips[i].name == clip_name) {
+      clip_index = i;
+      break;
+    }
+  }
+  if (clip_index >= manifest.clips.size() || manifest.bake_clip_frame == nullptr) {
+    return {};
+  }
+
+  constexpr auto k_hand_r =
+      static_cast<std::size_t>(Render::Humanoid::HumanoidBone::HandR);
+  std::vector<SwingSample> samples;
+  samples.reserve(manifest.clips[clip_index].frame_count);
+  for (std::uint32_t frame = 0; frame < manifest.clips[clip_index].frame_count;
+       ++frame) {
+    std::vector<QMatrix4x4> palettes;
+    manifest.bake_clip_frame(clip_index, frame, palettes, nullptr);
+    if (palettes.size() <= k_hand_r) {
+      return {};
+    }
+    samples.push_back({palettes[k_hand_r].column(3).toVector3D(),
+                       palettes[k_hand_r].column(1).toVector3D().normalized()});
+  }
+  return samples;
+}
+
+auto angle_between(const QVector3D& a, const QVector3D& b) -> float {
+  return std::acos(std::clamp(QVector3D::dotProduct(a, b), -1.0F, 1.0F));
+}
+
+} // namespace
+
+TEST(HumanoidSwordSwing, RpgCutsSweepWithoutStallingOnAKey) {
+  for (auto const* clip : {"rpg_sword_slash_left",
+                           "rpg_sword_slash_right",
+                           "rpg_sword_overhead",
+                           "rpg_sword_finisher"}) {
+    auto const samples = bake_sword_swing(clip);
+    ASSERT_GE(samples.size(), 8U) << clip;
+
+    std::vector<float> steps;
+    steps.reserve(samples.size());
+    for (std::size_t i = 1; i + 1 < samples.size(); ++i) {
+      steps.push_back(angle_between(samples[i - 1U].blade_axis, samples[i].blade_axis));
+    }
+    auto const total = std::accumulate(steps.begin(), steps.end(), 0.0F);
+    auto const mean = total / static_cast<float>(steps.size());
+    auto const slowest = *std::min_element(steps.begin(), steps.end());
+    auto const fastest = *std::max_element(steps.begin(), steps.end());
+
+    EXPECT_GT(slowest, mean * 0.05F) << clip << ": blade stalls mid-swing";
+    EXPECT_LT(fastest, mean * 6.0F) << clip << ": blade whips through one frame";
+  }
+}
+
+TEST(HumanoidSwordSwing, RpgCutsReturnToTheGuardTheyStartedFrom) {
+  for (auto const* clip : {"rpg_sword_slash_left",
+                           "rpg_sword_slash_right",
+                           "rpg_sword_overhead",
+                           "rpg_sword_thrust",
+                           "rpg_sword_finisher"}) {
+    auto const samples = bake_sword_swing(clip);
+    ASSERT_GE(samples.size(), 8U) << clip;
+
+    EXPECT_LT((samples.front().hand - samples.back().hand).length(), 0.08F) << clip;
+    EXPECT_LT(angle_between(samples.front().blade_axis, samples.back().blade_axis),
+              0.20F)
+        << clip;
+  }
+}
+
+TEST(AnimationCoreLocomotionManifest, StridePresenceIsFullEvenForASlowWalk) {
+  auto slow = walking_inputs();
+  slow.speed = 0.9F;
+  auto const sample = step_locomotion(slow, 0.0F, 1.0F, 0.0F, 1.0F, 120, 1.0F / 60.0F);
+
+  EXPECT_LT(sample.locomotion_blend, 0.75F);
+  EXPECT_GT(sample.locomotion_presence, 0.99F);
+  EXPECT_LT(sample.run_presence, 0.01F);
+
+  auto fast = walking_inputs();
+  fast.speed = 2.4F;
+  auto const brisk = step_locomotion(fast, 0.0F, 1.0F, 0.0F, 1.0F, 120, 1.0F / 60.0F);
+  EXPECT_NEAR(brisk.locomotion_presence, sample.locomotion_presence, 0.01F);
+
+  auto running = walking_inputs();
+  running.movement_state = Animation::MovementState::Run;
+  running.motion_state = Animation::HumanoidMotionState::Run;
+  running.speed = 4.6F;
+  auto const sprint =
+      step_locomotion(running, 0.0F, 1.0F, 0.0F, 1.0F, 120, 1.0F / 60.0F);
+  EXPECT_GT(sprint.run_presence, 0.99F);
+}
+
+TEST(AnimationCoreSelectionManifest, LocomotionCrossfadePicksTheTwoLeadingClips) {
+  auto const standing = Animation::resolve_locomotion_crossfade({
+      .resolved = Animation::StateId::Idle,
+      .locomotion_presence = 0.0F,
+      .run_presence = 0.0F,
+  });
+  EXPECT_FALSE(standing.active);
+  EXPECT_EQ(standing.primary, Animation::StateId::Idle);
+
+  auto const walking = Animation::resolve_locomotion_crossfade({
+      .resolved = Animation::StateId::Walk,
+      .locomotion_presence = 1.0F,
+      .run_presence = 0.0F,
+  });
+  EXPECT_FALSE(walking.active);
+  EXPECT_EQ(walking.primary, Animation::StateId::Walk);
+
+  auto const starting = Animation::resolve_locomotion_crossfade({
+      .resolved = Animation::StateId::Walk,
+      .locomotion_presence = 0.35F,
+      .run_presence = 0.0F,
+  });
+  EXPECT_TRUE(starting.active);
+  EXPECT_EQ(starting.primary, Animation::StateId::Walk);
+  EXPECT_EQ(starting.secondary, Animation::StateId::Idle);
+  EXPECT_NEAR(starting.secondary_weight, 0.65F, 1.0e-4F);
+
+  auto const stopping = Animation::resolve_locomotion_crossfade({
+      .resolved = Animation::StateId::Idle,
+      .locomotion_presence = 0.80F,
+      .run_presence = 0.0F,
+  });
+  EXPECT_TRUE(stopping.active);
+  EXPECT_EQ(stopping.primary, Animation::StateId::Idle);
+  EXPECT_EQ(stopping.secondary, Animation::StateId::Walk);
+  EXPECT_NEAR(stopping.secondary_weight, 0.80F, 1.0e-4F);
+
+  auto const breaking_into_a_run = Animation::resolve_locomotion_crossfade({
+      .resolved = Animation::StateId::Run,
+      .locomotion_presence = 1.0F,
+      .run_presence = 0.6F,
+  });
+  EXPECT_TRUE(breaking_into_a_run.active);
+  EXPECT_EQ(breaking_into_a_run.primary, Animation::StateId::Run);
+  EXPECT_EQ(breaking_into_a_run.secondary, Animation::StateId::Walk);
+  EXPECT_NEAR(breaking_into_a_run.secondary_weight, 0.40F, 1.0e-4F);
 }
 
 TEST(AnimationCoreLocomotionManifest, MotionStateOwnsWalkRunSelection) {
@@ -8534,11 +8929,10 @@ TEST(HumanoidPrepare, TurnSignalCreatesInnerOuterStrideAsymmetry) {
   Render::GL::HumanoidRendererBase::compute_locomotion_pose(
       555U, 0.25F, turning, variation, turning_pose);
 
-  float const neutral_asymmetry =
-      std::abs(std::abs(neutral_pose.foot_l.z()) - std::abs(neutral_pose.foot_r.z()));
-  float const turning_asymmetry =
-      std::abs(std::abs(turning_pose.foot_l.z()) - std::abs(turning_pose.foot_r.z()));
-  EXPECT_GT(turning_asymmetry, neutral_asymmetry + 0.001F);
+  auto const reach_ratio = [](const Render::GL::HumanoidPose& pose) {
+    return std::abs(pose.foot_l.z()) / std::max(1.0e-4F, std::abs(pose.foot_r.z()));
+  };
+  EXPECT_GT(reach_ratio(turning_pose), reach_ratio(neutral_pose) * 1.05F);
   EXPECT_LT(turning_pose.foot_l.x(), turning_pose.foot_r.x());
 }
 

--- a/tests/render/stateless_weapon_renderers_test.cpp
+++ b/tests/render/stateless_weapon_renderers_test.cpp
@@ -426,16 +426,21 @@ TEST(StatelessWeaponRenderers, RpgSwordAttackUsesAuthoredGripInsteadOfVariantSwa
   auto anim_b = anim_a;
   anim_b.inputs.attack_variant = 4U;
   anim_b.inputs.finisher_attack = true;
-  anim_b.attack_phase = 0.62F;
 
   EquipmentBatch batch_a;
   EquipmentBatch batch_b;
   SwordRenderer::submit(SwordRenderConfig{}, ctx, frames, palette, anim_a, batch_a);
   SwordRenderer::submit(SwordRenderConfig{}, ctx, frames, palette, anim_b, batch_b);
 
-  EXPECT_EQ(batch_a.archetypes.size(), 1U);
-  EXPECT_EQ(batch_b.archetypes.size(), 1U);
   EXPECT_EQ(hash_batch(batch_a), hash_batch(batch_b));
+
+  auto guard_only = anim_a;
+  guard_only.attack_phase = 0.02F;
+  EquipmentBatch guard_batch;
+  SwordRenderer::submit(
+      SwordRenderConfig{}, ctx, frames, palette, guard_only, guard_batch);
+  EXPECT_EQ(guard_batch.archetypes.size(), 1U);
+  EXPECT_GT(batch_a.archetypes.size(), guard_batch.archetypes.size());
 
   auto moved_grip_frames = frames;
   moved_grip_frames.grip_r.origin += QVector3D(0.0F, 0.24F, 0.0F);
@@ -443,6 +448,39 @@ TEST(StatelessWeaponRenderers, RpgSwordAttackUsesAuthoredGripInsteadOfVariantSwa
   SwordRenderer::submit(
       SwordRenderConfig{}, ctx, moved_grip_frames, palette, anim_a, moved_grip_batch);
   EXPECT_NE(hash_batch(batch_a), hash_batch(moved_grip_batch));
+}
+
+TEST(StatelessWeaponRenderers, RpgSwordCutDrawsATrailAcrossItsStrikeWindow) {
+  auto frames = make_frames();
+  frames.hand_r.radius = 0.05F;
+  frames.hand_r.depth = 0.10F;
+  frames.grip_r = frames.hand_r;
+  frames.grip_r.radius = 0.05F;
+  frames.grip_r.depth = 0.10F;
+
+  const auto palette = make_palette();
+  const auto ctx = make_ctx();
+
+  auto anim = make_anim();
+  anim.inputs.is_attacking = true;
+  anim.inputs.is_melee = true;
+  anim.inputs.attack_family = Engine::Core::CombatAttackFamily::Sword;
+  anim.inputs.has_sword_attack_animation = true;
+  anim.inputs.has_attack_offset = true;
+  anim.inputs.sword_attack_animation = Animation::SwordAttackAnimation::RpgSlashLeft;
+
+  auto archetype_count_at = [&](float phase) {
+    auto sampled = anim;
+    sampled.attack_phase = phase;
+    EquipmentBatch batch;
+    SwordRenderer::submit(SwordRenderConfig{}, ctx, frames, palette, sampled, batch);
+    return batch.archetypes.size();
+  };
+
+  EXPECT_EQ(archetype_count_at(0.10F), 1U);
+  EXPECT_GT(archetype_count_at(0.45F), 1U);
+  EXPECT_GT(archetype_count_at(0.60F), 1U);
+  EXPECT_EQ(archetype_count_at(0.90F), 1U);
 }
 
 TEST(StatelessWeaponRenderers, SwordProfileFieldsChangeVisibleMesh) {

--- a/tests/systems/combat_mode_test.cpp
+++ b/tests/systems/combat_mode_test.cpp
@@ -6,6 +6,7 @@
 #include "animation/bpat/bpat_format.h"
 #include "animation/bpat/bpat_registry.h"
 #include "animation/clip_manifest.h"
+#include "animation/death_pose_manifest.h"
 #include "core/component.h"
 #include "core/entity.h"
 #include "core/world.h"
@@ -2202,7 +2203,12 @@ TEST_F(CombatModeTest, LethalDamageStartsDeathSequenceBeforeCleanup) {
   ASSERT_NE(death, nullptr);
   EXPECT_EQ(death->state, DeathSequenceState::Dying);
   EXPECT_EQ(death->profile, DeathSequenceProfile::Infantry);
-  EXPECT_EQ(death->sequence_variant, 0U);
+
+  EXPECT_EQ(Animation::humanoid_infantry_death_collapse(death->sequence_variant),
+            Animation::HumanoidDeathCollapse::SideCrumple);
+  EXPECT_FLOAT_EQ(death->state_duration,
+                  Animation::humanoid_death_collapse_duration(
+                      Animation::HumanoidDeathCollapse::SideCrumple));
   EXPECT_FALSE(target->has_component<PendingRemovalComponent>());
   EXPECT_FALSE(movement->get_has_target());
 
@@ -2224,6 +2230,33 @@ TEST_F(CombatModeTest, LethalDamageStartsDeathSequenceBeforeCleanup) {
   EXPECT_LE(blood_stain->aspect_ratio, 1.34F);
   EXPECT_GE(blood_stain->seed, 0.0F);
   EXPECT_LT(blood_stain->seed, 1.0F);
+}
+
+TEST_F(CombatModeTest, TheFallMatchesWhereTheKillingBlowCameFrom) {
+
+  auto kill_from = [this](float attacker_x, float attacker_z) {
+    auto* attacker = world->create_entity();
+    attacker->add_component<TransformComponent>(attacker_x, 0.0F, attacker_z);
+    auto* attacker_unit = attacker->add_component<UnitComponent>(100, 100, 1.0F, 12.0F);
+    attacker_unit->owner_id = 1;
+    attacker_unit->spawn_type = Game::Units::SpawnType::Knight;
+
+    auto* target = world->create_entity();
+    target->add_component<TransformComponent>(0.0F, 0.0F, 0.0F);
+    auto* target_unit = target->add_component<UnitComponent>(30, 100, 1.0F, 12.0F);
+    target_unit->owner_id = 2;
+
+    Game::Systems::Combat::deal_damage(world.get(), target, 120, attacker->get_id());
+    auto const* death = target->get_component<DeathAnimationComponent>();
+    EXPECT_NE(death, nullptr);
+    return death != nullptr
+               ? Animation::humanoid_infantry_death_collapse(death->sequence_variant)
+               : Animation::HumanoidDeathCollapse::None;
+  };
+
+  EXPECT_EQ(kill_from(0.0F, 4.0F), Animation::HumanoidDeathCollapse::BackSprawl);
+  EXPECT_EQ(kill_from(0.0F, -4.0F), Animation::HumanoidDeathCollapse::FacePlant);
+  EXPECT_EQ(kill_from(4.0F, 0.0F), Animation::HumanoidDeathCollapse::SideCrumple);
 }
 
 TEST_F(CombatModeTest, NonLethalDamageQueuesPerSoldierCasualtyAnimations) {

--- a/tests/systems/commander_duel_test.cpp
+++ b/tests/systems/commander_duel_test.cpp
@@ -9,8 +9,10 @@
 #include "game/map/terrain_service.h"
 #include "game/systems/combat_actions/combat_action_definition.h"
 #include "game/systems/command_service.h"
+#include "game/systems/formation_combat_geometry.h"
 #include "game/systems/nation_registry.h"
 #include "game/systems/owner_registry.h"
+#include "game/systems/projectile_system.h"
 #include "game/systems/runtime_system_registry.h"
 #include "units/commander_catalog.h"
 #include "units/factory.h"
@@ -117,6 +119,178 @@ TEST(CommanderCatalogTest, EveryCommanderCarriesItsOwnSignatureMove) {
 
   EXPECT_EQ(moves.size(), definitions.size())
       << "two commanders share a signature move; each one has to fight like itself";
+}
+
+TEST_F(CommanderDuelTest, DuellistsCloseToWithinTheirWeaponsReach) {
+  struct Pair {
+    Game::Units::SpawnType a;
+    Game::Units::SpawnType b;
+    float max_settled;
+    const char* name;
+  };
+  for (auto const& pair : {Pair{Game::Units::SpawnType::RomanVeteranConsul,
+                                Game::Units::SpawnType::CarthageSwordCommander,
+                                1.45F,
+                                "sword commanders"},
+                           Pair{Game::Units::SpawnType::RomanVeteranConsul,
+                                Game::Units::SpawnType::Knight,
+                                1.40F,
+                                "commander against a swordsman"}}) {
+    Engine::Core::World world;
+    Game::Systems::register_runtime_systems(world);
+    auto* one = spawn(world,
+                      pair.a,
+                      1,
+                      QVector3D(-6.0F, 0.0F, 0.0F),
+                      Game::Systems::NationID::RomanRepublic);
+    auto* two = spawn(world,
+                      pair.b,
+                      2,
+                      QVector3D(6.0F, 0.0F, 0.0F),
+                      Game::Systems::NationID::Carthage);
+    ASSERT_NE(one, nullptr) << pair.name;
+    ASSERT_NE(two, nullptr) << pair.name;
+    order_attack(*one, *two);
+    order_attack(*two, *one);
+    for (int tick = 0; tick < 400; ++tick) {
+      world.update(0.05F);
+    }
+
+    auto const* ta = one->get_component<TransformComponent>();
+    auto const* tb = two->get_component<TransformComponent>();
+    ASSERT_NE(ta, nullptr);
+    ASSERT_NE(tb, nullptr);
+    float const settled =
+        std::hypot(tb->position.x - ta->position.x, tb->position.z - ta->position.z);
+    auto const geometry = Game::Systems::FormationCombat::contact_geometry(*one, *two);
+
+    EXPECT_LT(settled, pair.max_settled) << pair.name << " fights at arm's length";
+    EXPECT_GT(settled, geometry.contact_center_distance)
+        << pair.name << " has walked into its opponent";
+  }
+}
+
+TEST_F(CommanderDuelTest, SiegeEnginesStopShootingOnceLockedInMelee) {
+  Engine::Core::World world;
+  Game::Systems::register_runtime_systems(world);
+
+  auto* ballista = spawn(world,
+                         Game::Units::SpawnType::Ballista,
+                         1,
+                         QVector3D(0.0F, 0.0F, 0.0F),
+                         Game::Systems::NationID::RomanRepublic);
+  auto* brawler = spawn(world,
+                        Game::Units::SpawnType::Knight,
+                        2,
+                        QVector3D(1.2F, 0.0F, 0.0F),
+                        Game::Systems::NationID::Carthage);
+  ASSERT_NE(ballista, nullptr);
+  ASSERT_NE(brawler, nullptr);
+  order_attack(*brawler, *ballista);
+  order_attack(*ballista, *brawler);
+
+  auto* projectiles = world.get_system<Game::Systems::ProjectileSystem>();
+  ASSERT_NE(projectiles, nullptr);
+
+  std::size_t seen = 0;
+  int locked_frames = 0;
+  int ranged_while_locked = 0;
+  int shots_while_locked = 0;
+  for (int tick = 0; tick < 400; ++tick) {
+    world.update(0.05F);
+    auto const* attack = ballista->get_component<Engine::Core::AttackComponent>();
+    ASSERT_NE(attack, nullptr);
+    bool const locked = attack->in_melee_lock;
+    if (locked) {
+      ++locked_frames;
+      if (attack->current_mode == Engine::Core::AttackComponent::CombatMode::Ranged) {
+        ++ranged_while_locked;
+      }
+    }
+    std::size_t const now =
+        projectiles->projectiles().size() + projectiles->spent_projectiles().size();
+    if (now > seen && locked) {
+      shots_while_locked += static_cast<int>(now - seen);
+    }
+    seen = std::max(seen, now);
+  }
+
+  ASSERT_GT(locked_frames, 200) << "the ballista never got dragged into a melee";
+  EXPECT_EQ(shots_while_locked, 0);
+  EXPECT_LE(ranged_while_locked, 1)
+      << "a locked engine may not sit in ranged mode; one frame of overlap is the "
+         "tick contact is made";
+}
+
+TEST_F(CommanderDuelTest, SiegeEnginesStillShootWhenNothingIsOnTopOfThem) {
+  Engine::Core::World world;
+  Game::Systems::register_runtime_systems(world);
+
+  auto* ballista = spawn(world,
+                         Game::Units::SpawnType::Ballista,
+                         1,
+                         QVector3D(0.0F, 0.0F, 0.0F),
+                         Game::Systems::NationID::RomanRepublic);
+  auto* quarry = spawn(world,
+                       Game::Units::SpawnType::Knight,
+                       2,
+                       QVector3D(12.0F, 0.0F, 0.0F),
+                       Game::Systems::NationID::Carthage);
+  ASSERT_NE(ballista, nullptr);
+  ASSERT_NE(quarry, nullptr);
+  quarry->get_component<UnitComponent>()->speed = 0.0F;
+  order_attack(*ballista, *quarry);
+
+  auto* projectiles = world.get_system<Game::Systems::ProjectileSystem>();
+  ASSERT_NE(projectiles, nullptr);
+
+  std::size_t fired = 0;
+  for (int tick = 0; tick < 300; ++tick) {
+    world.update(0.05F);
+    fired = std::max(fired,
+                     projectiles->projectiles().size() +
+                         projectiles->spent_projectiles().size());
+  }
+  EXPECT_GT(fired, 0U) << "the melee-lock rule has silenced siege entirely";
+}
+
+TEST_F(CommanderDuelTest, ShootersSwitchToTheirSidearmWhenLocked) {
+  for (auto const spawn_type : {Game::Units::SpawnType::Archer,
+                                Game::Units::SpawnType::SkeletonArcher,
+                                Game::Units::SpawnType::GravePriest}) {
+    Engine::Core::World world;
+    Game::Systems::register_runtime_systems(world);
+    auto* shooter = spawn(world,
+                          spawn_type,
+                          1,
+                          QVector3D(0.0F, 0.0F, 0.0F),
+                          Game::Systems::NationID::RomanRepublic);
+    auto* brawler = spawn(world,
+                          Game::Units::SpawnType::Knight,
+                          2,
+                          QVector3D(1.2F, 0.0F, 0.0F),
+                          Game::Systems::NationID::Carthage);
+    ASSERT_NE(shooter, nullptr);
+    ASSERT_NE(brawler, nullptr);
+    order_attack(*brawler, *shooter);
+    order_attack(*shooter, *brawler);
+
+    int locked_frames = 0;
+    int ranged_while_locked = 0;
+    for (int tick = 0; tick < 400; ++tick) {
+      world.update(0.05F);
+      auto const* attack = shooter->get_component<Engine::Core::AttackComponent>();
+      if (attack == nullptr || !attack->in_melee_lock) {
+        continue;
+      }
+      ++locked_frames;
+      if (attack->current_mode == Engine::Core::AttackComponent::CombatMode::Ranged) {
+        ++ranged_while_locked;
+      }
+    }
+    ASSERT_GT(locked_frames, 200) << static_cast<int>(spawn_type);
+    EXPECT_LE(ranged_while_locked, 1) << static_cast<int>(spawn_type);
+  }
 }
 
 TEST_P(CommanderDuelTest, CommanderThrowsItsSignatureInADuel) {

--- a/tools/bpat_baker/main.cpp
+++ b/tools/bpat_baker/main.cpp
@@ -237,12 +237,15 @@ int main(int argc, char** argv) {
   static_assert(Render::Creature::k_humanoid_riding_sword_strike_clip == 21U);
   static_assert(Render::Creature::k_humanoid_riding_spear_thrust_clip == 22U);
   static_assert(Render::Creature::k_humanoid_die_infantry_clip == 23U);
-  static_assert(Render::Creature::k_humanoid_dead_mounted_clip == 26U);
-  static_assert(Render::Creature::k_humanoid_rpg_sword_slash_left_clip == 27U);
-  static_assert(Render::Creature::k_humanoid_rpg_sword_slash_right_clip == 28U);
-  static_assert(Render::Creature::k_humanoid_rpg_sword_overhead_clip == 29U);
-  static_assert(Render::Creature::k_humanoid_rpg_sword_thrust_clip == 30U);
-  static_assert(Render::Creature::k_humanoid_rpg_sword_finisher_clip == 31U);
+  static_assert(Render::Creature::k_humanoid_dead_infantry_clip ==
+                Render::Creature::k_humanoid_die_infantry_clip +
+                    Render::Creature::k_humanoid_infantry_death_variant_count);
+  static_assert(Render::Creature::k_humanoid_dead_mounted_clip == 30U);
+  static_assert(Render::Creature::k_humanoid_rpg_sword_slash_left_clip == 31U);
+  static_assert(Render::Creature::k_humanoid_rpg_sword_slash_right_clip == 32U);
+  static_assert(Render::Creature::k_humanoid_rpg_sword_overhead_clip == 33U);
+  static_assert(Render::Creature::k_humanoid_rpg_sword_thrust_clip == 34U);
+  static_assert(Render::Creature::k_humanoid_rpg_sword_finisher_clip == 35U);
   std::filesystem::path out_dir = "assets/creatures";
   if (argc >= 2) {
     out_dir = argv[1];


### PR DESCRIPTION
Smooth humanoid movement by replacing the discontinuous swing-foot curve with a stance-matched Hermite path, tracking locomotion presence independently from gait speed, and crossfading idle, walk, and run clips while residual strides finish cycling.

Keep authored RPG sword attacks continuous through their keyframes with Hermite position interpolation, spherical blade-direction interpolation, a shared guard pose, stance blending throughout the attack transaction, correct exit-blend progress, and attack-specific sword trail windows.

Replace stretched offset-based casualty poses with forward-kinematic back-sprawl, face-plant, side-crumple, and mounted-unseat collapses. Select infantry variants from the killing blow direction, keep runtime timing aligned with baked clips, and add held corpse variants plus structural ground-contact coverage.

Tighten melee behavior by using body scale for contact geometry, forcing melee-locked ranged units onto their close-combat path, interrupting incompatible ranged actions, and preventing siege engines from loading or firing while engaged.

Document the animation design and expand regression coverage for locomotion blending, sword continuity and trails, death-pose anatomy, directional casualties, duel spacing, and ranged-unit melee locks.