### PR TITLE
feat: expand campaign terrain, wildlife, and collapse systems

### DIFF
--- a/assets/maps/map_battle_cannae.json
+++ b/assets/maps/map_battle_cannae.json
@@ -2025,6 +2025,22 @@
       "player_id": 3,
       "behavior": "guard",
       "landmark": "cannae_ridge_watch"
+    },
+    {
+      "type": "spearman",
+      "x": 138.0,
+      "z": 606.0,
+      "player_id": 4,
+      "behavior": "guard",
+      "landmark": "cannae_south_sanctuary"
+    },
+    {
+      "type": "archer",
+      "x": 142.0,
+      "z": 606.0,
+      "player_id": 4,
+      "behavior": "guard",
+      "landmark": "cannae_south_sanctuary"
     }
   ],
   "world_props": [
@@ -3525,7 +3541,11 @@
             "skeleton_archer": 2
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "gold": 180,
+        "food": 140
+      }
     }
   ],
   "lakes": [],
@@ -5331,5 +5351,68 @@
       "z": 180,
       "radius": 26
     }
-  ]
+  ],
+  "wildlife": {
+    "enabled": true,
+    "seed": 0,
+    "sheep": {
+      "enabled": true,
+      "groups": 3,
+      "group_size_min": 4,
+      "group_size_max": 7,
+      "roam_radius": 16.0,
+      "respawn": true,
+      "respawn_delay": 90.0,
+      "spawn_areas": [
+        {
+          "x": 60,
+          "z": 180,
+          "radius": 24
+        }
+      ]
+    },
+    "wolves": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 2,
+      "group_size_max": 4,
+      "roam_radius": 22.0,
+      "aggression": 0.6,
+      "respawn": false,
+      "spawn_areas": [
+        {
+          "x": 560,
+          "z": 420,
+          "radius": 26
+        }
+      ],
+      "waves": [
+        {
+          "timing": 260.0,
+          "pack_size": 5,
+          "x": 330,
+          "z": 180,
+          "radius": 26,
+          "label": "Wolves have found the river screen."
+        },
+        {
+          "timing": 480.0,
+          "pack_size": 6,
+          "x": 560,
+          "z": 420,
+          "radius": 26,
+          "label": "The east pack is hunting the pocket."
+        }
+      ]
+    },
+    "birds": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 5,
+      "group_size_max": 9,
+      "flight_height": 14.0,
+      "flyover_interval_min": 45.0,
+      "flyover_interval_max": 120.0
+    }
+  }
 }

--- a/assets/maps/map_battle_ticino.json
+++ b/assets/maps/map_battle_ticino.json
@@ -3083,6 +3083,22 @@
       "player_id": 2,
       "behavior": "guard",
       "landmark": "ticino_ridge_watch"
+    },
+    {
+      "type": "spearman",
+      "x": 250.0,
+      "z": 56.0,
+      "player_id": 2,
+      "behavior": "guard",
+      "landmark": "ticino_north_sanctuary"
+    },
+    {
+      "type": "archer",
+      "x": 254.0,
+      "z": 56.0,
+      "player_id": 2,
+      "behavior": "guard",
+      "landmark": "ticino_north_sanctuary"
     }
   ],
   "world_props": [
@@ -4616,7 +4632,11 @@
             "grave_priest": 1
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "gold": 130,
+        "wood": 90
+      }
     },
     {
       "id": "bridge_watch",
@@ -4637,7 +4657,11 @@
             "skeleton_archer": 3
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "gold": 110,
+        "iron": 70
+      }
     }
   ],
   "lakes": [],
@@ -5923,5 +5947,60 @@
       "z": 440,
       "radius": 30
     }
-  ]
+  ],
+  "wildlife": {
+    "enabled": true,
+    "seed": 0,
+    "sheep": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 4,
+      "group_size_max": 7,
+      "roam_radius": 16.0,
+      "respawn": true,
+      "respawn_delay": 90.0,
+      "spawn_areas": [
+        {
+          "x": 330,
+          "z": 300,
+          "radius": 26
+        }
+      ]
+    },
+    "wolves": {
+      "enabled": true,
+      "groups": 1,
+      "group_size_min": 2,
+      "group_size_max": 4,
+      "roam_radius": 22.0,
+      "aggression": 0.6,
+      "respawn": false,
+      "spawn_areas": [
+        {
+          "x": 560,
+          "z": 440,
+          "radius": 28
+        }
+      ],
+      "waves": [
+        {
+          "timing": 240.0,
+          "pack_size": 4,
+          "x": 250,
+          "z": 380,
+          "radius": 24,
+          "label": "A pack is working the ford screen."
+        }
+      ]
+    },
+    "birds": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 5,
+      "group_size_max": 9,
+      "flight_height": 14.0,
+      "flyover_interval_min": 45.0,
+      "flyover_interval_max": 120.0
+    }
+  }
 }

--- a/assets/maps/map_battle_trasimene.json
+++ b/assets/maps/map_battle_trasimene.json
@@ -2401,6 +2401,22 @@
       "player_id": 2,
       "behavior": "guard",
       "landmark": "trasimene_basin_watch"
+    },
+    {
+      "type": "spearman",
+      "x": 498.0,
+      "z": 482.0,
+      "player_id": 3,
+      "behavior": "guard",
+      "landmark": "trasimene_ridge_sanctuary"
+    },
+    {
+      "type": "archer",
+      "x": 502.0,
+      "z": 482.0,
+      "player_id": 3,
+      "behavior": "guard",
+      "landmark": "trasimene_ridge_sanctuary"
     }
   ],
   "world_props": [
@@ -3893,7 +3909,11 @@
             "grave_priest": 1
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "gold": 160,
+        "iron": 60
+      }
     }
   ],
   "structures": [
@@ -5464,5 +5484,60 @@
       "z": 140,
       "radius": 26
     }
-  ]
+  ],
+  "wildlife": {
+    "enabled": true,
+    "seed": 0,
+    "sheep": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 4,
+      "group_size_max": 7,
+      "roam_radius": 16.0,
+      "respawn": true,
+      "respawn_delay": 90.0,
+      "spawn_areas": [
+        {
+          "x": 420,
+          "z": 140,
+          "radius": 24
+        }
+      ]
+    },
+    "wolves": {
+      "enabled": true,
+      "groups": 1,
+      "group_size_min": 2,
+      "group_size_max": 4,
+      "roam_radius": 22.0,
+      "aggression": 0.6,
+      "respawn": false,
+      "spawn_areas": [
+        {
+          "x": 230,
+          "z": 520,
+          "radius": 28
+        }
+      ],
+      "waves": [
+        {
+          "timing": 180.0,
+          "pack_size": 4,
+          "x": 230,
+          "z": 520,
+          "radius": 26,
+          "label": "The ambush wood has wolves in it already."
+        }
+      ]
+    },
+    "birds": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 5,
+      "group_size_max": 9,
+      "flight_height": 14.0,
+      "flyover_interval_min": 45.0,
+      "flyover_interval_max": 120.0
+    }
+  }
 }

--- a/assets/maps/map_battle_trebia.json
+++ b/assets/maps/map_battle_trebia.json
@@ -2711,6 +2711,22 @@
       "player_id": 3,
       "behavior": "guard",
       "landmark": "trebia_ford_watch"
+    },
+    {
+      "type": "spearman",
+      "x": 298.0,
+      "z": 290.0,
+      "player_id": 2,
+      "behavior": "guard",
+      "landmark": "trebia_south_sanctuary"
+    },
+    {
+      "type": "archer",
+      "x": 302.0,
+      "z": 290.0,
+      "player_id": 2,
+      "behavior": "guard",
+      "landmark": "trebia_south_sanctuary"
     }
   ],
   "world_props": [
@@ -4199,7 +4215,11 @@
             "grave_priest": 1
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "gold": 150,
+        "food": 120
+      }
     }
   ],
   "lakes": [],
@@ -5739,5 +5759,68 @@
       "z": 560,
       "radius": 32
     }
-  ]
+  ],
+  "wildlife": {
+    "enabled": true,
+    "seed": 0,
+    "sheep": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 4,
+      "group_size_max": 7,
+      "roam_radius": 16.0,
+      "respawn": true,
+      "respawn_delay": 90.0,
+      "spawn_areas": [
+        {
+          "x": 200,
+          "z": 560,
+          "radius": 28
+        }
+      ]
+    },
+    "wolves": {
+      "enabled": true,
+      "groups": 1,
+      "group_size_min": 2,
+      "group_size_max": 4,
+      "roam_radius": 22.0,
+      "aggression": 0.6,
+      "respawn": false,
+      "spawn_areas": [
+        {
+          "x": 470,
+          "z": 250,
+          "radius": 26
+        }
+      ],
+      "waves": [
+        {
+          "timing": 200.0,
+          "pack_size": 4,
+          "x": 470,
+          "z": 250,
+          "radius": 24,
+          "label": "Wolves are down off the bank."
+        },
+        {
+          "timing": 400.0,
+          "pack_size": 5,
+          "x": 200,
+          "z": 560,
+          "radius": 26,
+          "label": "A second pack has come up behind the south screen."
+        }
+      ]
+    },
+    "birds": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 5,
+      "group_size_max": 9,
+      "flight_height": 14.0,
+      "flyover_interval_min": 45.0,
+      "flyover_interval_max": 120.0
+    }
+  }
 }

--- a/assets/maps/map_battle_zama.json
+++ b/assets/maps/map_battle_zama.json
@@ -2712,6 +2712,38 @@
       "player_id": 3,
       "behavior": "guard",
       "landmark": "zama_numidian_watch"
+    },
+    {
+      "type": "spearman",
+      "x": 98.0,
+      "z": 472.0,
+      "player_id": 5,
+      "behavior": "guard",
+      "landmark": "zama_west_sanctuary"
+    },
+    {
+      "type": "archer",
+      "x": 102.0,
+      "z": 472.0,
+      "player_id": 5,
+      "behavior": "guard",
+      "landmark": "zama_west_sanctuary"
+    },
+    {
+      "type": "spearman",
+      "x": 83.16,
+      "z": 316.11,
+      "player_id": 5,
+      "behavior": "guard",
+      "landmark": "zama_plateau_sanctuary"
+    },
+    {
+      "type": "archer",
+      "x": 87.16,
+      "z": 316.11,
+      "player_id": 5,
+      "behavior": "guard",
+      "landmark": "zama_plateau_sanctuary"
     }
   ],
   "world_props": [
@@ -4542,7 +4574,11 @@
             "skeleton_archer": 2
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "gold": 220,
+        "iron": 120
+      }
     },
     {
       "id": "sepulcher_vanguard",
@@ -4573,7 +4609,12 @@
             "grave_priest": 2
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "gold": 260,
+        "stone": 140,
+        "iron": 140
+      }
     }
   ],
   "lakes": [],
@@ -6751,5 +6792,68 @@
       "z": 120,
       "radius": 28
     }
-  ]
+  ],
+  "wildlife": {
+    "enabled": true,
+    "seed": 0,
+    "sheep": {
+      "enabled": true,
+      "groups": 3,
+      "group_size_min": 4,
+      "group_size_max": 7,
+      "roam_radius": 16.0,
+      "respawn": true,
+      "respawn_delay": 90.0,
+      "spawn_areas": [
+        {
+          "x": 300,
+          "z": 120,
+          "radius": 26
+        }
+      ]
+    },
+    "wolves": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 2,
+      "group_size_max": 4,
+      "roam_radius": 22.0,
+      "aggression": 0.6,
+      "respawn": false,
+      "spawn_areas": [
+        {
+          "x": 400,
+          "z": 340,
+          "radius": 30
+        }
+      ],
+      "waves": [
+        {
+          "timing": 300.0,
+          "pack_size": 5,
+          "x": 620,
+          "z": 540,
+          "radius": 26,
+          "label": "Wolves are on the east screen."
+        },
+        {
+          "timing": 540.0,
+          "pack_size": 6,
+          "x": 400,
+          "z": 340,
+          "radius": 28,
+          "label": "The centre wood has emptied itself at you."
+        }
+      ]
+    },
+    "birds": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 5,
+      "group_size_max": 9,
+      "flight_height": 14.0,
+      "flyover_interval_min": 45.0,
+      "flyover_interval_max": 120.0
+    }
+  }
 }

--- a/assets/maps/map_campania_campaign.json
+++ b/assets/maps/map_campania_campaign.json
@@ -4619,7 +4619,12 @@
             "grave_priest": 1
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "gold": 200,
+        "wood": 150,
+        "stone": 100
+      }
     }
   ],
   "lakes": [],
@@ -6846,5 +6851,76 @@
       "z": 400,
       "radius": 30
     }
-  ]
+  ],
+  "wildlife": {
+    "enabled": true,
+    "seed": 0,
+    "sheep": {
+      "enabled": true,
+      "groups": 3,
+      "group_size_min": 4,
+      "group_size_max": 7,
+      "roam_radius": 16.0,
+      "respawn": true,
+      "respawn_delay": 90.0,
+      "spawn_areas": [
+        {
+          "x": 300,
+          "z": 100,
+          "radius": 26
+        }
+      ]
+    },
+    "wolves": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 2,
+      "group_size_max": 4,
+      "roam_radius": 22.0,
+      "aggression": 0.6,
+      "respawn": false,
+      "spawn_areas": [
+        {
+          "x": 520,
+          "z": 400,
+          "radius": 28
+        }
+      ],
+      "waves": [
+        {
+          "timing": 240.0,
+          "pack_size": 4,
+          "x": 520,
+          "z": 400,
+          "radius": 26,
+          "label": "Wolves are in the east screen."
+        },
+        {
+          "timing": 420.0,
+          "pack_size": 5,
+          "x": 300,
+          "z": 100,
+          "radius": 26,
+          "label": "A pack has come down on the pastures."
+        },
+        {
+          "timing": 600.0,
+          "pack_size": 6,
+          "x": 128,
+          "z": 256,
+          "radius": 24,
+          "label": "Something is hunting around the tomb."
+        }
+      ]
+    },
+    "birds": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 5,
+      "group_size_max": 9,
+      "flight_height": 14.0,
+      "flyover_interval_min": 45.0,
+      "flyover_interval_max": 120.0
+    }
+  }
 }

--- a/assets/maps/map_crossing_alps.json
+++ b/assets/maps/map_crossing_alps.json
@@ -51,7 +51,10 @@
       0.08
     ],
     "sway_speed": 0.7,
-    "sway_strength": 0.1
+    "sway_strength": 0.1,
+    "procedural_boulders_enabled": false,
+    "procedural_iron_ore_enabled": false,
+    "procedural_trees_enabled": false
   },
   "camera": {
     "center": [
@@ -2230,6 +2233,22 @@
       "player_id": 3,
       "behavior": "guard",
       "landmark": "alps_switchback_watch"
+    },
+    {
+      "type": "spearman",
+      "x": 58.0,
+      "z": 226.0,
+      "player_id": 2,
+      "behavior": "guard",
+      "landmark": "alps_ascent_sanctuary"
+    },
+    {
+      "type": "archer",
+      "x": 62.0,
+      "z": 226.0,
+      "player_id": 2,
+      "behavior": "guard",
+      "landmark": "alps_ascent_sanctuary"
     }
   ],
   "world_props": [
@@ -3746,7 +3765,11 @@
             "grave_priest": 1
           }
         }
-      ]
+      ],
+      "clear_reward": {
+        "stone": 140,
+        "iron": 100
+      }
     }
   ],
   "lakes": [],
@@ -5050,5 +5073,60 @@
       "z": 600,
       "radius": 30
     }
-  ]
+  ],
+  "wildlife": {
+    "enabled": true,
+    "seed": 0,
+    "sheep": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 4,
+      "group_size_max": 7,
+      "roam_radius": 16.0,
+      "respawn": true,
+      "respawn_delay": 90.0,
+      "spawn_areas": [
+        {
+          "x": 240,
+          "z": 260,
+          "radius": 24
+        }
+      ]
+    },
+    "wolves": {
+      "enabled": true,
+      "groups": 1,
+      "group_size_min": 2,
+      "group_size_max": 4,
+      "roam_radius": 22.0,
+      "aggression": 0.6,
+      "respawn": false,
+      "spawn_areas": [
+        {
+          "x": 150,
+          "z": 470,
+          "radius": 28
+        }
+      ],
+      "waves": [
+        {
+          "timing": 300.0,
+          "pack_size": 4,
+          "x": 470,
+          "z": 600,
+          "radius": 24,
+          "label": "Wolves have the scent of the column on the descent."
+        }
+      ]
+    },
+    "birds": {
+      "enabled": true,
+      "groups": 2,
+      "group_size_min": 5,
+      "group_size_max": 9,
+      "flight_height": 14.0,
+      "flyover_interval_min": 45.0,
+      "flyover_interval_max": 120.0
+    }
+  }
 }

--- a/assets/maps/map_crossing_rhone.json
+++ b/assets/maps/map_crossing_rhone.json
@@ -7618,7 +7618,11 @@
                 }
             ],
             "x": 37.59,
-            "z": 360.56
+            "z": 360.56,
+            "clear_reward": {
+                "gold": 120,
+                "food": 80
+            }
         }
     ],
     "victory": {
@@ -9020,5 +9024,50 @@
             "x": 134.0,
             "z": 240.0
         }
-    ]
+    ],
+    "wildlife": {
+        "enabled": true,
+        "seed": 0,
+        "sheep": {
+            "enabled": true,
+            "groups": 2,
+            "group_size_min": 4,
+            "group_size_max": 7,
+            "roam_radius": 16.0,
+            "respawn": true,
+            "respawn_delay": 90.0,
+            "spawn_areas": [
+                {
+                    "x": 250,
+                    "z": 470,
+                    "radius": 26
+                }
+            ]
+        },
+        "wolves": {
+            "enabled": true,
+            "groups": 1,
+            "group_size_min": 2,
+            "group_size_max": 4,
+            "roam_radius": 22.0,
+            "aggression": 0.6,
+            "respawn": false,
+            "spawn_areas": [
+                {
+                    "x": 150,
+                    "z": 300,
+                    "radius": 26
+                }
+            ]
+        },
+        "birds": {
+            "enabled": true,
+            "groups": 2,
+            "group_size_min": 5,
+            "group_size_max": 9,
+            "flight_height": 14.0,
+            "flyover_interval_min": 45.0,
+            "flyover_interval_max": 120.0
+        }
+    }
 }

--- a/assets/missions/battle_of_cannae.json
+++ b/assets/missions/battle_of_cannae.json
@@ -2,7 +2,7 @@
   "id": "battle_of_cannae",
   "title": "Battle of Cannae",
   "summary": "Execute the encirclement, then seize all three Roman camps before their reserves can restore the line.",
-  "teaching_goal": "Large-scale offense with multi-front awareness. Teaches maintaining the pocket while rotating into camp assaults.",
+  "teaching_goal": "Nothing new is taught here. The ridge, the bait and the beheading are all things you already know; Cannae only asks whether you can run three of them at once against four times your number.",
   "narrative_intent": "Hannibal's masterpiece becomes a prolonged operational battle, not a single frontal collision.",
   "historical_context": "216 BC: beside the Aufidus, Hannibal's deliberately yielding center drew a much larger Roman infantry mass forward while African infantry attacked its flanks and Carthaginian cavalry closed the rear. Two Roman camps supported the army.",
   "terrain_type": "apulian_river_plain",
@@ -200,13 +200,17 @@
       ],
       "min_count": 3,
       "description": "Crush all three Roman camps and seal the iron tomb shut. No escape."
+    },
+    {
+      "type": "eliminate_commanders",
+      "description": "Kill every enemy commander. A nation dies with the man who leads it: its camps fall neutral, its works come down and its troops leave the field."
     }
   ],
   "defeat_conditions": [
     {
       "type": "lose_structure",
       "structure_type": "barracks",
-      "description": "Your command falls — and the wings fold inward."
+      "description": "Your command falls \u2014 and the wings fold inward."
     },
     {
       "type": "lose_all_units",
@@ -214,7 +218,7 @@
     },
     {
       "type": "lose_commander",
-      "description": "The commander falls — and every line collapses behind him."
+      "description": "The commander falls \u2014 and every line collapses behind him."
     },
     {
       "type": "only_commander_remaining",
@@ -270,5 +274,6 @@
     }
   ],
   "include_ambient_undead": false,
-  "theme": "The battlefield becomes a closing iron tomb."
+  "theme": "The battlefield becomes a closing iron tomb.",
+  "victory_mode": "all"
 }

--- a/assets/missions/battle_of_ticino.json
+++ b/assets/missions/battle_of_ticino.json
@@ -2,7 +2,7 @@
   "id": "battle_of_ticino",
   "title": "Battle of Ticino",
   "summary": "First battle on Italian soil. Win the cavalry duel, then seize the Roman reserve camp before fresh reinforcements regroup.",
-  "teaching_goal": "Mobile offense with cavalry tempo. Teaches when to press an early advantage and convert it into a camp assault.",
+  "teaching_goal": "High ground doubles a bowman and hardens him against what shoots back. The ridge over the Roman camp is worth more than the extra squadron you would have spent the same minutes recruiting.",
   "narrative_intent": "Hannibal's first Italian victory is a test of tempo and cavalry control. Ford-shades complicate the flanks but do not replace the Roman enemy.",
   "historical_context": "218 BC: the Ticinus was primarily a cavalry engagement between reconnaissance forces. Roman consul Publius Cornelius Scipio was wounded and rescued during the retreat; the camp assault is a plausible dark-fantasy extension of that pursuit.",
   "terrain_type": "po_valley_river_plain",
@@ -151,6 +151,10 @@
       ],
       "min_count": 2,
       "description": "Take the bridge camp and the eastern reserve quarter before the Roman scouts vanish into the fog."
+    },
+    {
+      "type": "eliminate_commanders",
+      "description": "Kill every enemy commander. A nation dies with the man who leads it: its camps fall neutral, its works come down and its troops leave the field."
     }
   ],
   "defeat_conditions": [
@@ -165,7 +169,7 @@
     },
     {
       "type": "lose_commander",
-      "description": "The commander falls — and every line collapses behind him."
+      "description": "The commander falls \u2014 and every line collapses behind him."
     },
     {
       "type": "only_commander_remaining",
@@ -218,5 +222,6 @@
     }
   ],
   "include_ambient_undead": false,
-  "theme": "Hannibal's riders descend through river fog to trap Roman scouts before they escape across a torch-lit bridge."
+  "theme": "Hannibal's riders descend through river fog to trap Roman scouts before they escape across a torch-lit bridge.",
+  "victory_mode": "all"
 }

--- a/assets/missions/battle_of_trasimene.json
+++ b/assets/missions/battle_of_trasimene.json
@@ -2,7 +2,7 @@
   "id": "battle_of_trasimene",
   "title": "Battle of Lake Trasimene",
   "summary": "Spring the ambush and capture both Roman field camps within twenty minutes, before the mist lifts and a cohort escapes the basin.",
-  "teaching_goal": "Multi-vector offense from concealed positions. Teaches closing exits before shifting to camp seizure.",
+  "teaching_goal": "A nation stands on its commander. Kill him and the camps go quiet and unclaimed - which, against a twenty-minute clock, is the only version of this battle that finishes in time.",
   "narrative_intent": "The Roman column walks into a geographical trap and is destroyed by converging attacks while the lakeside Sepulcher altar remains an optional horror.",
   "historical_context": "217 BC: Hannibal drew Gaius Flaminius along the narrow northern shore of Lake Trasimene and attacked from concealed high ground in morning mist. The Roman marching column had little room to deploy and Flaminius was killed.",
   "terrain_type": "lakeside_hill_country",
@@ -122,6 +122,10 @@
       ],
       "min_count": 2,
       "description": "Seize both Roman camps. The ambush is not finished until their flags come down."
+    },
+    {
+      "type": "eliminate_commanders",
+      "description": "Kill every enemy commander. A nation dies with the man who leads it: its camps fall neutral, its works come down and its troops leave the field."
     }
   ],
   "defeat_conditions": [
@@ -133,7 +137,7 @@
     {
       "type": "lose_structure",
       "structure_type": "barracks",
-      "description": "Your camp falls — the field goes with it."
+      "description": "Your camp falls \u2014 the field goes with it."
     },
     {
       "type": "lose_all_units",
@@ -141,7 +145,7 @@
     },
     {
       "type": "lose_commander",
-      "description": "The commander falls — and every line collapses behind him."
+      "description": "The commander falls \u2014 and every line collapses behind him."
     },
     {
       "type": "only_commander_remaining",
@@ -194,5 +198,6 @@
     }
   ],
   "include_ambient_undead": false,
-  "theme": "Legions march in column through the shoreline corridor — and the hills swallow them whole."
+  "theme": "Legions march in column through the shoreline corridor \u2014 and the hills swallow them whole.",
+  "victory_mode": "all"
 }

--- a/assets/missions/battle_of_trebia.json
+++ b/assets/missions/battle_of_trebia.json
@@ -2,7 +2,7 @@
   "id": "battle_of_trebia",
   "title": "Battle of Trebia",
   "summary": "Hold the river line and break all three Roman crossings. Let the cold and the water do the work Sempronius will not.",
-  "teaching_goal": "Defense-to-offense transition. Teaches when to absorb the crossing, then commit the hidden strike force.",
+  "teaching_goal": "An assault walks toward your camp but turns for whatever it can see. Bait it with something visible and it will take the ground you chose instead of the ground it wanted.",
   "narrative_intent": "The Romans are baited into the winter river and punished by Mago's concealed force, then the defense becomes an assault on a complete winter camp.",
   "historical_context": "December 218 BC: Hannibal provoked Tiberius Sempronius Longus into crossing the cold Trebia before breakfast. Carthaginian infantry, cavalry, elephants, and Mago's hidden detachment struck the exhausted Roman army from front, flanks, and rear.",
   "terrain_type": "winter_river_plain",
@@ -57,7 +57,7 @@
             "z": 262
           },
           "phase": 1,
-          "label": "Sempronius’ first crossing",
+          "label": "Sempronius\u2019 first crossing",
           "warning_seconds": 18.0
         },
         {
@@ -230,6 +230,10 @@
       "type": "survive_waves",
       "wave_count": 3,
       "description": "Hold the southern bank through all three crossings. Sempronius spends his army on the ice; you have only to still be standing."
+    },
+    {
+      "type": "eliminate_commanders",
+      "description": "Kill every enemy commander. A nation dies with the man who leads it: its camps fall neutral, its works come down and its troops leave the field."
     }
   ],
   "defeat_conditions": [
@@ -244,7 +248,7 @@
     },
     {
       "type": "lose_commander",
-      "description": "The commander falls — and every line collapses behind him."
+      "description": "The commander falls \u2014 and every line collapses behind him."
     },
     {
       "type": "only_commander_remaining",
@@ -297,5 +301,6 @@
     }
   ],
   "include_ambient_undead": false,
-  "theme": "Freezing water, fog, and exhaustion turn the Roman advance into a ritual slaughter."
+  "theme": "Freezing water, fog, and exhaustion turn the Roman advance into a ritual slaughter.",
+  "victory_mode": "all"
 }

--- a/assets/missions/battle_of_zama.json
+++ b/assets/missions/battle_of_zama.json
@@ -2,7 +2,7 @@
   "id": "battle_of_zama",
   "title": "Battle of Zama",
   "summary": "Final battle in Africa: blunt Scipio's line, survive the Numidian cavalry, and seize all four Roman camps while breaking both risings of the dead.",
-  "teaching_goal": "Full-spectrum command. Teaches managing elephants and flank pressure while transitioning into a decisive camp assault.",
+  "teaching_goal": "The shrines you have walked past all campaign were never scenery. Zama reads back over every map behind it - and the Sepulcher has no commander to kill, so the one rule that has served you since Trasimene is the one rule that will not work here.",
   "narrative_intent": "The final confrontation is Carthage against three coordinated Roman commands, until an Iron Sepulcher host attacks from the battlefield's neglected flank.",
   "historical_context": "202 BC: Scipio arranged lanes through his infantry to blunt Hannibal's elephants, while Masinissa and Laelius commanded superior allied cavalry. The returning cavalry helped decide the battle. The Sepulcher intervention is the campaign's deliberate dark-fantasy break from history.",
   "terrain_type": "north_african_plain",
@@ -240,20 +240,24 @@
         "barracks"
       ],
       "min_count": 4,
-      "description": "Seize all four Roman camps — the consular line, Masinissa's Numidians, the rear guard, and the northern camp — before the cavalry closes your rear."
+      "description": "Seize all four Roman camps \u2014 the consular line, Masinissa's Numidians, the rear guard, and the northern camp \u2014 before the cavalry closes your rear."
     },
     {
       "type": "survive_undead_wave",
       "zone_id": "sepulcher_vanguard",
       "wave_count": 2,
       "description": "Break both Iron Sepulcher attacks. At Zama, the dead no longer remain outside the battle."
+    },
+    {
+      "type": "eliminate_commanders",
+      "description": "Kill every enemy commander. A nation dies with the man who leads it: its camps fall neutral, its works come down and its troops leave the field."
     }
   ],
   "defeat_conditions": [
     {
       "type": "lose_structure",
       "structure_type": "barracks",
-      "description": "Your command falls — and the wings fold inward."
+      "description": "Your command falls \u2014 and the wings fold inward."
     },
     {
       "type": "lose_all_units",
@@ -261,7 +265,7 @@
     },
     {
       "type": "lose_commander",
-      "description": "The commander falls — and every line collapses behind him."
+      "description": "The commander falls \u2014 and every line collapses behind him."
     },
     {
       "type": "only_commander_remaining",

--- a/assets/missions/campania_campaign.json
+++ b/assets/missions/campania_campaign.json
@@ -3,7 +3,7 @@
   "title": "The Campanian Vigil",
   "summary": "Defend Hannibal's fortified Campanian supply town and break all three coordinated Roman assaults arriving from separate consular roads.",
   "map_path": ":/assets/maps/map_campania_campaign.json",
-  "teaching_goal": "Build a durable economy, keep the camp gates supplied, rotate reserves between roads, and survive three clearly timed assault phases.",
+  "teaching_goal": "Supply is a target - and it cuts both ways. Your market and your homes are what the Romans are actually marching at, and their siege camp keeps its own stockpile within reach of a raid.",
   "narrative_intent": "After Cannae, Rome refuses the battle Hannibal wants. The Republic instead presses every road, ally, granary, and walled town. Beneath the orchards, Iron Sepulcher graves make even a successful defense feel temporary.",
   "historical_context": "215-212 BC: Hannibal campaigned across Campania while Capua served as his principal Italian ally and winter base. This dark-fantasy composite condenses several Roman attempts to contain and isolate the Carthaginian army.",
   "terrain_type": "campanian_plain",
@@ -470,6 +470,10 @@
       "type": "survive_waves",
       "wave_count": 3,
       "description": "Break all three Roman assault phases. The quarter holds when the last consular column is dead in the streets."
+    },
+    {
+      "type": "eliminate_commanders",
+      "description": "Kill every enemy commander. A nation dies with the man who leads it: its camps fall neutral, its works come down and its troops leave the field."
     }
   ],
   "defeat_conditions": [
@@ -584,5 +588,6 @@
       ]
     }
   ],
-  "include_ambient_undead": false
+  "include_ambient_undead": false,
+  "victory_mode": "all"
 }

--- a/assets/missions/crossing_the_alps.json
+++ b/assets/missions/crossing_the_alps.json
@@ -2,7 +2,7 @@
   "id": "crossing_the_alps",
   "title": "Crossing the Alps",
   "summary": "Provision the column for the descent: harvest timber, stone and iron from the pass while the mountain tribes contest every switchback.",
-  "teaching_goal": "Long-form offensive progression. Teaches keeping the column moving while absorbing attrition at each pass.",
+  "teaching_goal": "Timber only counts once a builder unloads it at the camp. The richest stands are the furthest from the stockpile, so the mission is won on the length of the walk, not the swing of the axe.",
   "narrative_intent": "The crossing is a running battle against terrain, local resistance, and Roman influence. Sepulcher grave-lights remain a dangerous side path rather than the campaign's main enemy.",
   "historical_context": "218 BC: Hannibal crossed the Alps with a multinational army, cavalry, baggage train, and surviving elephants. Ancient sources disagree on the route; this scenario combines contested passes and local attacks into one dark-fantasy ascent.",
   "terrain_type": "mountain",
@@ -206,6 +206,10 @@
         "iron": 300
       },
       "description": "Cut timber for the sledges, break stone for the road, and draw iron for the shoes and axles. The column crosses on what your builders can carry."
+    },
+    {
+      "type": "eliminate_commanders",
+      "description": "Kill every enemy commander. A nation dies with the man who leads it: its camps fall neutral, its works come down and its troops leave the field."
     }
   ],
   "defeat_conditions": [
@@ -220,7 +224,7 @@
     },
     {
       "type": "lose_commander",
-      "description": "The commander falls — and every line collapses behind him."
+      "description": "The commander falls \u2014 and every line collapses behind him."
     },
     {
       "type": "only_commander_remaining",
@@ -273,5 +277,6 @@
     }
   ],
   "include_ambient_undead": false,
-  "theme": "The mountain takes more lives than any sword. Reach the valley or feed the snow."
+  "theme": "The mountain takes more lives than any sword. Reach the valley or feed the snow.",
+  "victory_mode": "all"
 }

--- a/assets/missions/crossing_the_rhone.json
+++ b/assets/missions/crossing_the_rhone.json
@@ -1,10 +1,10 @@
 {
   "id": "crossing_the_rhone",
-  "title": "Crossing the Rhône",
-  "summary": "Cross the Rhône by one of several prepared routes, sever the eastern supply road, and capture two Roman advance camps before Scipio reaches the river.",
-  "teaching_goal": "Introduce maze navigation, multiple river crossings, and dealing with scattered enemy patrols plus fortified positions.",
+  "title": "Crossing the Rh\u00f4ne",
+  "summary": "Cross the Rh\u00f4ne by one of several prepared routes, sever the eastern supply road, and capture two Roman advance camps before Scipio reaches the river.",
+  "teaching_goal": "A camp is taken by standing in it, not by levelling it. Nine men cannot kill thirty-eight, but they can hold two gate yards long enough to claim them - and a Roman column without its commander stops being a column.",
   "narrative_intent": "A broad river operation with ferries, wooded detours, bridgeheads, and fortified supply quarters; the Iron Sepulcher occupies an avoidable ruin on the southern flank.",
-  "historical_context": "218 BC: Hannibal crossed the Rhône upstream from its mouth using boats, rafts, and a detached force sent across to turn local opposition. Scipio arrived too late; this altered history places Roman advance camps on the far-bank road to create the opening Carthage-versus-Rome engagement.",
+  "historical_context": "218 BC: Hannibal crossed the Rh\u00f4ne upstream from its mouth using boats, rafts, and a detached force sent across to turn local opposition. Scipio arrived too late; this altered history places Roman advance camps on the far-bank road to create the opening Carthage-versus-Rome engagement.",
   "terrain_type": "river_valley",
   "map_path": ":/assets/maps/map_crossing_rhone.json",
   "player_setup": {
@@ -80,6 +80,10 @@
       ],
       "min_count": 2,
       "description": "Seize the two river forts. Leave no crossing for Scipio's army to inherit."
+    },
+    {
+      "type": "eliminate_commanders",
+      "description": "Kill every enemy commander. A nation dies with the man who leads it: its camps fall neutral, its works come down and its troops leave the field."
     }
   ],
   "defeat_conditions": [
@@ -89,7 +93,7 @@
     },
     {
       "type": "lose_commander",
-      "description": "The commander falls — and every line collapses behind him."
+      "description": "The commander falls \u2014 and every line collapses behind him."
     },
     {
       "type": "only_commander_remaining",
@@ -124,7 +128,7 @@
       "actions": [
         {
           "type": "show_message",
-          "text": "Two bridges cross the Rhône. Choose your path wisely - you may need both routes!"
+          "text": "Two bridges cross the Rh\u00f4ne. Choose your path wisely - you may need both routes!"
         }
       ]
     },
@@ -142,5 +146,6 @@
     }
   ],
   "include_ambient_undead": false,
-  "theme": "The river is wide, the far bank is guarded, and every minute standing still costs blood."
+  "theme": "The river is wide, the far bank is guarded, and every minute standing still costs blood.",
+  "victory_mode": "all"
 }

--- a/docs/AMBIENT_WILDLIFE.md
+++ b/docs/AMBIENT_WILDLIFE.md
@@ -199,6 +199,42 @@ Setting `respawn` to false lets a hunted-out herd stay gone. Bird `spawn_areas` 
 matter when flyovers are turned off, because a flyover enters from the map edge rather
 than from an anchor.
 
+### Wolf packs on a schedule
+
+`spawn_areas` put wolves on the map from the first frame. A `waves` list on the wolves
+block instead releases packs partway through a mission, which turns ambient wildlife into
+a threat a designer can time:
+
+```json
+"wolves": {
+  "enabled": true,
+  "groups": 1,
+  "spawn_areas": [{ "x": 470, "z": 250, "radius": 26 }],
+  "waves": [
+    { "timing": 200.0, "pack_size": 4, "x": 470, "z": 250, "radius": 24,
+      "label": "Wolves are down off the bank." },
+    { "timing": 400.0, "pack_size": 5, "x": 200, "z": 560, "radius": 26 }
+  ]
+}
+```
+
+| Field       | Required | Meaning                                                   |
+| ----------- | -------- | --------------------------------------------------------- |
+| `timing`    | Yes      | Seconds from mission start                                |
+| `pack_size` | No       | Wolves in the pack (default 4, clamped to 64)             |
+| `x` / `z`   | No       | Where the pack dens, in the map's coordinate system       |
+| `radius`    | No       | How far from that point a wolf may be anchored            |
+| `label`     | No       | Announcement text; a wave without one gets a generic line |
+
+Waves are sorted by `timing` on load and each releases exactly once. Which have fired is
+written into the save alongside the elapsed clock, so reloading a mission does not send a
+spent pack in again. A wave pack is a normal group once it lands — it hunts, it can be
+killed, and `respawn: false` keeps it dead.
+
+Woods are the natural place to den a pack. Wolves count as forest-passable, so a pack in a
+grove can come at a column that has no way to follow it in; see
+[the grove rules](../scripts/RTS_MAP_DESIGN.md).
+
 ### Derived placement
 
 `game/wildlife/wildlife_placement.cpp` fills in what an author left out, using only what

--- a/docs/CAMPAIGN_MISSIONS.md
+++ b/docs/CAMPAIGN_MISSIONS.md
@@ -31,23 +31,29 @@ the first opens with a barracks.
 
 ## Objectives and timers
 
-| #   | Mission                  | Victory                                           | Defeat                                                              | Optional             | Hard timer |
-| --- | ------------------------ | ------------------------------------------------- | ------------------------------------------------------------------- | -------------------- | ---------- |
-| 1   | Crossing the Rhône       | Capture 2 barracks                                | units / commander / commander-alone                                 | Finish inside 10 min | —          |
-| 2   | Crossing the Alps        | Gather 600 wood, 350 stone, 300 iron              | structures / units / commander / commander-alone                    | Survive 15 min       | —          |
-| 3   | Battle of Ticino         | Capture 2 barracks                                | structures / units / commander / commander-alone                    | Wave count           | —          |
-| 4   | Battle of Trebia         | Survive 3 wave phases                             | structures / units / commander / commander-alone                    | Wave count           | —          |
-| 5   | Battle of Lake Trasimene | Capture 2 barracks                                | **20 min limit** + structures / units / commander / commander-alone | Wave count           | 20 min     |
-| 6   | Battle of Cannae         | Capture 3 barracks                                | structures / units / commander / commander-alone                    | Control structures   | —          |
-| 7   | The Campanian Vigil      | Survive 3 wave phases                             | structures / units / commander / commander-alone                    | Control + capture    | —          |
-| 8   | Battle of Zama           | Capture 4 barracks **and** survive 2 undead waves | structures / units / commander / commander-alone                    | Capture structures   | —          |
+| #   | Mission                  | Victory                                                          | Defeat                                                              | Optional             | Hard timer |
+| --- | ------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------------------- | -------------------- | ---------- |
+| 1   | Crossing the Rhône       | Capture 2 barracks + kill every commander                        | units / commander / commander-alone                                 | Finish inside 10 min | —          |
+| 2   | Crossing the Alps        | Gather 600 wood, 350 stone, 300 iron + kill every commander      | structures / units / commander / commander-alone                    | Survive 15 min       | —          |
+| 3   | Battle of Ticino         | Capture 2 barracks + kill every commander                        | structures / units / commander / commander-alone                    | Wave count           | —          |
+| 4   | Battle of Trebia         | Survive 3 wave phases + kill every commander                     | structures / units / commander / commander-alone                    | Wave count           | —          |
+| 5   | Battle of Lake Trasimene | Capture 2 barracks + kill every commander                        | **20 min limit** + structures / units / commander / commander-alone | Wave count           | 20 min     |
+| 6   | Battle of Cannae         | Capture 3 barracks + kill every commander                        | structures / units / commander / commander-alone                    | Control structures   | —          |
+| 7   | The Campanian Vigil      | Survive 3 wave phases + kill every commander                     | structures / units / commander / commander-alone                    | Control + capture    | —          |
+| 8   | Battle of Zama           | Capture 4 barracks, survive 2 undead waves, kill every commander | structures / units / commander / commander-alone                    | Capture structures   | —          |
 
 Trasimene is the only mission that can be lost to the clock. Every other timer
 is either an optional objective or a wave schedule.
 
-Zama is the only mission with `victory_mode: "all"` — it ships two victory
-conditions and needs both. Every other mission has a single condition, so the
-mode is irrelevant there.
+Every mission now runs `victory_mode: "all"` and every mission carries
+`eliminate_commanders`. A nation dies with the man who leads it: on a commander's
+death its barracks fall to the neutral owner, its other works come down and its
+troops leave the field. That makes decapitation the shortest route to a capture
+objective rather than a way around one — a neutral camp is still a camp you have
+to walk into. `MissionAssetRulesTest.DecapitationObjectivesHaveCommandersToKill`
+fails the build if any AI setup ships without a `commander_troop`, because the
+rule only arms once an enemy commander has been seen and an unarmed rule would
+make the mission unwinnable.
 
 ## Economy
 
@@ -99,6 +105,39 @@ phase-driven schedule are the same design.
 
 The modifier rises monotonically. The star column is what the campaign list
 draws: `ceil((modifier - 1.0) / 0.15)`, clamped to 1–5.
+
+"Enemy troops on the map" counts line troops only: spawns owned by player 2 or
+above, minus builders and civilians, and **minus anything tagged with a
+`landmark`**. Sanctuary wardens and watch pickets are deliberately outside the
+number because they are not part of the army the mission is balanced against.
+
+## Ground worth walking to
+
+Every mission ships at least one dead zone, and every dead zone pays a
+`clear_reward` when its garrison breaks — spendable resources, never counted as
+harvested, so a hoard funds the next push without shortcutting the Alps gather
+objective. See [IRON_SEPULCHER.md](IRON_SEPULCHER.md).
+
+Every standalone sanctuary now has one or two wardens on it. Two men do not make
+a battle; they make the shrine cost something, which is the point.
+
+Every map authors its wildlife rather than inheriting the derived default: a
+sheep pasture somewhere worth the detour, a wolf range denned in a wood, and —
+from the Alps onward — wolf packs on a schedule. Wolves are forest-passable and
+cavalry is not, so a pack in a grove is a threat a mounted column cannot chase.
+See [AMBIENT_WILDLIFE.md](AMBIENT_WILDLIFE.md) and
+[RTS_MAP_DESIGN.md](../scripts/RTS_MAP_DESIGN.md).
+
+| #   | Mission                  | Dead zones | Wolf packs |
+| --- | ------------------------ | ---------: | ---------: |
+| 1   | Crossing the Rhône       |          1 |          0 |
+| 2   | Crossing the Alps        |          1 |          1 |
+| 3   | Battle of Ticino         |          2 |          1 |
+| 4   | Battle of Trebia         |          1 |          2 |
+| 5   | Battle of Lake Trasimene |          1 |          1 |
+| 6   | Battle of Cannae         |          1 |          2 |
+| 7   | The Campanian Vigil      |          1 |          3 |
+| 8   | Battle of Zama           |          2 |          2 |
 
 ## Notes for anyone tuning this
 

--- a/docs/IRON_SEPULCHER.md
+++ b/docs/IRON_SEPULCHER.md
@@ -21,6 +21,7 @@ Everything below is driven by `undead_zones` in a map file and implemented by
     "team_id": 99,
     "awaken_on": ["unit_enters_radius"],
     "fog_density": 0.28,
+    "clear_reward": { "gold": 150, "stone": 80 },
     "waves": [
       { "trigger": "initial", "units": { "skeleton_swordsman": 2 } },
       { "trigger": "after_clear", "units": { "skeleton_archer": 3 } }
@@ -29,15 +30,28 @@ Everything below is driven by `undead_zones` in a map file and implemented by
 ]
 ```
 
-| Field         | Meaning                                                                                    |
-| ------------- | ------------------------------------------------------------------------------------------ |
-| `awaken_on`   | `unit_enters_radius` (default) or `mission_start`.                                         |
-| `waves`       | Optional. Omit it to get the default garrison (see below).                                 |
-| `anchor_type` | The decorative prop the guardians rise around. It does not decide whether a shrine exists. |
-| `fog_density` | Optional. `0` disables the zone haze.                                                      |
+| Field          | Meaning                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| `awaken_on`    | `unit_enters_radius` (default) or `mission_start`.                                         |
+| `waves`        | Optional. Omit it to get the default garrison (see below).                                 |
+| `anchor_type`  | The decorative prop the guardians rise around. It does not decide whether a shrine exists. |
+| `fog_density`  | Optional. `0` disables the zone haze.                                                      |
+| `clear_reward` | Optional. Resources paid out once the garrison is broken.                                  |
 
 `owner_id` is a real owner: it is registered as an AI owner of nation
 `iron_sepulcher`, which resolves to the `sepulcher_defense` AI profile.
+
+### Clearing a zone for profit
+
+`clear_reward` is paid once, when the garrison breaks — whether the anchor was
+destroyed or captured. A capture pays the new owner of the anchor; a kill pays
+the local player. The amounts are added to the balance as spendable resources
+and are deliberately **not** counted as harvested, so a hoard can fund a push
+without shortcutting an `accumulate_resources` objective.
+
+This is what turns a dead zone from an obstacle into a decision: the barrow is
+optional, it costs troops, and it pays for the assault it delays. Every mission
+in the Second Punic War campaign ships at least one.
 
 ## The default garrison
 

--- a/docs/MISSION_FRAMEWORK.md
+++ b/docs/MISSION_FRAMEWORK.md
@@ -413,6 +413,7 @@ Supported victory condition types:
 - **accumulate_resources**: Harvest the specified resource totals
 - **control_structures**: Control the specified structure types
 - **capture_structures**: Capture the specified structure types from another nation
+- **eliminate_commanders**: Kill every enemy commander
 
 By default victory conditions are evaluated as **OR** conditions: if any configured victory
 condition is satisfied, the mission ends in victory. Set `"victory_mode": "all"` on the mission
@@ -454,6 +455,32 @@ unwinnable; the validator rejects that.
     "description": "Break all three Roman assault phases"
 }
 ```
+
+#### eliminate_commanders
+
+A nation stands on its commander. When the last commander of an owner dies,
+`Game::Systems::NationCollapse` hands that owner's barracks to the neutral owner, takes
+down its other structures and clears its troops from the field. `eliminate_commanders` is
+satisfied once no enemy commander is left alive.
+
+The rule **arms** only after an enemy commander has been seen. At mission start the
+roster has not spawned and the count is legitimately zero; without arming, the mission
+would be won on its first evaluated frame. The consequence for authors is that every AI
+setup in a mission carrying this condition needs a `commander_troop` — an AI without one
+can never arm the rule, which makes the mission unwinnable.
+`MissionAssetRulesTest.DecapitationObjectivesHaveCommandersToKill` fails the build if that
+happens. Iron Sepulcher units are excluded from the count: the dead have no commander, so
+a Sepulcher zone can never block the objective.
+
+```json
+{
+    "type": "eliminate_commanders",
+    "description": "Kill every enemy commander"
+}
+```
+
+Pair it with `"victory_mode": "all"`. Under the default `"any"` it becomes an independent
+shortcut past whatever else the mission asks for.
 
 #### accumulate_resources
 

--- a/docs/PATHFINDING_ARCHITECTURE.md
+++ b/docs/PATHFINDING_ARCHITECTURE.md
@@ -133,6 +133,38 @@ Units are not written into this grid. A unit standing in a cell does not make th
 
 The same order is used for regional rebuilds: reset the region to terrain, reapply buildings/resources intersecting the region, then force mandatory traversal cells in that region to `Walkable`.
 
+## Forest cells and passability
+
+`CellValue::Forest` marks the open ground inside an authored grove (`groves` in the map
+file). It is the one cell value whose walkability depends on who is asking:
+
+```cpp
+enum class Passability : std::uint8_t { Light, Heavy };
+```
+
+`Light` treats `Forest` as walkable; `Heavy` does not. Everything else — `Walkable`,
+`Blocked`, `Tree`, `Boulder`, `IronOre` — reads the same for both. `find_path`,
+`is_walkable`, `is_world_position_walkable`, `is_world_segment_walkable` and
+`find_nearest_walkable_point` all take a `Passability`, defaulting to `Light`.
+
+Which units are light is decided by `Game::Units::can_enter_forest`: commanders, archers,
+swordsmen, healers, builders, civilians, the Sepulcher's dead and wildlife. Spearmen,
+cavalry, catapults, ballistae and elephants are heavy. The answer is stamped onto
+`MovementComponent` once at spawn, in `UnitFactoryRegistry::create`, so no call site has to
+look up a spawn type to path.
+
+Three details that matter:
+
+- **The path cache is keyed on passability.** Without that, a route computed for a
+  swordsman would be served to the elephant behind him.
+- **A group move uses the heaviest member's passability.** A shared corridor has to be
+  walkable by everyone who will follow it; light units that fall back to individual paths
+  still get `Light`.
+- **Forest only claims cells that were already `Walkable`,** and roads are excluded, so a
+  road driven through a wood stays a lane the siege train can use. `apply_forest_cells`
+  runs after the terrain and building passes and before the bridge/hill-entrance pass, so
+  a bridge or ramp inside a wood also stays open.
+
 ## Enemy Units Are Not Empty Ground
 
 This is the most important separation in the system:

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(
     systems/battlefield_capture.cpp
     systems/order_service.cpp
     systems/movement_system.cpp
+    systems/nation_collapse_service.cpp
     systems/combat_system.cpp
     systems/combat_system/combat_utils.cpp
     systems/combat_system/structure_combat.cpp

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -251,6 +251,9 @@ public:
 
   [[nodiscard]] auto get_stuck_time() const -> float { return stuck_timer; }
 
+  [[nodiscard]] auto get_can_enter_forest() const -> bool { return can_enter_forest; }
+  void set_can_enter_forest(bool allowed) { can_enter_forest = allowed; }
+
 private:
   friend class Game::Systems::MovementSystem;
   friend class Serialization;
@@ -275,6 +278,7 @@ private:
 
   bool precise_arrival{false};
   EntityID structure_approach_target_id{0};
+  bool can_enter_forest{true};
 };
 
 enum class PlayerOrderIntentKind : std::uint8_t {

--- a/game/map/json_keys.h
+++ b/game/map/json_keys.h
@@ -13,6 +13,7 @@ inline constexpr const char* CAMERA = "camera";
 inline constexpr const char* SPAWNS = "spawns";
 inline constexpr const char* STRUCTURES = "structures";
 inline constexpr const char* UNDEAD_ZONES = "undead_zones";
+inline constexpr const char* GROVES = "groves";
 inline constexpr const char* FIRECAMPS = "firecamps";
 inline constexpr const char* TERRAIN = "terrain";
 inline constexpr const char* RIVERS = "rivers";
@@ -71,6 +72,11 @@ inline constexpr const char* SOIL_ROUGHNESS = "soil_roughness";
 inline constexpr const char* SNOW_COLOR = "snow_color";
 inline constexpr const char* GROUND_IRREGULARITY_ENABLED =
     "ground_irregularity_enabled";
+inline constexpr const char* PROCEDURAL_BOULDERS_ENABLED =
+    "procedural_boulders_enabled";
+inline constexpr const char* PROCEDURAL_IRON_ORE_ENABLED =
+    "procedural_iron_ore_enabled";
+inline constexpr const char* PROCEDURAL_TREES_ENABLED = "procedural_trees_enabled";
 inline constexpr const char* IRREGULARITY_SCALE = "irregularity_scale";
 inline constexpr const char* IRREGULARITY_AMPLITUDE = "irregularity_amplitude";
 
@@ -86,6 +92,7 @@ inline constexpr const char* ID = "id";
 inline constexpr const char* ANCHOR_TYPE = "anchor_type";
 inline constexpr const char* FOG_DENSITY = "fog_density";
 inline constexpr const char* WAVE_TIMEOUT = "wave_timeout";
+inline constexpr const char* CLEAR_REWARD = "clear_reward";
 inline constexpr const char* LEASH_RADIUS = "leash_radius";
 inline constexpr const char* AWAKEN_ON = "awaken_on";
 inline constexpr const char* WAVES = "waves";
@@ -149,6 +156,10 @@ inline constexpr const char* WILDLIFE_FLYOVER_INTERVAL_MIN = "flyover_interval_m
 inline constexpr const char* WILDLIFE_FLYOVER_INTERVAL_MAX = "flyover_interval_max";
 inline constexpr const char* WILDLIFE_SPAWN_AREAS = "spawn_areas";
 inline constexpr const char* WILDLIFE_RADIUS = "radius";
+inline constexpr const char* WILDLIFE_WAVES = "waves";
+inline constexpr const char* WILDLIFE_WAVE_TIMING = "timing";
+inline constexpr const char* WILDLIFE_WAVE_PACK_SIZE = "pack_size";
+inline constexpr const char* WILDLIFE_WAVE_LABEL = "label";
 
 inline constexpr const char* WORLD_PROPS = "world_props";
 inline constexpr const char* FOG_ZONES = "fog_zones";

--- a/game/map/map_definition.h
+++ b/game/map/map_definition.h
@@ -112,6 +112,13 @@ struct UndeadWave {
   std::vector<UndeadWaveUnitSpawn> units;
 };
 
+struct Grove {
+  QString id;
+  float x = 0.0F;
+  float z = 0.0F;
+  float radius = 8.0F;
+};
+
 inline constexpr float k_undead_zone_default_fog_density = 0.28F;
 inline constexpr float k_undead_zone_default_wave_timeout = 45.0F;
 
@@ -130,6 +137,8 @@ struct UndeadZone {
   float wave_timeout_seconds = k_undead_zone_default_wave_timeout;
   std::vector<QString> awaken_on;
   std::vector<UndeadWave> waves;
+
+  Game::Systems::ResourceAmounts clear_reward;
 };
 
 [[nodiscard]] inline auto default_undead_waves() -> std::vector<UndeadWave> {
@@ -435,6 +444,7 @@ struct MapDefinition {
   std::vector<StructureEntry> structures;
   std::vector<WorldProp> world_props;
   std::vector<UndeadZone> undead_zones;
+  std::vector<Grove> groves;
   std::vector<FogZone> fog_zones;
   BiomeSettings biome;
   CoordSystem coordSystem = CoordSystem::Grid;

--- a/game/map/map_loader.cpp
+++ b/game/map/map_loader.cpp
@@ -252,6 +252,18 @@ void read_biome(const QJsonObject& obj, BiomeSettings& out) {
     out.ground_irregularity_enabled =
         obj.value(GROUND_IRREGULARITY_ENABLED).toBool(out.ground_irregularity_enabled);
   }
+  if (obj.contains(PROCEDURAL_BOULDERS_ENABLED)) {
+    out.procedural_boulders_enabled =
+        obj.value(PROCEDURAL_BOULDERS_ENABLED).toBool(out.procedural_boulders_enabled);
+  }
+  if (obj.contains(PROCEDURAL_IRON_ORE_ENABLED)) {
+    out.procedural_iron_ore_enabled =
+        obj.value(PROCEDURAL_IRON_ORE_ENABLED).toBool(out.procedural_iron_ore_enabled);
+  }
+  if (obj.contains(PROCEDURAL_TREES_ENABLED)) {
+    out.procedural_trees_enabled =
+        obj.value(PROCEDURAL_TREES_ENABLED).toBool(out.procedural_trees_enabled);
+  }
   if (obj.contains(IRREGULARITY_SCALE)) {
     out.irregularity_scale =
         float(obj.value(IRREGULARITY_SCALE).toDouble(out.irregularity_scale));
@@ -408,11 +420,36 @@ void read_wildlife_species(const QJsonObject& obj,
   out.flyover_interval_max = float(
       obj.value(WILDLIFE_FLYOVER_INTERVAL_MAX).toDouble(out.flyover_interval_max));
 
+  const float tile =
+      coord_sys == CoordSystem::Grid ? std::max(0.0001F, grid.tile_size) : 1.0F;
+
+  if (obj.value(WILDLIFE_WAVES).isArray()) {
+    out.waves.clear();
+    for (const auto& value : obj.value(WILDLIFE_WAVES).toArray()) {
+      if (!value.isObject()) {
+        continue;
+      }
+      const QJsonObject wave_obj = value.toObject();
+      Game::Wildlife::WildlifeWave wave;
+      wave.timing = float(wave_obj.value(WILDLIFE_WAVE_TIMING).toDouble(0.0));
+      wave.pack_size = wave_obj.value(WILDLIFE_WAVE_PACK_SIZE).toInt(wave.pack_size);
+      wave.label = wave_obj.value(WILDLIFE_WAVE_LABEL).toString().toStdString();
+      const QVector3D center = authored_position(float(wave_obj.value(X).toDouble(0.0)),
+                                                 float(wave_obj.value(Z).toDouble(0.0)),
+                                                 grid,
+                                                 coord_sys);
+      wave.area.x = center.x();
+      wave.area.z = center.z();
+      wave.area.radius =
+          float(wave_obj.value(WILDLIFE_RADIUS).toDouble(double(out.roam_radius))) *
+          tile;
+      out.waves.push_back(wave);
+    }
+  }
+
   if (!obj.value(WILDLIFE_SPAWN_AREAS).isArray()) {
     return;
   }
-  const float tile =
-      coord_sys == CoordSystem::Grid ? std::max(0.0001F, grid.tile_size) : 1.0F;
   out.spawn_areas.clear();
   for (const auto& value : obj.value(WILDLIFE_SPAWN_AREAS).toArray()) {
     if (!value.isObject()) {
@@ -572,6 +609,30 @@ void append_undead_wave_units_from_object(const QJsonObject& obj, UndeadWave& ou
   }
 }
 
+void read_starting_resources(const QJsonObject& obj,
+                             Game::Systems::ResourceAmounts& out);
+
+void read_groves(const QJsonArray& arr, std::vector<Grove>& out) {
+  out.clear();
+  out.reserve(arr.size());
+  int next_grove_index = 1;
+  for (const auto& val : arr) {
+    auto obj = val.toObject();
+    Grove grove;
+    grove.id = obj.value(ID).toString().trimmed();
+    if (grove.id.isEmpty()) {
+      grove.id = QStringLiteral("grove_%1").arg(next_grove_index++);
+    }
+    grove.x = float(obj.value(X).toDouble(0.0));
+    grove.z = float(obj.value(Z).toDouble(0.0));
+    grove.radius = float(obj.value(RADIUS).toDouble(grove.radius));
+    if (grove.radius <= 0.0F) {
+      continue;
+    }
+    out.push_back(grove);
+  }
+}
+
 void read_undead_zones(const QJsonArray& arr, std::vector<UndeadZone>& out) {
   out.clear();
   out.reserve(arr.size());
@@ -612,6 +673,10 @@ void read_undead_zones(const QJsonArray& arr, std::vector<UndeadZone>& out) {
 
     if (zone.awaken_on.empty()) {
       zone.awaken_on.push_back(QStringLiteral("unit_enters_radius"));
+    }
+
+    if (obj.contains(CLEAR_REWARD) && obj.value(CLEAR_REWARD).isObject()) {
+      read_starting_resources(obj.value(CLEAR_REWARD).toObject(), zone.clear_reward);
     }
 
     if (obj.contains(WAVES) && obj.value(WAVES).isArray()) {
@@ -1352,6 +1417,12 @@ auto MapLoader::load_from_json_file(const QString& path,
     read_undead_zones(root.value(UNDEAD_ZONES).toArray(), out_map.undead_zones);
   } else {
     out_map.undead_zones.clear();
+  }
+
+  if (root.contains(GROVES) && root.value(GROVES).isArray()) {
+    read_groves(root.value(GROVES).toArray(), out_map.groves);
+  } else {
+    out_map.groves.clear();
   }
 
   out_map.lakes.clear();

--- a/game/map/mission_victory_rules.cpp
+++ b/game/map/mission_victory_rules.cpp
@@ -132,6 +132,11 @@ auto build_victory_rules(const MissionDefinition& mission)
       continue;
     }
 
+    if (type == "eliminate_commanders") {
+      rules.victory_rules.emplace_back(Game::Systems::EliminateCommandersVictoryRule{});
+      continue;
+    }
+
     qWarning() << "Unsupported mission victory condition type" << condition.type;
   }
 

--- a/game/map/procedural_tree_generation.cpp
+++ b/game/map/procedural_tree_generation.cpp
@@ -602,14 +602,20 @@ auto generate_procedural_world_props(const TerrainHeightMap& height_map,
   std::vector<WorldProp> generated;
   generated.reserve(
       static_cast<size_t>(height_map.get_width() * height_map.get_height() / 8));
-  append_generated_boulders(
-      generated, height_map, biome_settings, coord_system, anchor_world_props);
-  append_generated_iron_ore(
-      generated, height_map, biome_settings, coord_system, anchor_world_props);
-  append_generated_pines(
-      generated, height_map, biome_settings, coord_system, anchor_world_props);
-  append_generated_olives(
-      generated, height_map, biome_settings, coord_system, anchor_world_props);
+  if (biome_settings.procedural_boulders_enabled) {
+    append_generated_boulders(
+        generated, height_map, biome_settings, coord_system, anchor_world_props);
+  }
+  if (biome_settings.procedural_iron_ore_enabled) {
+    append_generated_iron_ore(
+        generated, height_map, biome_settings, coord_system, anchor_world_props);
+  }
+  if (biome_settings.procedural_trees_enabled) {
+    append_generated_pines(
+        generated, height_map, biome_settings, coord_system, anchor_world_props);
+    append_generated_olives(
+        generated, height_map, biome_settings, coord_system, anchor_world_props);
+  }
   return generated;
 }
 

--- a/game/map/terrain.h
+++ b/game/map/terrain.h
@@ -184,6 +184,10 @@ struct BiomeSettings {
   float irregularity_scale = 0.15F;
   float irregularity_amplitude = 0.08F;
 
+  bool procedural_boulders_enabled = true;
+  bool procedural_iron_ore_enabled = true;
+  bool procedural_trees_enabled = true;
+
   float snow_coverage = 0.0F;
   float moisture_level = 0.5F;
   float crack_intensity = 0.0F;

--- a/game/map/terrain_service.cpp
+++ b/game/map/terrain_service.cpp
@@ -353,6 +353,7 @@ void TerrainService::initialize(const MapDefinition& map_def) {
   m_coord_system = map_def.coordSystem;
 
   m_road_segments = map_def.roads;
+  m_groves = map_def.groves;
   rebuild_road_spatial_index();
   m_authored_world_props = map_def.world_props;
   normalize_world_props(m_authored_world_props);
@@ -375,6 +376,7 @@ void TerrainService::clear() {
   m_authored_world_props.clear();
   m_world_props.clear();
   m_road_segments.clear();
+  m_groves.clear();
   m_road_query_segments.clear();
   m_road_index_offsets.clear();
   m_road_index_segment_ids.clear();

--- a/game/map/terrain_service.h
+++ b/game/map/terrain_service.h
@@ -100,6 +100,8 @@ public:
   [[nodiscard]] auto navigation_topology_revision() const -> std::uint64_t {
     return m_navigation_topology_revision;
   }
+  [[nodiscard]] auto groves() const -> const std::vector<Grove>& { return m_groves; }
+
   [[nodiscard]] auto authored_world_props() const -> const std::vector<WorldProp>& {
     return m_authored_world_props;
   }
@@ -209,6 +211,7 @@ private:
   CoordSystem m_coord_system{CoordSystem::Grid};
   std::vector<WorldProp> m_authored_world_props;
   std::vector<WorldProp> m_world_props;
+  std::vector<Grove> m_groves;
   std::vector<RoadSegment> m_road_segments;
   struct RoadQuerySegment {
     float start_x{0.0F};

--- a/game/systems/capture_system.h
+++ b/game/systems/capture_system.h
@@ -13,6 +13,10 @@ class CaptureSystem : public Engine::Core::System {
 public:
   void update(Engine::Core::World* world, float delta_time) override;
 
+  static void transfer_barrack_ownership(Engine::Core::World* world,
+                                         Engine::Core::Entity* barrack,
+                                         int new_owner_id);
+
 private:
   static void process_barrack_capture(Engine::Core::World* world, float delta_time);
   static auto count_nearby_troops(Engine::Core::World* world,
@@ -20,9 +24,6 @@ private:
                                   float barrack_z,
                                   int owner_id,
                                   float radius) -> int;
-  static void transfer_barrack_ownership(Engine::Core::World* world,
-                                         Engine::Core::Entity* barrack,
-                                         int new_owner_id);
 };
 
 } // namespace Game::Systems

--- a/game/systems/commander_system.cpp
+++ b/game/systems/commander_system.cpp
@@ -1,12 +1,17 @@
 #include "commander_system.h"
 
+#include <QCoreApplication>
+
 #include <algorithm>
 #include <cmath>
 #include <optional>
 
 #include "../core/component.h"
+#include "../core/event_manager.h"
 #include "../core/world.h"
 #include "command_service.h"
+#include "nation_collapse_service.h"
+#include "owner_registry.h"
 #include "troop_profile_service.h"
 #include "units/spawn_type.h"
 
@@ -246,6 +251,27 @@ void reset_commander_modified_stats(Engine::Core::World* world) {
   }
 }
 
+void collapse_nation_if_leaderless(Engine::Core::World& world, int owner_id) {
+  if (NationCollapse::has_living_commander(world, owner_id)) {
+    return;
+  }
+  if (!NationCollapse::collapse_owner(world, owner_id)) {
+    return;
+  }
+
+  const auto& owners = OwnerRegistry::instance();
+  const QString name = QString::fromStdString(owners.get_owner_name(owner_id));
+  Engine::Core::EventManager::instance().publish(Engine::Core::MissionAnnouncementEvent(
+      name.isEmpty()
+          ? QCoreApplication::translate(
+                "CommanderSystem",
+                "Their commander is dead. The host breaks and its camps stand empty.")
+          : QCoreApplication::translate(
+                "CommanderSystem",
+                "%1 has lost its commander. The host breaks and its camps stand empty.")
+                .arg(name)));
+}
+
 void apply_commander_death_shock(Engine::Core::World* world,
                                  Engine::Core::Entity* commander_entity,
                                  Engine::Core::CommanderComponent& commander,
@@ -345,6 +371,7 @@ void CommanderSystem::update(Engine::Core::World* world, float delta_time) {
         commander->aura_ability_remaining = 0.0F;
         apply_commander_death_shock(
             world, commander_entity, *commander, *unit, *transform);
+        collapse_nation_if_leaderless(*world, unit->owner_id);
       }
       if (commander->flag_rally_in_progress || commander->flag_rally_flag_active ||
           commander->flag_rally_issue_commands) {

--- a/game/systems/movement_orders.cpp
+++ b/game/systems/movement_orders.cpp
@@ -23,11 +23,19 @@ constexpr float same_target_threshold_sq = 0.01F;
 
 constexpr int k_recovery_search_radius = 16;
 
-auto is_direct_path_walkable(const QVector3D& from, const QVector3D& to) -> bool {
+auto passability_for(const Engine::Core::MovementComponent& movement)
+    -> Pathfinding::Passability {
+  return movement.get_can_enter_forest() ? Pathfinding::Passability::Light
+                                         : Pathfinding::Passability::Heavy;
+}
+
+auto is_direct_path_walkable(const QVector3D& from,
+                             const QVector3D& to,
+                             Pathfinding::Passability passability) -> bool {
   auto* pathfinder = CommandService::get_pathfinder();
   if (pathfinder != nullptr) {
     pathfinder->update_navigation_grid();
-    return pathfinder->is_world_segment_walkable(from, to);
+    return pathfinder->is_world_segment_walkable(from, to, passability);
   }
 
   return CommandService::is_world_position_walkable(to);
@@ -289,13 +297,14 @@ void MovementSystem::assign_navigation_target(
   QVector3D const current_pos(transform.position.x, 0.0F, transform.position.z);
 
   bool const bridge_route = segment_traverses_bridge(current_pos, requested_target);
-  if (start == end ||
-      (is_direct_path_walkable(current_pos, requested_target) && !bridge_route)) {
+  if (start == end || (is_direct_path_walkable(
+                           current_pos, requested_target, passability_for(movement)) &&
+                       !bridge_route)) {
     assign_direct_target(movement, resolve_walkable_direct_target(requested_target));
     return;
   }
 
-  auto const path = pathfinder->find_path(start, end);
+  auto const path = pathfinder->find_path(start, end, passability_for(movement));
   bool const include_first_waypoint = should_include_resolved_start_waypoint(start);
   if (!assign_path_to_movement(
           *pathfinder, path, transform, movement, include_first_waypoint)) {
@@ -348,7 +357,8 @@ auto MovementSystem::assign_local_recovery_move(
   QVector3D resolved_goal = safe_pos;
   if (had_active_target) {
     Point const desired_goal = CommandService::world_to_grid(goal.x(), goal.z());
-    auto const route = pathfinder->find_path(recovery_cell, desired_goal);
+    auto const route =
+        pathfinder->find_path(recovery_cell, desired_goal, passability_for(*movement));
     if (route.size() > 1) {
       recovery_waypoints.reserve(route.size());
       for (std::size_t idx = 1; idx < route.size(); ++idx) {
@@ -480,12 +490,23 @@ void MovementSystem::issue_move_units(Engine::Core::World& world,
       CommandService::world_to_grid(leader_start.x(), leader_start.z());
   Point const leader_target_cell =
       CommandService::world_to_grid(leader_target.x(), leader_target.z());
-  bool const leader_direct = leader_start_cell == leader_target_cell ||
-                             (is_direct_path_walkable(leader_start, leader_target) &&
-                              !segment_traverses_bridge(leader_start, leader_target));
+
+  auto group_passability = Pathfinding::Passability::Light;
+  for (auto const& move : prepared) {
+    if (move.movement != nullptr && !move.movement->get_can_enter_forest()) {
+      group_passability = Pathfinding::Passability::Heavy;
+      break;
+    }
+  }
+
+  bool const leader_direct =
+      leader_start_cell == leader_target_cell ||
+      (is_direct_path_walkable(leader_start, leader_target, group_passability) &&
+       !segment_traverses_bridge(leader_start, leader_target));
   std::vector<Point> corridor;
   if (!leader_direct) {
-    corridor = pathfinder->find_path(leader_start_cell, leader_target_cell);
+    corridor =
+        pathfinder->find_path(leader_start_cell, leader_target_cell, group_passability);
   }
 
   constexpr int k_shared_corridor_region_radius = 16;
@@ -542,9 +563,10 @@ void MovementSystem::issue_move_units(Engine::Core::World& world,
       Point const start = CommandService::world_to_grid(current.x(), current.z());
       Point const target =
           CommandService::world_to_grid(targets[i].x(), targets[i].z());
-      bool const direct =
-          start == target || (is_direct_path_walkable(current, targets[i]) &&
-                              !segment_traverses_bridge(current, targets[i]));
+      bool const direct = start == target ||
+                          (is_direct_path_walkable(
+                               current, targets[i], passability_for(*move.movement)) &&
+                           !segment_traverses_bridge(current, targets[i]));
       if (direct || movement_system == nullptr ||
           synchronous_fallbacks < k_path_requests_per_tick) {
         assign_navigation_target(

--- a/game/systems/nation_collapse_service.cpp
+++ b/game/systems/nation_collapse_service.cpp
@@ -1,0 +1,112 @@
+#include "nation_collapse_service.h"
+
+#include <vector>
+
+#include "../core/component.h"
+#include "../core/entity.h"
+#include "../core/event_manager.h"
+#include "../core/ownership_constants.h"
+#include "../core/world.h"
+#include "../units/spawn_type.h"
+#include "building_collision_registry.h"
+#include "capture_system.h"
+#include "marketplace_system.h"
+#include "wall_network_service.h"
+
+namespace Game::Systems::NationCollapse {
+
+namespace {
+
+void tear_down_structure(Engine::Core::World& world, Engine::Core::Entity& entity) {
+  BuildingCollisionRegistry::instance().unregister_building(entity.get_id());
+
+  if (auto* unit = entity.get_component<Engine::Core::UnitComponent>();
+      unit != nullptr && unit->spawn_type == Game::Units::SpawnType::Marketplace) {
+    MarketplaceSystem::instance().unregister_marketplace(unit->owner_id);
+  }
+
+  const bool was_wall =
+      entity.get_component<Engine::Core::WallSegmentComponent>() != nullptr;
+
+  if (auto* renderable = entity.get_component<Engine::Core::RenderableComponent>()) {
+    renderable->visible = false;
+  }
+  entity.add_component<Engine::Core::PendingRemovalComponent>();
+
+  if (was_wall) {
+    WallNetworkService::refresh_world(world);
+  }
+}
+
+void disband_troop(Engine::Core::Entity& entity, Engine::Core::UnitComponent& unit) {
+  unit.health = 0;
+  Engine::Core::get_or_add_component<Engine::Core::DeathAnimationComponent>(entity);
+  Engine::Core::EventManager::instance().publish(
+      Engine::Core::UnitDiedEvent(entity.get_id(), unit.owner_id, unit.spawn_type));
+}
+
+} // namespace
+
+auto has_living_commander(Engine::Core::World& world, int owner_id) -> bool {
+  for (auto* entity : world.get_entities_with<Engine::Core::CommanderComponent>()) {
+    if (entity == nullptr ||
+        entity->has_component<Engine::Core::PendingRemovalComponent>()) {
+      continue;
+    }
+    auto* unit = entity->get_component<Engine::Core::UnitComponent>();
+    if (unit != nullptr && unit->owner_id == owner_id && unit->health > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto collapse_owner(Engine::Core::World& world, int owner_id) -> bool {
+  if (Game::Core::is_neutral_owner(owner_id)) {
+    return false;
+  }
+
+  std::vector<Engine::Core::Entity*> owned;
+  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+    if (entity == nullptr ||
+        entity->has_component<Engine::Core::PendingRemovalComponent>()) {
+      continue;
+    }
+    auto* unit = entity->get_component<Engine::Core::UnitComponent>();
+    if (unit != nullptr && unit->owner_id == owner_id) {
+      owned.push_back(entity);
+    }
+  }
+
+  bool collapsed_anything = false;
+  for (auto* entity : owned) {
+    auto* unit = entity->get_component<Engine::Core::UnitComponent>();
+    if (unit == nullptr) {
+      continue;
+    }
+
+    if (unit->spawn_type == Game::Units::SpawnType::Barracks) {
+      if (unit->health > 0) {
+        CaptureSystem::transfer_barrack_ownership(
+            &world, entity, Game::Core::NEUTRAL_OWNER_ID);
+        collapsed_anything = true;
+      }
+      continue;
+    }
+
+    if (Game::Units::is_building_spawn(unit->spawn_type)) {
+      tear_down_structure(world, *entity);
+      collapsed_anything = true;
+      continue;
+    }
+
+    if (Game::Units::is_troop_spawn(unit->spawn_type) && unit->health > 0) {
+      disband_troop(*entity, *unit);
+      collapsed_anything = true;
+    }
+  }
+
+  return collapsed_anything;
+}
+
+} // namespace Game::Systems::NationCollapse

--- a/game/systems/nation_collapse_service.h
+++ b/game/systems/nation_collapse_service.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace Engine::Core {
+class World;
+}
+
+namespace Game::Systems {
+
+namespace NationCollapse {
+
+[[nodiscard]] auto has_living_commander(Engine::Core::World& world,
+                                        int owner_id) -> bool;
+
+auto collapse_owner(Engine::Core::World& world, int owner_id) -> bool;
+
+} // namespace NationCollapse
+
+} // namespace Game::Systems

--- a/game/systems/pathfinding.cpp
+++ b/game/systems/pathfinding.cpp
@@ -152,11 +152,22 @@ void Pathfinding::set_obstacle(int x, int y, bool is_obstacle) {
   m_navigation_revision.fetch_add(1, std::memory_order_release);
 }
 
-auto Pathfinding::is_walkable(int x, int y) const -> bool {
+auto Pathfinding::is_walkable(int x, int y, Passability passability) const -> bool {
   if (x < 0 || x >= m_width || y < 0 || y >= m_height) {
     return false;
   }
-  return cell_value(x, y) == CellValue::Walkable;
+  auto const value = cell_value(x, y);
+  if (value == CellValue::Walkable) {
+    return true;
+  }
+  return value == CellValue::Forest && passability == Passability::Light;
+}
+
+auto Pathfinding::is_forest(int x, int y) const -> bool {
+  if (x < 0 || x >= m_width || y < 0 || y >= m_height) {
+    return false;
+  }
+  return cell_value(x, y) == CellValue::Forest;
 }
 
 auto Pathfinding::is_tree(int x, int y) const -> bool {
@@ -196,16 +207,17 @@ auto Pathfinding::is_terrain_walkable(int x, int y) const -> bool {
          CellValue::Walkable;
 }
 
-auto Pathfinding::is_world_position_walkable(const QVector3D& world_position) const
-    -> bool {
+auto Pathfinding::is_world_position_walkable(const QVector3D& world_position,
+                                             Passability passability) const -> bool {
   Point const grid = world_to_grid(world_position.x(), world_position.z());
-  return is_walkable(grid.x, grid.y);
+  return is_walkable(grid.x, grid.y, passability);
 }
 
 auto Pathfinding::is_world_segment_walkable(const QVector3D& from,
-                                            const QVector3D& to) const -> bool {
-  auto segment_point_walkable = [this](const QVector3D& point) -> bool {
-    return is_world_position_walkable(point);
+                                            const QVector3D& to,
+                                            Passability passability) const -> bool {
+  auto segment_point_walkable = [this, passability](const QVector3D& point) -> bool {
+    return is_world_position_walkable(point, passability);
   };
 
   if (!segment_point_walkable(to)) {
@@ -319,6 +331,7 @@ void Pathfinding::process_dirty_regions() {
       }
 
       force_navigation_passages_walkable(0, m_width - 1, 0, m_height - 1);
+      apply_forest_cells(0, m_width - 1, 0, m_height - 1);
       apply_resource_prop_cells(0, m_width - 1, 0, m_height - 1);
       force_map_passage_cells_walkable(0, m_width - 1, 0, m_height - 1);
 
@@ -369,6 +382,7 @@ void Pathfinding::update_region(int min_x, int max_x, int min_z, int max_z) {
       });
 
   force_navigation_passages_walkable(min_x, max_x, min_z, max_z);
+  apply_forest_cells(min_x, max_x, min_z, max_z);
   apply_resource_prop_cells(min_x, max_x, min_z, max_z);
   force_map_passage_cells_walkable(min_x, max_x, min_z, max_z);
 }
@@ -467,6 +481,75 @@ void Pathfinding::apply_resource_prop_cells(int min_x,
   }
 }
 
+void Pathfinding::rebuild_forest_index() {
+  m_forest_cells.assign(
+      static_cast<std::size_t>(m_width) * static_cast<std::size_t>(m_height), false);
+
+  auto& terrain_service = Game::Map::TerrainService::instance();
+  if (!terrain_service.is_initialized() || terrain_service.groves().empty()) {
+    return;
+  }
+
+  const auto* height_map = terrain_service.get_height_map();
+  float const tile_size =
+      height_map != nullptr ? std::max(height_map->get_tile_size(), 0.0001F) : 1.0F;
+  bool const world_space =
+      terrain_service.coord_system() == Game::Map::CoordSystem::World;
+
+  for (auto const& grove : terrain_service.groves()) {
+    float center_x = grove.x;
+    float center_z = grove.z;
+    float radius = grove.radius;
+    if (world_space) {
+      center_x = grove.x / tile_size - m_grid_offset_x;
+      center_z = grove.z / tile_size - m_grid_offset_z;
+      radius = grove.radius / tile_size;
+    }
+
+    int const min_x = std::max(0, static_cast<int>(std::floor(center_x - radius)));
+    int const max_x =
+        std::min(m_width - 1, static_cast<int>(std::ceil(center_x + radius)));
+    int const min_z = std::max(0, static_cast<int>(std::floor(center_z - radius)));
+    int const max_z =
+        std::min(m_height - 1, static_cast<int>(std::ceil(center_z + radius)));
+    float const radius_sq = radius * radius;
+
+    for (int grid_z = min_z; grid_z <= max_z; ++grid_z) {
+      for (int grid_x = min_x; grid_x <= max_x; ++grid_x) {
+        float const dx = static_cast<float>(grid_x) - center_x;
+        float const dz = static_cast<float>(grid_z) - center_z;
+        if (dx * dx + dz * dz > radius_sq) {
+          continue;
+        }
+
+        QVector3D const world = grid_to_world({grid_x, grid_z});
+        if (terrain_service.is_point_on_road(world.x(), world.z())) {
+          continue;
+        }
+        m_forest_cells[static_cast<std::size_t>(to_index(grid_x, grid_z))] = true;
+      }
+    }
+  }
+}
+
+void Pathfinding::apply_forest_cells(int min_x, int max_x, int min_z, int max_z) {
+  if (m_forest_cells.empty()) {
+    return;
+  }
+  for (int grid_z = min_z; grid_z <= max_z; ++grid_z) {
+    for (int grid_x = min_x; grid_x <= max_x; ++grid_x) {
+      auto const index = static_cast<std::size_t>(to_index(grid_x, grid_z));
+      if (index >= m_forest_cells.size() || !m_forest_cells[index]) {
+        continue;
+      }
+
+      if (m_navigation_grid.get(grid_x, grid_z) == CellValue::Walkable) {
+        m_navigation_grid.set(grid_x, grid_z, CellValue::Forest);
+      }
+    }
+  }
+}
+
 void Pathfinding::rebuild_world_prop_index() {
   auto& terrain_service = Game::Map::TerrainService::instance();
   const auto* height_map = terrain_service.get_height_map();
@@ -547,6 +630,7 @@ void Pathfinding::update_navigation_grid() {
 
   if (terrain_topology_revision !=
       m_applied_terrain_topology_revision.load(std::memory_order_acquire)) {
+    rebuild_forest_index();
     std::lock_guard<std::mutex> const dirty_lock(m_dirty_mutex);
     m_full_update_required = true;
   }
@@ -564,14 +648,15 @@ void Pathfinding::update_navigation_grid() {
 }
 
 auto Pathfinding::find_path(const Point& start,
-                            const Point& end) -> std::vector<Point> {
+                            const Point& end,
+                            Passability passability) -> std::vector<Point> {
 
   if (m_navigation_grid_dirty.load(std::memory_order_acquire)) {
     update_navigation_grid();
   }
 
   std::uint64_t const revision = navigation_revision();
-  PathCacheKey const key{start.x, start.y, end.x, end.y};
+  PathCacheKey const key{start.x, start.y, end.x, end.y, passability};
   {
     std::lock_guard<std::mutex> const cache_lock(m_path_cache_mutex);
     if (m_path_cache_revision != revision) {
@@ -584,7 +669,7 @@ auto Pathfinding::find_path(const Point& start,
   }
 
   std::shared_lock<std::shared_mutex> const navigation_lock(m_navigation_mutex);
-  auto path = find_path_internal(start, end);
+  auto path = find_path_internal(start, end, passability);
   std::lock_guard<std::mutex> const cache_lock(m_path_cache_mutex);
   if (m_path_cache_revision != revision || navigation_revision() != revision) {
     return path;
@@ -606,25 +691,27 @@ auto Pathfinding::PathCacheKeyHash::operator()(const PathCacheKey& key) const no
   combine(key.start_y);
   combine(key.end_x);
   combine(key.end_y);
+  combine(static_cast<int>(key.passability));
   return result;
 }
 
 auto Pathfinding::find_path_internal(const Point& start,
-                                     const Point& end) -> std::vector<Point> {
+                                     const Point& end,
+                                     Passability passability) -> std::vector<Point> {
   SearchBuffers& buffers = search_buffers_for(this);
   ensure_working_buffers(buffers);
 
-  auto const is_walkableFunc = [this](int x, int y) -> bool {
-    return is_walkable(x, y);
+  auto const is_walkableFunc = [this, passability](int x, int y) -> bool {
+    return is_walkable(x, y, passability);
   };
 
   if (!is_walkableFunc(start.x, start.y) || !is_walkableFunc(end.x, end.y)) {
     Point resolved_start = start;
     Point resolved_end = end;
     if ((!is_walkableFunc(start.x, start.y) &&
-         !resolve_walkable_endpoint(start, resolved_start)) ||
+         !resolve_walkable_endpoint(start, resolved_start, passability)) ||
         (!is_walkableFunc(end.x, end.y) &&
-         !resolve_walkable_endpoint(end, resolved_end))) {
+         !resolve_walkable_endpoint(end, resolved_end, passability))) {
       return {};
     }
 
@@ -632,7 +719,7 @@ auto Pathfinding::find_path_internal(const Point& start,
       return {};
     }
 
-    return find_path_internal(resolved_start, resolved_end);
+    return find_path_internal(resolved_start, resolved_end, passability);
   }
 
   const int start_idx = to_index(start);
@@ -688,7 +775,8 @@ auto Pathfinding::find_path_internal(const Point& start,
     }
 
     std::array<Point, 8> neighbors{};
-    const std::size_t neighbor_count = collect_neighbors(current_point, neighbors);
+    const std::size_t neighbor_count =
+        collect_neighbors(current_point, neighbors, passability);
 
     for (std::size_t i = 0; i < neighbor_count; ++i) {
       const Point& neighbor = neighbors[i];
@@ -737,9 +825,10 @@ auto Pathfinding::find_path_internal(const Point& start,
 }
 
 auto Pathfinding::resolve_walkable_endpoint(const Point& requested,
-                                            Point& resolved) const -> bool {
-  auto const is_walkable_func = [this](int x, int y) -> bool {
-    return is_walkable(x, y);
+                                            Point& resolved,
+                                            Passability passability) const -> bool {
+  auto const is_walkable_func = [this, passability](int x, int y) -> bool {
+    return is_walkable(x, y, passability);
   };
 
   if (is_walkable_func(requested.x, requested.y)) {
@@ -921,7 +1010,8 @@ void Pathfinding::set_parent(SearchBuffers& buffers,
 }
 
 auto Pathfinding::collect_neighbors(const Point& point,
-                                    std::array<Point, 8>& buffer) const -> std::size_t {
+                                    std::array<Point, 8>& buffer,
+                                    Passability passability) const -> std::size_t {
   std::size_t count = 0;
   for (int dx = -1; dx <= 1; ++dx) {
     for (int dy = -1; dy <= 1; ++dy) {
@@ -937,8 +1027,8 @@ auto Pathfinding::collect_neighbors(const Point& point,
       }
 
       if (dx != 0 && dy != 0) {
-        if (!is_walkable(point.x + dx, point.y) ||
-            !is_walkable(point.x, point.y + dy)) {
+        if (!is_walkable(point.x + dx, point.y, passability) ||
+            !is_walkable(point.x, point.y + dy, passability)) {
           continue;
         }
       }
@@ -1037,9 +1127,10 @@ auto Pathfinding::pop_open_node(SearchBuffers& buffers) -> Pathfinding::QueueNod
 
 auto Pathfinding::find_nearest_walkable_point(const Point& point,
                                               int max_search_radius,
-                                              const Pathfinding& pathfinder) -> Point {
-  auto const is_walkableFunc = [&pathfinder](int x, int y) -> bool {
-    return pathfinder.is_walkable(x, y);
+                                              const Pathfinding& pathfinder,
+                                              Passability passability) -> Point {
+  auto const is_walkableFunc = [&pathfinder, passability](int x, int y) -> bool {
+    return pathfinder.is_walkable(x, y, passability);
   };
 
   if (is_walkableFunc(point.x, point.y)) {

--- a/game/systems/pathfinding.h
+++ b/game/systems/pathfinding.h
@@ -50,6 +50,13 @@ public:
     Tree = 2,
     Boulder = 3,
     IronOre = 4,
+
+    Forest = 5,
+  };
+
+  enum class Passability : std::uint8_t {
+    Light = 0,
+    Heavy = 1,
   };
 
   class NavigationGrid {
@@ -81,16 +88,22 @@ public:
   auto grid_to_world(const Point& grid_pos) const -> QVector3D;
 
   void set_obstacle(int x, int y, bool is_obstacle);
-  auto is_walkable(int x, int y) const -> bool;
+  auto
+  is_walkable(int x, int y, Passability passability = Passability::Light) const -> bool;
   auto is_tree(int x, int y) const -> bool;
+  auto is_forest(int x, int y) const -> bool;
   auto is_boulder(int x, int y) const -> bool;
   auto is_iron_ore(int x, int y) const -> bool;
   auto cell_value(int x, int y) const -> CellValue;
 
   [[nodiscard]] auto is_terrain_walkable(int x, int y) const -> bool;
-  auto is_world_position_walkable(const QVector3D& world_position) const -> bool;
-  auto is_world_segment_walkable(const QVector3D& from,
-                                 const QVector3D& to) const -> bool;
+  auto is_world_position_walkable(const QVector3D& world_position,
+                                  Passability passability = Passability::Light) const
+      -> bool;
+  auto
+  is_world_segment_walkable(const QVector3D& from,
+                            const QVector3D& to,
+                            Passability passability = Passability::Light) const -> bool;
   auto path_waypoint_world_position(const Point& path_cell) const -> QVector3D;
 
   void update_navigation_grid();
@@ -106,19 +119,29 @@ public:
 
   [[nodiscard]] auto obstruction_revision() const -> std::uint64_t;
 
-  auto find_path(const Point& start, const Point& end) -> std::vector<Point>;
+  auto find_path(const Point& start,
+                 const Point& end,
+                 Passability passability = Passability::Light) -> std::vector<Point>;
 
   [[nodiscard]] auto navigation_revision() const -> std::uint64_t {
     return m_navigation_revision.load(std::memory_order_acquire);
   }
 
-  static auto find_nearest_walkable_point(const Point& point,
-                                          int max_search_radius,
-                                          const Pathfinding& pathfinder) -> Point;
+  static auto
+  find_nearest_walkable_point(const Point& point,
+                              int max_search_radius,
+                              const Pathfinding& pathfinder,
+                              Passability passability = Passability::Light) -> Point;
 
 private:
-  auto find_path_internal(const Point& start, const Point& end) -> std::vector<Point>;
-  auto resolve_walkable_endpoint(const Point& requested, Point& resolved) const -> bool;
+  auto find_path_internal(const Point& start,
+                          const Point& end,
+                          Passability passability) -> std::vector<Point>;
+  auto resolve_walkable_endpoint(const Point& requested,
+                                 Point& resolved,
+                                 Passability passability) const -> bool;
+  void apply_forest_cells(int min_x, int max_x, int min_z, int max_z);
+  void rebuild_forest_index();
   void force_map_passage_cells_walkable(int min_x, int max_x, int min_z, int max_z);
   void force_navigation_passages_walkable(int min_x, int max_x, int min_z, int max_z);
 
@@ -153,7 +176,8 @@ private:
                          int parent_index);
 
   auto collect_neighbors(const Point& point,
-                         std::array<Point, 8>& buffer) const -> std::size_t;
+                         std::array<Point, 8>& buffer,
+                         Passability passability) const -> std::size_t;
   void build_path(int start_index,
                   int end_index,
                   std::uint32_t generation,
@@ -182,6 +206,7 @@ private:
     int start_y;
     int end_x;
     int end_y;
+    Passability passability;
 
     auto operator==(const PathCacheKey&) const -> bool = default;
   };
@@ -217,6 +242,7 @@ private:
   std::atomic<std::uint64_t> m_obstruction_revision{0};
   std::atomic<std::uint64_t> m_applied_terrain_topology_revision{0};
   std::unordered_map<int, CellValue> m_world_prop_cells;
+  std::vector<bool> m_forest_cells;
   std::atomic<std::uint64_t> m_navigation_revision{1};
   std::uint64_t m_path_cache_revision{0};
   std::unordered_map<PathCacheKey, std::vector<Point>, PathCacheKeyHash> m_path_cache;

--- a/game/systems/undead_awakening_system.cpp
+++ b/game/systems/undead_awakening_system.cpp
@@ -3,6 +3,7 @@
 #include <QCoreApplication>
 #include <QDebug>
 #include <QJsonObject>
+#include <QStringList>
 #include <QVector3D>
 #include <qjsonarray.h>
 #include <qjsonobject.h>
@@ -14,12 +15,14 @@
 #include "core/component.h"
 #include "core/entity.h"
 #include "core/event_manager.h"
+#include "core/ownership_constants.h"
 #include "core/world.h"
 #include "game/map/terrain_service.h"
 #include "game/map/undead_shrine_placement.h"
 #include "game/systems/global_stats_registry.h"
 #include "game/systems/nation_registry.h"
 #include "game/systems/owner_registry.h"
+#include "game/systems/player_resource_registry.h"
 #include "units/factory.h"
 #include "units/unit.h"
 
@@ -459,6 +462,49 @@ void UndeadAwakeningSystem::break_garrison(Engine::Core::World& world,
     Engine::Core::EventManager::instance().publish(
         Engine::Core::AudioCueEvent("alert.objective_complete"));
   }
+
+  pay_clear_reward(world, zone, captured);
+}
+
+void UndeadAwakeningSystem::pay_clear_reward(Engine::Core::World& world,
+                                             const RuntimeZone& zone,
+                                             bool captured) const {
+  if (zone.definition.clear_reward.empty()) {
+    return;
+  }
+
+  int beneficiary = OwnerRegistry::instance().get_local_player_id();
+  if (captured && zone.anchor_entity_id != 0) {
+    auto* anchor = world.get_entity(zone.anchor_entity_id);
+    auto* unit = anchor != nullptr
+                     ? anchor->get_component<Engine::Core::UnitComponent>()
+                     : nullptr;
+    if (unit != nullptr && !Game::Core::is_neutral_owner(unit->owner_id)) {
+      beneficiary = unit->owner_id;
+    }
+  }
+
+  auto& resources = PlayerResourceRegistry::instance();
+  QStringList spoils;
+  for (ResourceType const type : k_all_resource_types) {
+    int const amount = zone.definition.clear_reward.get(type);
+    if (amount <= 0) {
+      continue;
+    }
+    resources.add(beneficiary, type, amount);
+    spoils.append(QStringLiteral("%1 %2").arg(amount).arg(
+        QString::fromLatin1(resource_type_key(type))));
+  }
+
+  if (spoils.isEmpty() ||
+      beneficiary != OwnerRegistry::instance().get_local_player_id()) {
+    return;
+  }
+
+  Engine::Core::EventManager::instance().publish(Engine::Core::MissionAnnouncementEvent(
+      QCoreApplication::translate("UndeadAwakeningSystem",
+                                  "The barrow gives up its hoard: %1.")
+          .arg(spoils.join(QStringLiteral(", ")))));
 }
 
 void UndeadAwakeningSystem::refresh_capture_lock(Engine::Core::World& world,

--- a/game/systems/undead_awakening_system.h
+++ b/game/systems/undead_awakening_system.h
@@ -81,6 +81,9 @@ private:
   void refresh_active_spawns(Engine::Core::World& world, RuntimeZone& zone) const;
   void refresh_anchor_structure(Engine::Core::World& world, RuntimeZone& zone);
   void break_garrison(Engine::Core::World& world, RuntimeZone& zone, bool captured);
+  void pay_clear_reward(Engine::Core::World& world,
+                        const RuntimeZone& zone,
+                        bool captured) const;
   void refresh_capture_lock(Engine::Core::World& world, const RuntimeZone& zone) const;
   void awaken_zone(Engine::Core::World& world, RuntimeZone& zone);
   void try_spawn_next_wave(Engine::Core::World& world, RuntimeZone& zone);

--- a/game/systems/victory_service.cpp
+++ b/game/systems/victory_service.cpp
@@ -194,6 +194,8 @@ void VictoryService::reset() {
   m_requires_captured_structure_tracking = false;
   m_has_only_commander_defeat_rule = false;
   m_only_commander_defeat_armed = false;
+  m_has_eliminate_commanders_rule = false;
+  m_eliminate_commanders_armed = false;
   m_world_state_dirty = false;
   m_last_world_summary = {};
   m_has_world_summary = false;
@@ -231,8 +233,9 @@ void VictoryService::update(Engine::Core::World& world, float delta_time) {
 
   m_world_ptr = &world;
 
-  if (m_has_only_commander_defeat_rule && !m_only_commander_defeat_armed) {
-    update_only_commander_defeat_arming(summarize_world(world));
+  if ((m_has_only_commander_defeat_rule && !m_only_commander_defeat_armed) ||
+      (m_has_eliminate_commanders_rule && !m_eliminate_commanders_armed)) {
+    update_rule_arming(summarize_world(world));
   }
 
   if (m_startup_delay > 0.0F) {
@@ -298,6 +301,7 @@ void VictoryService::refresh_rule_metadata() {
   m_has_time_limit_defeat = false;
   m_requires_captured_structure_tracking = false;
   m_has_only_commander_defeat_rule = false;
+  m_has_eliminate_commanders_rule = false;
   m_only_commander_structure_types.clear();
 
   for (const auto& rule : m_rule_set.victory_rules) {
@@ -333,6 +337,10 @@ void VictoryService::refresh_rule_metadata() {
             [this](const SurviveWavesVictoryRule&) { m_has_wave_victory = true; },
             [this](const AccumulateResourcesVictoryRule&) {
               m_has_resource_victory = true;
+            },
+            [this](const EliminateCommandersVictoryRule&) {
+              m_has_world_based_rules = true;
+              m_has_eliminate_commanders_rule = true;
             }},
         rule);
   }
@@ -368,15 +376,17 @@ void VictoryService::refresh_rule_metadata() {
   }
 }
 
-void VictoryService::update_only_commander_defeat_arming(const WorldSummary& summary) {
-  if (m_only_commander_defeat_armed || !m_has_only_commander_defeat_rule) {
-    return;
+void VictoryService::update_rule_arming(const WorldSummary& summary) {
+  if (m_has_only_commander_defeat_rule && !m_only_commander_defeat_armed &&
+      (summary.local_non_commander_troop_count > 0 ||
+       count_matching_structures(summary.local_owned_structure_counts,
+                                 m_only_commander_structure_types) > 0)) {
+    m_only_commander_defeat_armed = true;
   }
 
-  if (summary.local_non_commander_troop_count > 0 ||
-      count_matching_structures(summary.local_owned_structure_counts,
-                                m_only_commander_structure_types) > 0) {
-    m_only_commander_defeat_armed = true;
+  if (m_has_eliminate_commanders_rule && !m_eliminate_commanders_armed &&
+      summary.enemy_commander_count > 0) {
+    m_eliminate_commanders_armed = true;
   }
 }
 
@@ -387,7 +397,7 @@ void VictoryService::evaluate_polled_rules() {
 void VictoryService::evaluate_world_state(Engine::Core::World& world) {
   m_last_world_summary = summarize_world(world);
   m_has_world_summary = true;
-  update_only_commander_defeat_arming(m_last_world_summary);
+  update_rule_arming(m_last_world_summary);
   m_world_state_dirty = false;
   evaluate_rules(m_last_world_summary);
 }
@@ -479,6 +489,12 @@ auto VictoryService::summarize_world(Engine::Core::World& world) const -> WorldS
       } else if (Game::Units::is_troop_spawn(unit->spawn_type)) {
         summary.local_non_commander_troop_count += 1;
       }
+    } else if (entity->get_component<Engine::Core::CommanderComponent>() != nullptr &&
+               m_owner_registry.are_enemies(m_local_owner_id, unit->owner_id)) {
+      if (m_rule_set.include_ambient_undead ||
+          unit->nation_id != Game::Systems::NationID::IronSepulcher) {
+        summary.enemy_commander_count += 1;
+      }
     }
 
     if (!track_structures) {
@@ -555,6 +571,9 @@ auto VictoryService::check_victory_rule(const VictoryRule& rule,
           [this](const AccumulateResourcesVictoryRule& resource_rule) {
             return PlayerResourceRegistry::instance().has_harvested_at_least(
                 m_local_owner_id, resource_rule.required);
+          },
+          [this, &summary](const EliminateCommandersVictoryRule&) {
+            return m_eliminate_commanders_armed && summary.enemy_commander_count == 0;
           }},
       rule);
 }

--- a/game/systems/victory_service.h
+++ b/game/systems/victory_service.h
@@ -70,6 +70,8 @@ struct AccumulateResourcesVictoryRule {
   ResourceAmounts required;
 };
 
+struct EliminateCommandersVictoryRule {};
+
 using VictoryRule = std::variant<EliminationVictoryRule,
                                  SurviveTimeVictoryRule,
                                  ControlStructuresVictoryRule,
@@ -78,7 +80,8 @@ using VictoryRule = std::variant<EliminationVictoryRule,
                                  PurifyShrineVictoryRule,
                                  SurviveUndeadWaveVictoryRule,
                                  SurviveWavesVictoryRule,
-                                 AccumulateResourcesVictoryRule>;
+                                 AccumulateResourcesVictoryRule,
+                                 EliminateCommandersVictoryRule>;
 
 struct NoUnitsDefeatRule {};
 
@@ -144,6 +147,7 @@ private:
     bool local_has_units = false;
     int local_commander_count = 0;
     int local_non_commander_troop_count = 0;
+    int enemy_commander_count = 0;
     QHash<QString, int> enemy_structure_counts;
     QHash<QString, int> local_owned_structure_counts;
     QHash<QString, int> local_captured_structure_counts;
@@ -155,7 +159,7 @@ private:
   void mark_world_dirty();
   void reevaluate_world_state();
   void refresh_rule_metadata();
-  void update_only_commander_defeat_arming(const WorldSummary& summary);
+  void update_rule_arming(const WorldSummary& summary);
   void evaluate_polled_rules();
   void evaluate_world_state(Engine::Core::World& world);
   void evaluate_rules(const WorldSummary& summary);
@@ -182,6 +186,8 @@ private:
   bool m_requires_captured_structure_tracking = false;
   bool m_has_only_commander_defeat_rule = false;
   bool m_only_commander_defeat_armed = false;
+  bool m_has_eliminate_commanders_rule = false;
+  bool m_eliminate_commanders_armed = false;
   bool m_world_state_dirty = false;
   std::vector<QString> m_only_commander_structure_types;
 

--- a/game/units/factory.cpp
+++ b/game/units/factory.cpp
@@ -51,6 +51,21 @@ auto owner_has_living_commander(Engine::Core::World& world, int owner_id) -> boo
 
 } // namespace
 
+void UnitFactoryRegistry::apply_forest_passability(Engine::Core::World& world,
+                                                   Unit* unit,
+                                                   SpawnType type) {
+  if (unit == nullptr) {
+    return;
+  }
+  auto* entity = world.get_entity(unit->id());
+  if (entity == nullptr) {
+    return;
+  }
+  if (auto* movement = entity->get_component<Engine::Core::MovementComponent>()) {
+    movement->set_can_enter_forest(can_enter_forest(type));
+  }
+}
+
 void register_built_in_units(UnitFactoryRegistry& reg) {
   reg.register_factory(SpawnType::Archer,
                        [](Engine::Core::World& world, const SpawnParams& params) {

--- a/game/units/factory.h
+++ b/game/units/factory.h
@@ -24,7 +24,10 @@ public:
     if (it == m_factories.end()) {
       return nullptr;
     }
-    return it->second(world, params);
+    auto unit = it->second(world, params);
+
+    apply_forest_passability(world, unit.get(), type);
+    return unit;
   }
 
   auto create(TroopType type,
@@ -35,6 +38,9 @@ public:
   }
 
 private:
+  static void
+  apply_forest_passability(Engine::Core::World& world, Unit* unit, SpawnType type);
+
   std::unordered_map<SpawnType, Factory> m_factories;
 };
 

--- a/game/units/spawn_type.h
+++ b/game/units/spawn_type.h
@@ -364,6 +364,30 @@ inline auto is_wall_network_spawn(SpawnType type) -> bool {
          type == SpawnType::HorseSpearman;
 }
 
+[[nodiscard]] inline auto can_enter_forest(SpawnType type) noexcept -> bool {
+  switch (type) {
+  case SpawnType::Archer:
+  case SpawnType::Knight:
+  case SpawnType::Healer:
+  case SpawnType::Builder:
+  case SpawnType::Civilian:
+  case SpawnType::SkeletonSwordsman:
+  case SpawnType::SkeletonArcher:
+  case SpawnType::GravePriest:
+  case SpawnType::RomanLegionOrganizer:
+  case SpawnType::RomanVeteranConsul:
+  case SpawnType::RomanFieldCommander:
+  case SpawnType::CarthageSpearCommander:
+  case SpawnType::CarthageBowCommander:
+  case SpawnType::CarthageSwordCommander:
+  case SpawnType::Sheep:
+  case SpawnType::Wolf:
+    return true;
+  default:
+    return false;
+  }
+}
+
 inline auto can_use_attack_mode(SpawnType type) -> bool {
   return type != SpawnType::Healer && type != SpawnType::Builder &&
          !is_building_spawn(type) && !is_wildlife_spawn(type);

--- a/game/wildlife/wildlife_config.cpp
+++ b/game/wildlife/wildlife_config.cpp
@@ -36,6 +36,16 @@ void sanitize_species(SpeciesConfig& config) noexcept {
   for (auto& area : config.spawn_areas) {
     area.radius = std::clamp(area.radius, 1.0F, k_max_roam_radius);
   }
+  for (auto& wave : config.waves) {
+    wave.timing = std::max(0.0F, wave.timing);
+    wave.pack_size = std::clamp(wave.pack_size, 1, k_max_group_size);
+    wave.area.radius = std::clamp(wave.area.radius, 1.0F, k_max_roam_radius);
+  }
+  std::stable_sort(config.waves.begin(),
+                   config.waves.end(),
+                   [](const WildlifeWave& lhs, const WildlifeWave& rhs) {
+                     return lhs.timing < rhs.timing;
+                   });
 }
 
 } // namespace

--- a/game/wildlife/wildlife_config.h
+++ b/game/wildlife/wildlife_config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "wildlife_species.h"
@@ -11,6 +12,13 @@ struct SpawnArea {
   float x{0.0F};
   float z{0.0F};
   float radius{18.0F};
+};
+
+struct WildlifeWave {
+  float timing{0.0F};
+  int pack_size{4};
+  SpawnArea area;
+  std::string label;
 };
 
 struct SpeciesConfig {
@@ -31,6 +39,7 @@ struct SpeciesConfig {
   float flyover_interval_max{0.0F};
 
   std::vector<SpawnArea> spawn_areas;
+  std::vector<WildlifeWave> waves;
 
   [[nodiscard]] auto clamped_group_size(std::uint32_t roll) const noexcept -> int;
 

--- a/game/wildlife/wildlife_system.cpp
+++ b/game/wildlife/wildlife_system.cpp
@@ -1,6 +1,8 @@
 #include "wildlife_system.h"
 
+#include <QCoreApplication>
 #include <QJsonArray>
+#include <QString>
 #include <QVector3D>
 
 #include <algorithm>
@@ -10,6 +12,7 @@
 
 #include "../core/component.h"
 #include "../core/entity.h"
+#include "../core/event_manager.h"
 #include "../core/ownership_constants.h"
 #include "../core/world.h"
 #include "../map/map_definition.h"
@@ -347,6 +350,73 @@ void WildlifeSystem::spawn_initial_population(Engine::Core::World& world) {
     for (int member = 0; member < group.desired_size; ++member) {
       spawn_member(world, group, config);
     }
+  }
+}
+
+void WildlifeSystem::release_due_packs(Engine::Core::World& world, float delta_time) {
+  const auto& config = m_settings.for_species(Species::Wolf);
+  if (config.waves.empty()) {
+    return;
+  }
+
+  m_elapsed += delta_time;
+  if (m_released_waves.size() != config.waves.size()) {
+    m_released_waves.resize(config.waves.size(), false);
+  }
+
+  for (std::size_t index = 0; index < config.waves.size(); ++index) {
+    if (m_released_waves[index]) {
+      continue;
+    }
+    const auto& wave = config.waves[index];
+    if (m_elapsed < wave.timing) {
+
+      break;
+    }
+    m_released_waves[index] = true;
+
+    GroupState group;
+    group.id = m_next_group_id++;
+    group.species = Species::Wolf;
+    group.roam_radius = std::max(config.roam_radius, wave.area.radius);
+    group.rng_state = seed_for(m_seed, Species::Wolf, static_cast<int>(index) + 4096);
+    group.desired_size = wave.pack_size;
+
+    float anchor_x = wave.area.x;
+    float anchor_z = wave.area.z;
+    bool anchored = false;
+    for (float scale : {1.0F, 1.8F, 3.0F}) {
+      if (pick_open_point(group.rng_state,
+                          wave.area.x,
+                          wave.area.z,
+                          0.0F,
+                          wave.area.radius * scale,
+                          anchor_x,
+                          anchor_z)) {
+        anchored = true;
+        break;
+      }
+    }
+    if (!anchored) {
+      continue;
+    }
+
+    group.home_x = anchor_x;
+    group.home_z = anchor_z;
+    m_groups.push_back(group);
+    m_group_runtime.emplace_back();
+
+    auto& stored = m_groups.back();
+    for (int member = 0; member < stored.desired_size; ++member) {
+      spawn_member(world, stored, config);
+    }
+
+    Engine::Core::EventManager::instance().publish(
+        Engine::Core::MissionAnnouncementEvent(
+            wave.label.empty()
+                ? QCoreApplication::translate("WildlifeSystem",
+                                              "Wolves are moving on the valley.")
+                : QString::fromStdString(wave.label)));
   }
 }
 
@@ -729,6 +799,8 @@ void WildlifeSystem::update(Engine::Core::World* world, float delta_time) {
     }
   }
 
+  release_due_packs(*world, delta_time);
+
   m_threat_refresh -= delta_time;
   if (m_threat_refresh <= 0.0F) {
     m_threat_refresh = k_threat_refresh_interval;
@@ -828,6 +900,13 @@ auto WildlifeSystem::serialize_state() const -> QJsonObject {
   state["enabled"] = m_enabled;
   state["seed"] = static_cast<qint64>(m_seed);
   state["next_group_id"] = static_cast<int>(m_next_group_id);
+  state["elapsed"] = static_cast<double>(m_elapsed);
+
+  QJsonArray released_waves;
+  for (bool const released : m_released_waves) {
+    released_waves.append(released);
+  }
+  state["released_waves"] = released_waves;
 
   QJsonArray groups;
   for (const auto& group : m_groups) {
@@ -904,6 +983,12 @@ void WildlifeSystem::restore_state(const QJsonObject& state) {
   m_seed = static_cast<std::uint32_t>(state.value("seed").toVariant().toULongLong());
   m_next_group_id =
       static_cast<std::uint16_t>(state.value("next_group_id").toInt(m_next_group_id));
+  m_elapsed = static_cast<float>(state.value("elapsed").toDouble(0.0));
+
+  m_released_waves.clear();
+  for (const auto& value : state.value("released_waves").toArray()) {
+    m_released_waves.push_back(value.toBool(false));
+  }
 
   m_groups.clear();
   const QJsonArray groups = state.value("groups").toArray();

--- a/game/wildlife/wildlife_system.h
+++ b/game/wildlife/wildlife_system.h
@@ -122,6 +122,7 @@ private:
 
   void ensure_factory_registry();
   void spawn_initial_population(Engine::Core::World& world);
+  void release_due_packs(Engine::Core::World& world, float delta_time);
   void plan_groups();
   auto spawn_member(Engine::Core::World& world,
                     GroupState& group,
@@ -181,6 +182,8 @@ private:
   bool m_enabled{false};
   bool m_spawn_pending{false};
   bool m_restored{false};
+  float m_elapsed{0.0F};
+  std::vector<bool> m_released_waves;
 };
 
 } // namespace Game::Wildlife

--- a/render/entity/nations/carthage/marketplace_renderer.cpp
+++ b/render/entity/nations/carthage/marketplace_renderer.cpp
@@ -121,6 +121,51 @@ void add_spice_basket(BuildingArchetypeDesc& desc,
                 BuildingLODMask::Full);
 }
 
+void add_stall_canopy(BuildingArchetypeDesc& desc,
+                      const CarthageMarketPalette& c,
+                      const QVector3D& center,
+                      float half_x,
+                      float half_z,
+                      float post_h,
+                      const QVector3D& cloth,
+                      const QVector3D& cloth_shade) {
+  constexpr float post_r = 0.016F;
+  float const top = center.y() + post_h;
+
+  for (float const sx : {-1.0F, 1.0F}) {
+    for (float const sz : {-1.0F, 1.0F}) {
+      desc.add_cylinder(
+          QVector3D(center.x() + sx * half_x, center.y(), center.z() + sz * half_z),
+          QVector3D(center.x() + sx * half_x, top, center.z() + sz * half_z),
+          post_r,
+          c.wood_dark,
+          k_building_state_mask_intact,
+          BuildingLODMask::Full);
+    }
+  }
+
+  desc.add_cylinder(QVector3D(center.x(), top + 0.055F, center.z() - half_z),
+                    QVector3D(center.x(), top + 0.055F, center.z() + half_z),
+                    0.010F,
+                    c.wood_medium,
+                    k_building_state_mask_intact,
+                    BuildingLODMask::Full);
+  for (float const side : {-1.0F, 1.0F}) {
+    desc.add_rotated_box(
+        QVector3D(center.x() + side * half_x * 0.52F, top + 0.028F, center.z()),
+        QVector3D(half_x * 0.60F, 0.011F, half_z * 1.04F),
+        QVector3D(0.0F, 0.0F, side * 15.0F),
+        side < 0.0F ? cloth : cloth_shade,
+        BuildingStateMask::Normal | BuildingStateMask::Damaged);
+  }
+
+  desc.add_box(QVector3D(center.x() - half_x * 0.98F, top + 0.006F, center.z()),
+               QVector3D(0.012F, 0.026F, half_z * 1.02F),
+               c.cloth_gold,
+               BuildingStateMask::Normal | BuildingStateMask::Damaged,
+               BuildingLODMask::Full);
+}
+
 auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
   CarthageMarketPalette const c;
   float height_multiplier = 1.0F;
@@ -152,7 +197,7 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                  BuildingLODMask::Full);
   }
 
-  float const wall_h = 0.72F * height_multiplier;
+  float const wall_h = 0.44F * height_multiplier;
   desc.add_box(QVector3D(0.92F, wall_h * 0.5F + 0.14F, 0.0F),
                QVector3D(0.14F, wall_h * 0.5F, 1.10F),
                c.sandstone);
@@ -182,22 +227,10 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                  BuildingLODMask::Full);
   }
 
-  if (state != BuildingState::Destroyed) {
-    float const merlon_y = wall_h + 0.18F;
-    auto add_merlon =
-        [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-          desc.add_box(
-              center, size, color, k_building_state_mask_intact, BuildingLODMask::Full);
-        };
-    add_merlon_strip_z(add_merlon,
-                       0.92F,
-                       merlon_y,
-                       -0.90F,
-                       0.36F,
-                       6,
-                       QVector3D(0.10F, 0.10F, 0.12F),
-                       c.brick);
-  }
+  desc.add_box(QVector3D(0.92F, wall_h + 0.17F, 0.0F),
+               QVector3D(0.17F, 0.035F, 1.14F),
+               c.sandstone_dark,
+               k_building_state_mask_intact);
 
   float const side_wall_h = 0.44F * height_multiplier;
   desc.add_box(QVector3D(0.20F, side_wall_h * 0.5F + 0.14F, -1.08F),
@@ -242,38 +275,18 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
   }
 
   float const post_h = 0.88F * height_multiplier;
-  desc.add_box(QVector3D(-0.82F, post_h * 0.5F, -0.72F),
-               QVector3D(0.05F, post_h * 0.5F, 0.05F),
-               c.wood_dark);
-  desc.add_box(QVector3D(-0.82F, post_h * 0.5F, 0.72F),
-               QVector3D(0.05F, post_h * 0.5F, 0.05F),
-               c.wood_dark);
-  desc.add_box(QVector3D(0.18F, post_h * 0.5F, -0.72F),
-               QVector3D(0.05F, post_h * 0.5F, 0.05F),
-               c.wood_dark);
-  desc.add_box(QVector3D(0.18F, post_h * 0.5F, 0.72F),
-               QVector3D(0.05F, post_h * 0.5F, 0.05F),
-               c.wood_dark);
-
   float const awning_y = post_h + 0.04F;
-  for (int panel = 0; panel < 8; ++panel) {
-    float const z = -0.715F + static_cast<float>(panel) * 0.205F;
-    float const sag = (panel == 3 || panel == 4) ? 0.025F : 0.0F;
-    desc.add_rotated_box(QVector3D(-0.32F, awning_y - sag, z),
-                         QVector3D(0.60F, 0.012F, 0.098F),
-                         QVector3D(0.0F, 0.0F, -5.5F),
-                         (panel % 2 == 0) ? c.cloth_oxblood : c.cloth_oxblood_faded,
-                         BuildingStateMask::Normal | BuildingStateMask::Damaged);
+  for (float const z : {-0.56F, 0.0F, 0.56F}) {
+    add_stall_canopy(desc,
+                     c,
+                     QVector3D(-0.32F, counter_h + 0.06F, z),
+                     0.27F,
+                     0.18F,
+                     0.30F * height_multiplier,
+                     c.cloth_oxblood,
+                     c.cloth_oxblood_faded);
   }
 
-  desc.add_box(QVector3D(-0.32F, awning_y - 0.03F, 0.80F),
-               QVector3D(0.58F, 0.02F, 0.04F),
-               c.cloth_gold,
-               BuildingStateMask::Normal | BuildingStateMask::Damaged);
-  desc.add_box(QVector3D(-0.32F, awning_y - 0.03F, -0.80F),
-               QVector3D(0.58F, 0.02F, 0.04F),
-               c.cloth_gold,
-               BuildingStateMask::Normal | BuildingStateMask::Damaged);
   for (float const z : {-0.80F, 0.80F}) {
     desc.add_cylinder(QVector3D(-0.88F, awning_y - 0.02F, z),
                       QVector3D(-0.82F, 0.16F, z),
@@ -346,15 +359,25 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                  BuildingLODMask::Full);
   }
 
-  float const rear_awning_y = (post_h * 0.85F) + 0.04F;
-  for (int panel = 0; panel < 6; ++panel) {
-    float const z = -0.575F + static_cast<float>(panel) * 0.23F;
-    desc.add_rotated_box(QVector3D(0.52F, rear_awning_y, z),
-                         QVector3D(0.30F, 0.010F, 0.108F),
-                         QVector3D(0.0F, 0.0F, 4.0F),
-                         (panel % 2 == 0) ? c.indigo : c.cloth_oxblood,
-                         BuildingStateMask::Normal,
-                         BuildingLODMask::Full);
+  for (float const z : {-0.62F, 0.0F, 0.62F}) {
+    desc.add_box(QVector3D(0.46F, 0.14F + 0.19F, z),
+                 QVector3D(0.24F, 0.035F, 0.26F),
+                 c.wood_medium);
+    for (float const sz : {-1.0F, 1.0F}) {
+      desc.add_box(QVector3D(0.46F, 0.14F + 0.095F, z + sz * 0.22F),
+                   QVector3D(0.030F, 0.095F, 0.030F),
+                   c.wood_dark,
+                   k_building_state_mask_intact,
+                   BuildingLODMask::Full);
+    }
+    add_stall_canopy(desc,
+                     c,
+                     QVector3D(0.46F, 0.14F, z),
+                     0.24F,
+                     0.20F,
+                     0.56F * height_multiplier,
+                     c.indigo,
+                     c.cloth_oxblood);
   }
 
   add_spice_basket(desc, QVector3D(-0.53F, counter_h + 0.06F, -0.36F), c.saffron, c);

--- a/render/entity/nations/carthage/temple_renderer.cpp
+++ b/render/entity/nations/carthage/temple_renderer.cpp
@@ -34,6 +34,7 @@ struct CarthageTemplePalette {
   QVector3D saffron{0.76F, 0.36F, 0.035F};
   QVector3D ember{0.76F, 0.19F, 0.025F};
   QVector3D soot{0.15F, 0.13F, 0.12F};
+  QVector3D verdigris{0.26F, 0.44F, 0.39F};
 };
 
 constexpr std::uint8_t k_temple_team_slot = 1;
@@ -227,16 +228,18 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
   desc.set_full_lod_max_distance(84.0F);
 
   desc.add_box(
-      QVector3D(0.0F, 0.050F, 0.0F), QVector3D(1.38F, 0.050F, 1.16F), c.basalt);
+      QVector3D(0.0F, 0.055F, 0.0F), QVector3D(1.38F, 0.055F, 1.16F), c.basalt);
   desc.add_box(
-      QVector3D(0.0F, 0.155F, 0.0F), QVector3D(1.31F, 0.055F, 1.09F), c.sandstone_dark);
+      QVector3D(0.0F, 0.195F, 0.0F), QVector3D(1.33F, 0.085F, 1.11F), c.sandstone_dark);
   desc.add_box(
-      QVector3D(0.0F, 0.245F, 0.0F), QVector3D(1.25F, 0.035F, 1.03F), c.sandstone);
-  desc.add_box(QVector3D(0.0F, 0.290F, 0.0F),
+      QVector3D(0.0F, 0.345F, 0.0F), QVector3D(1.29F, 0.065F, 1.07F), c.sandstone_dark);
+  desc.add_box(
+      QVector3D(0.0F, 0.435F, 0.0F), QVector3D(1.25F, 0.035F, 1.03F), c.sandstone);
+  desc.add_box(QVector3D(0.0F, 0.475F, 0.0F),
                QVector3D(1.27F, 0.010F, 1.05F),
                c.sandstone_light);
 
-  float const podium_y = 0.300F;
+  float const podium_y = 0.485F;
 
   for (float const joint_x : {-0.84F, -0.24F, 0.36F, 0.96F}) {
     desc.add_box(QVector3D(joint_x, 0.165F, 0.0F),
@@ -251,17 +254,17 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
                k_building_state_mask_intact,
                BuildingLODMask::Full);
 
-  for (int step = 0; step < 4; ++step) {
+  for (int step = 0; step < 6; ++step) {
     float const step_index = static_cast<float>(step);
-    float const top = 0.074F * (step_index + 1.0F);
-    desc.add_box(QVector3D(-1.600F + 0.086F * step_index, top * 0.5F, 0.0F),
-                 QVector3D(0.045F, top * 0.5F, 0.62F),
+    float const top = 0.081F * (step_index + 1.0F);
+    desc.add_box(QVector3D(-1.700F + 0.078F * step_index, top * 0.5F, 0.0F),
+                 QVector3D(0.041F, top * 0.5F, 0.62F),
                  (step % 2 == 0) ? c.sandstone_dark : c.sandstone,
                  k_building_state_mask_intact);
   }
   for (float const cheek : {-1.0F, 1.0F}) {
-    desc.add_box(QVector3D(-1.47F, 0.15F, cheek * 0.675F),
-                 QVector3D(0.19F, 0.15F, 0.055F),
+    desc.add_box(QVector3D(-1.50F, 0.24F, cheek * 0.675F),
+                 QVector3D(0.25F, 0.24F, 0.055F),
                  c.basalt,
                  k_building_state_mask_intact);
   }
@@ -469,36 +472,34 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
                c.sandstone,
                k_building_state_mask_intact);
 
-  constexpr float k_merlon_half_h = 0.098F;
-  float const merlon_y = cornice_y + 0.140F + k_merlon_half_h;
-  auto add_merlon =
-      [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-        desc.add_box(center, size, color, k_building_state_mask_intact);
-        desc.add_box(center + QVector3D(0.0F, size.y() + 0.015F, 0.0F),
-                     QVector3D(size.x() * 1.20F, 0.015F, size.z() * 1.20F),
-                     c.basalt,
-                     k_building_state_mask_intact,
-                     BuildingLODMask::Full);
-      };
-
-  add_merlon_strip_z(add_merlon,
-                     1.245F,
-                     merlon_y,
-                     -0.84F,
-                     0.28F,
-                     7,
-                     QVector3D(0.050F, k_merlon_half_h, 0.078F),
-                     c.sandstone_light);
-  for (float const side : {-1.0F, 1.0F}) {
-    add_merlon_strip_x(add_merlon,
-                       merlon_y,
-                       side * 0.925F,
-                       -0.24F,
-                       0.29F,
-                       6,
-                       QVector3D(0.078F, k_merlon_half_h, 0.050F),
-                       c.sandstone_light);
+  for (int course = 0; course < 3; ++course) {
+    float const t = static_cast<float>(course);
+    desc.add_box(QVector3D(0.47F, cornice_y + 0.156F + 0.042F * t, 0.0F),
+                 QVector3D(0.86F + 0.035F * t, 0.021F, 1.01F + 0.035F * t),
+                 (course % 2 == 0) ? c.sandstone_light : c.sandstone,
+                 k_building_state_mask_intact);
   }
+  desc.add_box(QVector3D(0.47F, cornice_y + 0.290F, 0.0F),
+               QVector3D(0.94F, 0.020F, 1.09F),
+               c.verdigris,
+               k_building_state_mask_intact);
+
+  desc.add_box(QVector3D(0.47F, cornice_y + 0.312F, 0.0F),
+               QVector3D(0.88F, 0.014F, 1.03F),
+               c.sandstone_light,
+               k_building_state_mask_intact);
+  for (float const side : {-1.0F, 1.0F}) {
+    desc.add_box(QVector3D(0.47F, cornice_y + 0.326F, side * 1.015F),
+                 QVector3D(0.88F, 0.010F, 0.020F),
+                 c.gold,
+                 BuildingStateMask::Normal,
+                 BuildingLODMask::Full);
+  }
+  desc.add_box(QVector3D(1.335F, cornice_y + 0.326F, 0.0F),
+               QVector3D(0.020F, 0.010F, 1.03F),
+               c.gold,
+               BuildingStateMask::Normal,
+               BuildingLODMask::Full);
 
   desc.add_box(QVector3D(0.62F, cornice_y + 0.230F, 0.0F),
                QVector3D(0.44F, 0.108F, 0.48F),
@@ -522,7 +523,7 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
                BuildingStateMask::Normal,
                BuildingLODMask::Full);
 
-  float const pillar_height = 1.34F * height_multiplier;
+  float const pillar_height = 1.86F * height_multiplier;
   add_votive_pillar(desc, c, -1.16F, 0.62F, podium_y, pillar_height);
   add_votive_pillar(desc, c, -1.16F, -0.62F, podium_y, pillar_height);
 

--- a/render/entity/nations/roman/marketplace_renderer.cpp
+++ b/render/entity/nations/roman/marketplace_renderer.cpp
@@ -126,6 +126,51 @@ void add_produce_basket(BuildingArchetypeDesc& desc,
   }
 }
 
+void add_stall_canopy(BuildingArchetypeDesc& desc,
+                      const RomanMarketPalette& c,
+                      const QVector3D& center,
+                      float half_x,
+                      float half_z,
+                      float post_h,
+                      const QVector3D& cloth,
+                      const QVector3D& cloth_shade) {
+  constexpr float post_r = 0.016F;
+  float const top = center.y() + post_h;
+
+  for (float const sx : {-1.0F, 1.0F}) {
+    for (float const sz : {-1.0F, 1.0F}) {
+      desc.add_cylinder(
+          QVector3D(center.x() + sx * half_x, center.y(), center.z() + sz * half_z),
+          QVector3D(center.x() + sx * half_x, top, center.z() + sz * half_z),
+          post_r,
+          c.cedar_dark,
+          k_building_state_mask_intact,
+          BuildingLODMask::Full);
+    }
+  }
+
+  desc.add_cylinder(QVector3D(center.x(), top + 0.055F, center.z() - half_z),
+                    QVector3D(center.x(), top + 0.055F, center.z() + half_z),
+                    0.010F,
+                    c.cedar,
+                    k_building_state_mask_intact,
+                    BuildingLODMask::Full);
+  for (float const side : {-1.0F, 1.0F}) {
+    desc.add_rotated_box(
+        QVector3D(center.x() + side * half_x * 0.52F, top + 0.028F, center.z()),
+        QVector3D(half_x * 0.60F, 0.011F, half_z * 1.04F),
+        QVector3D(0.0F, 0.0F, side * 15.0F),
+        side < 0.0F ? cloth : cloth_shade,
+        BuildingStateMask::Normal | BuildingStateMask::Damaged);
+  }
+
+  desc.add_box(QVector3D(center.x() - half_x * 0.98F, top + 0.006F, center.z()),
+               QVector3D(0.012F, 0.026F, half_z * 1.02F),
+               c.cloth_gold,
+               BuildingStateMask::Normal | BuildingStateMask::Damaged,
+               BuildingLODMask::Full);
+}
+
 auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
   RomanMarketPalette const c;
   float height_multiplier = 1.0F;
@@ -173,7 +218,7 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                  BuildingLODMask::Full);
   }
 
-  float const wall_h = 0.78F * height_multiplier;
+  float const wall_h = 0.46F * height_multiplier;
   desc.add_box(QVector3D(0.92F, wall_h * 0.5F + 0.16F, 0.0F),
                QVector3D(0.12F, wall_h * 0.5F, 1.10F),
                c.limestone);
@@ -258,24 +303,17 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
   }
 
   float const awning_y = col_height + 0.20F;
-  for (int panel = 0; panel < 8; ++panel) {
-    float const z = -0.77F + static_cast<float>(panel) * 0.22F;
-    float const sag = (panel == 3 || panel == 4) ? 0.025F : 0.0F;
-    desc.add_rotated_box(QVector3D(-0.20F, awning_y - sag, z),
-                         QVector3D(0.64F, 0.012F, 0.105F),
-                         QVector3D(0.0F, 0.0F, -4.5F),
-                         (panel % 2 == 0) ? c.cloth_red : c.cloth_red_faded,
-                         BuildingStateMask::Normal | BuildingStateMask::Damaged);
+  for (float const z : {-0.56F, 0.0F, 0.56F}) {
+    add_stall_canopy(desc,
+                     c,
+                     QVector3D(-0.20F, counter_h + 0.06F, z),
+                     0.27F,
+                     0.18F,
+                     0.30F * height_multiplier,
+                     c.cloth_gold,
+                     c.ochre);
   }
 
-  desc.add_box(QVector3D(-0.20F, awning_y - 0.03F, 0.86F),
-               QVector3D(0.62F, 0.02F, 0.04F),
-               c.cloth_gold,
-               BuildingStateMask::Normal | BuildingStateMask::Damaged);
-  desc.add_box(QVector3D(-0.20F, awning_y - 0.03F, -0.86F),
-               QVector3D(0.62F, 0.02F, 0.04F),
-               c.cloth_gold,
-               BuildingStateMask::Normal | BuildingStateMask::Damaged);
   for (float const z : {-0.86F, 0.86F}) {
     desc.add_cylinder(QVector3D(-0.83F, awning_y - 0.02F, z),
                       QVector3D(-0.76F, 0.20F, z),
@@ -285,45 +323,24 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                       BuildingLODMask::Full);
   }
 
-  desc.add_box(QVector3D(0.92F, wall_h + 0.26F, 0.0F),
-               QVector3D(0.20F, 0.04F, 1.08F),
-               c.terracotta,
-               k_building_state_mask_intact);
-  add_tile_rows_z(
-      [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-        desc.add_box(
-            center, size, color, k_building_state_mask_intact, BuildingLODMask::Full);
-      },
-      wall_h + 0.32F,
-      -0.88F,
-      0.88F,
-      0.44F,
-      QVector3D(0.18F, 0.02F, 0.06F),
-      c.terracotta_dark);
-
-  float const hall_roof_y = wall_h + 0.38F;
-  desc.add_rotated_box(QVector3D(0.72F, hall_roof_y, 0.0F),
-                       QVector3D(0.38F, 0.055F, 1.18F),
-                       QVector3D(0.0F, 0.0F, 12.0F),
-                       c.terracotta,
-                       k_building_state_mask_intact);
-  desc.add_rotated_box(QVector3D(0.72F, hall_roof_y + 0.01F, 0.0F),
-                       QVector3D(0.38F, 0.055F, 1.18F),
-                       QVector3D(0.0F, 0.0F, -12.0F),
-                       c.terracotta_dark,
-                       k_building_state_mask_intact,
-                       BuildingLODMask::Full);
-  for (float const z : {-0.86F, -0.43F, 0.0F, 0.43F, 0.86F}) {
-    desc.add_cylinder(QVector3D(0.34F, 0.16F, z),
-                      QVector3D(0.34F, 0.16F + col_height * 0.82F, z),
-                      0.045F,
-                      c.marble,
-                      k_building_state_mask_intact);
-    desc.add_box(QVector3D(0.34F, 0.18F, z),
-                 QVector3D(0.065F, 0.025F, 0.065F),
-                 c.limestone_dark,
-                 k_building_state_mask_intact,
-                 BuildingLODMask::Full);
+  for (float const z : {-0.74F, 0.0F, 0.74F}) {
+    desc.add_box(
+        QVector3D(0.46F, 0.16F + 0.19F, z), QVector3D(0.26F, 0.035F, 0.28F), c.cedar);
+    for (float const sz : {-1.0F, 1.0F}) {
+      desc.add_box(QVector3D(0.46F, 0.16F + 0.095F, z + sz * 0.24F),
+                   QVector3D(0.030F, 0.095F, 0.030F),
+                   c.cedar_dark,
+                   k_building_state_mask_intact,
+                   BuildingLODMask::Full);
+    }
+    add_stall_canopy(desc,
+                     c,
+                     QVector3D(0.46F, 0.16F, z),
+                     0.24F,
+                     0.21F,
+                     0.58F * height_multiplier,
+                     c.cloth_red,
+                     c.cloth_red_faded);
   }
 
   for (float const z : {-0.52F, 0.52F}) {
@@ -429,8 +446,14 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                           0.72F,
                           c.gold,
                           c.terracotta_dark);
+
+  desc.add_cylinder(QVector3D(0.92F, wall_h + 0.20F, -1.02F),
+                    QVector3D(0.92F, wall_h + 0.86F, -1.02F),
+                    0.020F,
+                    c.cedar_dark,
+                    k_building_state_mask_intact);
   add_roman_roof_standard(
-      desc, QVector3D(0.72F, hall_roof_y + 0.10F, 0.0F), 0.58F, c.gold, c.cloth_red);
+      desc, QVector3D(0.92F, wall_h + 0.86F, -1.02F), 0.58F, c.gold, c.cloth_red);
 
   add_ruin_dressing(desc,
                     RuinDressing{.extent = QVector3D(1.16F, 0.0F, 1.16F),

--- a/render/entity/nations/roman/temple_renderer.cpp
+++ b/render/entity/nations/roman/temple_renderer.cpp
@@ -34,6 +34,7 @@ struct RomanTemplePalette {
   QVector3D soot{0.16F, 0.14F, 0.12F};
   QVector3D flame{0.88F, 0.47F, 0.12F};
   QVector3D cedar{0.40F, 0.25F, 0.13F};
+  QVector3D verdigris{0.29F, 0.46F, 0.40F};
 };
 
 constexpr std::uint8_t k_temple_team_slot = 1;
@@ -249,15 +250,17 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
   desc.set_full_lod_max_distance(84.0F);
 
   desc.add_box(
-      QVector3D(0.0F, 0.050F, 0.0F), QVector3D(1.38F, 0.050F, 1.10F), c.limestone_dark);
+      QVector3D(0.0F, 0.055F, 0.0F), QVector3D(1.38F, 0.055F, 1.10F), c.limestone_dark);
   desc.add_box(
-      QVector3D(0.0F, 0.155F, 0.0F), QVector3D(1.31F, 0.055F, 1.03F), c.limestone);
+      QVector3D(0.0F, 0.195F, 0.0F), QVector3D(1.33F, 0.085F, 1.05F), c.limestone);
   desc.add_box(
-      QVector3D(0.0F, 0.248F, 0.0F), QVector3D(1.25F, 0.038F, 0.97F), c.marble_shade);
+      QVector3D(0.0F, 0.345F, 0.0F), QVector3D(1.29F, 0.065F, 1.01F), c.limestone);
   desc.add_box(
-      QVector3D(0.0F, 0.296F, 0.0F), QVector3D(1.27F, 0.010F, 0.99F), c.marble);
+      QVector3D(0.0F, 0.435F, 0.0F), QVector3D(1.25F, 0.038F, 0.97F), c.marble_shade);
+  desc.add_box(
+      QVector3D(0.0F, 0.478F, 0.0F), QVector3D(1.27F, 0.010F, 0.99F), c.marble);
 
-  float const podium_y = 0.306F;
+  float const podium_y = 0.488F;
 
   for (int course = 0; course < 4; ++course) {
     float const course_y = 0.110F + 0.048F * static_cast<float>(course);
@@ -275,22 +278,22 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
                  BuildingLODMask::Full);
   }
 
-  for (int step = 0; step < 4; ++step) {
+  for (int step = 0; step < 6; ++step) {
     float const step_index = static_cast<float>(step);
-    float const top = 0.076F * (step_index + 1.0F);
-    desc.add_box(QVector3D(-1.605F + 0.088F * step_index, top * 0.5F, 0.0F),
-                 QVector3D(0.046F, top * 0.5F, 0.76F),
+    float const top = 0.081F * (step_index + 1.0F);
+    desc.add_box(QVector3D(-1.700F + 0.078F * step_index, top * 0.5F, 0.0F),
+                 QVector3D(0.041F, top * 0.5F, 0.76F),
                  (step % 2 == 0) ? c.marble_shade : c.limestone,
                  k_building_state_mask_intact);
   }
   for (float const cheek : {-1.0F, 1.0F}) {
-    desc.add_box(QVector3D(-1.47F, 0.15F, cheek * 0.815F),
-                 QVector3D(0.20F, 0.15F, 0.055F),
+    desc.add_box(QVector3D(-1.50F, 0.24F, cheek * 0.815F),
+                 QVector3D(0.26F, 0.24F, 0.055F),
                  c.limestone,
                  k_building_state_mask_intact);
   }
 
-  float const column_height = 1.18F * height_multiplier;
+  float const column_height = 1.52F * height_multiplier;
   bool const ruined = state == BuildingState::Destroyed;
 
   int column_index = 0;
@@ -434,7 +437,7 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
 
   float const pediment_y = entablature_y + 0.152F;
 
-  float const pediment_rise = 0.62F;
+  float const pediment_rise = 0.42F;
   float const pediment_half_z = 0.90F;
 
   auto add_tympanum = [&](float face_x, float face_dir, const QVector3D& field) {
@@ -509,7 +512,7 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
       pediment_half_z,
       pediment_rise,
       0.038F,
-      c.terracotta);
+      c.bronze);
 
   {
     float const theta = std::atan2(pediment_rise, pediment_half_z);
@@ -518,7 +521,7 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
         std::sqrt(pediment_half_z * pediment_half_z + pediment_rise * pediment_rise) *
         0.5F;
     float const surface_lift = (0.038F + 0.012F) / std::cos(theta);
-    QVector3D const cover_tile = c.terracotta * 0.72F + c.terracotta_dark * 0.28F;
+    QVector3D const cover_tile = c.bronze * 0.62F + c.verdigris * 0.38F;
     for (int rib = 0; rib < 17; ++rib) {
       float const x = -1.22F + static_cast<float>(rib) * 0.155F;
       for (float const side : {-1.0F, 1.0F}) {
@@ -536,7 +539,7 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
 
   desc.add_box(QVector3D(0.02F, pediment_y + pediment_rise + 0.030F, 0.0F),
                QVector3D(1.30F, 0.030F, 0.058F),
-               c.terracotta_dark,
+               c.gold,
                k_building_state_mask_intact);
 
   for (float const side : {-1.0F, 1.0F}) {
@@ -544,7 +547,7 @@ auto build_temple_archetype(BuildingState state) -> RenderArchetype {
       float const x = -1.20F + static_cast<float>(antefix) * 0.30F;
       desc.add_box(QVector3D(x, pediment_y + 0.052F, side * 0.905F),
                    QVector3D(0.036F, 0.042F, 0.014F),
-                   c.terracotta_dark,
+                   c.verdigris,
                    k_building_state_mask_intact,
                    BuildingLODMask::Full);
       desc.add_box(QVector3D(x, pediment_y + 0.084F, side * 0.905F),

--- a/render/wildlife/sheep_manifest.cpp
+++ b/render/wildlife/sheep_manifest.cpp
@@ -33,7 +33,7 @@ constexpr std::array<SheepClipSpec, 6> k_sheep_clips{{
     {{"graze", 120U, 24.0F, true}, 1.0F, 0.0F, 0.0F, false, false, SheepGait::Stand},
     {{"walk", 24U, 24.0F, true}, 0.0F, 0.42F, 0.0F, false, false, SheepGait::Walk},
     {{"run", 16U, 24.0F, true}, 0.0F, 1.0F, 1.0F, false, false, SheepGait::Run},
-    {{"die", 20U, 20.0F, false}, 0.0F, 0.0F, 1.0F, true, false, SheepGait::Stand},
+    {{"die", 30U, 22.0F, false}, 0.0F, 0.0F, 1.0F, true, false, SheepGait::Stand},
     {{"dead", 1U, 1.0F, true}, 0.0F, 0.0F, 1.0F, true, true, SheepGait::Stand},
 }};
 

--- a/render/wildlife/sheep_spec.cpp
+++ b/render/wildlife/sheep_spec.cpp
@@ -176,44 +176,67 @@ void fill_head(RigPose& pose, const SheepDrive& drive) {
 }
 
 void apply_collapse(RigPose& pose, const SheepDrive& drive) {
-  float const fall = std::clamp(drive.collapse, 0.0F, 1.0F);
-  if (fall <= 0.0F) {
+  float const phase = std::clamp(drive.collapse, 0.0F, 1.0F);
+  if (phase <= 0.0F) {
     return;
   }
 
-  float const ease = fall * fall * (3.0F - (2.0F * fall));
-  float const roll = 0.125F * ease;
+  DeathMotion const m = death_motion(phase);
 
-  auto settle = [&](QVector3D& p, float keep, float side) {
-    p.setY(0.058F + ((p.y() - 0.058F) * keep));
-    p.setX(p.x() + side);
+  constexpr float k_lying_y = 0.175F;
+  constexpr float k_rest_body_y = 0.439F;
+  constexpr float k_roll_radians = -1.62F;
+
+  float const descent = (k_rest_body_y - k_lying_y) * m.fall;
+  QVector3D const spine(0.0F, k_lying_y, 0.0F);
+  float const roll = k_roll_radians * m.roll;
+  float const head_descent = (k_rest_body_y - k_lying_y) * m.head;
+
+  auto place = [&](QVector3D& p, float descent_amount, float bounce_weight) {
+    p.setY(p.y() - descent_amount + (m.settle * 0.019F * bounce_weight));
+    p = roll_about_spine(p, spine, roll);
+    p.setY(std::max(p.y(), 0.020F));
   };
 
-  settle(pose.root, 1.0F - (0.55F * ease), roll * 0.4F);
-  settle(pose.body_rear, 1.0F - (0.74F * ease), roll);
-  settle(pose.body_front, 1.0F - (0.72F * ease), roll);
-  settle(pose.withers, 1.0F - (0.76F * ease), roll);
+  place(pose.root, descent * 0.92F, 0.5F);
+  place(pose.body_rear, descent, 1.0F);
+  place(pose.body_front, descent, 0.9F);
+  place(pose.withers, descent, 0.8F);
 
   for (std::size_t i = 0; i < k_leg_count; ++i) {
     float const out = (i % 2U == 0U) ? -1.0F : 1.0F;
-    settle(pose.legs[i].shoulder, 1.0F - (0.72F * ease), roll);
-    settle(pose.legs[i].knee, 1.0F - (0.88F * ease), roll + (out * 0.070F * ease));
-    settle(pose.legs[i].foot, 1.0F - (0.94F * ease), roll + (out * 0.120F * ease));
-    settle(pose.legs[i].toe, 1.0F - (0.96F * ease), roll + (out * 0.145F * ease));
+
+    float const fold = m.buckle * 0.62F;
+    float const kick = m.thrash * 0.042F * out;
+
+    pose.legs[i].knee += QVector3D(0.0F, -0.030F * fold, 0.018F * fold * out);
+    pose.legs[i].foot += QVector3D(0.0F, -0.048F * fold, 0.034F * fold * out + kick);
+    pose.legs[i].toe += QVector3D(0.0F, -0.054F * fold, 0.042F * fold * out + kick);
+
+    place(pose.legs[i].shoulder, descent, 0.9F);
+    place(pose.legs[i].knee, descent, 0.7F);
+    place(pose.legs[i].foot, descent, 0.5F);
+    place(pose.legs[i].toe, descent, 0.4F);
   }
 
-  settle(pose.poll, 1.0F - (0.84F * ease), roll * 1.2F);
-  settle(pose.muzzle, 1.0F - (0.94F * ease), roll * 1.5F);
-  settle(pose.jaw_hinge, 1.0F - (0.90F * ease), roll * 1.3F);
-  settle(pose.jaw_tip, 1.0F - (0.95F * ease), roll * 1.5F);
-  settle(pose.ear_base_l, 1.0F - (0.84F * ease), roll * 1.2F);
-  settle(pose.ear_base_r, 1.0F - (0.84F * ease), roll * 1.2F);
-  settle(pose.ear_tip_l, 1.0F - (0.88F * ease), roll * 1.4F);
-  settle(pose.ear_tip_r, 1.0F - (0.88F * ease), roll * 1.4F);
+  pose.poll += QVector3D(0.0F, 0.0F, -0.030F * m.head);
+  pose.muzzle += QVector3D(0.0F, 0.0F, -0.052F * m.head);
 
-  settle(pose.tail_base, 1.0F - (0.76F * ease), roll);
-  settle(pose.tail_mid, 1.0F - (0.88F * ease), roll * 1.3F);
-  settle(pose.tail_tip, 1.0F - (0.94F * ease), roll * 1.5F);
+  place(pose.poll, head_descent, 0.7F);
+  place(pose.muzzle, head_descent, 0.6F);
+  place(pose.jaw_hinge, head_descent, 0.6F);
+  place(pose.jaw_tip, head_descent, 0.5F);
+  pose.jaw_tip += QVector3D(0.0F, -0.016F * m.head, 0.010F * m.head);
+
+  place(pose.ear_base_l, head_descent, 0.5F);
+  place(pose.ear_base_r, head_descent, 0.5F);
+  place(pose.ear_tip_l, head_descent, 0.4F);
+  place(pose.ear_tip_r, head_descent, 0.4F);
+
+  float const tail_lag = std::clamp(m.head * 1.05F, 0.0F, 1.0F);
+  place(pose.tail_base, descent, 0.8F);
+  place(pose.tail_mid, (k_rest_body_y - k_lying_y) * tail_lag, 0.6F);
+  place(pose.tail_tip, (k_rest_body_y - k_lying_y) * tail_lag, 0.5F);
 }
 
 auto make_pose(const SheepDrive& drive) -> RigPose {

--- a/render/wildlife/wildlife_rig.cpp
+++ b/render/wildlife/wildlife_rig.cpp
@@ -1,6 +1,8 @@
 #include "wildlife_rig.h"
 
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <string_view>
 
 namespace Render::Wildlife {
@@ -156,6 +158,58 @@ void evaluate_wildlife_skeleton(const RigPose& pose, BonePalette& out) noexcept 
                                       const_cast<RigPose*>(&pose),
                                       QVector3D(1.0F, 0.0F, 0.0F),
                                       std::span<QMatrix4x4>(out));
+}
+
+namespace {
+
+[[nodiscard]] auto saturate(float value) noexcept -> float {
+  return std::clamp(value, 0.0F, 1.0F);
+}
+
+[[nodiscard]] auto smoothstep01(float t) noexcept -> float {
+  float const x = saturate(t);
+  return x * x * (3.0F - (2.0F * x));
+}
+
+[[nodiscard]] auto ease_out(float t) noexcept -> float {
+  float const inv = 1.0F - saturate(t);
+  return 1.0F - (inv * inv);
+}
+
+[[nodiscard]] auto ease_in(float t) noexcept -> float {
+  float const x = saturate(t);
+  return x * x;
+}
+
+} // namespace
+
+auto death_motion(float phase) noexcept -> DeathMotion {
+  float const p = saturate(phase);
+  constexpr float k_impact = 0.58F;
+
+  DeathMotion motion;
+  motion.buckle = ease_out(p / 0.22F);
+  motion.fall = ease_in(p / k_impact);
+  motion.roll = smoothstep01((p - 0.18F) / 0.62F);
+  motion.head = ease_in((p - 0.10F) / 0.62F);
+
+  if (p > k_impact) {
+    float const since = (p - k_impact) / (1.0F - k_impact);
+    motion.settle = std::exp(-5.0F * since) * std::sin(since * 12.0F);
+  }
+
+  motion.thrash =
+      std::sin(p * 22.0F) * (1.0F - smoothstep01(p / 0.30F)) * saturate(p / 0.06F);
+  return motion;
+}
+
+auto roll_about_spine(const QVector3D& point,
+                      const QVector3D& pivot,
+                      float radians) noexcept -> QVector3D {
+  QVector3D const d = point - pivot;
+  float const c = std::cos(radians);
+  float const s = std::sin(radians);
+  return pivot + QVector3D((d.x() * c) - (d.y() * s), (d.x() * s) + (d.y() * c), d.z());
 }
 
 } // namespace Render::Wildlife

--- a/render/wildlife/wildlife_rig.h
+++ b/render/wildlife/wildlife_rig.h
@@ -84,4 +84,25 @@ wildlife_topology() noexcept -> const Render::Creature::SkeletonTopology&;
 
 void evaluate_wildlife_skeleton(const RigPose& pose, BonePalette& out) noexcept;
 
+struct DeathMotion {
+
+  float buckle{0.0F};
+
+  float fall{0.0F};
+
+  float roll{0.0F};
+
+  float head{0.0F};
+
+  float settle{0.0F};
+
+  float thrash{0.0F};
+};
+
+[[nodiscard]] auto death_motion(float phase) noexcept -> DeathMotion;
+
+[[nodiscard]] auto roll_about_spine(const QVector3D& point,
+                                    const QVector3D& pivot,
+                                    float radians) noexcept -> QVector3D;
+
 } // namespace Render::Wildlife

--- a/render/wildlife/wolf_manifest.cpp
+++ b/render/wildlife/wolf_manifest.cpp
@@ -56,7 +56,7 @@ constexpr std::array<WolfClipSpec, 7> k_wolf_clips{{
      false,
      WolfGait::Walk},
     {{"run", 14U, 26.0F, true}, 1.0F, 0.0F, 0.25F, false, false, false, WolfGait::Run},
-    {{"bite", 18U, 24.0F, false},
+    {{"bite", 28U, 26.0F, false},
      0.0F,
      0.55F,
      1.0F,
@@ -64,7 +64,7 @@ constexpr std::array<WolfClipSpec, 7> k_wolf_clips{{
      false,
      false,
      WolfGait::Stand},
-    {{"die", 20U, 20.0F, false}, 0.0F, 0.0F, 1.0F, false, true, false, WolfGait::Stand},
+    {{"die", 30U, 22.0F, false}, 0.0F, 0.0F, 1.0F, false, true, false, WolfGait::Stand},
     {{"dead", 1U, 1.0F, true}, 0.0F, 0.0F, 1.0F, false, true, true, WolfGait::Stand},
 }};
 
@@ -98,17 +98,43 @@ void bake_wolf_clip_frame(std::size_t clip_index,
   drive.ear_pin = clip.ear_pin;
   drive.gait = clip.gait;
   if (clip.bites) {
-    constexpr float k_contact_phase = 0.34F;
+
+    constexpr float k_gather_end = 0.26F;
+    constexpr float k_contact = 0.34F;
+    constexpr float k_worry_end = 0.74F;
+
     auto smoothstep = [](float value) {
       float const t = std::clamp(value, 0.0F, 1.0F);
       return t * t * (3.0F - (2.0F * t));
     };
-    float const windup = smoothstep(phase / k_contact_phase);
-    float const recovery =
-        1.0F - smoothstep((phase - k_contact_phase) / (1.0F - k_contact_phase));
-    drive.lunge = windup * recovery;
-    drive.jaw_open = std::sin(std::numbers::pi_v<float> *
-                              std::clamp(phase / k_contact_phase, 0.0F, 1.0F));
+
+    if (phase < k_gather_end) {
+
+      float const t = phase / k_gather_end;
+      drive.lunge = -0.22F * smoothstep(t);
+      drive.jaw_open = smoothstep(t) * 0.85F;
+      drive.crouch = 0.55F + (0.35F * smoothstep(t));
+    } else if (phase < k_contact) {
+
+      float const t = (phase - k_gather_end) / (k_contact - k_gather_end);
+      drive.lunge = -0.22F + (1.22F * t);
+      drive.jaw_open = 0.85F * (1.0F - (t * t));
+      drive.crouch = 0.90F - (0.62F * t);
+    } else if (phase < k_worry_end) {
+
+      float const t = (phase - k_contact) / (k_worry_end - k_contact);
+      drive.lunge = 1.0F - (0.18F * t);
+      drive.jaw_open = 0.0F;
+      drive.crouch = 0.28F + (0.14F * t);
+      drive.head_shake = std::sin(t * std::numbers::pi_v<float> * 3.0F) *
+                         (1.0F - smoothstep(t)) * 1.0F;
+    } else {
+
+      float const t = (phase - k_worry_end) / (1.0F - k_worry_end);
+      drive.lunge = 0.82F * (1.0F - smoothstep(t));
+      drive.jaw_open = 0.0F;
+      drive.crouch = 0.42F * (1.0F - smoothstep(t));
+    }
     drive.stride_phase = 0.0F;
   }
   if (clip.collapses) {

--- a/render/wildlife/wolf_spec.cpp
+++ b/render/wildlife/wolf_spec.cpp
@@ -242,9 +242,18 @@ auto rotate_about_x(const QVector3D& point,
   return pivot + QVector3D(d.x(), (d.y() * c) - (d.z() * s), (d.y() * s) + (d.z() * c));
 }
 
+auto rotate_about_y(const QVector3D& point,
+                    const QVector3D& pivot,
+                    float radians) -> QVector3D {
+  QVector3D const d = point - pivot;
+  float const c = std::cos(radians);
+  float const s = std::sin(radians);
+  return pivot + QVector3D((d.x() * c) + (d.z() * s), d.y(), (d.z() * c) - (d.x() * s));
+}
+
 void apply_lunge(RigPose& pose, const WolfDrive& drive) {
   float const lunge = std::clamp(drive.lunge, 0.0F, 1.0F);
-  if (lunge <= 0.0F && drive.jaw_open <= 0.0F) {
+  if (lunge <= 0.0F && drive.jaw_open <= 0.0F && drive.head_shake == 0.0F) {
     return;
   }
 
@@ -292,6 +301,29 @@ void apply_lunge(RigPose& pose, const WolfDrive& drive) {
 
   pose.jaw_tip = rotate_about_x(pose.jaw_tip, pose.jaw_hinge, 0.50F * drive.jaw_open);
 
+  if (drive.head_shake != 0.0F) {
+    float const yaw = 0.55F * drive.head_shake;
+    QVector3D const neck = pose.withers;
+    pose.poll = rotate_about_y(pose.poll, neck, yaw);
+    pose.muzzle = rotate_about_y(pose.muzzle, neck, yaw);
+    pose.jaw_hinge = rotate_about_y(pose.jaw_hinge, neck, yaw);
+    pose.jaw_tip = rotate_about_y(pose.jaw_tip, neck, yaw);
+    pose.ear_base_l = rotate_about_y(pose.ear_base_l, neck, yaw);
+    pose.ear_base_r = rotate_about_y(pose.ear_base_r, neck, yaw);
+    pose.ear_tip_l = rotate_about_y(pose.ear_tip_l, neck, yaw);
+    pose.ear_tip_r = rotate_about_y(pose.ear_tip_r, neck, yaw);
+
+    float const counter = -0.18F * drive.head_shake;
+    QVector3D const spine_pivot = pose.body_rear;
+    pose.body_front = rotate_about_y(pose.body_front, spine_pivot, counter);
+    pose.withers = rotate_about_y(pose.withers, spine_pivot, counter);
+    for (std::size_t i = 0; i < 2U; ++i) {
+      pose.legs[i].shoulder =
+          rotate_about_y(pose.legs[i].shoulder, spine_pivot, counter);
+      pose.legs[i].knee = rotate_about_y(pose.legs[i].knee, spine_pivot, counter);
+    }
+  }
+
   pose.tail_base += surge;
   pose.tail_mid += surge;
   pose.tail_tip += surge;
@@ -301,45 +333,73 @@ void apply_lunge(RigPose& pose, const WolfDrive& drive) {
 }
 
 void apply_collapse(RigPose& pose, const WolfDrive& drive) {
-  float const fall = std::clamp(drive.collapse, 0.0F, 1.0F);
-  if (fall <= 0.0F) {
+  float const phase = std::clamp(drive.collapse, 0.0F, 1.0F);
+  if (phase <= 0.0F) {
     return;
   }
 
-  float const ease = fall * fall * (3.0F - (2.0F * fall));
-  float const roll = 0.135F * ease;
+  DeathMotion const m = death_motion(phase);
 
-  auto settle = [&](QVector3D& p, float keep, float side) {
-    p.setY(0.055F + ((p.y() - 0.055F) * keep));
-    p.setX(p.x() + side);
+  constexpr float k_lying_y = 0.150F;
+  constexpr float k_rest_body_y = 0.505F;
+  constexpr float k_roll_radians = -1.42F;
+
+  float const descent = (k_rest_body_y - k_lying_y) * m.fall;
+  QVector3D const spine(0.0F, k_lying_y, 0.0F);
+  float const roll = k_roll_radians * m.roll;
+
+  float const head_descent = (k_rest_body_y - k_lying_y) * m.head;
+
+  auto settle_bounce = [&](float weight) {
+    return m.settle * 0.022F * weight;
   };
 
-  settle(pose.root, 1.0F - (0.55F * ease), roll * 0.4F);
-  settle(pose.body_rear, 1.0F - (0.72F * ease), roll);
-  settle(pose.body_front, 1.0F - (0.70F * ease), roll);
-  settle(pose.withers, 1.0F - (0.74F * ease), roll);
+  auto place = [&](QVector3D& p, float descent_amount, float bounce_weight) {
+    p.setY(p.y() - descent_amount + settle_bounce(bounce_weight));
+    p = roll_about_spine(p, spine, roll);
+    p.setY(std::max(p.y(), 0.018F));
+  };
+
+  place(pose.root, descent * 0.92F, 0.5F);
+  place(pose.body_rear, descent, 1.0F);
+  place(pose.body_front, descent, 0.9F);
+  place(pose.withers, descent, 0.8F);
 
   for (std::size_t i = 0; i < k_leg_count; ++i) {
     float const out = (i % 2U == 0U) ? -1.0F : 1.0F;
-    settle(pose.legs[i].shoulder, 1.0F - (0.70F * ease), roll);
-    settle(pose.legs[i].knee, 1.0F - (0.86F * ease), roll + (out * 0.075F * ease));
-    settle(pose.legs[i].foot, 1.0F - (0.94F * ease), roll + (out * 0.130F * ease));
-    settle(pose.legs[i].toe, 1.0F - (0.96F * ease), roll + (out * 0.155F * ease));
+    float const fold = m.buckle;
+    float const twitch = m.thrash * 0.030F * out;
+
+    pose.legs[i].knee += QVector3D(0.0F, -0.055F * fold, 0.030F * fold * out);
+    pose.legs[i].foot += QVector3D(0.0F, -0.090F * fold, 0.062F * fold * out + twitch);
+    pose.legs[i].toe += QVector3D(0.0F, -0.100F * fold, 0.076F * fold * out + twitch);
+
+    place(pose.legs[i].shoulder, descent, 0.9F);
+    place(pose.legs[i].knee, descent, 0.7F);
+    place(pose.legs[i].foot, descent, 0.5F);
+    place(pose.legs[i].toe, descent, 0.4F);
   }
 
-  settle(pose.poll, 1.0F - (0.80F * ease), roll * 1.2F);
-  settle(pose.muzzle, 1.0F - (0.92F * ease), roll * 1.5F);
-  pose.muzzle += QVector3D(0.0F, 0.0F, 0.045F * ease);
-  settle(pose.jaw_hinge, 1.0F - (0.88F * ease), roll * 1.3F);
-  settle(pose.jaw_tip, 1.0F - (0.94F * ease), roll * 1.5F);
-  settle(pose.ear_base_l, 1.0F - (0.82F * ease), roll * 1.2F);
-  settle(pose.ear_base_r, 1.0F - (0.82F * ease), roll * 1.2F);
-  settle(pose.ear_tip_l, 1.0F - (0.86F * ease), roll * 1.4F);
-  settle(pose.ear_tip_r, 1.0F - (0.86F * ease), roll * 1.4F);
+  place(pose.poll, head_descent, 0.7F);
+  place(pose.muzzle, head_descent, 0.6F);
+  pose.muzzle += QVector3D(0.0F, 0.0F, 0.055F * m.head);
+  place(pose.jaw_hinge, head_descent, 0.6F);
+  place(pose.jaw_tip, head_descent, 0.5F);
 
-  settle(pose.tail_base, 1.0F - (0.74F * ease), roll);
-  settle(pose.tail_mid, 1.0F - (0.88F * ease), roll * 1.3F);
-  settle(pose.tail_tip, 1.0F - (0.94F * ease), roll * 1.6F);
+  pose.jaw_tip += QVector3D(0.0F, -0.022F * m.head, 0.014F * m.head);
+
+  place(pose.ear_base_l, head_descent, 0.5F);
+  place(pose.ear_base_r, head_descent, 0.5F);
+  place(pose.ear_tip_l, head_descent, 0.4F);
+  place(pose.ear_tip_r, head_descent, 0.4F);
+
+  float const tail_lag = std::clamp(m.head * 1.05F, 0.0F, 1.0F);
+  float const tail_flick = m.thrash * 0.045F;
+  pose.tail_mid += QVector3D(tail_flick, 0.0F, 0.0F);
+  pose.tail_tip += QVector3D(tail_flick * 1.6F, 0.0F, 0.0F);
+  place(pose.tail_base, descent, 0.8F);
+  place(pose.tail_mid, (k_rest_body_y - k_lying_y) * tail_lag, 0.6F);
+  place(pose.tail_tip, (k_rest_body_y - k_lying_y) * tail_lag, 0.5F);
 }
 
 auto make_pose(const WolfDrive& drive) -> RigPose {

--- a/render/wildlife/wolf_spec.h
+++ b/render/wildlife/wolf_spec.h
@@ -38,6 +38,8 @@ struct WolfDrive {
   float ear_pin{0.0F};
   float lunge{0.0F};
   float jaw_open{0.0F};
+
+  float head_shake{0.0F};
   float collapse{0.0F};
   WolfGait gait{WolfGait::Stand};
 };

--- a/scripts/RTS_MAP_DESIGN.md
+++ b/scripts/RTS_MAP_DESIGN.md
@@ -134,12 +134,29 @@ in either order, and hand-placed scatter survives both.
 
 ### Groves
 
-A map's `groves` array places standalone woods. A forest does not block
-movement - it marks its ground as forest, which thickens the tree scatter and
-gives cover - so place one for what it screens: the approach to a wall with no
-gate on it, the flank of a road a column has to march down, the timber a gather
-objective is measured against. A wood inside 22 units of a settlement wall grows
-through the streets and is rejected.
+A map's `groves` array places standalone woods, and the engine reads it: every
+open cell inside a grove's radius becomes a **forest** cell in the navigation
+grid. Forest is passable to commanders, archers, swordsmen, healers, builders,
+civilians, the Sepulcher's dead and wildlife. It is closed to spearmen, all
+cavalry, catapults, ballistae and elephants - they path around it.
+
+So a wood is a filter, not just a screen. Place one for what it lets through:
+the approach to a wall with no gate on it, the flank of a road a column has to
+march down, the timber a gather objective is measured against, the den a wolf
+pack comes out of. A wood across the only route to a camp makes that camp an
+infantry problem.
+
+Two rules keep this from stranding an army:
+
+- **A road driven through a wood stays open to everyone.** Forest is only
+  applied to cells that are not on a road, so laying a road across a wood is how
+  you leave a lane for the siege train.
+- **Trunks, boulders and buildings keep their own cell value.** Forest only
+  claims ground that was already walkable, so a wood never turns a blocked cell
+  passable.
+
+A wood inside 22 units of a settlement wall grows through the streets and is
+rejected. Woods are editable in the map editor under Terrain → Wood.
 
 After moving settlements or resizing hills, re-run the road generator: approach
 roads and bridges are routed around terrain and must be repaired.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(
     map/wave_archetype_catalog_test.cpp
     map/campaign_loader_test.cpp
     map/campaign_roster_test.cpp
+    map/campaign_content_integration_test.cpp
     map/campaign_province_data_test.cpp
     map/time_of_day_test.cpp
     systems/rain_manager_test.cpp

--- a/tests/db/campaign_end_to_end_test.cpp
+++ b/tests/db/campaign_end_to_end_test.cpp
@@ -135,6 +135,26 @@ protected:
     ASSERT_NE(entity->add_component<Engine::Core::CommanderComponent>(), nullptr);
   }
 
+  static auto add_enemy_commander(Engine::Core::World& world) -> Engine::Core::Entity* {
+    auto* entity = world.create_entity();
+    if (entity == nullptr) {
+      return nullptr;
+    }
+    auto* unit = entity->add_component<Engine::Core::UnitComponent>();
+    if (unit == nullptr) {
+      return nullptr;
+    }
+    unit->owner_id = 2;
+    unit->nation_id = NationID::RomanRepublic;
+    unit->spawn_type = Game::Units::SpawnType::RomanFieldCommander;
+    unit->health = 100;
+    unit->max_health = 100;
+    if (entity->add_component<Engine::Core::CommanderComponent>() == nullptr) {
+      return nullptr;
+    }
+    return entity;
+  }
+
   static auto add_enemy_barracks(Engine::Core::World& world) -> Engine::Core::Entity* {
     auto* entity = world.create_entity();
     if (entity == nullptr) {
@@ -193,6 +213,8 @@ TEST_F(CampaignEndToEndTest, TheOpeningMissionCanBeWonAndAdvancesTheCampaign) {
   add_captured_barracks(world);
   auto* enemy_camp = add_enemy_barracks(world);
   ASSERT_NE(enemy_camp, nullptr);
+  auto* enemy_commander = add_enemy_commander(world);
+  ASSERT_NE(enemy_commander, nullptr);
   service.update(world, 0.4F);
   ASSERT_FALSE(service.is_game_over())
       << "the mission ended before its objective was met";
@@ -204,6 +226,14 @@ TEST_F(CampaignEndToEndTest, TheOpeningMissionCanBeWonAndAdvancesTheCampaign) {
   enemy_camp->get_component<Engine::Core::UnitComponent>()->owner_id = 1;
   Engine::Core::EventManager::instance().publish(
       Engine::Core::BarrackCapturedEvent(enemy_camp->get_id(), 2, 1));
+
+  ASSERT_FALSE(service.is_game_over())
+      << "taking the camps is only half of it while the consul still lives";
+
+  enemy_commander->get_component<Engine::Core::UnitComponent>()->health = 0;
+  Engine::Core::EventManager::instance().publish(Engine::Core::UnitDiedEvent(
+      enemy_commander->get_id(), 2, Game::Units::SpawnType::RomanFieldCommander));
+  service.update(world, 0.4F);
 
   ASSERT_TRUE(service.is_game_over())
       << "meeting the objective did not end the mission";

--- a/tests/map/campaign_content_integration_test.cpp
+++ b/tests/map/campaign_content_integration_test.cpp
@@ -1,0 +1,198 @@
+
+
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "core/world.h"
+#include "game/map/campaign_definition.h"
+#include "game/map/campaign_loader.h"
+#include "game/map/map_definition.h"
+#include "game/map/map_loader.h"
+#include "game/map/mission_definition.h"
+#include "game/map/mission_loader.h"
+#include "game/map/terrain_service.h"
+#include "game/systems/building_collision_registry.h"
+#include "game/systems/nation_registry.h"
+#include "game/systems/owner_registry.h"
+#include "game/systems/pathfinding.h"
+#include "game/systems/undead_awakening_system.h"
+#include "game/wildlife/wildlife_system.h"
+
+namespace {
+
+auto asset_path(const QString& relative) -> QString {
+  QDir dir(QDir::currentPath());
+  for (int hop = 0; hop < 6; ++hop) {
+    const QString candidate = dir.filePath(QStringLiteral("assets/") + relative);
+    if (QFileInfo::exists(candidate)) {
+      return candidate;
+    }
+    if (!dir.cdUp()) {
+      break;
+    }
+  }
+  return QStringLiteral("assets/") + relative;
+}
+
+auto load_campaign() -> Game::Campaign::CampaignDefinition {
+  Game::Campaign::CampaignDefinition campaign;
+  QString error;
+  EXPECT_TRUE(Game::Campaign::CampaignLoader::load_from_json_file(
+      asset_path(QStringLiteral("campaigns/second_punic_war.json")), campaign, &error))
+      << error.toStdString();
+  return campaign;
+}
+
+class CampaignContentIntegrationTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    auto& owners = Game::Systems::OwnerRegistry::instance();
+    owners.clear();
+    owners.register_owner_with_id(1, Game::Systems::OwnerType::Player, "Player");
+    owners.set_owner_team(1, 1);
+    owners.set_local_player_id(1);
+
+    auto& nations = Game::Systems::NationRegistry::instance();
+    nations.clear();
+    nations.initialize_defaults();
+    nations.set_player_nation(1, Game::Systems::NationID::Carthage);
+
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+  }
+
+  void TearDown() override {
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::NationRegistry::instance().clear();
+    Game::Systems::OwnerRegistry::instance().clear();
+  }
+};
+
+TEST_F(CampaignContentIntegrationTest, EveryMissionsGroundStandsUpAndMeansWhatItSays) {
+  const auto campaign = load_campaign();
+  ASSERT_FALSE(campaign.missions.empty());
+
+  for (const auto& entry : campaign.missions) {
+    const std::string where = entry.mission_id.toStdString();
+
+    Game::Mission::MissionDefinition mission;
+    QString mission_error;
+    ASSERT_TRUE(Game::Mission::MissionLoader::load_from_json_file(
+        asset_path(QStringLiteral("missions/%1.json").arg(entry.mission_id)),
+        mission,
+        &mission_error))
+        << where << ": " << mission_error.toStdString();
+
+    Game::Map::MapDefinition map;
+    QString map_error;
+    ASSERT_TRUE(Game::Map::MapLoader::load_from_json_file(
+        asset_path(
+            QStringLiteral("maps/%1").arg(QFileInfo(mission.map_path).fileName())),
+        map,
+        &map_error))
+        << where << ": " << map_error.toStdString();
+
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Map::TerrainService::instance().initialize(map);
+
+    ASSERT_FALSE(map.undead_zones.empty()) << where << " ships no dead zone";
+    for (const auto& zone : map.undead_zones) {
+      EXPECT_FALSE(zone.clear_reward.empty())
+          << where << " dead zone " << zone.id.toStdString() << " pays nothing";
+    }
+
+    ASSERT_FALSE(map.groves.empty()) << where << " ships no wood";
+
+    Game::Systems::Pathfinding pathfinding(map.grid.width, map.grid.height);
+    pathfinding.update_navigation_grid();
+
+    int forest_cells = 0;
+    for (int z = 0; z < map.grid.height; ++z) {
+      for (int x = 0; x < map.grid.width; ++x) {
+        if (pathfinding.is_forest(x, z)) {
+          forest_cells += 1;
+          EXPECT_TRUE(pathfinding.is_walkable(
+              x, z, Game::Systems::Pathfinding::Passability::Light))
+              << where << ": forest must stay open to foot troops";
+          EXPECT_FALSE(pathfinding.is_walkable(
+              x, z, Game::Systems::Pathfinding::Passability::Heavy))
+              << where << ": forest must stay shut to horses and siege";
+        }
+      }
+    }
+    EXPECT_GT(forest_cells, 0) << where << ": authored woods produced no forest ground";
+
+    Engine::Core::World world;
+    Game::Systems::UndeadAwakeningSystem undead;
+    undead.configure(map);
+    undead.update(&world, 0.1F);
+    for (const auto& zone : map.undead_zones) {
+      EXPECT_TRUE(undead.has_zone(zone.id))
+          << where << ": dead zone " << zone.id.toStdString() << " did not configure";
+    }
+
+    Game::Wildlife::WildlifeSystem wildlife;
+    wildlife.configure(map);
+    wildlife.update(&world, 0.1F);
+    EXPECT_TRUE(wildlife.is_enabled()) << where << ": wildlife is switched off";
+    EXPECT_TRUE(wildlife.settings().sheep.enabled)
+        << where << ": no herd worth raiding";
+    EXPECT_TRUE(wildlife.settings().wolves.enabled) << where << ": no wolves";
+
+    Game::Map::TerrainService::instance().clear();
+  }
+}
+
+TEST_F(CampaignContentIntegrationTest, ScheduledWolfPacksBuildTowardTheLateCampaign) {
+  const auto campaign = load_campaign();
+
+  int missions_with_packs = 0;
+  for (const auto& entry : campaign.missions) {
+    Game::Mission::MissionDefinition mission;
+    QString mission_error;
+    ASSERT_TRUE(Game::Mission::MissionLoader::load_from_json_file(
+        asset_path(QStringLiteral("missions/%1.json").arg(entry.mission_id)),
+        mission,
+        &mission_error))
+        << mission_error.toStdString();
+
+    Game::Map::MapDefinition map;
+    QString map_error;
+    ASSERT_TRUE(Game::Map::MapLoader::load_from_json_file(
+        asset_path(
+            QStringLiteral("maps/%1").arg(QFileInfo(mission.map_path).fileName())),
+        map,
+        &map_error))
+        << map_error.toStdString();
+
+    const auto& waves = map.wildlife.wolves.waves;
+    if (waves.empty()) {
+      continue;
+    }
+    missions_with_packs += 1;
+
+    EXPECT_TRUE(std::is_sorted(waves.begin(),
+                               waves.end(),
+                               [](const Game::Wildlife::WildlifeWave& lhs,
+                                  const Game::Wildlife::WildlifeWave& rhs) {
+                                 return lhs.timing < rhs.timing;
+                               }))
+        << entry.mission_id.toStdString() << ": wolf waves are out of order";
+    for (const auto& wave : waves) {
+      EXPECT_GT(wave.timing, 0.0F)
+          << entry.mission_id.toStdString() << ": a wave at t=0 is a spawn area";
+      EXPECT_GT(wave.pack_size, 0)
+          << entry.mission_id.toStdString() << ": an empty pack";
+    }
+  }
+
+  EXPECT_GE(missions_with_packs, 5)
+      << "scheduled wolf packs are meant to be a campaign-wide pressure, not a one-off";
+}
+
+} // namespace

--- a/tests/map/map_loader_test.cpp
+++ b/tests/map/map_loader_test.cpp
@@ -95,6 +95,63 @@ TEST(MapLoaderTest, ParsesUndeadZonesAndWaveSpawns) {
   EXPECT_EQ(zone.waves[1].units[0].count, 3);
 }
 
+TEST(MapLoaderTest, ParsesUndeadZoneClearReward) {
+  QTemporaryFile temp_file;
+  ASSERT_TRUE(temp_file.open());
+
+  const QJsonObject root{
+      {"name", "Undead Reward Test"},
+      {"grid", QJsonObject{{"width", 32}, {"height", 32}, {"tile_size", 1.0}}},
+      {"undead_zones",
+       QJsonArray{
+           QJsonObject{{"id", "hoard"},
+                       {"x", 16},
+                       {"z", 16},
+                       {"clear_reward",
+                        QJsonObject{{"gold", 150}, {"stone", 80}, {"iron", 40}}}},
+           QJsonObject{{"id", "no_hoard"}, {"x", 8}, {"z", 8}}}}};
+  temp_file.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+  temp_file.flush();
+
+  Game::Map::MapDefinition map_definition;
+  QString error;
+  ASSERT_TRUE(Game::Map::MapLoader::load_from_json_file(
+      temp_file.fileName(), map_definition, &error))
+      << error.toStdString();
+
+  ASSERT_EQ(map_definition.undead_zones.size(), 2);
+  const auto& rewarded = map_definition.undead_zones[0];
+  EXPECT_EQ(rewarded.clear_reward.get(Game::Systems::ResourceType::Gold), 150);
+  EXPECT_EQ(rewarded.clear_reward.get(Game::Systems::ResourceType::Stone), 80);
+  EXPECT_EQ(rewarded.clear_reward.get(Game::Systems::ResourceType::Iron), 40);
+  EXPECT_EQ(rewarded.clear_reward.get(Game::Systems::ResourceType::Wood), 0);
+  EXPECT_TRUE(map_definition.undead_zones[1].clear_reward.empty());
+}
+
+TEST(MapLoaderTest, ParsesProceduralScatterOptOuts) {
+  QTemporaryFile temp_file;
+  ASSERT_TRUE(temp_file.open());
+
+  const QJsonObject root{
+      {"name", "Scatter Opt Out Test"},
+      {"grid", QJsonObject{{"width", 64}, {"height", 64}, {"tile_size", 1.0}}},
+      {"biome",
+       QJsonObject{{"procedural_boulders_enabled", false},
+                   {"procedural_iron_ore_enabled", false}}}};
+  temp_file.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+  temp_file.flush();
+
+  Game::Map::MapDefinition map_definition;
+  QString error;
+  ASSERT_TRUE(Game::Map::MapLoader::load_from_json_file(
+      temp_file.fileName(), map_definition, &error))
+      << error.toStdString();
+
+  EXPECT_FALSE(map_definition.biome.procedural_boulders_enabled);
+  EXPECT_FALSE(map_definition.biome.procedural_iron_ore_enabled);
+  EXPECT_TRUE(map_definition.biome.procedural_trees_enabled);
+}
+
 TEST(MapLoaderTest, ParsesUndeadVictoryObjectives) {
   QTemporaryFile temp_file;
   ASSERT_TRUE(temp_file.open());

--- a/tests/map/mission_asset_rules_test.cpp
+++ b/tests/map/mission_asset_rules_test.cpp
@@ -6,8 +6,11 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 
+#include <algorithm>
 #include <gtest/gtest.h>
 
+#include "game/map/campaign_definition.h"
+#include "game/map/campaign_loader.h"
 #include "game/map/map_definition.h"
 #include "game/map/map_loader.h"
 #include "game/map/mission_definition.h"
@@ -313,6 +316,46 @@ TEST(MissionAssetRulesTest, CaptureObjectivesMatchEnemyOwnedBarracks) {
     EXPECT_EQ(capture_target, expectation.capture_target) << expectation.mission_id;
     EXPECT_LE(capture_target, enemy_barracks)
         << expectation.mission_id << " cannot be won";
+  }
+}
+
+TEST(MissionAssetRulesTest, DecapitationObjectivesHaveCommandersToKill) {
+  Game::Campaign::CampaignDefinition campaign;
+  QString campaign_error;
+  ASSERT_TRUE(Game::Campaign::CampaignLoader::load_from_json_file(
+      asset_dir_path(QStringLiteral("campaigns/second_punic_war.json")),
+      campaign,
+      &campaign_error))
+      << campaign_error.toStdString();
+
+  for (const auto& entry : campaign.missions) {
+    Game::Mission::MissionDefinition mission;
+    QString mission_error;
+    ASSERT_TRUE(Game::Mission::MissionLoader::load_from_json_file(
+        asset_dir_path(QStringLiteral("missions/%1.json").arg(entry.mission_id)),
+        mission,
+        &mission_error))
+        << mission_error.toStdString();
+
+    const bool wants_decapitation =
+        std::any_of(mission.victory_conditions.begin(),
+                    mission.victory_conditions.end(),
+                    [](const Game::Mission::Condition& condition) {
+                      return condition.type == QStringLiteral("eliminate_commanders");
+                    });
+    if (!wants_decapitation) {
+      continue;
+    }
+
+    ASSERT_FALSE(mission.ai_setups.empty())
+        << entry.mission_id.toStdString()
+        << " asks the player to kill commanders but ships no opponents";
+    for (const auto& ai_setup : mission.ai_setups) {
+      EXPECT_TRUE(ai_setup.commander_troop.has_value() &&
+                  !ai_setup.commander_troop->trimmed().isEmpty())
+          << entry.mission_id.toStdString() << " AI " << ai_setup.id.toStdString()
+          << " has no commander to kill, so eliminate_commanders can never arm";
+    }
   }
 }
 

--- a/tests/map/terrain_service_test.cpp
+++ b/tests/map/terrain_service_test.cpp
@@ -7,6 +7,7 @@
 #include "game/core/world.h"
 #include "game/map/map_definition.h"
 #include "game/map/map_transformer.h"
+#include "game/map/procedural_tree_generation.h"
 #include "game/map/scatter/spawn_validator.h"
 #include "game/map/terrain_service.h"
 #include "game/systems/nation_registry.h"
@@ -917,6 +918,76 @@ TEST_F(TerrainServiceTest, SkirmishLoaderKeepsRuntimeHarvestScatterAvailable) {
                             return !prop.persistent &&
                                    Game::Map::is_harvestable_world_prop_type(prop.type);
                           }));
+}
+
+TEST_F(TerrainServiceTest, ProceduralScatterOptOutsSuppressTheirSpecies) {
+  const auto count_type = [](const std::vector<Game::Map::WorldProp>& props,
+                             Game::Map::WorldProp::Type type) {
+    return std::count_if(
+        props.begin(), props.end(), [type](const Game::Map::WorldProp& prop) {
+          return prop.type == type;
+        });
+  };
+
+  const auto count_trees =
+      [&count_type](const std::vector<Game::Map::WorldProp>& props) {
+        return count_type(props, Game::Map::WorldProp::Type::PineTree) +
+               count_type(props, Game::Map::WorldProp::Type::OliveTree);
+      };
+
+  const auto build_height_map = [](Game::Map::GroundType ground_type,
+                                   Game::Map::BiomeSettings& out_biome) {
+    Game::Map::MapDefinition map_def;
+    map_def.grid.width = 96;
+    map_def.grid.height = 96;
+    map_def.grid.tile_size = 1.0F;
+    Game::Map::apply_ground_type_defaults(map_def.biome, ground_type);
+    map_def.biome.seed = 4242U;
+    map_def.biome.ground_irregularity_enabled = true;
+    map_def.biome.irregularity_amplitude =
+        std::max(0.65F, map_def.biome.irregularity_amplitude);
+
+    auto& terrain = Game::Map::TerrainService::instance();
+    terrain.initialize(map_def);
+    out_biome = map_def.biome;
+    return terrain.get_height_map();
+  };
+
+  Game::Map::BiomeSettings rocky_biome;
+  const auto* rocky_height_map =
+      build_height_map(Game::Map::GroundType::SoilRocky, rocky_biome);
+  ASSERT_NE(rocky_height_map, nullptr);
+
+  const auto minerals_baseline = Game::Map::generate_procedural_world_props(
+      *rocky_height_map, rocky_biome, Game::Map::CoordSystem::World, {});
+  ASSERT_GT(count_type(minerals_baseline, Game::Map::WorldProp::Type::Boulder), 0);
+  ASSERT_GT(count_type(minerals_baseline, Game::Map::WorldProp::Type::IronOre), 0);
+
+  auto no_minerals = rocky_biome;
+  no_minerals.procedural_boulders_enabled = false;
+  no_minerals.procedural_iron_ore_enabled = false;
+  const auto without_minerals = Game::Map::generate_procedural_world_props(
+      *rocky_height_map, no_minerals, Game::Map::CoordSystem::World, {});
+  EXPECT_EQ(count_type(without_minerals, Game::Map::WorldProp::Type::Boulder), 0);
+  EXPECT_EQ(count_type(without_minerals, Game::Map::WorldProp::Type::IronOre), 0);
+  EXPECT_EQ(count_trees(without_minerals), count_trees(minerals_baseline));
+
+  Game::Map::BiomeSettings forest_biome;
+  const auto* forest_height_map =
+      build_height_map(Game::Map::GroundType::ForestMud, forest_biome);
+  ASSERT_NE(forest_height_map, nullptr);
+
+  const auto trees_baseline = Game::Map::generate_procedural_world_props(
+      *forest_height_map, forest_biome, Game::Map::CoordSystem::World, {});
+  ASSERT_GT(count_trees(trees_baseline), 0);
+
+  auto no_trees = forest_biome;
+  no_trees.procedural_trees_enabled = false;
+  const auto without_trees = Game::Map::generate_procedural_world_props(
+      *forest_height_map, no_trees, Game::Map::CoordSystem::World, {});
+  EXPECT_EQ(count_trees(without_trees), 0);
+  EXPECT_EQ(count_type(without_trees, Game::Map::WorldProp::Type::Boulder),
+            count_type(trees_baseline, Game::Map::WorldProp::Type::Boulder));
 }
 
 } // namespace

--- a/tests/render/wildlife_action_pose_test.cpp
+++ b/tests/render/wildlife_action_pose_test.cpp
@@ -9,6 +9,7 @@
 #include "render/entity/registry.h"
 #include "render/entity/wildlife/wildlife_draw_state.h"
 #include "render/wildlife/sheep_spec.h"
+#include "render/wildlife/wildlife_rig.h"
 #include "render/wildlife/wolf_spec.h"
 
 namespace {
@@ -28,6 +29,22 @@ auto lowest_point(const Render::Wildlife::RigPose& pose) -> float {
 
 auto highest_point(const Render::Wildlife::RigPose& pose) -> float {
   return std::max({pose.body_front.y(), pose.body_rear.y(), pose.withers.y()});
+}
+
+auto mean_foot_offset(const Render::Wildlife::RigPose& pose) -> float {
+  float total = 0.0F;
+  for (const auto& leg : pose.legs) {
+    total += leg.foot.x();
+  }
+  return total / static_cast<float>(pose.legs.size());
+}
+
+auto body_to_foot_drop(const Render::Wildlife::RigPose& pose) -> float {
+  float feet = pose.legs[0].foot.y();
+  for (const auto& leg : pose.legs) {
+    feet = std::min(feet, leg.foot.y());
+  }
+  return highest_point(pose) - feet;
 }
 
 TEST(WildlifeActionPose, WolfLungeDrivesTheWholeBodyForward) {
@@ -105,7 +122,9 @@ TEST(WildlifeActionPose, WolfCollapsePutsTheAnimalOnTheGround) {
   EXPECT_LT(highest_point(down), highest_point(up) * 0.45F);
   EXPECT_LT(down.muzzle.y(), up.muzzle.y() * 0.35F);
 
-  EXPECT_GT(std::abs(down.body_front.x() - up.body_front.x()), 0.05F);
+  EXPECT_GT(std::abs(mean_foot_offset(down)), 0.25F);
+  EXPECT_LT(std::abs(mean_foot_offset(up)), 0.05F);
+  EXPECT_LT(body_to_foot_drop(down), body_to_foot_drop(up) * 0.5F);
 
   EXPECT_GE(lowest_point(down), -0.05F);
 }
@@ -138,8 +157,95 @@ TEST(WildlifeActionPose, SheepCollapsePutsTheAnimalOnTheGround) {
 
   EXPECT_LT(highest_point(down), highest_point(up) * 0.45F);
   EXPECT_LT(down.muzzle.y(), up.muzzle.y() * 0.40F);
-  EXPECT_GT(std::abs(down.body_front.x() - up.body_front.x()), 0.05F);
+  EXPECT_GT(std::abs(mean_foot_offset(down)), 0.25F);
+  EXPECT_LT(std::abs(mean_foot_offset(up)), 0.05F);
+  EXPECT_LT(body_to_foot_drop(down), body_to_foot_drop(up) * 0.5F);
   EXPECT_GE(lowest_point(down), -0.05F);
+}
+
+TEST(WildlifeDeathMotion, LegsGiveWayBeforeTheBodyHasFallen) {
+
+  const auto early = Render::Wildlife::death_motion(0.15F);
+  EXPECT_GT(early.buckle, 0.6F) << "the legs should be most of the way gone by 15%";
+  EXPECT_LT(early.fall, 0.15F) << "the body should barely have moved yet";
+}
+
+TEST(WildlifeDeathMotion, TheHeadArrivesAfterTheBody) {
+  for (float const phase : {0.25F, 0.40F, 0.55F}) {
+    const auto m = Render::Wildlife::death_motion(phase);
+    EXPECT_LT(m.head, m.fall) << "dead weight on a neck lands after the body, at phase "
+                              << phase;
+  }
+}
+
+TEST(WildlifeDeathMotion, TheBodyBouncesOnceAndThenLiesStill) {
+  const auto before_impact = Render::Wildlife::death_motion(0.40F);
+  EXPECT_FLOAT_EQ(before_impact.settle, 0.0F)
+      << "nothing should bounce before the body has hit anything";
+
+  bool bounced = false;
+  for (int step = 0; step <= 20; ++step) {
+    float const phase = 0.58F + (0.42F * static_cast<float>(step) / 20.0F);
+    bounced = bounced || std::abs(Render::Wildlife::death_motion(phase).settle) > 0.05F;
+  }
+  EXPECT_TRUE(bounced) << "the impact should produce a visible settle";
+
+  const auto at_rest = Render::Wildlife::death_motion(1.0F);
+  EXPECT_LT(std::abs(at_rest.settle), 0.02F)
+      << "and it should have damped out by the end";
+}
+
+TEST(WildlifeDeathMotion, TheStruggleIsOverEarly) {
+  bool struggled = false;
+  for (int step = 0; step <= 10; ++step) {
+    float const phase = 0.02F + (0.18F * static_cast<float>(step) / 10.0F);
+    struggled =
+        struggled || std::abs(Render::Wildlife::death_motion(phase).thrash) > 0.2F;
+  }
+  EXPECT_TRUE(struggled)
+      << "there should be a struggle while there is strength for one";
+
+  for (float const late : {0.55F, 0.75F, 1.0F}) {
+    EXPECT_LT(std::abs(Render::Wildlife::death_motion(late).thrash), 0.02F)
+        << "and nothing should still be twitching at phase " << late;
+  }
+}
+
+TEST(WildlifeDeathMotion, EveryStageIsFinishedWhenTheClipIs) {
+  const auto done = Render::Wildlife::death_motion(1.0F);
+  EXPECT_FLOAT_EQ(done.buckle, 1.0F);
+  EXPECT_FLOAT_EQ(done.fall, 1.0F);
+  EXPECT_FLOAT_EQ(done.roll, 1.0F);
+  EXPECT_FLOAT_EQ(done.head, 1.0F);
+}
+
+TEST(WildlifeActionPose, WolfWorriesWhatItHasHoldOf) {
+
+  WolfDrive holding;
+  holding.gait = WolfGait::Stand;
+  holding.lunge = 1.0F;
+  WolfDrive shaking = holding;
+  shaking.head_shake = 1.0F;
+
+  const auto still = Render::Wildlife::wolf_pose(holding);
+  const auto worried = Render::Wildlife::wolf_pose(shaking);
+
+  EXPECT_GT(std::abs(worried.muzzle.x() - still.muzzle.x()), 0.05F);
+
+  float const muzzle_swing = std::abs(worried.muzzle.x() - still.muzzle.x());
+  float const withers_swing = std::abs(worried.withers.x() - still.withers.x());
+  EXPECT_GT(muzzle_swing, withers_swing);
+
+  WolfDrive const other_way = [&] {
+    WolfDrive d = holding;
+    d.head_shake = -1.0F;
+    return d;
+  }();
+  const auto worried_other = Render::Wildlife::wolf_pose(other_way);
+  EXPECT_LT((worried.muzzle.x() - still.muzzle.x()) *
+                (worried_other.muzzle.x() - still.muzzle.x()),
+            0.0F)
+      << "the shake has to go both ways or it is a lean, not a shake";
 }
 
 TEST(WildlifeActionState, BiteAndDeathProgressComeFromSimulationComponents) {

--- a/tests/systems/commander_system_test.cpp
+++ b/tests/systems/commander_system_test.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "game/core/component.h"
+#include "game/core/ownership_constants.h"
 #include "game/core/world.h"
 #include "game/systems/command_service.h"
 #include "game/systems/commander_system.h"
@@ -1160,6 +1161,101 @@ TEST(CommanderAuraAbilityTest, TroopsOutsideRadiusGetNoBoost) {
   EXPECT_EQ(ally_unit->health, base_health);
   auto* buff = ally->get_component<Engine::Core::CommanderAuraBuffComponent>();
   EXPECT_TRUE(buff == nullptr || !buff->active);
+}
+
+namespace {
+
+struct CollapseFixture {
+  Engine::Core::Entity* commander = nullptr;
+  Engine::Core::Entity* barracks = nullptr;
+  Engine::Core::Entity* marketplace = nullptr;
+  Engine::Core::Entity* troop = nullptr;
+};
+
+auto add_owned_unit(Engine::Core::World& world,
+                    int owner_id,
+                    Game::Units::SpawnType spawn_type,
+                    float x) -> Engine::Core::Entity* {
+  auto* entity = world.create_entity();
+  auto* unit = entity->add_component<Engine::Core::UnitComponent>();
+  auto* transform = entity->add_component<Engine::Core::TransformComponent>();
+  unit->owner_id = owner_id;
+  unit->spawn_type = spawn_type;
+  unit->health = 100;
+  unit->max_health = 100;
+  transform->position = {x, 0.0F, 0.0F};
+  if (Game::Units::is_building_spawn(spawn_type)) {
+    entity->add_component<Engine::Core::BuildingComponent>();
+    entity->add_component<Engine::Core::RenderableComponent>("", "");
+  }
+  return entity;
+}
+
+auto build_collapse_scenario(Engine::Core::World& world,
+                             int owner_id) -> CollapseFixture {
+  CollapseFixture fixture;
+  fixture.commander =
+      add_owned_unit(world, owner_id, Game::Units::SpawnType::Knight, 0.0F);
+  fixture.commander->add_component<Engine::Core::CommanderComponent>();
+  fixture.barracks =
+      add_owned_unit(world, owner_id, Game::Units::SpawnType::Barracks, 10.0F);
+  fixture.marketplace =
+      add_owned_unit(world, owner_id, Game::Units::SpawnType::Marketplace, 20.0F);
+  fixture.troop =
+      add_owned_unit(world, owner_id, Game::Units::SpawnType::Spearman, 30.0F);
+  return fixture;
+}
+
+} // namespace
+
+TEST(CommanderSystemTest, CommanderDeathTurnsTheNationsCampsNeutralAndDisbandsIt) {
+  Engine::Core::World world;
+  auto fixture = build_collapse_scenario(world, 2);
+
+  auto* bystander = add_owned_unit(world, 1, Game::Units::SpawnType::Spearman, 40.0F);
+
+  Game::Systems::CommanderSystem system;
+  system.update(&world, 0.1F);
+  EXPECT_EQ(fixture.barracks->get_component<Engine::Core::UnitComponent>()->owner_id, 2)
+      << "a living commander must keep its nation intact";
+
+  fixture.commander->get_component<Engine::Core::UnitComponent>()->health = 0;
+  system.update(&world, 0.1F);
+
+  EXPECT_EQ(fixture.barracks->get_component<Engine::Core::UnitComponent>()->owner_id,
+            Game::Core::NEUTRAL_OWNER_ID)
+      << "camps must be left standing and capturable, not destroyed";
+  EXPECT_GT(fixture.barracks->get_component<Engine::Core::UnitComponent>()->health, 0);
+  EXPECT_TRUE(
+      fixture.marketplace->has_component<Engine::Core::PendingRemovalComponent>());
+  EXPECT_EQ(fixture.troop->get_component<Engine::Core::UnitComponent>()->health, 0);
+
+  EXPECT_EQ(bystander->get_component<Engine::Core::UnitComponent>()->health, 100)
+      << "another owner's forces must be untouched";
+}
+
+TEST(CommanderSystemTest, NationOnlyCollapsesWhenItsLastCommanderFalls) {
+  Engine::Core::World world;
+  auto fixture = build_collapse_scenario(world, 2);
+
+  auto* second_commander =
+      add_owned_unit(world, 2, Game::Units::SpawnType::Knight, 5.0F);
+  second_commander->add_component<Engine::Core::CommanderComponent>();
+
+  Game::Systems::CommanderSystem system;
+  fixture.commander->get_component<Engine::Core::UnitComponent>()->health = 0;
+  system.update(&world, 0.1F);
+
+  EXPECT_EQ(fixture.barracks->get_component<Engine::Core::UnitComponent>()->owner_id,
+            2);
+  EXPECT_EQ(fixture.troop->get_component<Engine::Core::UnitComponent>()->health, 100);
+
+  second_commander->get_component<Engine::Core::UnitComponent>()->health = 0;
+  system.update(&world, 0.1F);
+
+  EXPECT_EQ(fixture.barracks->get_component<Engine::Core::UnitComponent>()->owner_id,
+            Game::Core::NEUTRAL_OWNER_ID);
+  EXPECT_EQ(fixture.troop->get_component<Engine::Core::UnitComponent>()->health, 0);
 }
 
 } // namespace

--- a/tests/systems/pathfinding_test.cpp
+++ b/tests/systems/pathfinding_test.cpp
@@ -588,4 +588,74 @@ TEST_F(PathfindingTest, FindPathReturnsClosestReachableRouteWhenGoalIsSealedOff)
   EXPECT_TRUE(pathfinding.is_walkable(path.back().x, path.back().y));
 }
 
+TEST_F(PathfindingTest, GroveGroundIsForestThatOnlyLightUnitsMayEnter) {
+  Game::Map::MapDefinition map_def;
+  map_def.grid.width = 32;
+  map_def.grid.height = 32;
+  map_def.grid.tile_size = 1.0F;
+  map_def.biome.procedural_trees_enabled = false;
+  map_def.groves.push_back({.id = "wood", .x = 16.0F, .z = 16.0F, .radius = 4.0F});
+
+  Game::Map::TerrainService::instance().initialize(map_def);
+
+  Game::Systems::Pathfinding pathfinding(32, 32);
+  pathfinding.update_navigation_grid();
+
+  using Passability = Game::Systems::Pathfinding::Passability;
+
+  EXPECT_EQ(pathfinding.cell_value(16, 16),
+            Game::Systems::Pathfinding::CellValue::Forest);
+  EXPECT_TRUE(pathfinding.is_forest(16, 16));
+  EXPECT_TRUE(pathfinding.is_walkable(16, 16, Passability::Light));
+  EXPECT_FALSE(pathfinding.is_walkable(16, 16, Passability::Heavy));
+
+  EXPECT_FALSE(pathfinding.is_forest(2, 2)) << "ground outside the radius stays open";
+  EXPECT_TRUE(pathfinding.is_walkable(2, 2, Passability::Heavy));
+}
+
+TEST_F(PathfindingTest, HeavyUnitsRouteAroundAWoodThatLightUnitsWalkThrough) {
+  Game::Map::MapDefinition map_def;
+  map_def.grid.width = 41;
+  map_def.grid.height = 41;
+  map_def.grid.tile_size = 1.0F;
+  map_def.biome.procedural_trees_enabled = false;
+  map_def.groves.push_back({.id = "screen", .x = 20.0F, .z = 20.0F, .radius = 6.0F});
+
+  Game::Map::TerrainService::instance().initialize(map_def);
+
+  Game::Systems::Pathfinding pathfinding(41, 41);
+  pathfinding.update_navigation_grid();
+
+  using Passability = Game::Systems::Pathfinding::Passability;
+  const Game::Systems::Point start{20, 8};
+  const Game::Systems::Point goal{20, 32};
+
+  auto const light_path = pathfinding.find_path(start, goal, Passability::Light);
+  auto const heavy_path = pathfinding.find_path(start, goal, Passability::Heavy);
+
+  ASSERT_FALSE(light_path.empty());
+  ASSERT_FALSE(heavy_path.empty());
+  EXPECT_EQ(light_path.back(), goal);
+  EXPECT_EQ(heavy_path.back(), goal) << "the wood must be skirted, not a dead end";
+
+  auto crosses_forest = [&pathfinding](const std::vector<Game::Systems::Point>& path) {
+    return std::any_of(
+        path.begin(), path.end(), [&pathfinding](const Game::Systems::Point& cell) {
+          return pathfinding.is_forest(cell.x, cell.y);
+        });
+  };
+
+  EXPECT_TRUE(crosses_forest(light_path)) << "the straight line runs through the wood";
+  EXPECT_FALSE(crosses_forest(heavy_path));
+
+  auto widest_deviation = [](const std::vector<Game::Systems::Point>& path) {
+    int widest = 0;
+    for (const auto& cell : path) {
+      widest = std::max(widest, std::abs(cell.x - 20));
+    }
+    return widest;
+  };
+  EXPECT_GT(widest_deviation(heavy_path), widest_deviation(light_path));
+}
+
 } // namespace

--- a/tests/systems/undead_awakening_system_test.cpp
+++ b/tests/systems/undead_awakening_system_test.cpp
@@ -13,6 +13,7 @@
 #include "game/systems/global_stats_registry.h"
 #include "game/systems/nation_registry.h"
 #include "game/systems/owner_registry.h"
+#include "game/systems/player_resource_registry.h"
 #include "game/systems/undead_awakening_system.h"
 
 namespace {
@@ -558,6 +559,70 @@ TEST_F(UndeadAwakeningSystemTest, LosingTheShrineBreaksTheGarrisonAndClearsTheZo
   EXPECT_EQ(count_owner_units(world, 99), 0);
   EXPECT_TRUE(system.is_zone_cleared(k_shrine_zone_id));
   EXPECT_TRUE(system.is_shrine_purified(k_shrine_zone_id));
+}
+
+TEST_F(UndeadAwakeningSystemTest, BreakingTheGarrisonPaysTheAuthoredClearReward) {
+  Engine::Core::World world;
+  Game::Systems::UndeadAwakeningSystem system;
+
+  Game::Map::MapDefinition map_definition = make_shrine_map();
+  ASSERT_FALSE(map_definition.undead_zones.empty());
+  auto& reward = map_definition.undead_zones.front().clear_reward;
+  reward.set(Game::Systems::ResourceType::Stone, 120);
+  reward.set(Game::Systems::ResourceType::Iron, 60);
+
+  Game::Map::TerrainService::instance().initialize(map_definition);
+  system.configure(map_definition);
+
+  auto& resources = Game::Systems::PlayerResourceRegistry::instance();
+  const int stone_before = resources.get(1, Game::Systems::ResourceType::Stone);
+  const int iron_before = resources.get(1, Game::Systems::ResourceType::Iron);
+  const int gold_before = resources.get(1, Game::Systems::ResourceType::Gold);
+
+  add_intruder(world, {0.5F, 0.0F, 0.5F});
+  system.update(&world, 0.1F);
+  ASSERT_FALSE(system.is_zone_cleared(k_shrine_zone_id));
+  EXPECT_EQ(resources.get(1, Game::Systems::ResourceType::Stone), stone_before)
+      << "an unbroken garrison must not pay out";
+
+  world.get_entity(system.anchor_entity(k_shrine_zone_id))
+      ->get_component<Engine::Core::UnitComponent>()
+      ->health = 0;
+  system.update(&world, 0.1F);
+  ASSERT_TRUE(system.is_zone_cleared(k_shrine_zone_id));
+
+  EXPECT_EQ(resources.get(1, Game::Systems::ResourceType::Stone), stone_before + 120);
+  EXPECT_EQ(resources.get(1, Game::Systems::ResourceType::Iron), iron_before + 60);
+  EXPECT_EQ(resources.get(1, Game::Systems::ResourceType::Gold), gold_before)
+      << "unlisted resources must not be granted";
+
+  system.update(&world, 0.1F);
+  EXPECT_EQ(resources.get(1, Game::Systems::ResourceType::Stone), stone_before + 120)
+      << "the hoard must only be paid once";
+}
+
+TEST_F(UndeadAwakeningSystemTest, ZoneWithoutAClearRewardPaysNothing) {
+  Engine::Core::World world;
+  Game::Systems::UndeadAwakeningSystem system;
+
+  const Game::Map::MapDefinition map_definition = make_shrine_map();
+  ASSERT_TRUE(map_definition.undead_zones.front().clear_reward.empty());
+
+  Game::Map::TerrainService::instance().initialize(map_definition);
+  system.configure(map_definition);
+
+  auto& resources = Game::Systems::PlayerResourceRegistry::instance();
+  const int gold_before = resources.get(1, Game::Systems::ResourceType::Gold);
+
+  add_intruder(world, {0.5F, 0.0F, 0.5F});
+  system.update(&world, 0.1F);
+  world.get_entity(system.anchor_entity(k_shrine_zone_id))
+      ->get_component<Engine::Core::UnitComponent>()
+      ->health = 0;
+  system.update(&world, 0.1F);
+  ASSERT_TRUE(system.is_zone_cleared(k_shrine_zone_id));
+
+  EXPECT_EQ(resources.get(1, Game::Systems::ResourceType::Gold), gold_before);
 }
 
 TEST_F(UndeadAwakeningSystemTest, BrokenGarrisonSurvivesASaveLoadRoundTrip) {

--- a/tests/tools/map_editor_map_data_test.cpp
+++ b/tests/tools/map_editor_map_data_test.cpp
@@ -852,3 +852,83 @@ TEST(MapEditorMapDataTest, RadiusOnlyTerrainKeepsExtentsUnauthored) {
   EXPECT_NEAR(saved_hill.value(MapJsonKeys::width).toDouble(), 60.0, 1e-6);
   EXPECT_NEAR(saved_hill.value(MapJsonKeys::depth).toDouble(), 60.0, 1e-6);
 }
+
+TEST(MapEditorMapDataTest, GrovesAndUndeadClearRewardsSurviveARoundTrip) {
+  QTemporaryDir const temp_dir;
+  ASSERT_TRUE(temp_dir.isValid());
+
+  const QString input_path = temp_dir.filePath("input.json");
+  const QString output_path = temp_dir.filePath("output.json");
+
+  QJsonObject const input{
+      {"name", "Woods And Hoards"},
+      {MapJsonKeys::grid,
+       QJsonObject{{MapJsonKeys::width, 64},
+                   {MapJsonKeys::height, 64},
+                   {MapJsonKeys::tile_size, 1.0}}},
+      {MapJsonKeys::biome,
+       QJsonObject{{"procedural_boulders_enabled", false},
+                   {"procedural_iron_ore_enabled", false}}},
+      {"groves",
+       QJsonArray{QJsonObject{{"id", "north_screen"},
+                              {MapJsonKeys::x, 20},
+                              {MapJsonKeys::z, 30},
+                              {MapJsonKeys::radius, 14.5}}}},
+      {MapJsonKeys::undead_zones,
+       QJsonArray{
+           QJsonObject{{"id", "barrow"},
+                       {MapJsonKeys::x, 40},
+                       {MapJsonKeys::z, 40},
+                       {"clear_reward", QJsonObject{{"gold", 120}, {"iron", 60}}}}}},
+      {MapJsonKeys::wildlife,
+       QJsonObject{{"enabled", true},
+                   {"wolves",
+                    QJsonObject{{"enabled", true},
+                                {"groups", 0},
+                                {"waves",
+                                 QJsonArray{QJsonObject{{"timing", 240.0},
+                                                        {"pack_size", 5},
+                                                        {MapJsonKeys::x, 12},
+                                                        {MapJsonKeys::z, 50},
+                                                        {"label", "The pack"}}}}}}}}};
+  write_json(input_path, input);
+
+  MapEditor::MapData data;
+  ASSERT_TRUE(data.load_from_json(input_path));
+
+  ASSERT_EQ(data.groves().size(), 1);
+  EXPECT_EQ(data.groves().first().id, "north_screen");
+  EXPECT_FLOAT_EQ(data.groves().first().radius, 14.5F);
+  ASSERT_EQ(data.undead_zones().size(), 1);
+  EXPECT_EQ(data.undead_zones().first().clear_reward.value("gold").toInt(), 120);
+
+  ASSERT_TRUE(data.save_to_json(output_path));
+  const QJsonObject output = read_json(output_path);
+
+  ASSERT_TRUE(output.value("groves").isArray());
+  const QJsonObject saved_grove = output.value("groves").toArray().first().toObject();
+  EXPECT_EQ(saved_grove.value("id").toString(), "north_screen");
+  EXPECT_DOUBLE_EQ(saved_grove.value(MapJsonKeys::radius).toDouble(), 14.5);
+
+  const QJsonObject saved_zone =
+      output.value(MapJsonKeys::undead_zones).toArray().first().toObject();
+  ASSERT_TRUE(saved_zone.value("clear_reward").isObject());
+  EXPECT_EQ(saved_zone.value("clear_reward").toObject().value("iron").toInt(), 60);
+
+  ASSERT_TRUE(output.value(MapJsonKeys::biome).isObject());
+  EXPECT_FALSE(output.value(MapJsonKeys::biome)
+                   .toObject()
+                   .value("procedural_boulders_enabled")
+                   .toBool(true));
+
+  const QJsonArray saved_wolf_waves = output.value(MapJsonKeys::wildlife)
+                                          .toObject()
+                                          .value("wolves")
+                                          .toObject()
+                                          .value("waves")
+                                          .toArray();
+  ASSERT_EQ(saved_wolf_waves.size(), 1);
+  EXPECT_DOUBLE_EQ(saved_wolf_waves.first().toObject().value("timing").toDouble(),
+                   240.0);
+  EXPECT_EQ(saved_wolf_waves.first().toObject().value("pack_size").toInt(), 5);
+}

--- a/tests/wildlife/wildlife_system_test.cpp
+++ b/tests/wildlife/wildlife_system_test.cpp
@@ -675,4 +675,65 @@ TEST_F(WildlifeSystemTest, ShippedForestMapPopulatesEverySpeciesItEnables) {
   }
 }
 
+TEST_F(WildlifeSystemTest, WolfPacksArriveOnScheduleRatherThanAtMissionStart) {
+  World world;
+  WildlifeSystem system;
+
+  WildlifeSettings settings = make_settings();
+  settings.wolves.enabled = true;
+  settings.wolves.group_count = 0;
+  settings.wolves.roam_radius = 10.0F;
+  settings.wolves.waves = {
+      {.timing = 5.0F,
+       .pack_size = 3,
+       .area = {14.0F, 0.0F, 3.0F},
+       .label = "First pack"},
+      {.timing = 12.0F, .pack_size = 2, .area = {-14.0F, 0.0F, 3.0F}, .label = ""},
+  };
+  Game::Wildlife::sanitize(settings);
+  system.configure(settings, 7U);
+
+  advance(system, world, 1.0F);
+  EXPECT_EQ(count_species(world, Species::Wolf), 0)
+      << "a scheduled pack must not be on the field at mission start";
+
+  advance(system, world, 6.0F);
+  EXPECT_EQ(count_species(world, Species::Wolf), 3);
+
+  advance(system, world, 7.0F);
+  EXPECT_EQ(count_species(world, Species::Wolf), 5)
+      << "the second pack joins the first";
+
+  const float long_ago = 30.0F;
+  advance(system, world, long_ago);
+  EXPECT_EQ(count_species(world, Species::Wolf), 5)
+      << "each wave releases exactly once";
+}
+
+TEST_F(WildlifeSystemTest, ReleasedWolfWavesSurviveASaveLoadRoundTrip) {
+  World world;
+  WildlifeSystem system;
+
+  WildlifeSettings settings = make_settings();
+  settings.wolves.enabled = true;
+  settings.wolves.group_count = 0;
+  settings.wolves.waves = {
+      {.timing = 2.0F, .pack_size = 3, .area = {14.0F, 0.0F, 3.0F}, .label = ""}};
+  Game::Wildlife::sanitize(settings);
+  system.configure(settings, 7U);
+
+  advance(system, world, 4.0F);
+  ASSERT_EQ(count_species(world, Species::Wolf), 3);
+
+  const auto state = system.serialize_state();
+
+  WildlifeSystem restored;
+  restored.configure(settings, 7U);
+  restored.restore_state(state);
+  advance(restored, world, 10.0F);
+
+  EXPECT_EQ(count_species(world, Species::Wolf), 3)
+      << "a restored mission must not release an already-spent pack again";
+}
+
 } // namespace

--- a/tools/map_editor/editor_window.cpp
+++ b/tools/map_editor/editor_window.cpp
@@ -1329,6 +1329,9 @@ void EditorWindow::on_element_double_clicked(int element_type, int index) {
     if (!elem.waves.isEmpty()) {
       json["waves"] = elem.waves;
     }
+    if (!elem.clear_reward.isEmpty()) {
+      json["clear_reward"] = elem.clear_reward;
+    }
 
     title = "Edit Undead Zone: " + elem.id;
   } else if (element_type == static_cast<int>(ElementKind::WildlifeArea)) {
@@ -1344,6 +1347,19 @@ void EditorWindow::on_element_double_clicked(int element_type, int index) {
     json[MapJsonKeys::radius] = static_cast<double>(elem.radius);
 
     title = "Edit Wildlife Range: " + wildlife_species_label(elem.species);
+  } else if (element_type == static_cast<int>(ElementKind::Grove)) {
+    const auto& groves = m_map_data->groves();
+    if (index < 0 || index >= groves.size()) {
+      return;
+    }
+    const auto& elem = groves[index];
+
+    json["id"] = elem.id;
+    json[MapJsonKeys::x] = static_cast<double>(elem.x);
+    json[MapJsonKeys::z] = static_cast<double>(elem.z);
+    json[MapJsonKeys::radius] = static_cast<double>(elem.radius);
+
+    title = "Edit Wood: " + (elem.id.isEmpty() ? QStringLiteral("wood") : elem.id);
   } else {
     return;
   }
@@ -1590,6 +1606,7 @@ void EditorWindow::on_element_double_clicked(int element_type, int index) {
       elem.team_id = new_json["team_id"].toInt(99);
       elem.awaken_on = new_json["awaken_on"].toArray();
       elem.waves = new_json["waves"].toArray();
+      elem.clear_reward = new_json["clear_reward"].toObject();
 
       m_map_data->execute_command(
           std::make_unique<UpdateUndeadZoneCmd>(m_map_data,
@@ -1610,6 +1627,15 @@ void EditorWindow::on_element_double_clicked(int element_type, int index) {
                                                   m_map_data->wildlife_areas()[index],
                                                   elem,
                                                   "Edit wildlife range"));
+    } else if (element_type == static_cast<int>(ElementKind::Grove)) {
+      GroveElement elem;
+      elem.id = new_json["id"].toString();
+      elem.x = static_cast<float>(new_json[MapJsonKeys::x].toDouble());
+      elem.z = static_cast<float>(new_json[MapJsonKeys::z].toDouble());
+      elem.radius = static_cast<float>(new_json[MapJsonKeys::radius].toDouble(12.0));
+
+      m_map_data->execute_command(std::make_unique<UpdateGroveCmd>(
+          m_map_data, index, m_map_data->groves()[index], elem, "Edit wood"));
     }
   }
 }
@@ -2119,6 +2145,16 @@ void EditorWindow::on_selection_changed(int element_type, int index) {
     if (index < areas.size()) {
       const auto& e = areas[index];
       type_name = wildlife_species_label(e.species);
+      coords = QString("(%1, %2) r=%3")
+                   .arg(static_cast<int>(e.x))
+                   .arg(static_cast<int>(e.z))
+                   .arg(static_cast<int>(e.radius));
+    }
+  } else if (element_type == static_cast<int>(ElementKind::Grove)) {
+    const auto& groves = m_map_data->groves();
+    if (index < groves.size()) {
+      const auto& e = groves[index];
+      type_name = QStringLiteral("wood");
       coords = QString("(%1, %2) r=%3")
                    .arg(static_cast<int>(e.x))
                    .arg(static_cast<int>(e.z))

--- a/tools/map_editor/element_ops.cpp
+++ b/tools/map_editor/element_ops.cpp
@@ -69,6 +69,8 @@ auto category_label(int kind) -> QString {
     return QStringLiteral("Undead zone");
   case ElementKind::WildlifeArea:
     return QStringLiteral("Wildlife");
+  case ElementKind::Grove:
+    return QStringLiteral("Wood");
   }
   return {};
 }
@@ -89,6 +91,8 @@ auto count(const MapData& data, int kind) -> int {
     return static_cast<int>(data.undead_zones().size());
   case ElementKind::WildlifeArea:
     return static_cast<int>(data.wildlife_areas().size());
+  case ElementKind::Grove:
+    return static_cast<int>(data.groves().size());
   }
   return 0;
 }
@@ -116,6 +120,8 @@ auto snapshot(const MapData& data, int kind, int index) -> ElementSnapshot {
     return data.undead_zones()[index];
   case ElementKind::WildlifeArea:
     return data.wildlife_areas()[index];
+  case ElementKind::Grove:
+    return data.groves()[index];
   }
   return {};
 }
@@ -125,6 +131,7 @@ auto type_name(const ElementSnapshot& snap) -> QString {
                         [](std::monostate) { return QString{}; },
                         [](const UndeadZoneElement& e) { return e.anchor_type; },
                         [](const WildlifeAreaElement& e) { return e.species; },
+                        [](const GroveElement&) { return QStringLiteral("grove"); },
                         [](const auto& e) { return e.type; },
                     },
                     snap);
@@ -136,6 +143,9 @@ auto display_name(const ElementSnapshot& snap) -> QString {
   }
   if (const auto* area = std::get_if<WildlifeAreaElement>(&snap)) {
     return wildlife_species_label(area->species);
+  }
+  if (const auto* grove = std::get_if<GroveElement>(&snap)) {
+    return grove->id.isEmpty() ? QStringLiteral("wood") : grove->id;
   }
   return type_name(snap);
 }
@@ -316,6 +326,9 @@ auto summary(const ElementSnapshot& snap) -> QString {
   } else if (const auto* area = std::get_if<WildlifeAreaElement>(&snap)) {
     text +=
         QStringLiteral("\nrange %1").arg(static_cast<double>(area->radius), 0, 'f', 1);
+  } else if (const auto* grove = std::get_if<GroveElement>(&snap)) {
+    text += QStringLiteral("\nradius %1")
+                .arg(static_cast<double>(grove->radius), 0, 'f', 1);
   }
 
   return text;
@@ -332,6 +345,7 @@ void apply(MapData& data, int index, const ElementSnapshot& snap) {
           [&](const TroopSpawnElement& e) { data.update_troop_spawn(index, e); },
           [&](const UndeadZoneElement& e) { data.update_undead_zone(index, e); },
           [&](const WildlifeAreaElement& e) { data.update_wildlife_area(index, e); },
+          [&](const GroveElement& e) { data.update_grove(index, e); },
       },
       snap);
 }
@@ -359,6 +373,9 @@ auto make_add(MapData& data, const ElementSnapshot& snap) -> std::unique_ptr<Com
                         },
                         [&](const WildlifeAreaElement& e) -> std::unique_ptr<Command> {
                           return std::make_unique<AddWildlifeAreaCmd>(&data, e);
+                        },
+                        [&](const GroveElement& e) -> std::unique_ptr<Command> {
+                          return std::make_unique<AddGroveCmd>(&data, e);
                         },
                     },
                     snap);
@@ -389,6 +406,8 @@ auto make_remove(MapData& data, int kind, int index) -> std::unique_ptr<Command>
   case ElementKind::WildlifeArea:
     return std::make_unique<RemoveWildlifeAreaCmd>(
         &data, index, data.wildlife_areas()[index]);
+  case ElementKind::Grove:
+    return std::make_unique<RemoveGroveCmd>(&data, index, data.groves()[index]);
   }
   return {};
 }
@@ -431,6 +450,10 @@ auto make_update(MapData& data,
           [&](const WildlifeAreaElement& e) -> std::unique_ptr<Command> {
             return std::make_unique<UpdateWildlifeAreaCmd>(
                 &data, index, std::get<WildlifeAreaElement>(before), e, description);
+          },
+          [&](const GroveElement& e) -> std::unique_ptr<Command> {
+            return std::make_unique<UpdateGroveCmd>(
+                &data, index, std::get<GroveElement>(before), e, description);
           },
       },
       after);

--- a/tools/map_editor/element_ops.h
+++ b/tools/map_editor/element_ops.h
@@ -20,9 +20,10 @@ enum class ElementKind {
   TroopSpawn = 4,
   UndeadZone = 5,
   WildlifeArea = 6,
+  Grove = 7,
 };
 
-inline constexpr int k_element_kind_count = 7;
+inline constexpr int k_element_kind_count = 8;
 
 struct ElementRef {
   int kind = -1;
@@ -45,7 +46,8 @@ using ElementSnapshot = std::variant<std::monostate,
                                      StructureElement,
                                      TroopSpawnElement,
                                      UndeadZoneElement,
-                                     WildlifeAreaElement>;
+                                     WildlifeAreaElement,
+                                     GroveElement>;
 
 namespace ElementOps {
 

--- a/tools/map_editor/json_schema.cpp
+++ b/tools/map_editor/json_schema.cpp
@@ -380,6 +380,11 @@ auto undead_zone_schema() -> JsonSchema {
           "2}}]",
           QJsonArray{QJsonObject{{"trigger", "initial"},
                                  {"units", QJsonObject{{"skeleton_swordsman", 2}}}}}),
+      optional_field("clear_reward",
+                     "object",
+                     "none",
+                     "Resources paid out when the zone's garrison is broken.",
+                     QJsonObject{{"gold", 100}}),
   };
 
   return schema;
@@ -394,6 +399,32 @@ auto JsonSchema::find(const QString& key) const -> const JsonFieldSpec* {
     }
   }
   return nullptr;
+}
+
+auto grove_schema() -> JsonSchema {
+  JsonSchema schema;
+  schema.title = QStringLiteral("Wood");
+  schema.summary = QStringLiteral(
+      "A standalone wood. Its ground is closed to cavalry, siege and elephants; "
+      "commanders, archers, swordsmen, healers, builders, civilians and wildlife "
+      "thread it freely. A road driven through a wood stays open to everyone, so "
+      "lay one across a wood you still want a column to be able to cross.");
+
+  schema.fields = {
+      optional_field("id",
+                     "string",
+                     "auto",
+                     "Name used in the editor and in map notes.",
+                     QStringLiteral("wood_1")),
+      grid_x_field(),
+      grid_z_field(),
+      optional_field("radius",
+                     "number",
+                     "12",
+                     "How far the wood reaches from its centre, in cells.",
+                     12.0),
+  };
+  return schema;
 }
 
 auto schema_for_element(int element_kind, const QString& sub_type) -> JsonSchema {
@@ -413,6 +444,8 @@ auto schema_for_element(int element_kind, const QString& sub_type) -> JsonSchema
     return undead_zone_schema();
   case ElementKind::WildlifeArea:
     return wildlife_area_schema();
+  case ElementKind::Grove:
+    return grove_schema();
   }
   return {};
 }
@@ -563,6 +596,22 @@ auto schema_for_biome() -> JsonSchema {
                      "preset",
                      "Enables the irregular ground edge.",
                      true),
+      optional_field("procedural_boulders_enabled",
+                     "bool",
+                     "preset",
+                     "Scatters boulders procedurally. Disable to hand-place stone.",
+                     true),
+      optional_field("procedural_iron_ore_enabled",
+                     "bool",
+                     "preset",
+                     "Scatters iron ore procedurally. Disable to hand-place iron.",
+                     true),
+      optional_field(
+          "procedural_trees_enabled",
+          "bool",
+          "preset",
+          "Scatters pines and olives procedurally. Disable to hand-place wood.",
+          true),
       optional_field("irregularity_scale",
                      "number",
                      "preset",

--- a/tools/map_editor/map_canvas.cpp
+++ b/tools/map_editor/map_canvas.cpp
@@ -99,8 +99,9 @@ auto terrain_footprint_cells(const TerrainElement& elem) -> float {
   return std::max(extent > 0.0F ? extent : 0.0F, elem.radius);
 }
 
-constexpr std::array<int, 7> k_category_paint_order = {
+constexpr std::array<int, 8> k_category_paint_order = {
     static_cast<int>(ElementKind::Terrain),
+    static_cast<int>(ElementKind::Grove),
     static_cast<int>(ElementKind::Linear),
     static_cast<int>(ElementKind::WildlifeArea),
     static_cast<int>(ElementKind::WorldProp),
@@ -1133,6 +1134,9 @@ void MapCanvas::draw_one_element(QPainter& painter, const ElementRef& ref) {
   case ElementKind::UndeadZone:
     draw_undead_zone_element(painter, ref.index);
     break;
+  case ElementKind::Grove:
+    draw_grove_element(painter, ref.index);
+    break;
   case ElementKind::WildlifeArea:
     draw_wildlife_area_element(painter, ref.index);
     break;
@@ -1503,6 +1507,54 @@ void MapCanvas::draw_undead_zone_element(QPainter& painter, int i) {
     painter.drawText(QRect(center.x() - 40, center.y() + radius_px + 2, 80, 14),
                      Qt::AlignCenter,
                      elem.id);
+  }
+
+  painter.restore();
+}
+
+void MapCanvas::draw_grove_element(QPainter& painter, int i) {
+  if (i < 0 || i >= m_map_data->groves().size()) {
+    return;
+  }
+
+  const QColor& hover_ring_color =
+      m_current_tool == ToolType::Eraser ? k_hover_erase_color : k_hover_select_color;
+
+  const auto& elem = m_map_data->groves()[i];
+  QPoint const center = grid_to_widget(elem.x, elem.z);
+
+  auto const kind = static_cast<int>(ElementKind::Grove);
+  bool const is_selected = is_selected_element(kind, i);
+  bool const is_hovered = (m_hovered_type == kind && m_hovered_index == i);
+
+  const int radius_px = static_cast<int>(elem.radius * m_zoom * grid_cell_size);
+
+  const QColor fill(46, 92, 52, 90);
+  const QColor outline(104, 168, 108);
+
+  painter.save();
+  painter.setRenderHint(QPainter::Antialiasing, true);
+
+  painter.setBrush(fill);
+  if (is_selected) {
+    painter.setPen(QPen(Qt::yellow, 2));
+  } else if (is_hovered) {
+    painter.setPen(QPen(hover_ring_color, 2));
+  } else {
+    painter.setPen(QPen(outline, 1, Qt::DashLine));
+  }
+  painter.drawEllipse(center, radius_px, radius_px);
+
+  painter.setPen(outline);
+  QFont f = painter.font();
+  f.setPointSize(9);
+  painter.setFont(f);
+  painter.drawText(QRect(center.x() - 10, center.y() - 10, 20, 20),
+                   Qt::AlignCenter,
+                   QStringLiteral("\U0001F332"));
+
+  if (labels_visible() && !elem.id.isEmpty()) {
+    painter.drawText(center.x() + radius_px + 4, center.y(), elem.id);
   }
 
   painter.restore();
@@ -2774,6 +2826,21 @@ MapCanvas::HitResult MapCanvas::hit_test(const QPoint& pos) const {
     consider_hit(5, i, -1, (cursor - center_vec).length(), zone_radius_px + 4.0F, 6);
   }
 
+  const auto& groves = m_map_data->groves();
+  for (int i = groves.size() - 1; i >= 0; --i) {
+    const auto& elem = groves[i];
+    const QPoint center = grid_to_widget(elem.x, elem.z);
+    const QVector2D center_vec(static_cast<float>(center.x()),
+                               static_cast<float>(center.y()));
+    const float grove_radius_px = elem.radius * m_zoom * grid_cell_size;
+    consider_hit(static_cast<int>(ElementKind::Grove),
+                 i,
+                 -1,
+                 (cursor - center_vec).length(),
+                 grove_radius_px + 4.0F,
+                 8);
+  }
+
   const auto& wildlife_areas = m_map_data->wildlife_areas();
   for (int i = wildlife_areas.size() - 1; i >= 0; --i) {
     const auto& elem = wildlife_areas[i];
@@ -2944,6 +3011,13 @@ void MapCanvas::place_element(const QPointF& raw_grid_pos) {
       return;
     }
     m_map_data->execute_command(std::make_unique<AddTroopSpawnCmd>(m_map_data, elem));
+  } else if (m_current_tool == ToolType::Grove) {
+    GroveElement elem;
+    static int grove_counter = 0;
+    elem.id = QStringLiteral("wood_%1").arg(++grove_counter);
+    elem.x = static_cast<float>(grid_pos.x());
+    elem.z = static_cast<float>(grid_pos.y());
+    m_map_data->execute_command(std::make_unique<AddGroveCmd>(m_map_data, elem));
   } else if (is_wildlife_tool(m_current_tool)) {
     WildlifeAreaElement elem;
     elem.species = wildlife_species_for_tool(m_current_tool);

--- a/tools/map_editor/map_canvas.h
+++ b/tools/map_editor/map_canvas.h
@@ -121,6 +121,7 @@ private:
   [[nodiscard]] QPolygonF linear_polyline_px(const LinearElement& elem) const;
   void draw_undead_zone_element(QPainter& painter, int index);
   void draw_wildlife_area_element(QPainter& painter, int index);
+  void draw_grove_element(QPainter& painter, int index);
   void draw_linear_preview(QPainter& painter);
   void draw_mission_overlays(QPainter& painter);
   void draw_derived_commanders(QPainter& painter);

--- a/tools/map_editor/map_data.cpp
+++ b/tools/map_editor/map_data.cpp
@@ -501,6 +501,7 @@ bool MapData::load_from_json(const QString& file_path, QString* out_error) {
                                        MapJsonKeys::bridges,
                                        MapJsonKeys::undead_zones,
                                        MapJsonKeys::fog_zones,
+                                       MapJsonKeys::groves,
                                        MapJsonKeys::wildlife};
   m_extra_root_fields = copyExtraFields(root, known_root_keys);
 
@@ -585,6 +586,7 @@ bool MapData::load_from_json(const QString& file_path, QString* out_error) {
   if (root.contains(MapJsonKeys::fog_zones)) {
     parse_fog_zones_array(root[MapJsonKeys::fog_zones].toArray());
   }
+  parse_groves_array(root[MapJsonKeys::groves].toArray());
   parse_wildlife_object(root[MapJsonKeys::wildlife].toObject());
 
   m_undo_stack.clear();
@@ -694,6 +696,13 @@ QJsonObject MapData::build_root_json() const {
   QJsonArray const fog_zones_arr = fog_zones_to_json();
   if (!fog_zones_arr.isEmpty()) {
     root[MapJsonKeys::fog_zones] = fog_zones_arr;
+  }
+
+  QJsonArray const groves_arr = groves_to_json();
+  if (!groves_arr.isEmpty()) {
+    root[MapJsonKeys::groves] = groves_arr;
+  } else {
+    root.remove(MapJsonKeys::groves);
   }
 
   QJsonObject const wildlife_obj = wildlife_to_json();
@@ -1495,6 +1504,7 @@ void MapData::parse_undead_zones_array(const QJsonArray& arr) {
     elem.team_id = obj["team_id"].toInt(99);
     elem.awaken_on = obj["awaken_on"].toArray();
     elem.waves = obj["waves"].toArray();
+    elem.clear_reward = obj["clear_reward"].toObject();
     m_undead_zones.append(elem);
   }
 }
@@ -1518,6 +1528,9 @@ QJsonArray MapData::undead_zones_to_json() const {
     }
     if (!elem.waves.isEmpty()) {
       obj["waves"] = elem.waves;
+    }
+    if (!elem.clear_reward.isEmpty()) {
+      obj["clear_reward"] = elem.clear_reward;
     }
     arr.append(obj);
   }
@@ -1573,6 +1586,65 @@ auto wildlife_species_label(const QString& species) -> QString {
     return QStringLiteral("bird roost");
   }
   return QStringLiteral("sheep pasture");
+}
+
+void MapData::parse_groves_array(const QJsonArray& arr) {
+  m_groves.clear();
+  for (const auto& val : arr) {
+    const QJsonObject obj = val.toObject();
+    GroveElement elem;
+    elem.id = obj["id"].toString();
+    elem.x = static_cast<float>(obj[MapJsonKeys::x].toDouble());
+    elem.z = static_cast<float>(obj[MapJsonKeys::z].toDouble());
+    elem.radius = static_cast<float>(obj[MapJsonKeys::radius].toDouble(12.0));
+    m_groves.append(elem);
+  }
+}
+
+QJsonArray MapData::groves_to_json() const {
+  QJsonArray arr;
+  for (const auto& elem : m_groves) {
+    QJsonObject obj;
+    if (!elem.id.isEmpty()) {
+      obj["id"] = elem.id;
+    }
+    obj[MapJsonKeys::x] = static_cast<double>(elem.x);
+    obj[MapJsonKeys::z] = static_cast<double>(elem.z);
+    obj[MapJsonKeys::radius] = static_cast<double>(elem.radius);
+    arr.append(obj);
+  }
+  return arr;
+}
+
+void MapData::add_grove(const GroveElement& element) {
+  m_groves.append(element);
+  set_modified(true);
+  emit data_changed();
+}
+
+void MapData::insert_grove(int index, const GroveElement& element) {
+  if (index < 0 || index > m_groves.size()) {
+    index = m_groves.size();
+  }
+  m_groves.insert(index, element);
+  set_modified(true);
+  emit data_changed();
+}
+
+void MapData::update_grove(int index, const GroveElement& element) {
+  if (index >= 0 && index < m_groves.size()) {
+    m_groves[index] = element;
+    set_modified(true);
+    emit data_changed();
+  }
+}
+
+void MapData::remove_grove(int index) {
+  if (index >= 0 && index < m_groves.size()) {
+    m_groves.removeAt(index);
+    set_modified(true);
+    emit data_changed();
+  }
 }
 
 void MapData::add_wildlife_area(const WildlifeAreaElement& element) {

--- a/tools/map_editor/map_data.h
+++ b/tools/map_editor/map_data.h
@@ -101,6 +101,14 @@ struct UndeadZoneElement {
   int team_id = 99;
   QJsonArray awaken_on;
   QJsonArray waves;
+  QJsonObject clear_reward;
+};
+
+struct GroveElement {
+  QString id;
+  float x = 0.0F;
+  float z = 0.0F;
+  float radius = 12.0F;
 };
 
 struct WildlifeAreaElement {
@@ -211,6 +219,12 @@ public:
   void update_undead_zone(int index, const UndeadZoneElement& element);
   void remove_undead_zone(int index);
 
+  [[nodiscard]] const QVector<GroveElement>& groves() const { return m_groves; }
+  void add_grove(const GroveElement& element);
+  void insert_grove(int index, const GroveElement& element);
+  void update_grove(int index, const GroveElement& element);
+  void remove_grove(int index);
+
   [[nodiscard]] const QVector<WildlifeAreaElement>& wildlife_areas() const {
     return m_wildlife_areas;
   }
@@ -254,6 +268,7 @@ private:
   QVector<UndeadZoneElement> m_undead_zones;
   QVector<FogZoneElement> m_fog_zones;
   QVector<WildlifeAreaElement> m_wildlife_areas;
+  QVector<GroveElement> m_groves;
 
   QJsonObject m_biome;
   QJsonObject m_camera;
@@ -288,6 +303,7 @@ private:
   void parse_spawns_array(const QJsonArray& arr);
   void parse_undead_zones_array(const QJsonArray& arr);
   void parse_fog_zones_array(const QJsonArray& arr);
+  void parse_groves_array(const QJsonArray& arr);
   void parse_wildlife_object(const QJsonObject& obj);
   void parse_structures_array(const QJsonArray& arr);
 
@@ -302,6 +318,7 @@ private:
   [[nodiscard]] QJsonObject troop_to_spawn_json(const TroopSpawnElement& elem) const;
   [[nodiscard]] QJsonArray undead_zones_to_json() const;
   [[nodiscard]] QJsonArray fog_zones_to_json() const;
+  [[nodiscard]] QJsonArray groves_to_json() const;
   [[nodiscard]] QJsonObject wildlife_to_json() const;
 };
 
@@ -720,6 +737,64 @@ private:
   int m_index;
   WildlifeAreaElement m_before;
   WildlifeAreaElement m_after;
+  QString m_desc;
+};
+
+class AddGroveCmd : public Command {
+public:
+  AddGroveCmd(MapData* data, GroveElement elem)
+      : m_data(data)
+      , m_elem(std::move(elem)) {}
+  void execute() override {
+    m_index = m_data->groves().size();
+    m_data->add_grove(m_elem);
+  }
+  void undo() override { m_data->remove_grove(m_index); }
+  [[nodiscard]] QString description() const override { return "Plant wood"; }
+
+private:
+  MapData* m_data;
+  GroveElement m_elem;
+  int m_index = -1;
+};
+
+class RemoveGroveCmd : public Command {
+public:
+  RemoveGroveCmd(MapData* data, int index, GroveElement elem)
+      : m_data(data)
+      , m_index(index)
+      , m_elem(std::move(elem)) {}
+  void execute() override { m_data->remove_grove(m_index); }
+  void undo() override { m_data->insert_grove(m_index, m_elem); }
+  [[nodiscard]] QString description() const override { return "Fell wood"; }
+
+private:
+  MapData* m_data;
+  int m_index;
+  GroveElement m_elem;
+};
+
+class UpdateGroveCmd : public Command {
+public:
+  UpdateGroveCmd(MapData* data,
+                 int index,
+                 GroveElement before,
+                 GroveElement after,
+                 QString desc = "Edit wood")
+      : m_data(data)
+      , m_index(index)
+      , m_before(std::move(before))
+      , m_after(std::move(after))
+      , m_desc(std::move(desc)) {}
+  void execute() override { m_data->update_grove(m_index, m_after); }
+  void undo() override { m_data->update_grove(m_index, m_before); }
+  [[nodiscard]] QString description() const override { return m_desc; }
+
+private:
+  MapData* m_data;
+  int m_index;
+  GroveElement m_before;
+  GroveElement m_after;
   QString m_desc;
 };
 

--- a/tools/map_editor/map_json_keys.h
+++ b/tools/map_editor/map_json_keys.h
@@ -35,6 +35,7 @@ inline constexpr const char* fog_density = Game::Map::JsonKeys::FOG_DENSITY;
 inline constexpr const char* exposure = Game::Map::JsonKeys::EXPOSURE;
 inline constexpr const char* undead_zones = Game::Map::JsonKeys::UNDEAD_ZONES;
 inline constexpr const char* fog_zones = Game::Map::JsonKeys::FOG_ZONES;
+inline constexpr const char* groves = Game::Map::JsonKeys::GROVES;
 inline constexpr const char* wildlife = Game::Map::JsonKeys::WILDLIFE;
 inline constexpr const char* wildlife_enabled = Game::Map::JsonKeys::WILDLIFE_ENABLED;
 inline constexpr const char* wildlife_groups = Game::Map::JsonKeys::WILDLIFE_GROUPS;

--- a/tools/map_editor/tool_panel.cpp
+++ b/tools/map_editor/tool_panel.cpp
@@ -106,6 +106,9 @@ auto toolDescription(ToolType tool) -> QString {
   case ToolType::UndeadZone:
     return "Place an undead zone (shrine or ruins anchor with skeleton wave spawns). "
            "Double-click to edit waves.";
+  case ToolType::Grove:
+    return "Plant a wood. Its ground is closed to horses, siege and elephants; only "
+           "foot troops, builders and civilians can thread it.";
   case ToolType::WildlifeSheep:
     return "Mark a sheep pasture. Herds spawn inside the circle and graze within it.";
   case ToolType::WildlifeWolves:
@@ -208,6 +211,14 @@ void ToolPanel::setup_ui() {
                   "\u25B3",
                   "Place mountain peaks.",
                   ToolType::Mountain);
+  add_tool_button(terrain_layout,
+                  1,
+                  0,
+                  "Wood",
+                  "\U0001F332",
+                  "Plant a wood. Its ground is closed to horses, siege and elephants; "
+                  "only foot troops, builders and civilians can thread it.",
+                  ToolType::Grove);
   layout->addWidget(terrain_group);
 
   auto* props_group = new QGroupBox("World Props", this);

--- a/tools/map_editor/tool_panel.h
+++ b/tools/map_editor/tool_panel.h
@@ -54,6 +54,7 @@ enum class ToolType {
   TroopCivilian,
   TroopBuilder,
   UndeadZone,
+  Grove,
   WildlifeSheep,
   WildlifeWolves,
   WildlifeBirds,


### PR DESCRIPTION
Extend campaign maps and missions with authored woods, defensive landmark guards, undead clear rewards, and configurable sheep, wolf, and bird activity across the historical scenarios. Add map loading and schema support for grove terrain, wildlife settings, and procedural scatter controls while preserving authored map content and editor metadata.

Introduce forest-aware terrain and pathfinding rules so light units can traverse woods while cavalry, siege, and elephants are blocked unless roads provide an exception. Wire movement, terrain services, procedural tree generation, unit spawning, victory handling, and undead awakening into the new terrain and reward model.

Add nation-collapse handling that neutralizes barracks, tears down owned structures, disbands remaining troops, refreshes marketplace and wall registries, and integrates commander and capture behavior with victory state. Expand sheep and wolf rigs, manifests, poses, and runtime wildlife behavior for authored areas and scheduled hunting waves.

Update the map editor with grove placement, rendering, hit testing, undo/redo commands, JSON round-tripping, and clear-reward editing. Document the campaign, mission framework, pathfinding, ambient wildlife, and Iron Sepulcher content, and add regression coverage for campaign assets, map loading, terrain, pathfinding, undead awakening, commander behavior, wildlife, rendering, and editor data.