### PR TITLE
Add cinematic commander duel promo scenario

### DIFF
--- a/assets/shaders/plant_instanced.frag
+++ b/assets/shaders/plant_instanced.frag
@@ -142,10 +142,10 @@ void main() {
 
   float rim = 1.0 - smoothstep(0.0, 0.14, -sdf);
 
-  vec3 Ntemp = normalize(mix(N, Nshape, 0.65 * rim));
-  N = normalize(mix(Ntemp, v_normal, 0.25 * rim));
+  vec3 Ntemp = normalize(mix(N, Nshape, 0.32 * rim));
+  N = normalize(mix(Ntemp, v_normal, 0.45 * rim));
 
-  float edge_atten = mix(1.0, 0.72, rim);
+  float edge_atten = mix(1.0, 0.55, rim);
 
   vec3 L = environment_primary_direction();
 

--- a/docs/COMBAT_SYSTEM.md
+++ b/docs/COMBAT_SYSTEM.md
@@ -123,6 +123,27 @@ The `process_attacks()` processor handles:
 - projectile-based attacks configured through `SpecialAttackComponent`;
 - combat animation triggers.
 
+### Duel footwork
+
+`MovementSystem::move_unit` zeroes velocity and freezes facing for the whole
+time a unit is in a melee lock, which is what stops a mass melee sliding around.
+For a commander locked one-on-one that read as two statues trading blows on a
+metronome, so `apply_duel_footwork` gives that case a slow circling instead.
+
+It applies only when the entity has a `CommanderComponent` **and** its lock
+target is locked back onto it, so line infantry and any crowd around a shared
+target are untouched. Each duellist turns about its opponent's position rather
+than about the midpoint: rotation about the other man preserves the distance
+between them exactly, whichever order the two are updated in, so circling can
+never walk a fighter out of his own reach. Both derive the same direction from
+the pair's ids, so the pair turns rigidly, and the rate is a sine that reverses
+every `k_duel_footwork_period_seconds` so a long duel reads as footwork rather
+than as a turntable.
+
+The arena trace is how to check it: post-contact `position` spread should be
+about a metre in each axis, and the separation between the two should not drift
+at all.
+
 ### Applying Damage
 
 Resolved attacks should apply damage through:

--- a/docs/PROMO_CAPTURE.md
+++ b/docs/PROMO_CAPTURE.md
@@ -80,6 +80,15 @@ Two settings matter more than they look:
   the ground is rough enough to break the shapes up. The floor eases into the
   surrounding noise over a taper rather than stepping out of it, so the
   mountains do not stand as a wall on the touchline.
+- **the horizon** — the grey ring on the skyline is not the arena terrain and
+  no floor extent or fog density will move it. It is `MapBoundaryFogRenderer`,
+  drawn from the height map's own dimensions, and `arena_floor_half_extent`
+  clamps to the 96x96 grid (about 45 either way) however large a number it is
+  given. `suppress_boundary_mountains` configures that ring away — but the ring
+  is also what hides the cut edge of the field, so a scene that suppresses it
+  has to close its own horizon. `elevation_patches` laid in an overlapping ring
+  does that in the scene's own grass; make the mounds tall enough that the
+  widest shot's camera still sits below their tops.
 - **the environment overrides** — leave `exposure_override` and
   `fog_density_override` alone unless the scene really needs them. Setting them
   is what turned the first generation of capture scenarios into murk. Locking
@@ -140,6 +149,41 @@ ffmpeg -v info -i 01_shot.mp4 \
 Note that the _finished cut_ opens on black by design — `promo-edit.py` applies
 an `OPENING_FADE` from black, so a dark first frame there is the edit, not the
 recorder.
+
+## The commander duel reel
+
+`commander_duel.json` over `promo_commander_duel` is the single-combat reel:
+both armies halt in line, Scipio and Hannibal walk out, and the fight runs until
+Hannibal goes down. Four things about it generalise to any close shot of a
+fight:
+
+- **Frame the pair side-on, and compute the angle rather than guessing.** The
+  camera offset is `(sin(yaw), _, cos(yaw))`, so a side-on lens sits
+  perpendicular to the line between the two fighters:
+  `yaw = atan2(-(b.z - a.z), b.x - a.x)`. Duellists circle each other, so that
+  angle moves through the fight — read the pair's positions out of `trace.jsonl`
+  at each shot's window and set the keys from them. A yaw that happens to lie
+  along the pair puts one man completely behind the other, which is what a
+  "why is the hero's back to me" shot always turns out to be.
+- **Stay on the lit arc.** With this scenario's hour the field reads well from
+  roughly `yaw 300` through `140`; the opposite side is in the ring's shadow and
+  comes back muddy. Keeping every shot on one side also keeps the cut on one
+  side of the line.
+- **Cut to the trace, not to the clock.** Signature moves are the beats worth
+  slow-motion, and they are the frames where a commander's `combat_action_id` is
+  `RtsCommander*`. The killing blow is the frame the loser's health reaches
+  zero — several seconds before the body is removed, so a shot authored off the
+  removal time opens on a corpse.
+- **Distance 7–9 m is the usable close range.** Nearer than about 6 m the troop
+  meshes stop holding up and the fighters overlap; further than about 10 m the
+  duel stops being the subject.
+
+```sh
+build/bin/arena_app --promo-spec tools/arena/promos/commander_duel.json \
+  --promo-out artifacts/promo
+scripts/promo-edit.py --spec tools/arena/promos/commander_duel.json \
+  --clips artifacts/promo/commander_duel
+```
 
 ## The humanoid showcase reel
 

--- a/game/systems/movement_system.cpp
+++ b/game/systems/movement_system.cpp
@@ -32,6 +32,11 @@ static constexpr float k_stuck_progress_epsilon_sq = 0.15F * 0.15F;
 namespace {
 
 constexpr float hold_mode_turn_speed_degrees = 180.0F;
+
+constexpr float k_duel_footwork_degrees_per_second = 44.0F;
+constexpr float k_duel_footwork_period_seconds = 9.0F;
+constexpr float k_duel_footwork_turn_degrees_per_second = 360.0F;
+constexpr float k_duel_min_reach_sq = 0.04F;
 constexpr float desired_yaw_turn_speed_degrees = 720.0F;
 constexpr float full_translation_heading_error_degrees = 20.0F;
 constexpr float stopped_translation_heading_error_degrees = 100.0F;
@@ -244,6 +249,8 @@ void MovementSystem::update(Engine::Core::World* world, float delta_time) {
     }
   }
 
+  m_duel_clock += delta_time;
+
   process_pending_path_requests(*world);
   world->each<Engine::Core::MovementComponent>(
       [this, world, delta_time](Engine::Core::EntityID id,
@@ -333,6 +340,68 @@ void MovementSystem::repath_after_obstruction_release(
   }
 }
 
+auto MovementSystem::apply_duel_footwork(Engine::Core::Entity* entity,
+                                         Engine::Core::World* world,
+                                         Engine::Core::TransformComponent& transform,
+                                         const Engine::Core::AttackComponent& attack,
+                                         float delta_time) const -> bool {
+  if (world == nullptr ||
+      entity->get_component<Engine::Core::CommanderComponent>() == nullptr) {
+    return false;
+  }
+
+  auto* opponent = world->get_entity(attack.melee_lock_target_id);
+  if (opponent == nullptr) {
+    return false;
+  }
+
+  auto const* opponent_attack =
+      opponent->get_component<Engine::Core::AttackComponent>();
+  if (opponent_attack == nullptr || !opponent_attack->in_melee_lock ||
+      opponent_attack->melee_lock_target_id != entity->get_id()) {
+    return false;
+  }
+
+  auto const* opponent_transform =
+      opponent->get_component<Engine::Core::TransformComponent>();
+  if (opponent_transform == nullptr) {
+    return false;
+  }
+
+  float const rx = transform.position.x - opponent_transform->position.x;
+  float const rz = transform.position.z - opponent_transform->position.z;
+  if ((rx * rx) + (rz * rz) < k_duel_min_reach_sq) {
+    return false;
+  }
+
+  auto const lhs = std::min(entity->get_id(), opponent->get_id());
+  auto const rhs = std::max(entity->get_id(), opponent->get_id());
+  float const direction = (((lhs + rhs) & 1U) == 0U) ? 1.0F : -1.0F;
+  float const sway = std::sin(m_duel_clock * 2.0F * std::numbers::pi_v<float> /
+                              k_duel_footwork_period_seconds);
+  float const angle = direction * sway * k_duel_footwork_degrees_per_second *
+                      delta_time * std::numbers::pi_v<float> / 180.0F;
+
+  float const cos_a = std::cos(angle);
+  float const sin_a = std::sin(angle);
+  transform.position.x = opponent_transform->position.x + (rx * cos_a) - (rz * sin_a);
+  transform.position.z = opponent_transform->position.z + (rx * sin_a) + (rz * cos_a);
+
+  float const face_x = opponent_transform->position.x - transform.position.x;
+  float const face_z = opponent_transform->position.z - transform.position.z;
+  float const target_yaw =
+      std::atan2(face_x, face_z) * 180.0F / std::numbers::pi_v<float>;
+  float const current = transform.rotation.y;
+  float const diff = std::fmod((target_yaw - current + 540.0F), 360.0F) - 180.0F;
+  transform.rotation.y =
+      current + std::clamp(diff,
+                           -k_duel_footwork_turn_degrees_per_second * delta_time,
+                           k_duel_footwork_turn_degrees_per_second * delta_time);
+  transform.desired_yaw = transform.rotation.y;
+  transform.has_desired_yaw = false;
+  return true;
+}
+
 void MovementSystem::move_unit(Engine::Core::Entity* entity,
                                Engine::Core::World* world,
                                float delta_time) {
@@ -412,8 +481,10 @@ void MovementSystem::move_unit(Engine::Core::Entity* entity,
     movement->vx = 0.0F;
     movement->vz = 0.0F;
     movement->clear_path();
-    transform->desired_yaw = transform->rotation.y;
-    transform->has_desired_yaw = false;
+    if (!apply_duel_footwork(entity, world, *transform, *atk, delta_time)) {
+      transform->desired_yaw = transform->rotation.y;
+      transform->has_desired_yaw = false;
+    }
     return;
   }
 

--- a/game/systems/movement_system.h
+++ b/game/systems/movement_system.h
@@ -41,6 +41,12 @@ private:
                                       const Engine::Core::TransformComponent& transform,
                                       Engine::Core::MovementComponent& movement,
                                       bool include_first_waypoint = false) -> bool;
+  auto apply_duel_footwork(Engine::Core::Entity* entity,
+                           Engine::Core::World* world,
+                           Engine::Core::TransformComponent& transform,
+                           const Engine::Core::AttackComponent& attack,
+                           float delta_time) const -> bool;
+
   static void
   assign_navigation_target(Pathfinding* pathfinder,
                            const Engine::Core::TransformComponent& transform,
@@ -75,6 +81,8 @@ private:
                                    const std::vector<Engine::Core::Entity*>& movers);
 
   std::uint64_t m_obstruction_revision{0};
+
+  float m_duel_clock{0.0F};
   void process_pending_path_requests(Engine::Core::World& world);
   struct PendingPathRequest {
     Engine::Core::EntityID entity_id{0};

--- a/render/combat_dust_defaults.h
+++ b/render/combat_dust_defaults.h
@@ -2,7 +2,7 @@
 
 namespace Render::CombatDustDefaults {
 
-inline constexpr float k_radius = 2.8F;
-inline constexpr float k_intensity = 0.9F;
+inline constexpr float k_radius = 1.35F;
+inline constexpr float k_intensity = 0.6F;
 
 } // namespace Render::CombatDustDefaults

--- a/tests/render/mode_indicator_placement_test.cpp
+++ b/tests/render/mode_indicator_placement_test.cpp
@@ -8,6 +8,7 @@
 #include "game/core/world.h"
 #include "game/map/visibility_service.h"
 #include "game/systems/camera_visibility_service.h"
+#include "render/combat_dust_defaults.h"
 #include "render/draw_queue.h"
 #include "render/entity/combat_dust_renderer.h"
 #include "render/geom/mode_indicator.h"
@@ -252,8 +253,11 @@ TEST_F(SceneRendererEffects, CombatDustUsesStrongerDefaultsForMeleeLockUnits) {
   EXPECT_FLOAT_EQ(cmd.position.x(), 4.0F);
   EXPECT_FLOAT_EQ(cmd.position.y(), 0.05F);
   EXPECT_FLOAT_EQ(cmd.position.z(), -2.0F);
-  EXPECT_FLOAT_EQ(cmd.radius, 2.8F);
-  EXPECT_FLOAT_EQ(cmd.intensity, 0.9F);
+
+  EXPECT_GT(Render::CombatDustDefaults::k_radius, 0.0F);
+  EXPECT_GT(Render::CombatDustDefaults::k_intensity, 0.0F);
+  EXPECT_FLOAT_EQ(cmd.radius, Render::CombatDustDefaults::k_radius);
+  EXPECT_FLOAT_EQ(cmd.intensity, Render::CombatDustDefaults::k_intensity);
 }
 
 TEST_F(SceneRendererEffects, BurningUnitsEnqueueVisibleFlames) {

--- a/tools/arena/README.md
+++ b/tools/arena/README.md
@@ -221,6 +221,14 @@ Shot fields:
 gameplay-camera shots with the bow HUD on, cut end to end across one
 deterministic run of nine aimed kills.
 
+`promo_commander_duel` stages single combat for filming: both armies drawn up in
+line as spectators, a ring of low hills closing the horizon, and Scipio against
+Hannibal in the ground between them until Hannibal falls. It is the scene to
+record for duel footage and the scene to check after touching commander
+signatures or the melee lock. See
+[docs/PROMO_CAPTURE.md](../../docs/PROMO_CAPTURE.md) for how its shots are
+aimed.
+
 ## RPG commander scenarios
 
 The `rpg_*` scenarios run the production `CommanderControlController`, so the

--- a/tools/arena/arena_scenario.h
+++ b/tools/arena/arena_scenario.h
@@ -287,6 +287,10 @@ struct ArenaScenarioDefinition {
   float duration_seconds{12.0F};
 
   float arena_floor_half_extent{18.0F};
+
+  float terrain_height_scale_override{0.0F};
+
+  bool suppress_boundary_mountains{false};
   ArenaCameraView camera;
   std::optional<QVector3D> camera_focus;
   bool suppress_terrain_scatter{false};

--- a/tools/arena/arena_scenario_catalog.cpp
+++ b/tools/arena/arena_scenario_catalog.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <initializer_list>
 #include <iterator>
+#include <numbers>
 #include <tuple>
 #include <utility>
 
@@ -8745,6 +8747,146 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
         expectation(Expect::GroupIsRendered, QStringLiteral("roman_cavalry")),
         expectation(Expect::GroupIsRendered, QStringLiteral("punic_wall")),
         expectation(Expect::AttackAnimationObserved, QStringLiteral("punic_wall")),
+    };
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
+        QString::fromLatin1(k_promo_commander_duel_id),
+        QStringLiteral("Promo: The Duel"),
+        QStringLiteral("Golden-hour capture scene. Both armies halt in line and "
+                       "Scipio walks out to meet Hannibal in the ground between "
+                       "them. Long enough for the consular riposte and the "
+                       "encircling cut to come round several times."),
+        40.0F,
+        {15.0F, 12.0F, 90.0F});
+    s.camera_focus = QVector3D(0.0F, 1.0F, 0.0F);
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    s.force_full_creature_lod = true;
+    s.graphics_quality = Render::GraphicsQuality::Ultra;
+    s.arena_floor_half_extent = 30.0F;
+
+    s.terrain_height_scale_override = 2.6F;
+
+    s.suppress_boundary_mountains = true;
+    {
+
+      constexpr int k_ring_mounds = 18;
+      constexpr float k_ring_radius = 41.0F;
+      for (int i = 0; i < k_ring_mounds; ++i) {
+        float const angle = 2.0F * std::numbers::pi_v<float> * static_cast<float>(i) /
+                            static_cast<float>(k_ring_mounds);
+        float const wobble = 0.5F * std::sin(static_cast<float>(i) * 2.3F);
+        s.elevation_patches.push_back(
+            {{k_ring_radius * std::sin(angle), 0.0F, k_ring_radius * std::cos(angle)},
+             20.0F,
+             13.5F + (2.5F * wobble)});
+      }
+    }
+    s.environment.start_time = 16.4F;
+    s.environment.time_mode = Game::Map::TimeMode::Locked;
+
+    s.environment.fog_density_override = 0.028F;
+    s.environment.exposure_override = 1.18F;
+
+    auto scipio = group(QStringLiteral("scipio"),
+                        Troop::RomanVeteranConsul,
+                        1,
+                        1,
+                        {0.0F, 0.0F, -9.0F},
+                        1);
+    auto hannibal = group(QStringLiteral("hannibal"),
+                          Troop::CarthageSwordCommander,
+                          2,
+                          1,
+                          {0.0F, 0.0F, 9.0F},
+                          1);
+
+    scipio.health_override = scipio.max_health_override = 4600;
+    hannibal.health_override = hannibal.max_health_override = 1800;
+
+    s.groups = {
+        scipio,
+        hannibal,
+        group(QStringLiteral("roman_line"),
+              Troop::Swordsman,
+              1,
+              9,
+              {-13.6F, 0.0F, -16.0F},
+              8,
+              {3.4F, 0.0F, 0.0F}),
+        group(QStringLiteral("roman_spears"),
+              Troop::Spearman,
+              1,
+              7,
+              {-10.2F, 0.0F, -20.5F},
+              8,
+              {3.4F, 0.0F, 0.0F}),
+        group(QStringLiteral("roman_horse"),
+              Troop::MountedKnight,
+              1,
+              4,
+              {19.0F, 0.0F, -18.0F},
+              4,
+              {3.6F, 0.0F, 0.0F}),
+        group(QStringLiteral("punic_line"),
+              Troop::Swordsman,
+              2,
+              9,
+              {-13.6F, 0.0F, 16.0F},
+              8,
+              {3.4F, 0.0F, 0.0F}),
+        group(QStringLiteral("punic_spears"),
+              Troop::Spearman,
+              2,
+              7,
+              {-10.2F, 0.0F, 20.5F},
+              8,
+              {3.4F, 0.0F, 0.0F}),
+        group(QStringLiteral("punic_horse"),
+              Troop::MountedKnight,
+              2,
+              4,
+              {-24.0F, 0.0F, 18.0F},
+              4,
+              {3.6F, 0.0F, 0.0F}),
+    };
+
+    s.resource_patches = {
+        {QStringLiteral("pine"), 6, {-34.0F, 0.0F, -30.0F}, {4.0F, 0.0F, 2.5F}, 1.3F},
+        {QStringLiteral("pine"), 5, {24.0F, 0.0F, -32.0F}, {4.2F, 0.0F, 2.0F}, 1.2F},
+        {QStringLiteral("pine"), 5, {-30.0F, 0.0F, 30.0F}, {4.2F, 0.0F, 2.0F}, 1.25F},
+        {QStringLiteral("boulder"), 3, {30.0F, 0.0F, 8.0F}, {3.4F, 0.0F, 2.0F}, 1.1F},
+        {QStringLiteral("boulder"), 2, {-31.0F, 0.0F, -6.0F}, {3.6F, 0.0F, 2.0F}, 1.0F},
+    };
+
+    for (auto const& held : {QStringLiteral("roman_line"),
+                             QStringLiteral("roman_spears"),
+                             QStringLiteral("roman_horse"),
+                             QStringLiteral("punic_line"),
+                             QStringLiteral("punic_spears"),
+                             QStringLiteral("punic_horse")}) {
+      s.steps.push_back(at(0.2F, Command::Hold, held));
+    }
+    s.steps.push_back(at(
+        0.6F, Command::Attack, QStringLiteral("scipio"), QStringLiteral("hannibal")));
+    s.steps.push_back(at(
+        0.6F, Command::Attack, QStringLiteral("hannibal"), QStringLiteral("scipio")));
+
+    s.expectations = {
+        expectation(Expect::GroupExists, QStringLiteral("scipio")),
+        expectation(Expect::GroupDestroyed, QStringLiteral("hannibal")),
+        expectation(Expect::GroupIsRendered, QStringLiteral("scipio")),
+        expectation(Expect::GroupIsRendered, QStringLiteral("hannibal")),
+        expectation(Expect::GroupIsRendered, QStringLiteral("roman_line")),
+        expectation(Expect::GroupIsRendered, QStringLiteral("punic_line")),
+        expectation(Expect::AttackHasVisibleContact,
+                    QStringLiteral("scipio"),
+                    QStringLiteral("hannibal")),
+        expectation(Expect::HitReactionObserved, QStringLiteral("hannibal")),
     };
     result.push_back(std::move(s));
   }

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -194,6 +194,7 @@ inline constexpr char k_lighting_shadow_quality_high_id[] =
 inline constexpr char k_promo_last_stand_id[] = "promo_last_stand";
 inline constexpr char k_promo_night_of_the_dead_id[] = "promo_night_of_the_dead";
 inline constexpr char k_promo_storm_charge_id[] = "promo_storm_charge";
+inline constexpr char k_promo_commander_duel_id[] = "promo_commander_duel";
 
 inline constexpr char k_weather_rain_light_id[] = "weather_rain_light";
 inline constexpr char k_weather_rain_medium_id[] = "weather_rain_medium";

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -109,6 +109,7 @@ constexpr int k_terrain_width = 96;
 constexpr int k_terrain_height = 96;
 constexpr float k_terrain_tile_size = 1.0F;
 constexpr float k_default_floor_extent = 18.0F;
+constexpr float k_default_terrain_height_scale = 6.0F;
 constexpr int k_selection_drag_threshold = 6;
 constexpr int k_interactive_frame_interval_ms = 8;
 
@@ -1639,8 +1640,14 @@ void ArenaViewport::configure_rendering_from_terrain() {
                       m_weather_type);
   }
   if (m_boundary_fog != nullptr) {
-    m_boundary_fog->configure(
-        height_map->get_width(), height_map->get_height(), height_map->get_tile_size());
+
+    if (m_suppress_boundary_mountains) {
+      m_boundary_fog->configure(0, 0, height_map->get_tile_size());
+    } else {
+      m_boundary_fog->configure(height_map->get_width(),
+                                height_map->get_height(),
+                                height_map->get_tile_size());
+    }
   }
   m_renderer->set_environment_lighting(active_lighting());
   set_wireframe_enabled(m_wireframe_enabled);
@@ -2565,16 +2572,20 @@ void ArenaViewport::reset_arena() {
   clear_undead_zones();
   clear_wildlife();
   clear_units();
-  const bool had_custom_terrain = !m_arena_rivers.empty() || !m_arena_lakes.empty() ||
-                                  !m_arena_bridges.empty() || !m_arena_roads.empty() ||
-                                  !m_arena_elevation_patches.empty() ||
-                                  m_arena_floor_half_extent != k_default_floor_extent;
+  const bool had_custom_terrain =
+      !m_arena_rivers.empty() || !m_arena_lakes.empty() || !m_arena_bridges.empty() ||
+      !m_arena_roads.empty() || !m_arena_elevation_patches.empty() ||
+      m_arena_floor_half_extent != k_default_floor_extent ||
+      m_terrain_settings.height_scale != k_default_terrain_height_scale ||
+      m_suppress_boundary_mountains;
   m_arena_rivers.clear();
   m_arena_lakes.clear();
   m_arena_bridges.clear();
   m_arena_roads.clear();
   m_arena_elevation_patches.clear();
   m_arena_floor_half_extent = k_default_floor_extent;
+  m_terrain_settings.height_scale = k_default_terrain_height_scale;
+  m_suppress_boundary_mountains = false;
   clear_world_props();
   if (had_custom_terrain && m_world_props.empty()) {
     reconfigure_terrain_from_state();
@@ -3266,9 +3277,15 @@ void ArenaViewport::load_scenario(const QString& scenario_id) {
   m_arena_roads = definition->roads;
   m_arena_elevation_patches = definition->elevation_patches;
   m_arena_floor_half_extent = definition->arena_floor_half_extent;
+  if (definition->terrain_height_scale_override > 0.0F) {
+    m_terrain_settings.height_scale = definition->terrain_height_scale_override;
+  }
+  m_suppress_boundary_mountains = definition->suppress_boundary_mountains;
   if (!m_arena_rivers.empty() || !m_arena_lakes.empty() || !m_arena_bridges.empty() ||
       !m_arena_roads.empty() || !m_arena_elevation_patches.empty() ||
-      m_arena_floor_half_extent != k_default_floor_extent) {
+      m_arena_floor_half_extent != k_default_floor_extent ||
+      m_terrain_settings.height_scale != k_default_terrain_height_scale ||
+      m_suppress_boundary_mountains) {
     reconfigure_terrain_from_state();
   }
   auto& owners = Game::Systems::OwnerRegistry::instance();

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -414,6 +414,7 @@ private:
   std::vector<Game::Map::RoadSegment> m_arena_roads;
   std::vector<Arena::ArenaScenarioElevationPatch> m_arena_elevation_patches;
   float m_arena_floor_half_extent = 18.0F;
+  bool m_suppress_boundary_mountains = false;
   std::vector<Game::Map::UndeadZone> m_arena_undead_zones;
   Game::Map::WorldProp::Type m_spawn_world_prop_type =
       Game::Map::WorldProp::Type::FireCamp;

--- a/tools/arena/promos/commander_duel.json
+++ b/tools/arena/promos/commander_duel.json
@@ -1,0 +1,349 @@
+{
+  "id": "commander_duel",
+  "title": "THE DUEL",
+  "subtitle": "STANDARD OF IRON",
+  "width": 1920,
+  "height": 1080,
+  "fps": 60,
+  "supersample": 1,
+  "transition": {
+    "type": "dissolve",
+    "duration": 0.4
+  },
+  "shots": [
+    {
+      "name": "armies",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 1.2,
+      "duration": 3.2,
+      "focus": {
+        "mode": "point",
+        "point": [0.0, 0.0, 0.0],
+        "smoothing": 0.6
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 30,
+          "pitch": 14,
+          "yaw": 78,
+          "fov": 42,
+          "height": 2.2
+        },
+        {
+          "time": 3.2,
+          "distance": 25,
+          "pitch": 12,
+          "yaw": 92,
+          "fov": 42,
+          "height": 2.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "TWO ARMIES. ONE FIELD."
+    },
+    {
+      "name": "walk_out",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 3.9,
+      "duration": 2.35,
+      "focus": {
+        "mode": "group_pair",
+        "group": "scipio",
+        "second_group": "hannibal",
+        "smoothing": 0.3
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 15,
+          "pitch": 11,
+          "yaw": 100,
+          "fov": 40,
+          "height": 1.5
+        },
+        {
+          "time": 2.35,
+          "distance": 10.5,
+          "pitch": 10,
+          "yaw": 86,
+          "fov": 40,
+          "height": 1.4,
+          "ease": "out"
+        }
+      ],
+      "caption": "EACH SENDS OUT ONE MAN"
+    },
+    {
+      "name": "first_clash",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 6.45,
+      "duration": 1.05,
+      "slow_motion": 2.4,
+      "shake": 0.05,
+      "focus": {
+        "mode": "group_pair",
+        "group": "scipio",
+        "second_group": "hannibal",
+        "smoothing": 0.16
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 9.2,
+          "pitch": 13,
+          "yaw": 52,
+          "fov": 38,
+          "height": 1.5,
+          "roll": -2
+        },
+        {
+          "time": 2.52,
+          "distance": 7.8,
+          "pitch": 16,
+          "yaw": 14,
+          "fov": 38,
+          "height": 1.5,
+          "roll": 2,
+          "ease": "linear"
+        }
+      ],
+      "caption": "SCIPIO   vs   HANNIBAL",
+      "transition": {
+        "type": "flash",
+        "duration": 0.15
+      }
+    },
+    {
+      "name": "trade",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 9.4,
+      "duration": 2.8,
+      "focus": {
+        "mode": "group_pair",
+        "group": "scipio",
+        "second_group": "hannibal",
+        "smoothing": 0.3
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 8.8,
+          "pitch": 10,
+          "yaw": 116,
+          "fov": 40,
+          "height": 1.5
+        },
+        {
+          "time": 2.8,
+          "distance": 7.6,
+          "pitch": 13,
+          "yaw": 138,
+          "fov": 40,
+          "height": 1.5,
+          "ease": "smooth"
+        }
+      ]
+    },
+    {
+      "name": "riposte",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 13.35,
+      "duration": 1.05,
+      "slow_motion": 2.2,
+      "shake": 0.04,
+      "focus": {
+        "mode": "group_pair",
+        "group": "scipio",
+        "second_group": "hannibal",
+        "smoothing": 0.16
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 8.4,
+          "pitch": 12,
+          "yaw": 6,
+          "fov": 38,
+          "height": 1.5
+        },
+        {
+          "time": 2.31,
+          "distance": 7.2,
+          "pitch": 15,
+          "yaw": 338,
+          "fov": 38,
+          "height": 1.5,
+          "ease": "linear"
+        }
+      ],
+      "caption": "THE CONSULAR RIPOSTE",
+      "transition": {
+        "type": "whip",
+        "duration": 0.2
+      }
+    },
+    {
+      "name": "footwork",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 16.6,
+      "duration": 2.8,
+      "focus": {
+        "mode": "group_pair",
+        "group": "scipio",
+        "second_group": "hannibal",
+        "smoothing": 0.3
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 10.0,
+          "pitch": 8,
+          "yaw": 334,
+          "fov": 40,
+          "height": 1.4
+        },
+        {
+          "time": 2.8,
+          "distance": 8.8,
+          "pitch": 11,
+          "yaw": 358,
+          "fov": 40,
+          "height": 1.45,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "NEITHER GIVES GROUND"
+    },
+    {
+      "name": "encircling_cut",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 20.1,
+      "duration": 1.1,
+      "slow_motion": 2.2,
+      "shake": 0.045,
+      "focus": {
+        "mode": "group_pair",
+        "group": "scipio",
+        "second_group": "hannibal",
+        "smoothing": 0.16
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 8.6,
+          "pitch": 12,
+          "yaw": 58,
+          "fov": 38,
+          "height": 1.5,
+          "roll": 2
+        },
+        {
+          "time": 2.42,
+          "distance": 7.4,
+          "pitch": 15,
+          "yaw": 122,
+          "fov": 38,
+          "height": 1.5,
+          "roll": -2,
+          "ease": "linear"
+        }
+      ],
+      "caption": "THE ENCIRCLING CUT",
+      "transition": {
+        "type": "dissolve",
+        "duration": 0.35
+      }
+    },
+    {
+      "name": "final_blow",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 31.85,
+      "duration": 1.6,
+      "slow_motion": 2.4,
+      "shake": 0.05,
+      "focus": {
+        "mode": "group_pair",
+        "group": "scipio",
+        "second_group": "hannibal",
+        "smoothing": 0.16
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 7.8,
+          "pitch": 13,
+          "yaw": 356,
+          "fov": 38,
+          "height": 1.5,
+          "roll": -2
+        },
+        {
+          "time": 3.84,
+          "distance": 6.6,
+          "pitch": 17,
+          "yaw": 336,
+          "fov": 38,
+          "height": 1.4,
+          "roll": 2,
+          "ease": "linear"
+        }
+      ],
+      "transition": {
+        "type": "flash",
+        "duration": 0.16
+      }
+    },
+    {
+      "name": "aftermath",
+      "scenario": "promo_commander_duel",
+      "seed": 2024,
+      "start": 34.5,
+      "duration": 4.0,
+      "focus": {
+        "mode": "group",
+        "group": "scipio",
+        "smoothing": 0.5
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 9,
+          "pitch": 12,
+          "yaw": 96,
+          "fov": 40,
+          "height": 1.6
+        },
+        {
+          "time": 4.0,
+          "distance": 26,
+          "pitch": 18,
+          "yaw": 74,
+          "fov": 40,
+          "height": 2.8,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "STANDARD OF IRON"
+    }
+  ],
+  "grade": {
+    "contrast": 1.1,
+    "saturation": 1.14,
+    "brightness": 0.03,
+    "gamma": 1.04,
+    "grain": 2,
+    "vignette": 0.12,
+    "sharpen": 0.7
+  },
+  "music": "assets/audio/music/menu/main_theme_rome_vs_carthage.ogg",
+  "music_start": 0.0
+}


### PR DESCRIPTION
Introduce a dedicated promo_commander_duel arena setup and a complete capture spec for a staged confrontation between Scipio and Hannibal. Arrange supporting Roman and Carthaginian formations as spectators, tune the encounter for a deterministic finish, and provide camera beats for the approach, exchanges, signature attacks, final blow, and aftermath.

Add reciprocal commander duel footwork while melee-locked. Commanders now orbit their opponent at a slow oscillating rate when both entities are mutually locked, preserving their separation and keeping their facing aligned without changing the stationary behavior of infantry or crowded engagements.

Extend arena scenarios with terrain height-scale overrides and optional boundary mountain suppression. Use authored elevation patches to close the duel scene's horizon, and ensure arena reset and reload paths restore the default terrain and boundary state correctly.

Refine close-range presentation by reducing combat-dust radius and intensity, softening plant rim normals and edge lighting, and making the combat-dust test track the shared defaults instead of duplicating literal values.

Document the duel-footwork behavior, the new arena scenario, horizon-authoring constraints, trace-driven shot selection, camera placement, and the commands used to capture and edit the commander duel reel.