### PR TITLE
Expand wildlife combat and reshape sword points

### DIFF
--- a/docs/AMBIENT_WILDLIFE.md
+++ b/docs/AMBIENT_WILDLIFE.md
@@ -35,11 +35,27 @@ guarantees:
 
 - `VisibilityService` skips neutral units when it gathers vision sources, so wildlife
   never reveals a tile. A sheep cannot scout for you.
-- Wildlife is filtered out of automatic target selection (`is_valid_enemy_unit`) and never
-  auto-engages anything itself. Troops walk past a herd instead of stopping to kill it; a
-  hunt is something the player orders explicitly.
 - `is_troop_spawn` excludes both wildlife spawn types, so population counts, victory
   conditions and formation code ignore them.
+
+Neutrality decides who may be shot at, not what an animal _is_ to the combat code. An
+animal is an ordinary enemy of every owner (`is_valid_enemy_unit`), which is what makes an
+ordered hunt land, lets a wolf's bite provoke the retaliation every other hit provokes, and
+lets a soldier's swing connect with the wolf that is chewing on him. What neutrality buys
+is the second predicate, `is_auto_acquirable_enemy`: **passive** wildlife — every sheep, and
+any wolf that is not currently in a fight — is skipped by everything that picks a target on
+its own, so troops march past a herd, guard mode ignores it, towers do not waste bolts on
+it and the attack cursor does not paint a marker over every animal on the map. A wolf that
+has committed to a person, or that has been hit by one, carries `hostile_timer` for a few
+seconds; while it burns, that wolf is a target troops will take on their own initiative,
+which is what turns a pack rush into a fight instead of a massacre.
+
+The retaliation hook is the one place where wildlife takes a different path from a troop:
+`assign_retaliation_target_if_needed` records the attacker in `WildlifeComponent`
+(`aggressor_id`, `hostile_timer`) and stops, rather than hanging an `AttackTargetComponent`
+on the animal. An animal that carried one would be driven by the RTS attack processor and
+by its own brain at the same time, and the two would fight over its movement orders every
+tick.
 
 The renderer applies the matching rule on the presentation side: a bird is only submitted
 when its tile is _currently visible_, not merely explored, so a flock scattering in the
@@ -63,27 +79,37 @@ and the stat counters.
 `NatureBrain::tick` walks the behaviours from highest priority down and stops at the first
 one that returns true, so the priority ladder _is_ the animal's mind:
 
-| Priority   | Sheep           | Wolf           |
-| ---------- | --------------- | -------------- |
-| `Survival` | `sheep.flee`    | `wolf.retreat` |
-| `Interest` | `sheep.regroup` | `wolf.stalk`   |
-| `Routine`  | `sheep.graze`   | `wolf.menace`  |
-| `Ambient`  | `sheep.drift`   | `wolf.prowl`   |
+| Priority   | Sheep           | Wolf                          |
+| ---------- | --------------- | ----------------------------- |
+| `Survival` | `sheep.flee`    | `wolf.defend`, `wolf.retreat` |
+| `Interest` | `sheep.regroup` | `wolf.stalk`                  |
+| `Routine`  | `sheep.graze`   | `wolf.menace`                 |
+| `Ambient`  | `sheep.drift`   | `wolf.prowl`                  |
 
-**Sheep** graze, drift and panic. `sheep.flee` fires on any armed troop or wolf inside the
-alert radius and broadcasts the alarm to the whole group, so the herd bolts together;
+Two behaviours may share a priority, and `NatureBrain::add` keeps ties in registration
+order, so the table reads top to bottom exactly as the brain evaluates it.
+
+**Sheep** graze, drift and panic. `sheep.flee` fires on whoever last wounded the animal, on
+any armed troop or wolf inside the
+alert radius, and broadcasts the alarm to the whole group, so the herd bolts together;
 civilians and builders are deliberately weak threats, because a shepherd should not
 stampede the flock. `sheep.regroup` pulls back a sheep that has drifted too far from the
 centroid, which is what makes a herd read as a herd rather than as eight independent
 animals. Otherwise `sheep.graze` dwells in place and `sheep.drift` wanders near the herd.
 
-**Wolves** prowl, hunt and retreat. `wolf.retreat` calls the hunt off when troop strength
-near the wolf exceeds its tolerance (scaled by aggression). `wolf.stalk` picks the nearest
-sheep inside the detection radius, declines if the prey is standing behind a formation,
-and otherwise approaches on a per-wolf angle so the pack surrounds it instead of stacking;
-inside bite range it applies melee damage on the attack cooldown. With aggression at or
-above 0.5, `wolf.menace` closes on isolated civilians and holds a standoff distance —
-menacing, never damaging. `wolf.prowl` roams the pack anchor.
+**Wolves** prowl, hunt, fight and retreat. `wolf.defend` turns the animal on whoever
+wounded it and calls the rest of the pack in, unless the wolf is outnumbered — the same
+tolerance `wolf.retreat` uses, so exactly one of the two takes the tick: a pack answers a
+lone hunter and scatters from a column. `wolf.stalk` weighs the nearest sheep against the
+nearest person inside the detection radius, preferring livestock at equal distance and
+civilians over soldiers, and declines a quarry that is standing behind enough strength to
+hurt the pack — which, since a person counts toward the strength around themself, is what
+reduces to "wolves take the isolated and leave the escorted alone". It approaches on a
+per-wolf angle so the pack surrounds the target instead of stacking, and inside bite range
+applies melee damage on the attack cooldown. Committing to a person, rather than to a
+sheep, is what marks the wolf hostile. With aggression at or above 0.5, `wolf.menace`
+closes on civilians it declined to hunt and holds a standoff distance — menacing, never
+damaging. `wolf.prowl` roams the pack anchor.
 
 The ambient behaviours never decline, so an animal always has something to do.
 
@@ -194,8 +220,8 @@ same map always lays out the same way.
 ## Persistence
 
 The animals themselves are ordinary entities, so the world snapshot already carries them;
-`WildlifeComponent` adds species, behaviour, group id, anchor, timers and the RNG state to
-the entity payload. What the entity stream cannot express is the _population plan_ — the
+`WildlifeComponent` adds species, behaviour, group id, anchor, timers, the animal's
+current aggressor and the RNG state to the entity payload. What the entity stream cannot express is the _population plan_ — the
 group anchors, their desired sizes and their respawn countdowns — plus the birds, which
 have no entities at all. Those live in a `wildlife` object in the save metadata, written
 and restored beside the undead-zone state. A restored system does not re-run its initial
@@ -271,7 +297,7 @@ a white fleece is what made a grazing herd read as plastic.
 
 ## Arena fixtures
 
-Nine scenarios cover the feature; run them with
+Ten scenarios cover the feature; run them with
 `arena_app --batch --scenario <id>`:
 
 | Scenario                     | What it proves                                              |
@@ -280,6 +306,7 @@ Nine scenarios cover the feature; run them with
 | `wildlife_herd_flees_troops` | A patrol triggers the herd's flee response                  |
 | `wildlife_wolf_hunt`         | Pack stalking, bites, herd panic                            |
 | `wildlife_wolf_pack`         | Undisturbed prowl: wolf silhouette, coat and gait           |
+| `wildlife_wolf_ambush`       | A pack rushes a lone patrol; both sides take losses         |
 | `wildlife_bird_scatter`      | Resident flock cruise and burst under a marching column     |
 | `wildlife_bird_flyover`      | Empty sky, then a flock crosses it and leaves               |
 | `wildlife_mixed_pasture`     | Sheep, wolves and a passing flock in one frame              |
@@ -288,7 +315,8 @@ Nine scenarios cover the feature; run them with
 
 They assert through wildlife-specific expectations (`WildlifeGrazingObserved`,
 `WildlifeFleeObserved`, `WildlifeHuntObserved`, `WildlifeBirdsScattered`,
-`WildlifeBirdFlyoverObserved`, `WildlifePopulationHeld`) rather than by eye.
+`WildlifeBirdFlyoverObserved`, `WildlifePopulationHeld`,
+`WildlifeCasualtyObserved`) rather than by eye.
 
 ## Authoring in the map editor
 

--- a/docs/RENDERING_ARCHITECTURE.md
+++ b/docs/RENDERING_ARCHITECTURE.md
@@ -658,6 +658,29 @@ silently become visible to the other.
 
 **Caching.** `CreatureRenderBatch::add_humanoid` calls `resolve_pose_intent` once and passes the result into both `humanoid_state_for_anim` (via its two-argument overload) and the variant-table dispatch block. No system in the critical render path calls the resolver more than once per entity per frame.
 
+### Sword points are flattened cones, not spikes
+
+Every sword in the game — both nations, every commander variant, the mounted riders, and
+the baked static attachment — comes out of the single `sword_archetype` builder in
+`render/equipment/weapons/sword_renderer.cpp`. The blade below the point is a stack of
+oriented boxes: wide in the guard axis, thin (about a sixth of the blade width) in the
+flat axis.
+
+The point used to be `cone_from_to(blade3, blade4, tip_half_w)`, a _round_ cone whose
+radius came from `blade_tip_width_scale`. On the Roman gladius that is a 0.010 radius
+stuck on the end of a blade 0.065 half-wide, so the last fifth of every sword read as a
+needle welded to a blade. The fix is `oriented_cone_between`, which takes the same basis
+as `oriented_box_between` but doubles the length column, because the unit cone spans
+±0.5 in Y while the unit cube spans ±1. Feeding it the blade's own half-width and
+half-depth makes the point an elliptical cone whose base exactly matches the cross
+section it grows out of: a triangle seen from the flat side, a thin wedge seen edge-on,
+continuous silhouette from both.
+
+Consequence for the config: `blade_tip_width_scale` no longer sets the width of anything.
+It only shifts `tip_start_dist`, so a smaller value means the point starts further back
+and the triangle is longer and keener. The point's width is always the blade's width —
+anything else reintroduces the shoulder step that made the old tip look like a pin.
+
 > For the full animation/pose pipeline — bake step, BPAT clip resolution and sampling,
 > the procedural locomotion shaper, the combat visual state machine with marker-driven
 > melee damage sync, and the shared quadruped gait — see

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -1858,8 +1858,14 @@ public:
   float think_cooldown{0.0F};
   float state_timer{0.0F};
   float alarm_timer{0.0F};
+  float hostile_timer{0.0F};
   EntityID focus_id{0};
+  EntityID aggressor_id{0};
   std::uint32_t rng_state{0U};
+
+  [[nodiscard]] auto is_hostile() const noexcept -> bool {
+    return species == Game::Wildlife::Species::Wolf && hostile_timer > 0.0F;
+  }
 };
 
 class MovementIntentComponent : public Component {

--- a/game/core/serialization.cpp
+++ b/game/core/serialization.cpp
@@ -833,7 +833,9 @@ auto Serialization::serialize_entity(const Entity* entity) -> QJsonObject {
     wildlife_obj["think_cooldown"] = static_cast<double>(wildlife->think_cooldown);
     wildlife_obj["state_timer"] = static_cast<double>(wildlife->state_timer);
     wildlife_obj["alarm_timer"] = static_cast<double>(wildlife->alarm_timer);
+    wildlife_obj["hostile_timer"] = static_cast<double>(wildlife->hostile_timer);
     wildlife_obj["focus_id"] = static_cast<qint64>(wildlife->focus_id);
+    wildlife_obj["aggressor_id"] = static_cast<qint64>(wildlife->aggressor_id);
     wildlife_obj["rng_state"] = static_cast<qint64>(wildlife->rng_state);
     entity_obj["wildlife"] = wildlife_obj;
   }
@@ -1786,8 +1788,12 @@ void Serialization::deserialize_entity(Entity* entity, const QJsonObject& json) 
         static_cast<float>(wildlife_obj["state_timer"].toDouble(0.0));
     wildlife->alarm_timer =
         static_cast<float>(wildlife_obj["alarm_timer"].toDouble(0.0));
+    wildlife->hostile_timer =
+        static_cast<float>(wildlife_obj["hostile_timer"].toDouble(0.0));
     wildlife->focus_id =
         static_cast<EntityID>(wildlife_obj["focus_id"].toVariant().toULongLong());
+    wildlife->aggressor_id =
+        static_cast<EntityID>(wildlife_obj["aggressor_id"].toVariant().toULongLong());
     wildlife->rng_state =
         static_cast<std::uint32_t>(wildlife_obj["rng_state"].toVariant().toULongLong());
   }

--- a/game/systems/attack_targeting.cpp
+++ b/game/systems/attack_targeting.cpp
@@ -148,7 +148,8 @@ auto collect_attack_target_highlights(const AttackTargetingRequest& request)
     if (entity == nullptr) {
       continue;
     }
-    if (!Combat::is_valid_enemy_of_owner(request.local_owner_id, entity, true)) {
+    if (!Combat::is_auto_acquirable_enemy_of_owner(
+            request.local_owner_id, entity, true)) {
       continue;
     }
 

--- a/game/systems/combat_system/combat_utils.cpp
+++ b/game/systems/combat_system/combat_utils.cpp
@@ -124,9 +124,6 @@ auto is_valid_enemy_of_owner(int attacker_owner_id,
   if ((target_unit == nullptr) || (target_unit->health <= 0)) {
     return false;
   }
-  if (target->has_component<Engine::Core::WildlifeComponent>()) {
-    return false;
-  }
   if (target_unit->owner_id == attacker_owner_id) {
     return false;
   }
@@ -141,6 +138,31 @@ auto is_valid_enemy_of_owner(int attacker_owner_id,
   }
 
   return true;
+}
+
+auto is_passive_wildlife(Engine::Core::Entity* target) -> bool {
+  if (target == nullptr) {
+    return false;
+  }
+  const auto* wildlife = target->get_component<Engine::Core::WildlifeComponent>();
+  return (wildlife != nullptr) && !wildlife->is_hostile();
+}
+
+auto is_auto_acquirable_enemy(const Engine::Core::UnitComponent* attacker_unit,
+                              Engine::Core::Entity* target,
+                              bool allow_buildings) -> bool {
+  if (attacker_unit == nullptr) {
+    return false;
+  }
+  return is_auto_acquirable_enemy_of_owner(
+      attacker_unit->owner_id, target, allow_buildings);
+}
+
+auto is_auto_acquirable_enemy_of_owner(int attacker_owner_id,
+                                       Engine::Core::Entity* target,
+                                       bool allow_buildings) -> bool {
+  return is_valid_enemy_of_owner(attacker_owner_id, target, allow_buildings) &&
+         !is_passive_wildlife(target);
 }
 
 auto combat_radius(Engine::Core::Entity* entity) -> float {
@@ -335,7 +357,7 @@ auto find_nearest_enemy(Engine::Core::Entity* unit,
       continue;
     }
 
-    if (!is_valid_enemy_unit(unit_comp, target, false)) {
+    if (!is_auto_acquirable_enemy(unit_comp, target, false)) {
       continue;
     }
 

--- a/game/systems/combat_system/combat_utils.h
+++ b/game/systems/combat_system/combat_utils.h
@@ -45,6 +45,16 @@ auto is_valid_enemy_of_owner(int attacker_owner_id,
                              Engine::Core::Entity* target,
                              bool allow_buildings) -> bool;
 
+auto is_passive_wildlife(Engine::Core::Entity* target) -> bool;
+
+auto is_auto_acquirable_enemy(const Engine::Core::UnitComponent* attacker_unit,
+                              Engine::Core::Entity* target,
+                              bool allow_buildings) -> bool;
+
+auto is_auto_acquirable_enemy_of_owner(int attacker_owner_id,
+                                       Engine::Core::Entity* target,
+                                       bool allow_buildings) -> bool;
+
 auto combat_radius(Engine::Core::Entity* entity) -> float;
 
 auto is_in_range(Engine::Core::Entity* attacker,

--- a/game/systems/combat_system/damage_application.cpp
+++ b/game/systems/combat_system/damage_application.cpp
@@ -566,6 +566,18 @@ auto has_active_engagement(Engine::Core::World* world,
   return is_valid_enemy_unit(unit, current, true);
 }
 
+auto note_wildlife_aggressor(Engine::Core::Entity* target,
+                             Engine::Core::EntityID attacker_id) -> bool {
+  auto* wildlife = target->get_component<Engine::Core::WildlifeComponent>();
+  if (wildlife == nullptr) {
+    return false;
+  }
+  wildlife->aggressor_id = attacker_id;
+  wildlife->hostile_timer = Game::Wildlife::k_hostility_duration;
+  wildlife->think_cooldown = 0.0F;
+  return true;
+}
+
 auto can_retaliate(Engine::Core::Entity* entity,
                    const Engine::Core::UnitComponent* unit) -> bool {
   if ((entity == nullptr) || (unit == nullptr)) {
@@ -663,6 +675,10 @@ void assign_retaliation_target_if_needed(Engine::Core::World* world,
   }
 
   if (!is_valid_retaliation_attacker(attacker)) {
+    return;
+  }
+
+  if (note_wildlife_aggressor(target, attacker->get_id())) {
     return;
   }
 

--- a/game/systems/combat_system/siege_special_processor.cpp
+++ b/game/systems/combat_system/siege_special_processor.cpp
@@ -382,7 +382,7 @@ find_nearest_tower_target(Engine::Core::Entity* tower,
     if (entity == tower) {
       continue;
     }
-    if (!is_valid_enemy_unit(tower_unit, entity, true)) {
+    if (!is_auto_acquirable_enemy(tower_unit, entity, true)) {
       continue;
     }
     if (entity->has_component<Engine::Core::BuildingComponent>() &&

--- a/game/wildlife/nature_ai.cpp
+++ b/game/wildlife/nature_ai.cpp
@@ -23,6 +23,8 @@ constexpr float k_graze_dwell_max = 8.5F;
 constexpr float k_alarm_duration = 3.5F;
 constexpr float k_wolf_detect_multiplier = 1.4F;
 constexpr float k_wolf_bite_range = 1.35F;
+constexpr float k_wolf_defend_leash_multiplier = 2.2F;
+constexpr float k_livestock_preference = 0.7F;
 constexpr float k_pack_approach_spacing = 1.1F;
 constexpr float k_wolf_avoid_base_strength = 2.5F;
 constexpr float k_civilian_standoff = 3.0F;
@@ -76,6 +78,52 @@ void bolt_away_from(const NatureContext& ctx,
   actions.move_to(ctx, target_x, target_z);
 }
 
+auto distance_to(const NatureContext& ctx, const PreyRef& prey) -> float {
+  float const dx = prey.x - ctx.x;
+  float const dz = prey.z - ctx.z;
+  return std::sqrt((dx * dx) + (dz * dz));
+}
+
+auto bite_reach(const PreyRef& prey) -> float {
+  return k_wolf_bite_range + prey.radius;
+}
+
+auto overwhelmed(const NatureContext& ctx) -> bool {
+  return ctx.threats->strength_within(ctx.x, ctx.z, ctx.config->alert_radius) >=
+         wolf_avoid_threshold(*ctx.config);
+}
+
+auto guarded(const NatureContext& ctx, const PreyRef& prey) -> bool {
+  return ctx.threats->strength_within(prey.x, prey.z, ctx.config->alert_radius) >=
+         wolf_avoid_threshold(*ctx.config);
+}
+
+void close_and_bite(const NatureContext& ctx,
+                    NatureActions& actions,
+                    const PreyRef& prey) {
+  auto& wildlife = *ctx.wildlife;
+  wildlife.behavior = Behavior::Stalk;
+  wildlife.focus_id = prey.id;
+  actions.set_travel_speed(ctx, true);
+
+  if (distance_to(ctx, prey) <= bite_reach(prey)) {
+    actions.halt(ctx);
+    if (actions.bite(ctx, prey)) {
+      actions.note(NatureEvent::Bite);
+    }
+    return;
+  }
+
+  float const approach_angle =
+      static_cast<float>((wildlife.rng_state >> 8U) & 0xFFFFU) * (k_two_pi / 65536.0F);
+  float const spacing = k_pack_approach_spacing + prey.radius;
+  float const approach_x = prey.x + (std::cos(approach_angle) * spacing);
+  float const approach_z = prey.z + (std::sin(approach_angle) * spacing);
+  wildlife.target_x = approach_x;
+  wildlife.target_z = approach_z;
+  actions.move_to(ctx, approach_x, approach_z);
+}
+
 auto wander_anchor(const NatureContext& ctx, float& anchor_x, float& anchor_z) -> void {
   const auto& wildlife = *ctx.wildlife;
   anchor_x = ctx.herd.center_x;
@@ -99,9 +147,12 @@ public:
   }
 
   auto try_run(const NatureContext& ctx, NatureActions& actions) -> bool override {
-    ThreatQuery threat = ctx.threats->nearest(ctx.x, ctx.z, ctx.config->alert_radius);
-    if (threat.found && threat.strength < k_sheep_flee_strength_threshold) {
-      threat.found = false;
+    ThreatQuery threat = wounding_attacker(ctx, actions);
+    if (!threat.found) {
+      threat = ctx.threats->nearest(ctx.x, ctx.z, ctx.config->alert_radius);
+      if (threat.found && threat.strength < k_sheep_flee_strength_threshold) {
+        threat.found = false;
+      }
     }
     if (!threat.found) {
       threat = actions.nearest_pack_hunter(ctx.x, ctx.z, ctx.config->alert_radius);
@@ -119,6 +170,29 @@ public:
     actions.alert_herd(wildlife.group_id, k_alarm_duration);
     bolt_away_from(ctx, actions, threat.x, threat.z, 2.5F);
     return true;
+  }
+
+private:
+  static auto wounding_attacker(const NatureContext& ctx,
+                                NatureActions& actions) -> ThreatQuery {
+    auto& wildlife = *ctx.wildlife;
+    if (wildlife.hostile_timer <= 0.0F || wildlife.aggressor_id == 0) {
+      return {};
+    }
+    PreyRef const foe = actions.locate(wildlife.aggressor_id);
+    if (!foe.valid()) {
+      wildlife.aggressor_id = 0;
+      wildlife.hostile_timer = 0.0F;
+      return {};
+    }
+
+    ThreatQuery out;
+    out.found = true;
+    out.x = foe.x;
+    out.z = foe.z;
+    out.distance = distance_to(ctx, foe);
+    out.strength = 1.0F;
+    return out;
   }
 };
 
@@ -247,9 +321,7 @@ public:
   }
 
   auto try_run(const NatureContext& ctx, NatureActions& actions) -> bool override {
-    float const nearby =
-        ctx.threats->strength_within(ctx.x, ctx.z, ctx.config->alert_radius);
-    if (nearby < wolf_avoid_threshold(*ctx.config)) {
+    if (!overwhelmed(ctx)) {
       return false;
     }
     ThreatQuery const threat =
@@ -262,6 +334,44 @@ public:
     wildlife.behavior = Behavior::Flee;
     wildlife.state_timer = k_alarm_duration;
     bolt_away_from(ctx, actions, threat.x, threat.z, 3.0F);
+    return true;
+  }
+};
+
+class DefendBehavior : public NatureBehavior {
+public:
+  [[nodiscard]] auto name() const noexcept -> std::string_view override {
+    return "wolf.defend";
+  }
+  [[nodiscard]] auto priority() const noexcept -> NaturePriority override {
+    return NaturePriority::Survival;
+  }
+
+  auto try_run(const NatureContext& ctx, NatureActions& actions) -> bool override {
+    auto& wildlife = *ctx.wildlife;
+    if (wildlife.hostile_timer <= 0.0F || wildlife.aggressor_id == 0) {
+      return false;
+    }
+    if (overwhelmed(ctx)) {
+      return false;
+    }
+
+    PreyRef const foe = actions.locate(wildlife.aggressor_id);
+    if (!foe.valid()) {
+      wildlife.aggressor_id = 0;
+      wildlife.hostile_timer = 0.0F;
+      return false;
+    }
+    float const leash = ctx.config->roam_radius * k_wolf_defend_leash_multiplier;
+    if (distance_to(ctx, foe) > leash) {
+      return false;
+    }
+
+    if (wildlife.behavior != Behavior::Stalk) {
+      actions.note(NatureEvent::Hunt);
+    }
+    actions.mark_hostile(ctx, foe.id, true);
+    close_and_bite(ctx, actions, foe);
     return true;
   }
 };
@@ -280,13 +390,8 @@ public:
       return false;
     }
     float const detect_radius = ctx.config->roam_radius * k_wolf_detect_multiplier;
-    PreyRef const prey = actions.nearest_prey(ctx.x, ctx.z, detect_radius);
+    PreyRef const prey = pick_prey(ctx, actions, detect_radius);
     if (!prey.valid()) {
-      return false;
-    }
-    float const guarded =
-        ctx.threats->strength_within(prey.x, prey.z, ctx.config->alert_radius);
-    if (guarded >= wolf_avoid_threshold(*ctx.config)) {
       return false;
     }
 
@@ -294,32 +399,33 @@ public:
     if (wildlife.behavior != Behavior::Stalk) {
       actions.note(NatureEvent::Hunt);
     }
-    wildlife.behavior = Behavior::Stalk;
-    wildlife.focus_id = prey.id;
-    actions.set_travel_speed(ctx, true);
-
-    float const dx = prey.x - ctx.x;
-    float const dz = prey.z - ctx.z;
-    float const distance = std::sqrt((dx * dx) + (dz * dz));
-    if (distance <= k_wolf_bite_range) {
-      actions.halt(ctx);
-      if (actions.bite(ctx, prey)) {
-        actions.note(NatureEvent::Bite);
-      }
-      return true;
+    if (!prey.livestock) {
+      actions.mark_hostile(ctx, prey.id, true);
     }
-
-    float const approach_angle =
-        static_cast<float>((wildlife.rng_state >> 8U) & 0xFFFFU) *
-        (k_two_pi / 65536.0F);
-    float const approach_x =
-        prey.x + (std::cos(approach_angle) * k_pack_approach_spacing);
-    float const approach_z =
-        prey.z + (std::sin(approach_angle) * k_pack_approach_spacing);
-    wildlife.target_x = approach_x;
-    wildlife.target_z = approach_z;
-    actions.move_to(ctx, approach_x, approach_z);
+    close_and_bite(ctx, actions, prey);
     return true;
+  }
+
+private:
+  static auto pick_prey(const NatureContext& ctx,
+                        NatureActions& actions,
+                        float detect_radius) -> PreyRef {
+    PreyRef const livestock = actions.nearest_prey(ctx.x, ctx.z, detect_radius);
+    PreyRef const quarry = actions.nearest_quarry(ctx.x, ctx.z, detect_radius);
+    bool const prefer_livestock =
+        livestock.valid() &&
+        (!quarry.valid() || (distance_to(ctx, livestock) * k_livestock_preference) <=
+                                distance_to(ctx, quarry));
+
+    PreyRef const first = prefer_livestock ? livestock : quarry;
+    PreyRef const second = prefer_livestock ? quarry : livestock;
+    if (first.valid() && !guarded(ctx, first)) {
+      return first;
+    }
+    if (second.valid() && !guarded(ctx, second)) {
+      return second;
+    }
+    return {};
   }
 };
 
@@ -375,7 +481,7 @@ void NatureBrain::add(std::unique_ptr<NatureBehavior> behavior) {
                        behavior,
                        [](const std::unique_ptr<NatureBehavior>& lhs,
                           const std::unique_ptr<NatureBehavior>& rhs) {
-                         return static_cast<std::uint8_t>(lhs->priority()) >
+                         return static_cast<std::uint8_t>(lhs->priority()) >=
                                 static_cast<std::uint8_t>(rhs->priority());
                        });
   m_behaviors.insert(position, std::move(behavior));
@@ -406,6 +512,7 @@ auto make_sheep_brain() -> NatureBrain {
 
 auto make_wolf_brain() -> NatureBrain {
   NatureBrain brain;
+  brain.add(std::make_unique<DefendBehavior>());
   brain.add(std::make_unique<WolfRetreatBehavior>());
   brain.add(std::make_unique<StalkPreyBehavior>());
   brain.add(std::make_unique<MenaceBehavior>());

--- a/game/wildlife/nature_ai.h
+++ b/game/wildlife/nature_ai.h
@@ -45,6 +45,8 @@ struct PreyRef {
   Engine::Core::EntityID id{0};
   float x{0.0F};
   float z{0.0F};
+  float radius{0.0F};
+  bool livestock{false};
 
   [[nodiscard]] auto valid() const noexcept -> bool { return entity != nullptr; }
 };
@@ -74,6 +76,9 @@ public:
   virtual void halt(const NatureContext& ctx) = 0;
   virtual void set_travel_speed(const NatureContext& ctx, bool urgent) = 0;
   virtual void alert_herd(std::uint16_t group_id, float duration) = 0;
+  virtual void mark_hostile(const NatureContext& ctx,
+                            Engine::Core::EntityID foe_id,
+                            bool rally_pack) = 0;
   virtual void note(NatureEvent event) = 0;
 
   [[nodiscard]] virtual auto pick_open_point(std::uint32_t& rng,
@@ -85,6 +90,9 @@ public:
                                              float& out_z) -> bool = 0;
   [[nodiscard]] virtual auto
   nearest_prey(float world_x, float world_z, float radius) -> PreyRef = 0;
+  [[nodiscard]] virtual auto
+  nearest_quarry(float world_x, float world_z, float radius) -> PreyRef = 0;
+  [[nodiscard]] virtual auto locate(Engine::Core::EntityID entity_id) -> PreyRef = 0;
   [[nodiscard]] virtual auto
   nearest_pack_hunter(float world_x, float world_z, float radius) -> ThreatQuery = 0;
   [[nodiscard]] virtual auto bite(const NatureContext& ctx,

--- a/game/wildlife/wildlife_species.h
+++ b/game/wildlife/wildlife_species.h
@@ -14,6 +14,8 @@ enum class Species : std::uint8_t {
 
 inline constexpr std::size_t k_species_count = 3U;
 
+inline constexpr float k_hostility_duration = 9.0F;
+
 enum class Behavior : std::uint8_t {
   Graze = 0,
   Roam = 1,

--- a/game/wildlife/wildlife_system.cpp
+++ b/game/wildlife/wildlife_system.cpp
@@ -41,6 +41,7 @@ constexpr float k_pack_approach_spacing = 1.1F;
 constexpr float k_wolf_avoid_base_strength = 2.5F;
 constexpr float k_civilian_standoff = 3.0F;
 constexpr float k_civilian_threat_strength = 0.3F;
+constexpr float k_civilian_quarry_preference = 0.5F;
 constexpr float k_troop_threat_strength = 1.0F;
 constexpr float k_sheep_flee_strength_threshold = 0.5F;
 constexpr float k_spawn_scatter = 3.2F;
@@ -81,6 +82,29 @@ auto is_civilian_spawn(Game::Units::SpawnType type) -> bool {
          type == Game::Units::SpawnType::Builder;
 }
 
+auto resolve_prey(Engine::Core::World& world,
+                  Engine::Core::EntityID entity_id) -> PreyRef {
+  auto* entity = world.get_entity(entity_id);
+  if (entity == nullptr ||
+      entity->has_component<Engine::Core::PendingRemovalComponent>()) {
+    return {};
+  }
+  const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
+  const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
+  if (unit == nullptr || transform == nullptr || unit->health <= 0) {
+    return {};
+  }
+
+  PreyRef prey;
+  prey.entity = entity;
+  prey.id = entity_id;
+  prey.x = transform->position.x;
+  prey.z = transform->position.z;
+  prey.radius = std::max(0.0F, std::max(transform->scale.x, transform->scale.z) * 0.5F);
+  prey.livestock = is_wildlife_entity(*entity);
+  return prey;
+}
+
 } // namespace
 
 WildlifeSystem::WildlifeSystem() = default;
@@ -108,6 +132,7 @@ void WildlifeSystem::configure(const WildlifeSettings& settings,
   m_groups.clear();
   m_group_runtime.clear();
   m_animals.clear();
+  m_quarry.clear();
   m_threats.clear();
   m_stats.reset();
   m_next_group_id = 0U;
@@ -327,6 +352,7 @@ void WildlifeSystem::spawn_initial_population(Engine::Core::World& world) {
 
 void WildlifeSystem::rebuild_threats(Engine::Core::World& world) {
   m_threats.clear();
+  m_quarry.clear();
   for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr || is_wildlife_entity(*entity)) {
       continue;
@@ -349,6 +375,13 @@ void WildlifeSystem::rebuild_threats(Engine::Core::World& world) {
     source.strength = threat_strength_of(*unit);
     source.civilian = is_civilian_spawn(unit->spawn_type);
     m_threats.add(source);
+
+    QuarryRef quarry;
+    quarry.id = entity->get_id();
+    quarry.x = source.x;
+    quarry.z = source.z;
+    quarry.civilian = source.civilian;
+    m_quarry.push_back(quarry);
   }
   m_threats.finalize();
 }
@@ -428,6 +461,29 @@ auto WildlifeSystem::nearest_prey(float world_x,
   return best;
 }
 
+auto WildlifeSystem::nearest_quarry(float world_x,
+                                    float world_z,
+                                    float radius) const -> const QuarryRef* {
+  const QuarryRef* best = nullptr;
+  float best_score = 0.0F;
+  for (const auto& quarry : m_quarry) {
+    float const dx = quarry.x - world_x;
+    float const dz = quarry.z - world_z;
+    float const distance_sq = (dx * dx) + (dz * dz);
+    if (distance_sq >= radius * radius) {
+      continue;
+    }
+    float const score =
+        distance_sq * (quarry.civilian ? k_civilian_quarry_preference : 1.0F);
+    if (best != nullptr && score >= best_score) {
+      continue;
+    }
+    best_score = score;
+    best = &quarry;
+  }
+  return best;
+}
+
 void WildlifeSystem::alert_group(std::uint16_t group_id, float duration) {
   for (const auto& animal : m_animals) {
     if (animal.group != group_id || animal.entity == nullptr) {
@@ -436,6 +492,25 @@ void WildlifeSystem::alert_group(std::uint16_t group_id, float duration) {
     auto* wildlife = animal.entity->get_component<Engine::Core::WildlifeComponent>();
     if (wildlife != nullptr) {
       wildlife->alarm_timer = std::max(wildlife->alarm_timer, duration);
+    }
+  }
+}
+
+void WildlifeSystem::rally_pack(std::uint16_t group_id,
+                                Engine::Core::EntityID foe_id,
+                                float duration) {
+  for (const auto& animal : m_animals) {
+    if (animal.group != group_id || animal.species != Species::Wolf ||
+        animal.entity == nullptr) {
+      continue;
+    }
+    auto* wildlife = animal.entity->get_component<Engine::Core::WildlifeComponent>();
+    if (wildlife == nullptr) {
+      continue;
+    }
+    wildlife->hostile_timer = std::max(wildlife->hostile_timer, duration);
+    if (wildlife->aggressor_id == 0) {
+      wildlife->aggressor_id = foe_id;
     }
   }
 }
@@ -485,6 +560,18 @@ public:
     m_owner.alert_group(group_id, duration);
   }
 
+  void mark_hostile(const NatureContext& ctx,
+                    Engine::Core::EntityID foe_id,
+                    bool rally_pack) override {
+    auto& wildlife = *ctx.wildlife;
+    wildlife.hostile_timer = Game::Wildlife::k_hostility_duration;
+    wildlife.aggressor_id = foe_id;
+    if (rally_pack) {
+      m_owner.rally_pack(
+          wildlife.group_id, foe_id, Game::Wildlife::k_hostility_duration);
+    }
+  }
+
   void note(NatureEvent event) override {
     switch (event) {
     case NatureEvent::Flee:
@@ -512,10 +599,22 @@ public:
 
   auto nearest_prey(float world_x, float world_z, float radius) -> PreyRef override {
     const AnimalRef* found = m_owner.nearest_prey(world_x, world_z, radius);
-    if (found == nullptr || found->entity == nullptr) {
+    if (found == nullptr) {
       return {};
     }
-    return PreyRef{found->entity, found->id, found->x, found->z};
+    return resolve_prey(m_world, found->id);
+  }
+
+  auto nearest_quarry(float world_x, float world_z, float radius) -> PreyRef override {
+    const QuarryRef* found = m_owner.nearest_quarry(world_x, world_z, radius);
+    if (found == nullptr) {
+      return {};
+    }
+    return resolve_prey(m_world, found->id);
+  }
+
+  auto locate(Engine::Core::EntityID entity_id) -> PreyRef override {
+    return resolve_prey(m_world, entity_id);
   }
 
   auto nearest_pack_hunter(float world_x,
@@ -652,6 +751,10 @@ void WildlifeSystem::update(Engine::Core::World* world, float delta_time) {
 
     wildlife->state_timer = std::max(0.0F, wildlife->state_timer - delta_time);
     wildlife->alarm_timer = std::max(0.0F, wildlife->alarm_timer - delta_time);
+    wildlife->hostile_timer = std::max(0.0F, wildlife->hostile_timer - delta_time);
+    if (wildlife->hostile_timer <= 0.0F) {
+      wildlife->aggressor_id = 0;
+    }
     wildlife->think_cooldown -= delta_time;
     if (wildlife->think_cooldown > 0.0F) {
       continue;

--- a/game/wildlife/wildlife_system.h
+++ b/game/wildlife/wildlife_system.h
@@ -113,6 +113,13 @@ private:
     Species species{Species::Sheep};
   };
 
+  struct QuarryRef {
+    Engine::Core::EntityID id{0};
+    float x{0.0F};
+    float z{0.0F};
+    bool civilian{false};
+  };
+
   void ensure_factory_registry();
   void spawn_initial_population(Engine::Core::World& world);
   void plan_groups();
@@ -131,6 +138,8 @@ private:
              Species species);
 
   void alert_group(std::uint16_t group_id, float duration);
+  void
+  rally_pack(std::uint16_t group_id, Engine::Core::EntityID foe_id, float duration);
   void issue_move(Engine::Core::World& world,
                   Engine::Core::EntityID entity_id,
                   float world_x,
@@ -150,11 +159,14 @@ private:
                                      float& out_z) const -> bool;
   [[nodiscard]] auto
   nearest_prey(float world_x, float world_z, float radius) const -> const AnimalRef*;
+  [[nodiscard]] auto
+  nearest_quarry(float world_x, float world_z, float radius) const -> const QuarryRef*;
 
   WildlifeSettings m_settings{};
   std::vector<GroupState> m_groups;
   std::vector<GroupRuntime> m_group_runtime;
   std::vector<AnimalRef> m_animals;
+  std::vector<QuarryRef> m_quarry;
   ThreatField m_threats;
   WildlifeStats m_stats{};
   std::shared_ptr<Game::Units::UnitFactoryRegistry> m_factory_registry;

--- a/render/equipment/weapons/sword_renderer.cpp
+++ b/render/equipment/weapons/sword_renderer.cpp
@@ -162,6 +162,19 @@ auto oriented_box_between(const QVector3D& start,
   return local;
 }
 
+auto oriented_cone_between(const QVector3D& start,
+                           const QVector3D& end,
+                           float half_width,
+                           float half_depth,
+                           QVector3D right_hint = QVector3D(1.0F,
+                                                            0.0F,
+                                                            0.0F)) -> QMatrix4x4 {
+  QMatrix4x4 local =
+      oriented_box_between(start, end, half_width, half_depth, right_hint);
+  local.setColumn(1, local.column(1) * 2.0F);
+  return local;
+}
+
 auto hand_basis_transform(const QMatrix4x4& parent,
                           const AttachmentFrame& hand) -> QMatrix4x4 {
   QMatrix4x4 local;
@@ -281,7 +294,6 @@ auto sword_archetype(const SwordRenderConfig& config) -> const RenderArchetype& 
   float const upper_half_w = lerp(mid_half_w,
                                   base_half_w * 0.64F,
                                   clamp_f((taper_bias - 0.25F) * 0.9F, 0.0F, 1.0F));
-  float const tip_half_w = std::max(base_half_w * tip_scale, blade_thickness * 0.65F);
   float const belly_y = lerp(ricasso_len, l, 0.34F + taper_bias * 0.18F);
   float const tip_start_dist = lerp(belly_y, l, 0.44F + (1.0F - tip_scale) * 0.18F);
   float const handle_len = clamp_f(base_w * 1.35F, 0.09F, 0.16F);
@@ -424,7 +436,11 @@ auto sword_archetype(const SwordRenderConfig& config) -> const RenderArchetype& 
                            config.material_id);
 
   builder.add_palette_mesh(get_unit_cone(),
-                           Render::Geom::cone_from_to(blade3, blade4, tip_half_w),
+                           oriented_cone_between(blade3,
+                                                 blade4,
+                                                 upper_half_w,
+                                                 blade_thickness * 0.86F,
+                                                 QVector3D(1.0F, 0.0F, 0.0F)),
                            k_metal_slot,
                            nullptr,
                            1.0F,

--- a/tests/render/stateless_weapon_renderers_test.cpp
+++ b/tests/render/stateless_weapon_renderers_test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <limits>
 #include <utility>
+#include <vector>
 
 #include "render/entity/registry.h"
 #include "render/entity/renderer_constants.h"
@@ -481,6 +482,59 @@ TEST(StatelessWeaponRenderers, RpgSwordCutDrawsATrailAcrossItsStrikeWindow) {
   EXPECT_GT(archetype_count_at(0.45F), 1U);
   EXPECT_GT(archetype_count_at(0.60F), 1U);
   EXPECT_EQ(archetype_count_at(0.90F), 1U);
+}
+
+TEST(StatelessWeaponRenderers, SwordPointIsAFlatTriangleNotARoundPin) {
+  const auto frames = make_frames();
+  const auto anim = make_anim();
+  const auto palette = make_palette();
+  const auto ctx = make_ctx();
+
+  auto draw_aabb = [](const Render::GL::RenderArchetypeDraw& draw) {
+    AABB box;
+    for (const auto& v : draw.mesh->get_vertices()) {
+      box.include(
+          draw.local_model.map(QVector3D{v.position[0], v.position[1], v.position[2]}));
+    }
+    return box;
+  };
+
+  const std::vector<SwordRenderConfig> configs{SwordRenderConfig{},
+                                               RomanSwordRenderer{}.base_config()};
+  for (const auto& config : configs) {
+    EquipmentBatch batch;
+    SwordRenderer::submit(config, ctx, frames, palette, anim, batch);
+    ASSERT_FALSE(batch.archetypes.empty());
+    ASSERT_NE(batch.archetypes.front().archetype, nullptr);
+
+    AABB point;
+    float widest_blade = 0.0F;
+    for (const auto& draw : batch.archetypes.front().archetype->lods[0].draws) {
+      if (draw.mesh == nullptr) {
+        continue;
+      }
+      const AABB box = draw_aabb(draw);
+      if (box.mx.y() > point.mx.y()) {
+        point = box;
+      }
+    }
+    for (const auto& draw : batch.archetypes.front().archetype->lods[0].draws) {
+      if (draw.mesh == nullptr) {
+        continue;
+      }
+      const AABB box = draw_aabb(draw);
+      if (box.mn.y() > config.sword_length * 0.30F && box.mx.y() < point.mx.y()) {
+        widest_blade = std::max(widest_blade, box.mx.x() - box.mn.x());
+      }
+    }
+
+    const float point_width = point.mx.x() - point.mn.x();
+    const float point_thickness = point.mx.z() - point.mn.z();
+
+    ASSERT_GT(widest_blade, 0.0F);
+    EXPECT_GT(point_width, widest_blade * 0.70F);
+    EXPECT_LT(point_thickness, point_width * 0.55F);
+  }
 }
 
 TEST(StatelessWeaponRenderers, SwordProfileFieldsChangeVisibleMesh) {

--- a/tests/systems/combat_mode_test.cpp
+++ b/tests/systems/combat_mode_test.cpp
@@ -9,6 +9,7 @@
 #include "animation/death_pose_manifest.h"
 #include "core/component.h"
 #include "core/entity.h"
+#include "core/ownership_constants.h"
 #include "core/world.h"
 #include "systems/arrow_projectile.h"
 #include "systems/cleanup_system.h"
@@ -861,6 +862,52 @@ TEST_F(CombatModeTest, EnemyValidityHelperAllowsBuildingsOnlyWhenRequested) {
       Game::Systems::Combat::is_valid_enemy_unit(attacker_unit, building, false));
   EXPECT_TRUE(
       Game::Systems::Combat::is_valid_enemy_unit(attacker_unit, building, true));
+}
+
+TEST_F(CombatModeTest, OnlyHostileWildlifeIsAcquiredWithoutAnOrder) {
+  auto* attacker = world->create_entity();
+  attacker->add_component<TransformComponent>(0.0F, 0.0F, 0.0F);
+  auto* attacker_unit = attacker->add_component<UnitComponent>(100, 100, 1.0F, 12.0F);
+  attacker_unit->owner_id = 1;
+
+  auto* sheep = world->create_entity();
+  sheep->add_component<TransformComponent>(2.0F, 0.0F, 0.0F);
+  auto* sheep_unit = sheep->add_component<UnitComponent>(28, 28, 1.5F, 0.0F);
+  sheep_unit->owner_id = Game::Core::NEUTRAL_OWNER_ID;
+  sheep->add_component<WildlifeComponent>()->species = Game::Wildlife::Species::Sheep;
+
+  auto* wolf = world->create_entity();
+  wolf->add_component<TransformComponent>(4.0F, 0.0F, 0.0F);
+  auto* wolf_unit = wolf->add_component<UnitComponent>(55, 55, 3.1F, 14.0F);
+  wolf_unit->owner_id = Game::Core::NEUTRAL_OWNER_ID;
+  auto* wolf_state = wolf->add_component<WildlifeComponent>();
+  wolf_state->species = Game::Wildlife::Species::Wolf;
+
+  EXPECT_TRUE(Game::Systems::Combat::is_valid_enemy_unit(attacker_unit, sheep, false));
+  EXPECT_TRUE(Game::Systems::Combat::is_valid_enemy_unit(attacker_unit, wolf, false));
+  EXPECT_FALSE(
+      Game::Systems::Combat::is_auto_acquirable_enemy(attacker_unit, sheep, false));
+  EXPECT_FALSE(
+      Game::Systems::Combat::is_auto_acquirable_enemy(attacker_unit, wolf, false));
+
+  {
+    auto const query_context =
+        Game::Systems::Combat::build_combat_query_context(world.get());
+    EXPECT_EQ(Game::Systems::Combat::find_nearest_enemy(attacker, query_context, 10.0F),
+              nullptr);
+  }
+
+  wolf_state->hostile_timer = 5.0F;
+  EXPECT_TRUE(
+      Game::Systems::Combat::is_auto_acquirable_enemy(attacker_unit, wolf, false));
+
+  auto const query_context =
+      Game::Systems::Combat::build_combat_query_context(world.get());
+  auto* target =
+      Game::Systems::Combat::find_nearest_enemy(attacker, query_context, 10.0F);
+
+  ASSERT_NE(target, nullptr);
+  EXPECT_EQ(target->get_id(), wolf->get_id());
 }
 
 TEST_F(CombatModeTest, AutoEngagementUsesNearestEnemyInsideGuardRadius) {

--- a/tests/wildlife/wildlife_system_test.cpp
+++ b/tests/wildlife/wildlife_system_test.cpp
@@ -13,6 +13,10 @@
 #include "game/map/map_loader.h"
 #include "game/map/terrain_service.h"
 #include "game/systems/building_collision_registry.h"
+#include "game/systems/combat_system/attack_processor.h"
+#include "game/systems/combat_system/combat_action_processor.h"
+#include "game/systems/combat_system/combat_utils.h"
+#include "game/systems/combat_system/damage_application.h"
 #include "game/systems/command_service.h"
 #include "game/systems/nation_registry.h"
 #include "game/systems/owner_registry.h"
@@ -60,6 +64,25 @@ auto make_settings() -> WildlifeSettings {
   return settings;
 }
 
+auto lone_wolf_settings() -> WildlifeSettings {
+  WildlifeSettings settings = make_settings();
+  settings.sheep.enabled = false;
+  settings.sheep.group_count = 0;
+  settings.wolves.enabled = true;
+  settings.wolves.group_count = 1;
+  settings.wolves.group_size_min = 1;
+  settings.wolves.group_size_max = 1;
+  settings.wolves.aggression = 1.0F;
+  settings.wolves.roam_radius = 12.0F;
+  settings.wolves.spawn_areas = {{4.0F, 0.0F, 1.0F}};
+  return settings;
+}
+
+auto beside(Entity* entity, float offset_x) -> QVector3D {
+  const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
+  return {transform->position.x + offset_x, 0.0F, transform->position.z};
+}
+
 auto count_species(World& world, Species species) -> int {
   int count = 0;
   for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
@@ -96,6 +119,22 @@ auto add_troop(World& world,
   unit->spawn_type = type;
   unit->health = 100;
   unit->max_health = 100;
+  return entity;
+}
+
+auto add_armed_troop(World& world, const QVector3D& position) -> Entity* {
+  auto* entity = add_troop(world, position);
+  auto* attack = entity->add_component<Engine::Core::AttackComponent>();
+  attack->range = 1.6F;
+  attack->damage = 12;
+  attack->cooldown = 0.6F;
+  attack->melee_range = 1.6F;
+  attack->melee_damage = 12;
+  attack->melee_cooldown = 0.6F;
+  attack->can_melee = true;
+  attack->can_ranged = false;
+  attack->preferred_mode = Engine::Core::AttackComponent::CombatMode::Melee;
+  attack->current_mode = Engine::Core::AttackComponent::CombatMode::Melee;
   return entity;
 }
 
@@ -269,6 +308,127 @@ TEST_F(WildlifeSystemTest, WolvesBackOffFromLargeFormations) {
   const auto* wolf = wolves.front()->get_component<Engine::Core::WildlifeComponent>();
   ASSERT_NE(wolf, nullptr);
   EXPECT_EQ(wolf->behavior, Behavior::Flee);
+}
+
+TEST_F(WildlifeSystemTest, WolvesHuntIsolatedPeople) {
+  World world;
+  WildlifeSystem system;
+  system.configure(lone_wolf_settings(), 1U);
+  system.update(&world, 0.1F);
+
+  auto wolves = collect_species(world, Species::Wolf);
+  ASSERT_EQ(wolves.size(), 1U);
+  auto* victim =
+      add_troop(world, beside(wolves.front(), 1.0F), Game::Units::SpawnType::Civilian);
+  auto* victim_unit = victim->get_component<Engine::Core::UnitComponent>();
+  ASSERT_NE(victim_unit, nullptr);
+
+  advance(system, world, 4.0F);
+
+  const auto* wolf = wolves.front()->get_component<Engine::Core::WildlifeComponent>();
+  ASSERT_NE(wolf, nullptr);
+  EXPECT_EQ(wolf->behavior, Behavior::Stalk);
+  EXPECT_EQ(wolf->focus_id, victim->get_id());
+  EXPECT_TRUE(wolf->is_hostile());
+  EXPECT_GT(system.stats().bites, 0U);
+  EXPECT_LT(victim_unit->health, victim_unit->max_health);
+}
+
+TEST_F(WildlifeSystemTest, WolvesLeaveEscortedPeopleAlone) {
+  World world;
+  WildlifeSystem system;
+  system.configure(lone_wolf_settings(), 1U);
+  system.update(&world, 0.1F);
+
+  auto wolves = collect_species(world, Species::Wolf);
+  ASSERT_EQ(wolves.size(), 1U);
+  const QVector3D victim_position = beside(wolves.front(), 1.0F);
+  auto* victim = add_troop(world, victim_position, Game::Units::SpawnType::Civilian);
+  auto* victim_unit = victim->get_component<Engine::Core::UnitComponent>();
+  ASSERT_NE(victim_unit, nullptr);
+  for (int index = 0; index < 6; ++index) {
+    add_troop(world,
+              QVector3D(victim_position.x() + 1.0F + static_cast<float>(index) * 0.4F,
+                        0.0F,
+                        victim_position.z() + 1.0F));
+  }
+
+  advance(system, world, 4.0F);
+
+  const auto* wolf = wolves.front()->get_component<Engine::Core::WildlifeComponent>();
+  ASSERT_NE(wolf, nullptr);
+  EXPECT_FALSE(wolf->is_hostile());
+  EXPECT_EQ(system.stats().bites, 0U);
+  EXPECT_EQ(victim_unit->health, victim_unit->max_health);
+}
+
+TEST_F(WildlifeSystemTest, WoundedWolvesTurnOnTheirAttacker) {
+  World world;
+  WildlifeSystem system;
+  system.configure(lone_wolf_settings(), 1U);
+  system.update(&world, 0.1F);
+
+  auto wolves = collect_species(world, Species::Wolf);
+  ASSERT_EQ(wolves.size(), 1U);
+  auto* wolf_entity = wolves.front();
+  auto* hunter = add_troop(world, beside(wolf_entity, 1.0F));
+  auto* hunter_unit = hunter->get_component<Engine::Core::UnitComponent>();
+  ASSERT_NE(hunter_unit, nullptr);
+
+  Game::Systems::Combat::apply_unit_damage(&world, wolf_entity, 5, hunter->get_id());
+
+  const auto* wolf = wolf_entity->get_component<Engine::Core::WildlifeComponent>();
+  ASSERT_NE(wolf, nullptr);
+  EXPECT_TRUE(wolf->is_hostile());
+  EXPECT_EQ(wolf->aggressor_id, hunter->get_id());
+  EXPECT_EQ(wolf_entity->get_component<Engine::Core::AttackTargetComponent>(), nullptr);
+
+  advance(system, world, 3.0F);
+
+  EXPECT_EQ(wolf->behavior, Behavior::Stalk);
+  EXPECT_GT(system.stats().bites, 0U);
+  EXPECT_LT(hunter_unit->health, hunter_unit->max_health);
+}
+
+TEST_F(WildlifeSystemTest, TroopsAnswerAWolfThatBitesThem) {
+  World world;
+  WildlifeSystem system;
+  system.configure(lone_wolf_settings(), 1U);
+  system.update(&world, 0.1F);
+
+  auto wolves = collect_species(world, Species::Wolf);
+  ASSERT_EQ(wolves.size(), 1U);
+  auto* wolf_entity = wolves.front();
+  auto* wolf_unit = wolf_entity->get_component<Engine::Core::UnitComponent>();
+  ASSERT_NE(wolf_unit, nullptr);
+  auto* soldier = add_armed_troop(world, beside(wolf_entity, 1.2F));
+  soldier->get_component<Engine::Core::UnitComponent>()
+      ->render_individuals_per_unit_override = 1;
+  wolf_unit->render_individuals_per_unit_override = 1;
+
+  advance(system, world, 3.0F);
+
+  ASSERT_GT(system.stats().bites, 0U);
+  const auto* order = soldier->get_component<Engine::Core::AttackTargetComponent>();
+  ASSERT_NE(order, nullptr);
+  EXPECT_EQ(order->target_id, wolf_entity->get_id());
+
+  auto* soldier_transform = soldier->get_component<Engine::Core::TransformComponent>();
+  soldier_transform->rotation.y = 270.0F;
+  auto* soldier_attack = soldier->get_component<Engine::Core::AttackComponent>();
+  soldier_attack->time_since_last = soldier_attack->melee_cooldown;
+
+  Game::Systems::Combat::process_attacks(
+      &world, Game::Systems::Combat::build_combat_query_context(&world), 0.016F);
+
+  EXPECT_TRUE(soldier_attack->in_melee_lock);
+  EXPECT_EQ(soldier_attack->melee_lock_target_id, wolf_entity->get_id());
+
+  auto* state = soldier->get_component<Engine::Core::CombatStateComponent>();
+  Game::Systems::Combat::process_authored_combat_action(&world, *soldier, state, 0.39F);
+  Game::Systems::Combat::process_authored_combat_action(&world, *soldier, state, 0.02F);
+
+  EXPECT_LT(wolf_unit->health, wolf_unit->max_health);
 }
 
 TEST_F(WildlifeSystemTest, LostHerdMembersRespawnAfterTheConfiguredDelay) {

--- a/tools/arena/arena_scenario.cpp
+++ b/tools/arena/arena_scenario.cpp
@@ -324,6 +324,8 @@ auto expectation_name(ArenaExpectationKind kind) -> QString {
     return QStringLiteral("WildlifeBirdFlyoverObserved");
   case ArenaExpectationKind::WildlifePopulationHeld:
     return QStringLiteral("WildlifePopulationHeld");
+  case ArenaExpectationKind::WildlifeCasualtyObserved:
+    return QStringLiteral("WildlifeCasualtyObserved");
   }
   return QStringLiteral("Unknown");
 }
@@ -4133,6 +4135,15 @@ struct ArenaScenarioRunner::Impl {
         }
         break;
       }
+      case ArenaExpectationKind::WildlifeCasualtyObserved:
+        if (wildlife_observation.min_population >=
+            wildlife_observation.peak_population) {
+          add_issue(QStringLiteral("wildlife_never_culled"),
+                    QStringLiteral("no animal was killed during the run (population "
+                                   "held at %1)")
+                        .arg(wildlife_observation.peak_population));
+        }
+        break;
       case ArenaExpectationKind::NoRenderVisibilityChurn:
       case ArenaExpectationKind::RpgFormationSurvivesLensGap:
       case ArenaExpectationKind::FullCreatureDetailOnly:

--- a/tools/arena/arena_scenario.h
+++ b/tools/arena/arena_scenario.h
@@ -258,6 +258,7 @@ enum class ArenaExpectationKind : std::uint8_t {
   WildlifeBirdsScattered,
   WildlifeBirdFlyoverObserved,
   WildlifePopulationHeld,
+  WildlifeCasualtyObserved,
   RangeIndicatorObserved,
   RangeIndicatorCountAtMost,
 };

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -209,6 +209,7 @@ inline constexpr char k_wildlife_grazing_herd_id[] = "wildlife_grazing_herd";
 inline constexpr char k_wildlife_herd_flees_troops_id[] = "wildlife_herd_flees_troops";
 inline constexpr char k_wildlife_wolf_hunt_id[] = "wildlife_wolf_hunt";
 inline constexpr char k_wildlife_wolf_pack_id[] = "wildlife_wolf_pack";
+inline constexpr char k_wildlife_wolf_ambush_id[] = "wildlife_wolf_ambush";
 inline constexpr char k_wildlife_bird_scatter_id[] = "wildlife_bird_scatter";
 inline constexpr char k_wildlife_bird_flyover_id[] = "wildlife_bird_flyover";
 inline constexpr char k_wildlife_mixed_pasture_id[] = "wildlife_mixed_pasture";

--- a/tools/arena/arena_wildlife_scenarios.cpp
+++ b/tools/arena/arena_wildlife_scenarios.cpp
@@ -208,6 +208,42 @@ auto build_wildlife_definitions() -> std::vector<ArenaScenarioDefinition> {
 
   {
     auto s = definition(
+        QString::fromLatin1(k_wildlife_wolf_ambush_id),
+        QStringLiteral("Wildlife: Wolf Ambush"),
+        QStringLiteral("A pack rushes a lone patrol instead of a herd: the wolves "
+                       "close and bite, the soldiers answer, and both sides take "
+                       "losses."),
+        24.0F,
+        {22.0F, 46.0F, 26.0F});
+    Game::Wildlife::WildlifeSettings settings = Game::Wildlife::default_settings();
+    settings.enabled = true;
+    settings.seed = 31337U;
+    settings.sheep.enabled = false;
+    settings.sheep.group_count = 0;
+    settings.birds.enabled = false;
+    settings.birds.group_count = 0;
+    settings.wolves.enabled = true;
+    settings.wolves.group_count = 1;
+    settings.wolves.group_size_min = 4;
+    settings.wolves.group_size_max = 4;
+    settings.wolves.aggression = 1.0F;
+    settings.wolves.roam_radius = 16.0F;
+    settings.wolves.respawn = false;
+    settings.wolves.spawn_areas = {{10.0F, 0.0F, 0.0F}};
+    s.wildlife = settings;
+    s.groups = {patrol_group(
+        QStringLiteral("patrol"), Troop::Swordsman, {-14.0F, 0.0F, 0.0F}, 1)};
+    s.steps = {move_step(2.0F, QStringLiteral("patrol"), {2.0F, 0.0F, 0.0F})};
+    s.expectations = {
+        expectation(Expect::WildlifeHuntObserved),
+        expectation(Expect::GroupHealthReduced, QStringLiteral("patrol")),
+        expectation(Expect::WildlifeCasualtyObserved),
+    };
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
         QString::fromLatin1(k_wildlife_bird_scatter_id),
         QStringLiteral("Wildlife: Bird Scatter"),
         QStringLiteral("Flocks cruise and perch until a column marches underneath, "


### PR DESCRIPTION
Allow wolves to hunt isolated people, rally their pack after being attacked, and remain temporarily hostile long enough for troops to retaliate. Persist aggressor and hostility state, account for prey radius during bites, prefer livestock and civilians appropriately, and keep guarded targets or overwhelming formations unattractive.

Separate general enemy validity from automatic acquisition so explicitly ordered attacks can still hit neutral animals while passive wildlife remains ignored by guard behavior, towers, targeting highlights, and nearest-enemy searches. Add focused combat and wildlife coverage for hostile acquisition, escorted civilians, defensive aggression, bites, and troop counterattacks.

Replace round sword-tip cones with blade-oriented flattened cones whose bases match the blade profile. Document the rendering geometry, extend the renderer regression coverage, and add a wolf ambush arena scenario with wildlife casualty validation alongside the updated wildlife architecture notes.