### PR TITLE
Redesign stockpile and carried resource visuals

### DIFF
--- a/render/entity/barracks_stockpile.cpp
+++ b/render/entity/barracks_stockpile.cpp
@@ -30,19 +30,36 @@ constexpr float k_bed_height = 0.035F;
 constexpr float k_ground = k_bed_height * 2.0F;
 constexpr float k_detail_distance_sq = 5200.0F;
 
-constexpr float k_yard_back_x = k_stockpile_center_x - k_stockpile_half_width + 0.09F;
-constexpr float k_yard_near_z = k_stockpile_center_z - k_stockpile_half_depth + 0.09F;
-constexpr float k_yard_far_z = k_stockpile_center_z + k_stockpile_half_depth - 0.09F;
-constexpr float k_gate_x = k_stockpile_center_x + 0.55F;
-constexpr float k_stall_edge_x = k_stockpile_center_x + 0.10F;
-
-constexpr float k_pile_center_x = k_stockpile_center_x - 0.55F;
-constexpr float k_wood_pile_z = k_stockpile_center_z - 1.35F;
-constexpr float k_stone_pile_z = k_stockpile_center_z;
-constexpr float k_iron_pile_z = k_stockpile_center_z + 1.35F;
+constexpr float k_yard_inset = 0.10F;
+constexpr float k_yard_west_x =
+    k_stockpile_center_x - k_stockpile_half_width + k_yard_inset;
+constexpr float k_yard_east_x =
+    k_stockpile_center_x + k_stockpile_half_width - k_yard_inset;
+constexpr float k_yard_near_z =
+    k_stockpile_center_z - k_stockpile_half_depth + k_yard_inset;
+constexpr float k_yard_far_z =
+    k_stockpile_center_z + k_stockpile_half_depth - k_yard_inset;
 
 constexpr float k_rail_low_y = 0.17F;
 constexpr float k_rail_high_y = 0.34F;
+constexpr float k_post_height = 0.46F;
+constexpr float k_gate_post_height = 0.62F;
+
+constexpr float k_crib_center_x = k_stockpile_center_x - 0.62F;
+constexpr float k_crib_half_x = 0.56F;
+constexpr float k_crib_half_z = 0.58F;
+constexpr float k_crib_wall = 0.05F;
+constexpr float k_crib_height = 0.30F;
+constexpr float k_crib_front_height = 0.11F;
+constexpr float k_deck_top = k_ground + 0.03F;
+constexpr float k_crib_inner_x = k_crib_half_x - k_crib_wall;
+constexpr float k_crib_inner_z = k_crib_half_z - k_crib_wall;
+
+constexpr float k_wood_bay_z = k_stockpile_center_z - 1.32F;
+constexpr float k_stone_bay_z = k_stockpile_center_z;
+constexpr float k_iron_bay_z = k_stockpile_center_z + 1.32F;
+
+constexpr float k_apron_west_x = k_crib_center_x + k_crib_half_x + 0.08F;
 
 auto rand01(std::uint32_t seed) -> float {
   std::uint32_t value = seed + 0x9E3779B9U;
@@ -52,10 +69,6 @@ auto rand01(std::uint32_t seed) -> float {
   value *= 0xC2B2AE35U;
   value ^= value >> 16U;
   return static_cast<float>(value & 0xFFFFFFU) / static_cast<float>(0xFFFFFF);
-}
-
-auto jitter(std::uint32_t seed, float amount) -> float {
-  return ((rand01(seed) * 2.0F) - 1.0F) * amount;
 }
 
 auto tint(const QVector3D& color, float amount) -> QVector3D {
@@ -68,6 +81,10 @@ auto brighten(const QVector3D& color, float mix) -> QVector3D {
   return QVector3D(std::clamp(color.x() + ((1.0F - color.x()) * mix), 0.0F, 1.0F),
                    std::clamp(color.y() + ((1.0F - color.y()) * mix), 0.0F, 1.0F),
                    std::clamp(color.z() + ((1.0F - color.z()) * mix), 0.0F, 1.0F));
+}
+
+auto blend(const QVector3D& from, const QVector3D& to, float amount) -> QVector3D {
+  return from + ((to - from) * amount);
 }
 
 struct Yard {
@@ -154,18 +171,17 @@ void fence_post(ISubmitter& out,
                 float height,
                 const StockpileYardStyle& style) {
   auto const seed = static_cast<std::uint32_t>((x * 97.0F) + (z * 31.0F) + 400.0F);
-  float const lean = jitter(seed, 1.6F);
   box(out,
       yard,
       QVector3D(x, height * 0.5F, z),
-      QVector3D(0.072F, height * 0.5F, 0.072F),
-      lean,
-      tint(style.timber_dark, 0.92F + (rand01(seed * 3U) * 0.22F)));
+      QVector3D(0.070F, height * 0.5F, 0.070F),
+      0.0F,
+      tint(style.timber_dark, 0.94F + (rand01(seed) * 0.16F)));
   box(out,
       yard,
-      QVector3D(x, height + 0.025F, z),
-      QVector3D(0.088F, 0.028F, 0.088F),
-      lean,
+      QVector3D(x, height + 0.024F, z),
+      QVector3D(0.086F, 0.024F, 0.086F),
+      0.0F,
       style.timber);
 }
 
@@ -180,143 +196,139 @@ void draw_bed(ISubmitter& out, const Yard& yard, const StockpileYardStyle& style
   box(out,
       yard,
       QVector3D(
-          (k_yard_back_x + k_stall_edge_x) * 0.5F, k_ground, k_stockpile_center_z),
-      QVector3D((k_stall_edge_x - k_yard_back_x) * 0.5F,
-                0.004F,
-                k_stockpile_half_depth - 0.06F),
+          (k_apron_west_x + k_yard_east_x) * 0.5F, k_ground, k_stockpile_center_z),
+      QVector3D((k_yard_east_x - k_apron_west_x) * 0.5F,
+                0.005F,
+                k_stockpile_half_depth - k_yard_inset),
       0.0F,
-      tint(style.gravel, 0.86F));
+      blend(style.gravel, style.earth_light, 0.55F));
 
-  if (!yard.detailed) {
-    return;
-  }
-
-  QVector3D const scuff = (style.gravel + style.earth_light) * 0.5F;
-  constexpr std::array<std::array<float, 3>, 3> k_scuffs{
-      {{0.78F, 0.0F, 0.68F}, {0.52F, -1.15F, 0.40F}, {0.95F, 1.05F, 0.34F}}};
-  for (std::size_t i = 0; i < k_scuffs.size(); ++i) {
-    auto const seed = static_cast<std::uint32_t>(131 + (i * 41));
-    rock(out,
-         yard,
-         QVector3D(k_stockpile_center_x + k_scuffs.at(i).at(0),
-                   k_ground,
-                   k_stockpile_center_z + k_scuffs.at(i).at(1)),
-         QVector3D(k_scuffs.at(i).at(2), 0.006F, k_scuffs.at(i).at(2) * 0.78F),
-         rand01(seed) * 180.0F,
-         0.0F,
-         tint(scuff, 0.97F + (rand01(seed * 7U) * 0.07F)));
-  }
-}
-
-void draw_yard_clutter(ISubmitter& out,
-                       const Yard& yard,
-                       const StockpileYardStyle& style) {
-  constexpr float k_stack_x = k_stockpile_center_x + 0.98F;
-  constexpr float k_stack_z = k_stockpile_center_z - 1.55F;
-  constexpr float k_board_thickness = 0.021F;
-
-  for (int i = 0; i < 4; ++i) {
-    auto const seed = static_cast<std::uint32_t>(733 + (i * 47));
-    box(out,
-        yard,
-        QVector3D(k_stack_x + jitter(seed, 0.025F),
-                  k_ground + k_board_thickness +
-                      (static_cast<float>(i) * k_board_thickness * 2.2F),
-                  k_stack_z + jitter(seed * 3U, 0.05F)),
-        QVector3D(0.125F, k_board_thickness, 0.40F),
-        jitter(seed * 5U, 3.5F),
-        tint(style.timber, 0.84F + (rand01(seed * 7U) * 0.30F)));
-  }
-
-  for (int i = 0; i < 2; ++i) {
-    auto const seed = static_cast<std::uint32_t>(811 + (i * 53));
-    float const radius = 0.145F + (rand01(seed) * 0.025F);
-    rock(out,
-         yard,
-         QVector3D(k_stack_x + 0.31F + (static_cast<float>(i) * 0.27F),
-                   k_ground + (radius * 0.78F),
-                   k_stack_z + 0.30F + (static_cast<float>(i) * 0.22F)),
-         QVector3D(radius, radius * 0.86F, radius * 0.82F),
-         rand01(seed * 5U) * 360.0F,
-         jitter(seed * 7U, 12.0F),
-         tint(style.earth_light, 1.04F + (rand01(seed * 11U) * 0.12F)));
-  }
+  box(out,
+      yard,
+      QVector3D(
+          (k_yard_west_x + k_apron_west_x) * 0.5F, k_ground, k_stockpile_center_z),
+      QVector3D((k_apron_west_x - k_yard_west_x) * 0.5F,
+                0.004F,
+                k_stockpile_half_depth - k_yard_inset),
+      0.0F,
+      tint(style.gravel, 0.88F));
 }
 
 void draw_fence(ISubmitter& out, const Yard& yard, const StockpileYardStyle& style) {
-  constexpr float k_post_height = 0.44F;
-  constexpr float k_gate_post_height = 0.62F;
-
   rail_along_z(out,
                yard,
-               k_yard_back_x,
+               k_yard_west_x,
                k_yard_near_z,
                k_yard_far_z,
                k_rail_low_y,
                style.timber);
   rail_along_z(out,
                yard,
-               k_yard_back_x,
+               k_yard_west_x,
                k_yard_near_z,
                k_yard_far_z,
                k_rail_high_y,
                style.timber);
-  for (int i = 0; i < 4; ++i) {
-    float const t = static_cast<float>(i) / 3.0F;
+
+  constexpr int k_west_spans = 4;
+  for (int i = 1; i < k_west_spans; ++i) {
+    float const t = static_cast<float>(i) / static_cast<float>(k_west_spans);
     fence_post(out,
                yard,
-               k_yard_back_x,
+               k_yard_west_x,
                k_yard_near_z + (t * (k_yard_far_z - k_yard_near_z)),
                k_post_height,
                style);
   }
 
+  constexpr int k_side_spans = 3;
   for (int side = 0; side < 2; ++side) {
     float const z = (side == 0) ? k_yard_near_z : k_yard_far_z;
-    rail_along_x(out, yard, z, k_yard_back_x, k_gate_x, k_rail_low_y, style.timber);
-    rail_along_x(out, yard, z, k_yard_back_x, k_gate_x, k_rail_high_y, style.timber);
-    fence_post(out, yard, (k_yard_back_x + k_gate_x) * 0.5F, z, k_post_height, style);
-    fence_post(out, yard, k_gate_x, z, k_gate_post_height, style);
+    rail_along_x(
+        out, yard, z, k_yard_west_x, k_yard_east_x, k_rail_low_y, style.timber);
+    rail_along_x(
+        out, yard, z, k_yard_west_x, k_yard_east_x, k_rail_high_y, style.timber);
+    for (int i = 0; i < k_side_spans; ++i) {
+      float const t = static_cast<float>(i) / static_cast<float>(k_side_spans);
+      fence_post(out,
+                 yard,
+                 k_yard_west_x + (t * (k_yard_east_x - k_yard_west_x)),
+                 z,
+                 k_post_height,
+                 style);
+    }
+    fence_post(out, yard, k_yard_east_x, z, k_gate_post_height, style);
   }
 }
 
-void draw_timber_pile(ISubmitter& out,
+void draw_crib(ISubmitter& out,
+               const Yard& yard,
+               const StockpileYardStyle& style,
+               float bay_z) {
+  QVector3D const plank = style.timber;
+  QVector3D const frame = style.timber_dark;
+
+  box(out,
+      yard,
+      QVector3D(k_crib_center_x, k_deck_top - 0.015F, bay_z),
+      QVector3D(k_crib_half_x - 0.01F, 0.015F, k_crib_half_z - 0.01F),
+      0.0F,
+      tint(frame, 1.10F));
+
+  box(out,
+      yard,
+      QVector3D(k_crib_center_x - k_crib_half_x, k_crib_height * 0.5F, bay_z),
+      QVector3D(k_crib_wall, k_crib_height * 0.5F, k_crib_half_z),
+      0.0F,
+      plank);
+  for (int side = 0; side < 2; ++side) {
+    float const sign = (side == 0) ? -1.0F : 1.0F;
+    box(out,
+        yard,
+        QVector3D(
+            k_crib_center_x, k_crib_height * 0.5F, bay_z + (sign * k_crib_half_z)),
+        QVector3D(k_crib_half_x, k_crib_height * 0.5F, k_crib_wall),
+        0.0F,
+        plank);
+  }
+  box(out,
+      yard,
+      QVector3D(k_crib_center_x + k_crib_half_x, k_crib_front_height * 0.5F, bay_z),
+      QVector3D(k_crib_wall, k_crib_front_height * 0.5F, k_crib_half_z),
+      0.0F,
+      plank);
+
+  for (int corner = 0; corner < 4; ++corner) {
+    float const sx = ((corner & 1) == 0) ? -1.0F : 1.0F;
+    float const sz = ((corner & 2) == 0) ? -1.0F : 1.0F;
+    float const height = (sx < 0.0F) ? k_crib_height + 0.05F : k_crib_height;
+    box(out,
+        yard,
+        QVector3D(k_crib_center_x + (sx * k_crib_half_x),
+                  height * 0.5F,
+                  bay_z + (sz * k_crib_half_z)),
+        QVector3D(0.058F, height * 0.5F, 0.058F),
+        0.0F,
+        frame);
+  }
+}
+
+void draw_timber_load(ISubmitter& out,
                       const Yard& yard,
                       const StockpileYardStyle& style,
                       float fill,
                       float flash) {
-  constexpr float k_log_radius = 0.115F;
-  constexpr float k_log_half_length = 0.60F;
-  constexpr float k_stake_half_z = k_log_half_length + 0.13F;
-
-  for (int side = 0; side < 2; ++side) {
-    float const z = k_wood_pile_z + ((side == 0) ? -k_stake_half_z : k_stake_half_z);
-    box(out,
-        yard,
-        QVector3D(k_pile_center_x, 0.085F, z),
-        QVector3D(0.50F, 0.075F, 0.045F),
-        0.0F,
-        style.timber_dark);
-    for (int end = 0; end < 2; ++end) {
-      float const x = k_pile_center_x + ((end == 0) ? -0.47F : 0.47F);
-      box(out,
-          yard,
-          QVector3D(x, 0.31F, z),
-          QVector3D(0.045F, 0.31F, 0.045F),
-          0.0F,
-          style.timber_dark);
-    }
-  }
-
   if (fill <= 0.01F) {
     return;
   }
 
-  constexpr std::array<int, 4> k_row_counts{5, 4, 3, 2};
-  constexpr std::array<float, 4> k_row_offsets{-0.42F, -0.315F, -0.21F, -0.105F};
-  constexpr float k_log_pitch = 0.21F;
-  constexpr float k_row_pitch = 0.155F;
-  constexpr int k_max_logs = 14;
+  constexpr float k_log_radius = 0.100F;
+  constexpr float k_log_half_length = k_crib_inner_z - 0.01F;
+  constexpr float k_log_pitch = 0.213F;
+  constexpr float k_row_pitch = 0.176F;
+  constexpr std::array<int, 3> k_row_counts{4, 3, 2};
+  constexpr int k_max_logs = 9;
+
   int const logs =
       std::clamp(static_cast<int>(std::lround(fill * k_max_logs)), 1, k_max_logs);
   int drawn = 0;
@@ -324,41 +336,39 @@ void draw_timber_pile(ISubmitter& out,
   QVector3D const cut_face = brighten(style.timber, 0.42F);
 
   for (std::size_t row = 0; row < k_row_counts.size() && drawn < logs; ++row) {
-    float const y = 0.135F + (static_cast<float>(row) * k_row_pitch);
     int const count = k_row_counts.at(row);
+    float const y = k_deck_top + k_log_radius + (static_cast<float>(row) * k_row_pitch);
+    float const first_x = -(static_cast<float>(count - 1) * 0.5F * k_log_pitch);
     for (int i = 0; i < count && drawn < logs; ++i, ++drawn) {
       auto const seed = static_cast<std::uint32_t>(211 + (drawn * 29));
-      float const x = k_pile_center_x + k_row_offsets.at(row) +
-                      (static_cast<float>(i) * k_log_pitch);
-      float const half_length = k_log_half_length + jitter(seed * 3U, 0.045F);
-      float const shift = jitter(seed * 5U, 0.04F);
+      float const x = k_crib_center_x + first_x + (static_cast<float>(i) * k_log_pitch);
       QVector3D const color =
-          brighten(tint(style.timber, 0.80F + (rand01(seed) * 0.36F)), flash * 0.25F);
+          brighten(tint(style.timber, 0.86F + (rand01(seed) * 0.26F)), flash * 0.25F);
 
       submit_building_cylinder(out,
                                yard.frame,
-                               QVector3D(x, y, k_wood_pile_z + shift - half_length),
-                               QVector3D(x, y, k_wood_pile_z + shift + half_length),
+                               QVector3D(x, y, k_wood_bay_z - k_log_half_length),
+                               QVector3D(x, y, k_wood_bay_z + k_log_half_length),
                                k_log_radius,
                                color,
                                yard.white);
       if (yard.detailed) {
         for (int end = 0; end < 2; ++end) {
           float const z =
-              k_wood_pile_z + shift + ((end == 0) ? -half_length : half_length);
+              k_wood_bay_z + ((end == 0) ? -k_log_half_length : k_log_half_length);
           box(out,
               yard,
               QVector3D(x, y, z),
-              QVector3D(k_log_radius * 0.78F, k_log_radius * 0.78F, 0.018F),
+              QVector3D(k_log_radius * 0.80F, k_log_radius * 0.80F, 0.016F),
               0.0F,
-              tint(cut_face, 0.94F + (rand01(seed * 7U) * 0.12F)));
+              tint(cut_face, 0.96F + (rand01(seed * 7U) * 0.08F)));
         }
       }
     }
   }
 }
 
-void draw_stone_pile(ISubmitter& out,
+void draw_stone_load(ISubmitter& out,
                      const Yard& yard,
                      const StockpileYardStyle& style,
                      float fill,
@@ -367,170 +377,152 @@ void draw_stone_pile(ISubmitter& out,
     return;
   }
 
-  struct Course {
-    float y;
-    int count;
-    float first_z;
-  };
-  constexpr std::array<Course, 4> k_courses{{{0.180F, 4, -0.45F},
-                                             {0.368F, 3, -0.30F},
-                                             {0.556F, 2, -0.15F},
-                                             {0.744F, 1, 0.0F}}};
-  constexpr float k_block_pitch = 0.30F;
+  constexpr float k_block_half_x = 0.245F;
+  constexpr float k_block_half_y = 0.072F;
+  constexpr float k_block_half_z = 0.104F;
+  constexpr float k_block_pitch = 0.272F;
+  constexpr float k_course_pitch = 0.152F;
+  constexpr std::array<int, 4> k_course_counts{4, 3, 2, 1};
   constexpr int k_max_blocks = 10;
 
   int const blocks =
       std::clamp(static_cast<int>(std::lround(fill * k_max_blocks)), 1, k_max_blocks);
   int drawn = 0;
 
-  for (const auto& course : k_courses) {
-    if (drawn >= blocks) {
-      break;
-    }
-    for (int i = 0; i < course.count && drawn < blocks; ++i, ++drawn) {
-      auto const seed = static_cast<std::uint32_t>(331 + (drawn * 43));
+  QVector3D const face = blend(style.stone_mid, style.stone_light, 0.30F);
+  QVector3D const shade = tint(style.stone_dark, 0.78F);
 
-      QVector3D const base = ((drawn % 2) == 0) ? style.stone_light : style.stone_mid;
-      QVector3D const color =
-          brighten(tint(base, 0.92F + (rand01(seed) * 0.16F)), flash * 0.3F);
+  for (std::size_t course = 0; course < k_course_counts.size() && drawn < blocks;
+       ++course) {
+    int const count = k_course_counts.at(course);
+    float const y =
+        k_deck_top + k_block_half_y + (static_cast<float>(course) * k_course_pitch);
+    float const first_z = -(static_cast<float>(count - 1) * 0.5F * k_block_pitch);
+    float const course_shift = ((course % 2) == 0) ? -0.022F : 0.022F;
+    for (int i = 0; i < count && drawn < blocks; ++i, ++drawn) {
+      QVector3D const base = ((i + static_cast<int>(course)) % 2 == 0) ? face : shade;
       box(out,
           yard,
-          QVector3D(k_pile_center_x + jitter(seed * 3U, 0.016F),
-                    course.y,
-                    k_stone_pile_z + course.first_z +
-                        (static_cast<float>(i) * k_block_pitch)),
-          QVector3D(0.215F, 0.092F, 0.145F),
-          jitter(seed * 7U, 2.0F),
-          color);
+          QVector3D(k_crib_center_x + course_shift,
+                    y,
+                    k_stone_bay_z + first_z + (static_cast<float>(i) * k_block_pitch)),
+          QVector3D(k_block_half_x, k_block_half_y, k_block_half_z),
+          0.0F,
+          brighten(base, flash * 0.30F));
     }
-  }
-
-  if (fill > 0.35F) {
-    box(out,
-        yard,
-        QVector3D(k_pile_center_x + 0.40F, 0.100F, k_stone_pile_z - 0.52F),
-        QVector3D(0.205F, 0.090F, 0.145F),
-        -14.0F,
-        brighten(tint(style.stone_dark, 1.28F), flash * 0.25F));
-  }
-  if (!yard.detailed) {
-    return;
-  }
-  for (int i = 0; i < 4; ++i) {
-    auto const seed = static_cast<std::uint32_t>(509 + (i * 37));
-    rock(out,
-         yard,
-         QVector3D(k_pile_center_x + jitter(seed, 0.42F),
-                   k_ground + 0.02F,
-                   k_stone_pile_z + jitter(seed * 3U, 0.48F)),
-         QVector3D(0.075F + (rand01(seed * 5U) * 0.045F),
-                   0.035F,
-                   0.065F + (rand01(seed * 7U) * 0.04F)),
-         rand01(seed * 11U) * 360.0F,
-         0.0F,
-         tint(style.stone_dark, 0.95F + (rand01(seed * 13U) * 0.25F)));
   }
 }
 
-void draw_ore_pile(ISubmitter& out,
+void draw_ore_load(ISubmitter& out,
                    const Yard& yard,
                    const StockpileYardStyle& style,
                    float fill,
                    float flash) {
-  constexpr float k_bin_half_x = 0.46F;
-  constexpr float k_bin_half_z = 0.50F;
-  constexpr float k_wall = 0.045F;
-  constexpr float k_bin_height = 0.27F;
-
-  for (int side = 0; side < 2; ++side) {
-    float const sign = (side == 0) ? -1.0F : 1.0F;
-    box(out,
-        yard,
-        QVector3D(k_pile_center_x + (sign * k_bin_half_x),
-                  k_bin_height * 0.5F,
-                  k_iron_pile_z),
-        QVector3D(k_wall, k_bin_height * 0.5F, k_bin_half_z),
-        0.0F,
-        style.timber_dark);
-    box(out,
-        yard,
-        QVector3D(k_pile_center_x,
-                  k_bin_height * 0.5F,
-                  k_iron_pile_z + (sign * k_bin_half_z)),
-        QVector3D(k_bin_half_x, k_bin_height * 0.5F, k_wall),
-        0.0F,
-        style.timber_dark);
-  }
-  for (int corner = 0; corner < 4; ++corner) {
-    float const sx = ((corner & 1) == 0) ? -1.0F : 1.0F;
-    float const sz = ((corner & 2) == 0) ? -1.0F : 1.0F;
-    box(out,
-        yard,
-        QVector3D(k_pile_center_x + (sx * k_bin_half_x),
-                  k_bin_height * 0.56F,
-                  k_iron_pile_z + (sz * k_bin_half_z)),
-        QVector3D(0.062F, k_bin_height * 0.56F, 0.062F),
-        0.0F,
-        style.timber);
-  }
-
   if (fill <= 0.01F) {
     return;
   }
 
-  float const bed_top = 0.06F + (fill * (k_bin_height - 0.05F));
+  float const bed_top = k_deck_top + 0.03F + (fill * (k_crib_height - 0.10F));
   box(out,
       yard,
-      QVector3D(k_pile_center_x, bed_top * 0.5F, k_iron_pile_z),
-      QVector3D(k_bin_half_x - k_wall, bed_top * 0.5F, k_bin_half_z - k_wall),
+      QVector3D(k_crib_center_x, (k_deck_top + bed_top) * 0.5F, k_iron_bay_z),
+      QVector3D(k_crib_inner_x, (bed_top - k_deck_top) * 0.5F, k_crib_inner_z),
       0.0F,
-      brighten(tint(style.ore, 0.72F), flash * 0.30F));
+      brighten(blend(tint(style.ore, 1.02F), style.ore_rust, 0.22F), flash * 0.28F));
 
-  constexpr std::array<std::array<float, 2>, 10> k_lump_spots{{{-0.24F, -0.30F},
-                                                               {0.20F, -0.28F},
-                                                               {-0.05F, -0.02F},
-                                                               {0.26F, 0.22F},
-                                                               {-0.27F, 0.26F},
-                                                               {0.04F, 0.36F},
-                                                               {-0.14F, 0.12F},
-                                                               {0.16F, -0.05F},
-                                                               {-0.22F, -0.10F},
-                                                               {0.02F, -0.34F}}};
-  int const lumps = std::clamp(static_cast<int>(std::lround(fill * 12.0F)),
+  constexpr std::array<std::array<float, 2>, 9> k_lump_spots{{{-0.30F, -0.34F},
+                                                              {0.00F, -0.36F},
+                                                              {0.30F, -0.30F},
+                                                              {-0.32F, 0.00F},
+                                                              {0.00F, -0.02F},
+                                                              {0.31F, 0.03F},
+                                                              {-0.28F, 0.33F},
+                                                              {0.02F, 0.35F},
+                                                              {0.30F, 0.31F}}};
+  int const lumps = std::clamp(static_cast<int>(std::lround(fill * 11.0F)),
                                1,
                                static_cast<int>(k_lump_spots.size()));
   for (int i = 0; i < lumps; ++i) {
     auto const seed = static_cast<std::uint32_t>(457 + (i * 53));
-    float const radius = 0.10F + (rand01(seed) * 0.05F);
-    QVector3D const base = (rand01(seed * 3U) > 0.62F) ? style.ore_rust : style.ore;
-    rock(
-        out,
-        yard,
-        QVector3D(k_pile_center_x + k_lump_spots.at(i).at(0) + jitter(seed * 5U, 0.05F),
-                  bed_top + (radius * 0.5F) + (rand01(seed * 19U) * 0.04F),
-                  k_iron_pile_z + k_lump_spots.at(i).at(1) + jitter(seed * 7U, 0.05F)),
-        QVector3D(radius, radius * 0.76F, radius * 0.92F),
-        rand01(seed * 11U) * 360.0F,
-        jitter(seed * 13U, 22.0F),
-        brighten(tint(base, 0.88F + (rand01(seed * 17U) * 0.28F)), flash * 0.35F));
-  }
-
-  if (!yard.detailed) {
-    return;
-  }
-  for (int i = 0; i < 3; ++i) {
-    auto const seed = static_cast<std::uint32_t>(661 + (i * 31));
-    float const radius = 0.07F + (rand01(seed) * 0.035F);
+    float const radius = 0.088F + (rand01(seed) * 0.038F);
+    QVector3D const base = (rand01(seed * 3U) > 0.66F) ? style.ore_rust : style.ore;
     rock(out,
          yard,
-         QVector3D(k_pile_center_x + 0.62F + jitter(seed * 3U, 0.16F),
-                   k_ground + (radius * 0.5F),
-                   k_iron_pile_z + jitter(seed * 5U, 0.44F)),
-         QVector3D(radius, radius * 0.7F, radius * 0.9F),
-         rand01(seed * 7U) * 360.0F,
-         jitter(seed * 11U, 18.0F),
-         tint(style.ore_rust, 0.9F + (rand01(seed * 13U) * 0.3F)));
+         QVector3D(k_crib_center_x + k_lump_spots.at(i).at(0),
+                   bed_top + (radius * 0.38F),
+                   k_iron_bay_z + k_lump_spots.at(i).at(1)),
+         QVector3D(radius, radius * 0.62F, radius * 0.90F),
+         rand01(seed * 11U) * 360.0F,
+         0.0F,
+         brighten(tint(base, 1.08F + (rand01(seed * 17U) * 0.24F)), flash * 0.32F));
   }
+}
+
+void draw_barrel(ISubmitter& out,
+                 const Yard& yard,
+                 const StockpileYardStyle& style,
+                 float x,
+                 float z) {
+  constexpr float k_radius = 0.130F;
+  constexpr float k_height = 0.33F;
+
+  auto ring = [&](float from_y, float to_y, float radius, const QVector3D& color) {
+    submit_building_cylinder(out,
+                             yard.frame,
+                             QVector3D(x, from_y, z),
+                             QVector3D(x, to_y, z),
+                             radius,
+                             color,
+                             yard.white);
+  };
+
+  ring(k_ground, k_ground + k_height, k_radius, tint(style.timber, 1.02F));
+  ring(k_ground + 0.055F, k_ground + 0.085F, k_radius * 1.05F, style.timber_dark);
+  ring(k_ground + 0.235F, k_ground + 0.265F, k_radius * 1.05F, style.timber_dark);
+  ring(k_ground + k_height,
+       k_ground + k_height + 0.018F,
+       k_radius * 0.94F,
+       blend(style.timber, style.timber_dark, 0.55F));
+}
+
+void draw_yard_props(ISubmitter& out,
+                     const Yard& yard,
+                     const StockpileYardStyle& style) {
+  constexpr float k_lane_z = k_stockpile_center_z;
+  constexpr float k_lane_from_x = k_apron_west_x + 0.04F;
+  constexpr float k_lane_to_x = k_yard_east_x - 0.06F;
+  constexpr int k_lane_boards = 6;
+  constexpr float k_board_pitch =
+      (k_lane_to_x - k_lane_from_x) / static_cast<float>(k_lane_boards);
+
+  for (int i = 0; i < k_lane_boards; ++i) {
+    box(out,
+        yard,
+        QVector3D(k_lane_from_x + ((static_cast<float>(i) + 0.5F) * k_board_pitch),
+                  k_ground + 0.012F,
+                  k_lane_z),
+        QVector3D(k_board_pitch * 0.42F, 0.012F, 0.34F),
+        0.0F,
+        tint(style.timber, 0.90F + (static_cast<float>(i % 2) * 0.14F)));
+  }
+
+  constexpr float k_plank_x = k_yard_east_x - 0.30F;
+  constexpr float k_plank_z = k_yard_far_z - 0.70F;
+  constexpr float k_plank_thickness = 0.024F;
+  for (int i = 0; i < 4; ++i) {
+    box(out,
+        yard,
+        QVector3D(k_plank_x,
+                  k_ground + k_plank_thickness +
+                      (static_cast<float>(i) * k_plank_thickness * 2.1F),
+                  k_plank_z),
+        QVector3D(0.17F, k_plank_thickness, 0.46F),
+        0.0F,
+        tint(style.timber, 0.88F + (static_cast<float>(i) * 0.07F)));
+  }
+
+  draw_barrel(out, yard, style, k_yard_east_x - 0.28F, k_yard_near_z + 0.44F);
+  draw_barrel(out, yard, style, k_yard_east_x - 0.30F, k_yard_near_z + 0.78F);
 }
 
 } // namespace
@@ -576,8 +568,11 @@ void draw_barracks_stockpile(const DrawContext& ctx,
 
   draw_bed(out, yard, decayed);
   draw_fence(out, yard, decayed);
+  for (float const bay_z : {k_wood_bay_z, k_stone_bay_z, k_iron_bay_z}) {
+    draw_crib(out, yard, decayed, bay_z);
+  }
   if (yard.detailed) {
-    draw_yard_clutter(out, yard, decayed);
+    draw_yard_props(out, yard, decayed);
   }
 
   if (state == BuildingState::Destroyed) {
@@ -592,9 +587,9 @@ void draw_barracks_stockpile(const DrawContext& ctx,
   float const flash = std::clamp(
       stockpile->deposit_flash / k_stockpile_deposit_flash_seconds, 0.0F, 1.0F);
 
-  draw_timber_pile(out, yard, decayed, stockpile->wood_fill, flash);
-  draw_stone_pile(out, yard, decayed, stockpile->stone_fill, flash);
-  draw_ore_pile(out, yard, decayed, stockpile->iron_fill, flash);
+  draw_timber_load(out, yard, decayed, stockpile->wood_fill, flash);
+  draw_stone_load(out, yard, decayed, stockpile->stone_fill, flash);
+  draw_ore_load(out, yard, decayed, stockpile->iron_fill, flash);
 }
 
 } // namespace Render::GL

--- a/render/entity/carried_load_renderer.cpp
+++ b/render/entity/carried_load_renderer.cpp
@@ -29,8 +29,8 @@ constexpr float k_far_distance_sq = 120.0F * 120.0F;
 constexpr float k_detail_distance_sq = 46.0F * 46.0F;
 constexpr float k_cull_radius = 0.8F;
 
-constexpr float k_carry_height = 1.02F;
-constexpr float k_carry_forward = 0.22F;
+constexpr float k_carry_height = 1.00F;
+constexpr float k_carry_forward = 0.30F;
 constexpr int k_max_visible_carriers = 8;
 
 constexpr QVector3D k_timber{0.47F, 0.32F, 0.18F};
@@ -105,29 +105,37 @@ void draw_log(ISubmitter& out,
               const QMatrix4x4& frame,
               std::uint32_t seed,
               bool detailed) {
-  constexpr float k_radius = 0.064F;
-  constexpr float k_half_length = 0.32F;
+  constexpr float k_radius = 0.062F;
+  constexpr float k_half_length = 0.40F;
+  constexpr std::array<std::array<float, 2>, 3> k_bundle{
+      {{-0.066F, 0.0F}, {0.066F, 0.0F}, {0.0F, 0.112F}}};
 
-  float const skew = jitter(seed, 0.06F);
-  QVector3D const left(-k_half_length, k_carry_height, k_carry_forward - skew);
-  QVector3D const right(k_half_length, k_carry_height, k_carry_forward + skew);
-
-  out.mesh(get_unit_cylinder(10),
-           Render::Geom::cylinder_between(frame, left, right, k_radius),
-           tint(k_timber, 0.86F + (rand01(seed * 3U) * 0.30F)));
-
-  if (!detailed) {
-    return;
-  }
   Mesh* const cube = get_unit_cube();
-  for (const auto& end : {left, right}) {
-    put(out,
-        cube,
-        frame,
-        end,
-        QVector3D(0.012F, k_radius * 0.82F, k_radius * 0.82F),
-        QVector3D(),
-        tint(k_timber_cut, 0.94F + (rand01(seed * 7U) * 0.12F)));
+  for (std::size_t i = 0; i < k_bundle.size(); ++i) {
+    auto const log_seed = static_cast<std::uint32_t>(seed + 17U + (i * 41U));
+    float const skew = jitter(log_seed, 0.035F);
+    float const half_length = k_half_length + jitter(log_seed * 3U, 0.045F);
+    float const y = k_carry_height + k_bundle.at(i).at(1);
+    float const z = k_carry_forward + k_bundle.at(i).at(0);
+    QVector3D const left(-half_length, y - skew, z);
+    QVector3D const right(half_length, y + skew, z);
+
+    out.mesh(get_unit_cylinder(10),
+             Render::Geom::cylinder_between(frame, left, right, k_radius),
+             tint(k_timber, 0.84F + (rand01(log_seed * 5U) * 0.32F)));
+
+    if (!detailed) {
+      continue;
+    }
+    for (const auto& end : {left, right}) {
+      put(out,
+          cube,
+          frame,
+          end,
+          QVector3D(0.013F, k_radius * 0.84F, k_radius * 0.84F),
+          QVector3D(),
+          tint(k_timber_cut, 0.94F + (rand01(log_seed * 7U) * 0.12F)));
+    }
   }
 }
 
@@ -139,10 +147,10 @@ void draw_block(ISubmitter& out,
   put(out,
       cube,
       frame,
-      QVector3D(0.0F, k_carry_height - 0.06F, k_carry_forward + 0.04F),
-      QVector3D(0.125F, 0.086F, 0.104F),
-      QVector3D(0.0F, jitter(seed, 9.0F), 0.0F),
-      tint(k_stone_light, 0.88F + (rand01(seed * 3U) * 0.20F)));
+      QVector3D(0.0F, k_carry_height - 0.02F, k_carry_forward + 0.02F),
+      QVector3D(0.170F, 0.110F, 0.130F),
+      QVector3D(0.0F, jitter(seed, 7.0F), 0.0F),
+      tint(k_stone_light, 0.84F + (rand01(seed * 3U) * 0.20F)));
 
   if (!detailed) {
     return;
@@ -152,8 +160,8 @@ void draw_block(ISubmitter& out,
       (stone != nullptr) ? stone : cube,
       frame,
       QVector3D(
-          jitter(seed * 5U, 0.05F), k_carry_height + 0.09F, k_carry_forward + 0.03F),
-      QVector3D(0.058F, 0.044F, 0.052F),
+          jitter(seed * 5U, 0.05F), k_carry_height + 0.14F, k_carry_forward + 0.01F),
+      QVector3D(0.072F, 0.052F, 0.064F),
       QVector3D(0.0F, rand01(seed * 11U) * 360.0F, 0.0F),
       tint(k_stone_dark, 1.05F + (rand01(seed * 13U) * 0.20F)));
 }
@@ -164,9 +172,18 @@ void draw_ore_basket(ISubmitter& out,
                      bool detailed) {
   Mesh* const basket = get_unit_tapered_cylinder(0.72F, 1.0F, 10);
   QMatrix4x4 body = frame;
-  body.translate(0.0F, k_carry_height - 0.09F, k_carry_forward + 0.02F);
-  body.scale(0.125F, 0.092F, 0.112F);
+  body.translate(0.0F, k_carry_height - 0.04F, k_carry_forward);
+  body.scale(0.175F, 0.125F, 0.155F);
   out.mesh(basket, body, tint(k_basket, 0.90F + (rand01(seed) * 0.22F)));
+
+  Mesh* const cube = get_unit_cube();
+  put(out,
+      cube,
+      frame,
+      QVector3D(0.0F, k_carry_height + 0.085F, k_carry_forward),
+      QVector3D(0.180F, 0.018F, 0.160F),
+      QVector3D(),
+      tint(k_basket, 0.70F));
 
   if (!detailed) {
     return;
@@ -174,20 +191,20 @@ void draw_ore_basket(ISubmitter& out,
   Mesh* const stone = Render::Geom::Stone::get();
   Mesh* const fallback = get_unit_sphere();
   constexpr std::array<std::array<float, 2>, 3> k_lumps{
-      {{-0.055F, -0.030F}, {0.050F, 0.025F}, {0.000F, 0.055F}}};
+      {{-0.072F, -0.040F}, {0.068F, 0.032F}, {0.000F, 0.076F}}};
   for (std::size_t i = 0; i < k_lumps.size(); ++i) {
     auto const lump_seed = static_cast<std::uint32_t>(seed + 61U + (i * 37U));
-    float const radius = 0.044F + (rand01(lump_seed) * 0.016F);
+    float const radius = 0.058F + (rand01(lump_seed) * 0.020F);
     QVector3D const base = (rand01(lump_seed * 3U) > 0.6F) ? k_ore_rust : k_ore;
     put(out,
         (stone != nullptr) ? stone : fallback,
         frame,
         QVector3D(k_lumps.at(i).at(0),
-                  k_carry_height + 0.01F + (radius * 0.5F),
-                  k_carry_forward + 0.02F + k_lumps.at(i).at(1)),
+                  k_carry_height + 0.10F + (radius * 0.45F),
+                  k_carry_forward + k_lumps.at(i).at(1)),
         QVector3D(radius, radius * 0.78F, radius * 0.92F),
         QVector3D(0.0F, rand01(lump_seed * 5U) * 360.0F, 0.0F),
-        tint(base, 0.92F + (rand01(lump_seed * 7U) * 0.26F)));
+        tint(base, 0.98F + (rand01(lump_seed * 7U) * 0.26F)));
   }
 }
 
@@ -259,6 +276,9 @@ auto submit_carried_loads(Engine::Core::World* world,
     bool const detailed = distance_sq <= k_detail_distance_sq;
 
     float const unit_yaw = transform->rotation.y;
+    QVector3D const body_scale(std::max(transform->scale.x, 0.01F),
+                               std::max(transform->scale.y, 0.01F),
+                               std::max(transform->scale.z, 0.01F));
 
     auto submit_at = [&](float local_x, float local_z, float local_yaw, int slot) {
       QMatrix4x4 frame;
@@ -266,6 +286,7 @@ auto submit_carried_loads(Engine::Core::World* world,
       frame.rotate(unit_yaw, 0.0F, 1.0F, 0.0F);
       frame.translate(local_x, 0.0F, local_z);
       frame.rotate(local_yaw, 0.0F, 1.0F, 0.0F);
+      frame.scale(body_scale);
       draw_load(out,
                 frame,
                 type,


### PR DESCRIPTION
Rework the barracks stockpile yard around three consistent timber cribs for wood, stone, and iron. Replace the loose, irregular pile layouts with bounded bays, a dedicated apron, a complete perimeter fence, a loading lane, stacked planks, and barrels so the delivery area reads more clearly at gameplay distance.

Update each resource fill visualization to fit the new crib geometry. Wood is arranged as layered log courses with visible cut faces, stone uses a compact stepped block stack, and ore fills its bay with a colored bed and surface lumps. Preserve deposit-flash highlighting while simplifying random offsets for a cleaner and more intentional silhouette.

Improve carried-resource readability by enlarging stone and ore loads, rendering timber as a three-log bundle, and adjusting the carry offsets toward the hands. Apply each carrier's render scale to the load frame so resources remain aligned and proportioned for scaled unit models.

Run the repository formatter to normalize the updated renderer sources.