### PR TITLE
Improve foliage lighting and mode indicator visuals

### DIFF
--- a/assets/shaders/include/activity_indicator.glsl
+++ b/assets/shaders/include/activity_indicator.glsl
@@ -20,28 +20,37 @@ vec4 activity_indicator_shade(float layer,
   float breathe = 0.5 + 0.5 * sin(time * 2.0 + phase);
 
   if (layer < 0.5) {
-    float strength = mix(0.40, 0.15, clamp(radial, 0.0, 1.0));
+
+    float strength = mix(0.42, 0.05, clamp(radial, 0.0, 1.0));
     return vec4(vec3(0.0), alpha * strength);
   }
 
   if (layer < 1.5) {
-    return vec4(mix(vec3(0.0), tint, 0.14) * 0.10, clamp(alpha, 0.0, 1.0));
+
+    vec3 outline = mix(vec3(0.010), tint * 0.13, 0.45);
+    return vec4(outline, clamp(alpha, 0.0, 1.0));
   }
 
   float sheen = clamp(height * 0.5 + 0.5, 0.0, 1.0);
+  float smooth_sheen = sheen * sheen * (3.0 - 2.0 * sheen);
 
   vec3 base;
   float gloss;
+  float rim = 0.0;
   if (layer < 2.5) {
-    vec3 lit = mix(tint, vec3(1.0), 0.16);
-    vec3 deep = mix(tint, vec3(0.0), 0.34);
-    base = mix(deep, lit, sheen * sheen * (3.0 - 2.0 * sheen));
+    vec3 lit = mix(tint, vec3(1.0), 0.20);
+
+    vec3 deep = mix(tint, vec3(0.0), 0.26);
+    base = mix(deep, lit, smooth_sheen);
     gloss = 0.70;
+
+    rim = pow(smooth_sheen, 7.0) * 0.30;
   } else if (layer < 3.5) {
     base = mix(tint, vec3(1.0), 0.55);
     gloss = 1.05;
   } else {
-    base = mix(tint, vec3(0.0), 0.62);
+
+    base = mix(tint, vec3(0.0), mix(0.72, 0.46, smooth_sheen));
     gloss = 0.35;
   }
 
@@ -49,6 +58,7 @@ vec4 activity_indicator_shade(float layer,
   vec3 color = base * (ambient + 0.60 * lambert);
   color += vec3(1.0) * specular * gloss * 0.42;
   color += tint * fresnel * 0.30;
+  color += mix(tint, vec3(1.0), 0.7) * rim;
   color *= 0.96 + 0.08 * breathe;
 
   return vec4(color, clamp(alpha, 0.0, 1.0));

--- a/assets/shaders/olive_instanced.frag
+++ b/assets/shaders/olive_instanced.frag
@@ -36,12 +36,13 @@ void main() {
 
   vec3 geometric_normal = normalize(v_normal);
   vec3 l = environment_primary_direction();
+  vec3 view_dir = normalize(vec3(0.0, 0.86, 0.52));
 
   vec3 leaf_seed_offset =
       vec3(v_leaf_seed * 37.0, v_branch_id * 11.0, v_leaf_seed * 59.0);
   float footprint = max(fwidth(v_local_pos.x), fwidth(v_local_pos.z));
-  float fine_detail = 1.0 - smoothstep(0.004, 0.020, footprint);
-  float mid_detail = 1.0 - smoothstep(0.012, 0.048, footprint);
+  float fine_detail = 1.0 - smoothstep(0.003, 0.013, footprint);
+  float mid_detail = 1.0 - smoothstep(0.008, 0.030, footprint);
 
   float leaf_fine = soi_noise3(v_local_pos * vec3(26.0, 21.0, 26.0) + leaf_seed_offset);
   float leaf_clump = soi_noise3(v_local_pos * 9.5 + leaf_seed_offset.zxy);
@@ -54,10 +55,11 @@ void main() {
   float canopy_edge = smoothstep(0.10, 0.32, canopy_radius);
   float canopy_core = 1.0 - smoothstep(0.14, 0.40, canopy_radius);
 
-  vec3 leaf_dark_green = vec3(0.085, 0.150, 0.100);
-  vec3 leaf_mid_green = vec3(0.215, 0.310, 0.175);
-  vec3 leaf_light_green = vec3(0.375, 0.455, 0.250);
-  vec3 leaf_silver = vec3(0.500, 0.540, 0.455);
+  vec3 leaf_dark_green = vec3(0.085, 0.155, 0.108);
+  vec3 leaf_mid_green = vec3(0.250, 0.330, 0.180);
+  vec3 leaf_light_green = vec3(0.470, 0.560, 0.270);
+  vec3 leaf_silver = vec3(0.520, 0.555, 0.470);
+  vec3 leaf_sun = vec3(0.560, 0.640, 0.360);
 
   float color_choice =
       clamp(leaf_clump * 0.90 + (leaf_fine - 0.5) * 0.26 + 0.10, 0.0, 1.0);
@@ -65,36 +67,40 @@ void main() {
   leaf_color =
       mix(leaf_color, leaf_light_green, smoothstep(0.40, 0.90, leaf_mass) * 0.62);
 
-  vec3 n = geometric_normal;
+  leaf_color = mix(leaf_color, v_color, 0.50);
 
-  float ndl = dot(n, l);
+  vec3 n = geometric_normal;
+  vec3 shading_normal =
+      normalize(mix(n, n + vec3(0.0, 1.2, 0.0), v_foliage_mask * 0.50));
+
+  float ndl = dot(shading_normal, l);
   float diffuse = max(ndl, 0.0);
   float wrap = clamp((ndl + 0.24) / 1.24, 0.0, 1.0);
   wrap *= wrap * (3.0 - 2.0 * wrap);
-  float backlight = max(-ndl, 0.0);
-  float ambient = environment_ambient_intensity();
-  float sky_fill = smoothstep(-0.20, 0.85, n.y) * mix(0.05, 0.14, v_foliage_mask);
-  float lighting = ambient + wrap * mix(0.30, 0.66, v_foliage_mask) + sky_fill;
+  float backlight = max(-dot(n, l), 0.0);
 
-  vec3 sun_color = environment_primary_color() * environment_primary_intensity();
-  vec3 sky_color = environment_sky_color();
-  float lit_t = clamp(wrap * 1.2, 0.0, 1.0);
-  vec3 light_tint = mix(sky_color * 0.55, sun_color, lit_t);
+  vec3 sun = environment_primary_color() * environment_primary_intensity();
+  vec3 sky = environment_sky_color();
+  vec3 illumination =
+      environment_ambient_light(geometric_normal) * mix(1.0, 1.30, v_foliage_mask) +
+      sun * mix(diffuse * 0.72, wrap, v_foliage_mask);
 
   float silver_show =
       smoothstep(0.30, 0.80, 1.0 - diffuse) * smoothstep(0.35, 0.85, leaf_clump);
   leaf_color =
-      mix(leaf_color, leaf_silver, silver_show * mix(0.12, 0.24, canopy_height));
+      mix(leaf_color, leaf_silver, silver_show * mix(0.08, 0.16, canopy_height));
 
-  leaf_color = mix(leaf_color, v_color, 0.34);
+  float sun_catch = smoothstep(0.43, 1.00, wrap) * mix(0.20, 0.62, leaf_clump);
+  leaf_color = mix(leaf_color, leaf_sun, sun_catch * v_foliage_mask);
 
-  leaf_color *= mix(vec3(0.84, 0.95, 1.10), vec3(1.08, 1.03, 0.85), lit_t);
-
-  float underside = 1.0 - smoothstep(-0.10, 0.42, geometric_normal.y);
-  float canopy_ao = mix(0.74, 1.06, canopy_edge) * mix(0.90, 1.08, canopy_height);
-  leaf_color *= canopy_ao;
-  leaf_color *= mix(1.0, 0.66, canopy_core * v_foliage_mask);
-  leaf_color *= mix(1.0, 0.78, underside * v_foliage_mask);
+  float underside = 1.0 - smoothstep(-0.35, 0.05, geometric_normal.y);
+  float hemi = clamp(geometric_normal.y * 0.5 + 0.5, 0.0, 1.0);
+  float canopy_shape = mix(0.86, 1.06, canopy_edge) * mix(0.92, 1.08, canopy_height);
+  float canopy_occlusion =
+      clamp(canopy_shape * mix(1.0, 0.80, canopy_core) * mix(1.0, 0.88, underside),
+            0.42,
+            1.12);
+  float ao = mix(1.0, canopy_occlusion, v_foliage_mask) * mix(0.72, 1.0, hemi);
 
   float bark_u = v_tex_coord.x * TWO_PI;
   float bark_v = v_tex_coord.y;
@@ -107,8 +113,8 @@ void main() {
   float bark_texture =
       furrows * 0.46 + vertical_grain * 0.32 + bark_noise + bark_knots * 0.18;
 
-  vec3 bark_dark = vec3(0.25, 0.23, 0.20);
-  vec3 bark_mid = vec3(0.40, 0.37, 0.31);
+  vec3 bark_dark = vec3(0.29, 0.26, 0.22);
+  vec3 bark_mid = vec3(0.44, 0.40, 0.34);
   vec3 bark_light = vec3(0.52, 0.49, 0.42);
   vec3 bark_lichen = vec3(0.30, 0.33, 0.27);
 
@@ -123,15 +129,19 @@ void main() {
   bark_color *= mix(0.72, 1.0, smoothstep(0.0, 0.14, v_local_pos.y));
 
   vec3 base_color = mix(bark_color, leaf_color, v_foliage_mask);
-  vec3 color = base_color * lighting * light_tint * environment_exposure();
+  vec3 color = base_color * illumination * ao * environment_exposure();
 
   float translucency =
       backlight * backlight * v_foliage_mask * (0.14 + canopy_edge * 0.26);
-  color += leaf_color * vec3(0.42, 0.50, 0.22) * translucency;
+  color += leaf_color * vec3(0.42, 0.50, 0.22) * translucency * sun;
 
-  float leaf_sheen = pow(max(dot(n, normalize(l + vec3(0.0, 0.9, 0.3))), 0.0), 12.0) *
-                     v_foliage_mask * 0.085;
-  color += mix(sky_color, vec3(1.0), 0.35) * leaf_sheen;
+  vec3 half_dir = normalize(l + view_dir);
+  float leaf_spec =
+      pow(max(dot(shading_normal, half_dir), 0.0), 16.0) * v_foliage_mask * 0.060;
+  float rim = pow(1.0 - max(dot(geometric_normal, view_dir), 0.0), 4.0) *
+              mix(0.055, 0.085, v_foliage_mask);
+  color += sun * leaf_spec;
+  color += sky * rim;
 
   if (v_tex_coord.y < 0.035)
     discard;

--- a/assets/shaders/pine_instanced.frag
+++ b/assets/shaders/pine_instanced.frag
@@ -34,13 +34,14 @@ void main() {
 
   vec3 geometric_normal = normalize(v_normal);
   vec3 l = environment_primary_direction();
+  vec3 view_dir = normalize(vec3(0.0, 0.86, 0.52));
 
   vec3 needle_seed_offset =
       vec3(v_needle_seed * 41.0, v_needle_seed * 17.0, v_needle_seed * 63.0);
 
   float footprint = max(fwidth(v_local_pos.x), fwidth(v_local_pos.z));
-  float fine_detail = 1.0 - smoothstep(0.010, 0.045, footprint);
-  float mid_detail = 1.0 - smoothstep(0.026, 0.090, footprint);
+  float fine_detail = 1.0 - smoothstep(0.006, 0.026, footprint);
+  float mid_detail = 1.0 - smoothstep(0.016, 0.055, footprint);
 
   float needle_fine =
       soi_noise3(v_local_pos * vec3(30.0, 13.0, 30.0) + needle_seed_offset);
@@ -49,10 +50,10 @@ void main() {
   needle_fine = mix(0.5, needle_fine, fine_detail);
   needle_clump = mix(0.5, needle_clump, mid_detail);
 
-  vec3 needle_deep = vec3(0.042, 0.105, 0.070);
-  vec3 needle_mid = vec3(0.115, 0.250, 0.125);
-  vec3 needle_light = vec3(0.235, 0.420, 0.175);
-  vec3 needle_sun = vec3(0.470, 0.605, 0.250);
+  vec3 needle_deep = vec3(0.050, 0.128, 0.080);
+  vec3 needle_mid = vec3(0.150, 0.300, 0.165);
+  vec3 needle_light = vec3(0.330, 0.520, 0.240);
+  vec3 needle_sun = vec3(0.430, 0.630, 0.330);
 
   float grain =
       clamp(needle_clump * 0.80 + (needle_fine - 0.5) * 0.20 + 0.10, 0.0, 1.0);
@@ -60,48 +61,49 @@ void main() {
   needle_color =
       mix(needle_color, needle_light, smoothstep(0.48, 0.92, needle_tuft) * 0.45);
 
-  needle_color = mix(needle_color, v_color, 0.42);
+  needle_color = mix(needle_color, v_color, 0.55);
 
   float bump_height = needle_clump + needle_tuft * 0.55;
   vec3 n = mix(geometric_normal,
                perturb_normal(geometric_normal, v_world_pos, bump_height, 0.20),
                v_foliage_mask * mid_detail);
 
-  float ndl = dot(n, l);
+  vec3 shading_normal =
+      normalize(mix(n, n + vec3(0.0, 1.2, 0.0), v_foliage_mask * 0.50));
+
+  float ndl = dot(shading_normal, l);
   float diffuse = max(ndl, 0.0);
   float wrap = clamp((ndl + 0.26) / 1.26, 0.0, 1.0);
   wrap *= wrap * (3.0 - 2.0 * wrap);
-  float backlight = max(-ndl, 0.0);
-  float ambient = environment_ambient_intensity();
-  float sky_fill = smoothstep(-0.25, 0.85, n.y) * mix(0.08, 0.16, v_foliage_mask);
-  float lighting = ambient + wrap * mix(0.42, 0.70, v_foliage_mask) + sky_fill;
+  float backlight = max(-dot(n, l), 0.0);
 
-  vec3 sun_color = environment_primary_color() * environment_primary_intensity();
-  vec3 sky_color = environment_sky_color();
-  float lit_t = clamp(wrap * 1.15, 0.0, 1.0);
-  vec3 light_tint = mix(sky_color * 0.55, sun_color, lit_t);
+  vec3 sun = environment_primary_color() * environment_primary_intensity();
+  vec3 sky = environment_sky_color();
+  vec3 illumination =
+      environment_ambient_light(geometric_normal) * mix(1.0, 1.30, v_foliage_mask) +
+      sun * mix(diffuse * 0.72, wrap, v_foliage_mask);
 
-  float underside = 1.0 - smoothstep(0.02, 0.44, geometric_normal.y);
+  float sun_catch = smoothstep(0.45, 1.00, wrap) * mix(0.20, 0.62, needle_clump);
+  needle_color = mix(needle_color, needle_sun, sun_catch * v_foliage_mask);
+
+  float underside = 1.0 - smoothstep(-0.30, 0.10, geometric_normal.y);
   float radius = length(v_local_pos.xz);
   float canopy_core = 1.0 - smoothstep(0.06, 0.42, radius);
   float shelf_ao = underside * (0.40 + canopy_core * 0.55);
-  needle_color *= mix(1.0, 0.38, clamp(shelf_ao, 0.0, 1.0) * v_foliage_mask);
-
   float bough_edge = smoothstep(0.30, 0.95, v_bough) * (1.0 - underside);
-  needle_color *= mix(1.0, 1.14, bough_edge * v_foliage_mask);
-  needle_color *= mix(1.0, 0.72, canopy_core * v_foliage_mask * 0.85);
-
   float canopy_height = clamp(v_tex_coord.y, 0.0, 1.12);
-  needle_color *= mix(0.80, 1.14, smoothstep(0.34, 1.06, canopy_height));
 
-  float tip_lit = smoothstep(0.20, 0.80, diffuse) * bough_edge;
-  needle_color = mix(needle_color, needle_sun, tip_lit * 0.26 * needle_clump);
-
-  needle_color *= mix(vec3(0.86, 0.96, 1.10), vec3(1.07, 1.02, 0.86), lit_t);
+  float shelf = mix(1.0, 0.55, clamp(shelf_ao, 0.0, 1.0));
+  float core = mix(1.0, 0.80, canopy_core * 0.85);
+  float tier = mix(0.88, 1.10, smoothstep(0.34, 1.06, canopy_height));
+  float bough_lift = mix(1.0, 1.10, bough_edge);
+  float hemi = clamp(geometric_normal.y * 0.5 + 0.5, 0.0, 1.0);
+  float canopy_occlusion = clamp(shelf * core * tier * bough_lift, 0.42, 1.12);
+  float ao = mix(1.0, canopy_occlusion, v_foliage_mask) * mix(0.72, 1.0, hemi);
 
   float old_needles = (1.0 - smoothstep(0.42, 0.70, v_tex_coord.y)) *
                       smoothstep(0.72, 0.96, needle_fine);
-  needle_color = mix(needle_color, vec3(0.30, 0.235, 0.125), old_needles * 0.30);
+  needle_color = mix(needle_color, vec3(0.34, 0.265, 0.145), old_needles * 0.30);
 
   float bark_stripe = sin(v_tex_coord.y * 45.0 + v_bark_seed * TWO_PI) * 0.1 + 0.9;
   float bark_noise = soi_hash_15a407(vec2(v_tex_coord.x * 18.0 + v_bark_seed * 4.3,
@@ -119,17 +121,20 @@ void main() {
   trunk_color *= mix(1.0, 0.62, smoothstep(0.30, 0.58, v_local_pos.y));
 
   vec3 base_color = mix(trunk_color, needle_color, v_foliage_mask);
-  vec3 color = base_color * lighting * light_tint * environment_exposure();
+  vec3 color = base_color * illumination * ao * environment_exposure();
 
   float translucency = backlight * backlight *
                        (0.20 + smoothstep(0.82, 1.02, v_tex_coord.y) * 0.22) *
                        v_foliage_mask * (0.35 + bough_edge * 0.85);
-  color += needle_color * vec3(0.34, 0.46, 0.20) * translucency;
+  color += needle_color * vec3(0.34, 0.46, 0.20) * translucency * sun;
 
-  float needle_sheen =
-      pow(max(dot(n, normalize(l + vec3(0.0, 0.8, 0.35))), 0.0), 14.0) *
-      v_foliage_mask * 0.055;
-  color += mix(sky_color, sun_color, 0.5) * needle_sheen;
+  vec3 half_dir = normalize(l + view_dir);
+  float needle_spec =
+      pow(max(dot(shading_normal, half_dir), 0.0), 20.0) * v_foliage_mask * 0.045;
+  float rim = pow(1.0 - max(dot(geometric_normal, view_dir), 0.0), 4.0) *
+              mix(0.055, 0.085, v_foliage_mask);
+  color += sun * needle_spec;
+  color += sky * rim;
 
   if (v_tex_coord.y < 0.028)
     discard;

--- a/render/geom/attack_target_markers.cpp
+++ b/render/geom/attack_target_markers.cpp
@@ -20,7 +20,7 @@ constexpr float k_hovered_alpha = 0.9F;
 constexpr float k_hostile_thickness = 0.09F;
 constexpr float k_hovered_thickness = 0.16F;
 constexpr float k_hovered_ring_scale = 1.18F;
-constexpr float k_glyph_alpha = 0.95F;
+constexpr float k_glyph_alpha = Render::Geom::k_indicator_alpha;
 
 const QVector3D k_hostile_color(0.86F, 0.22F, 0.16F);
 const QVector3D k_hovered_color(1.0F, 0.42F, 0.28F);

--- a/render/geom/icon_glyph.cpp
+++ b/render/geom/icon_glyph.cpp
@@ -273,7 +273,7 @@ void GlyphBuilder::emit_skirt(const std::vector<BoundaryEdge>& edges,
     return;
   }
 
-  constexpr int k_corner_segments = 7;
+  constexpr int k_corner_segments = 12;
 
   for (BoundaryEdge const& edge : edges) {
     QVector2D const inner_from = edge.from + edge.outward * inner_offset;
@@ -371,7 +371,7 @@ void GlyphBuilder::polyline(std::span<const QVector2D> points,
     const QVector2D& b = points[(i + 1U) % points.size()];
     bar(a, b, width);
     if (i + 1U < segments || closed) {
-      disc(b, width * 0.5F, 8);
+      disc(b, width * 0.5F, 14);
     }
   }
 }

--- a/render/geom/mode_indicator.cpp
+++ b/render/geom/mode_indicator.cpp
@@ -17,13 +17,13 @@ constexpr float k_glyph_detail_depth = 0.118F;
 
 constexpr GlyphBuilder::GlyphExtrusion k_glyph_extrusion{
     .outline_depth = 0.030F,
-    .outline_width = 0.036F,
+    .outline_width = 0.034F,
     .back_depth = 0.030F,
     .face_depth = k_glyph_face_depth,
     .shadow_depth = -0.070F,
-    .shadow_grow = 0.052F,
-    .halo_grow = 0.118F,
-    .shadow_offset = {0.004F, -0.009F},
+    .shadow_grow = 0.046F,
+    .halo_grow = 0.112F,
+    .shadow_offset = {0.008F, -0.020F},
 };
 
 struct KindStyle {
@@ -61,30 +61,42 @@ constexpr std::array<KindStyle, k_indicator_kind_count> k_kind_styles = {{
 }
 
 void add_sword(GlyphBuilder& builder, float rotation) {
+  const std::array<QVector2D, 4> blade = {{
+      {-0.056F, -0.07F},
+      {0.056F, -0.07F},
+      {0.042F, 0.30F},
+      {-0.042F, 0.30F},
+  }};
   builder.set_transform({0.0F, -0.02F}, rotation);
-  builder.bar({0.0F, -0.02F}, {0.0F, 0.26F}, 0.135F);
-  builder.arrow_head({0.0F, 0.44F}, {0.0F, 1.0F}, 0.20F, 0.088F);
-  builder.bar({-0.20F, -0.06F}, {0.20F, -0.06F}, 0.100F);
-  builder.bar({0.0F, -0.04F}, {0.0F, -0.26F}, 0.092F);
-  builder.disc({0.0F, -0.30F}, 0.072F, 12);
+  builder.convex(blade);
+  builder.arrow_head({0.0F, 0.46F}, {0.0F, 1.0F}, 0.16F, 0.042F);
+  builder.bar({-0.155F, -0.07F}, {0.155F, -0.07F}, 0.072F);
+  builder.bar({0.0F, -0.07F}, {0.0F, -0.28F}, 0.068F);
+  builder.disc({0.0F, -0.30F}, 0.054F, 18);
   builder.reset_transform();
 }
 
 void build_attack(GlyphBuilder& builder) {
   builder.begin_glyph();
-  add_sword(builder, 0.62F);
-  add_sword(builder, -0.62F);
+  add_sword(builder, 0.72F);
+  add_sword(builder, -0.72F);
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_guard(GlyphBuilder& builder) {
-  const std::array<QVector2D, 6> shield = {{
-      {0.00F, 0.34F},
-      {-0.27F, 0.21F},
-      {-0.27F, -0.06F},
-      {0.00F, -0.36F},
-      {0.27F, -0.06F},
-      {0.27F, 0.21F},
+  const std::array<QVector2D, 7> shield = {{
+      {-0.29F, 0.32F},
+      {0.29F, 0.32F},
+      {0.29F, 0.02F},
+      {0.17F, -0.22F},
+      {0.00F, -0.38F},
+      {-0.17F, -0.22F},
+      {-0.29F, 0.02F},
+  }};
+  const std::array<QVector2D, 3> chevron = {{
+      {-0.15F, 0.11F},
+      {0.00F, -0.04F},
+      {0.15F, 0.11F},
   }};
   builder.begin_glyph();
   builder.convex(shield);
@@ -92,191 +104,238 @@ void build_guard(GlyphBuilder& builder) {
 
   builder.set_layer(GlyphLayer::Accent);
   builder.set_depth(k_glyph_detail_depth);
-  builder.disc({0.0F, 0.0F}, 0.105F, 18);
+  builder.polyline(chevron, 0.086F);
 }
 
 void build_hold(GlyphBuilder& builder) {
-  const std::array<QVector2D, 3> pennant = {{
-      {0.04F, 0.36F},
-      {0.38F, 0.17F},
-      {0.04F, -0.02F},
+  const std::array<QVector2D, 4> banner = {{
+      {0.02F, 0.38F},
+      {0.36F, 0.29F},
+      {0.36F, 0.09F},
+      {0.02F, 0.18F},
   }};
   builder.begin_glyph();
-  builder.bar({-0.04F, 0.40F}, {-0.04F, -0.30F}, 0.115F);
-  builder.convex(pennant);
-  builder.bar({-0.30F, -0.34F}, {0.24F, -0.34F}, 0.110F);
+  builder.bar({-0.04F, 0.42F}, {-0.04F, -0.26F}, 0.090F);
+  builder.convex(banner);
+  builder.rect({-0.02F, -0.30F}, {0.13F, 0.045F});
+  builder.rect({-0.02F, -0.38F}, {0.23F, 0.050F});
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_patrol(GlyphBuilder& builder) {
-  constexpr float radius = 0.26F;
-  constexpr float width = 0.115F;
   builder.begin_glyph();
-  for (int side = 0; side < 2; ++side) {
-    float const base = side == 0 ? 0.35F : 0.35F + k_pi;
-    builder.ring(
-        {0.0F, 0.0F}, radius - width * 0.5F, radius + width * 0.5F, 12, base, 2.05F);
-    float const tip_angle = base + 2.05F;
-    QVector2D const tip(std::cos(tip_angle) * radius, std::sin(tip_angle) * radius);
-    QVector2D const tangent(-std::sin(tip_angle), std::cos(tip_angle));
-    builder.arrow_head(tip + tangent * 0.19F, tangent, 0.21F, 0.15F);
-  }
+  builder.bar({-0.30F, 0.16F}, {0.15F, 0.16F}, 0.105F);
+  builder.arrow_head({0.36F, 0.16F}, {1.0F, 0.0F}, 0.21F, 0.150F);
+  builder.bar({0.30F, -0.16F}, {-0.15F, -0.16F}, 0.105F);
+  builder.arrow_head({-0.36F, -0.16F}, {-1.0F, 0.0F}, 0.21F, 0.150F);
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_move(GlyphBuilder& builder) {
   const std::array<QVector2D, 3> chevron = {{
-      {-0.24F, -0.06F},
-      {0.00F, 0.16F},
-      {0.24F, -0.06F},
+      {-0.26F, -0.04F},
+      {0.00F, 0.19F},
+      {0.26F, -0.04F},
   }};
   const std::array<QVector2D, 3> chevron_low = {{
-      {-0.24F, -0.26F},
+      {-0.26F, -0.27F},
       {0.00F, -0.04F},
-      {0.24F, -0.26F},
+      {0.26F, -0.27F},
   }};
   builder.begin_glyph();
-  builder.polyline(chevron, 0.125F);
-  builder.polyline(chevron_low, 0.125F);
+  builder.polyline(chevron, 0.128F);
+  builder.polyline(chevron_low, 0.128F);
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_construct(GlyphBuilder& builder) {
+  const std::array<QVector2D, 6> head = {{
+      {-0.26F, 0.36F},
+      {0.26F, 0.36F},
+      {0.30F, 0.28F},
+      {0.26F, 0.16F},
+      {-0.26F, 0.16F},
+      {-0.30F, 0.28F},
+  }};
   builder.begin_glyph();
-  builder.set_transform({0.0F, 0.0F}, -0.35F);
-  builder.rect({0.0F, 0.23F}, {0.24F, 0.125F});
-  builder.rect({-0.15F, 0.34F}, {0.095F, 0.075F});
-  builder.bar({0.0F, 0.20F}, {0.0F, -0.34F}, 0.105F);
+  builder.set_transform({0.02F, -0.02F}, -0.30F);
+  builder.convex(head);
+  builder.bar({0.0F, 0.20F}, {0.0F, -0.36F}, 0.098F);
   builder.reset_transform();
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_repair(GlyphBuilder& builder) {
   builder.begin_glyph();
-  builder.bar({-0.15F, -0.19F}, {0.13F, 0.13F}, 0.125F);
-  builder.ring({0.19F, 0.20F}, 0.070F, 0.165F, 14, 1.15F, 4.55F);
-  builder.ring({-0.21F, -0.24F}, 0.052F, 0.125F, 12, 1.15F + k_pi, 4.55F);
+  builder.bar({-0.17F, -0.21F}, {0.17F, 0.21F}, 0.104F);
+  builder.ring({0.23F, 0.27F}, 0.082F, 0.180F, 20, 1.10F, 4.55F);
+  builder.ring({-0.23F, -0.27F}, 0.082F, 0.180F, 20, 1.10F + k_pi, 4.55F);
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_dismantle(GlyphBuilder& builder) {
   builder.begin_glyph();
-  builder.rect({-0.19F, -0.28F}, {0.15F, 0.090F});
-  builder.rect({0.15F, -0.28F}, {0.15F, 0.090F});
-  builder.rect({-0.28F, -0.07F}, {0.11F, 0.090F});
-  builder.rect({-0.01F, -0.07F}, {0.14F, 0.090F});
-  builder.rect({-0.18F, 0.14F}, {0.15F, 0.090F});
-  builder.rect({0.21F, 0.24F}, {0.14F, 0.085F}, 0.62F);
+  builder.rect({-0.180F, -0.32F}, {0.145F, 0.078F});
+  builder.rect({0.155F, -0.32F}, {0.145F, 0.078F});
+  builder.rect({-0.290F, -0.15F}, {0.035F, 0.078F});
+  builder.rect({-0.020F, -0.15F}, {0.185F, 0.078F});
+  builder.rect({0.255F, -0.15F}, {0.050F, 0.078F});
+  builder.rect({-0.180F, 0.02F}, {0.145F, 0.078F});
+  builder.rect({0.105F, 0.02F}, {0.100F, 0.078F});
+  builder.rect({-0.24F, 0.19F}, {0.085F, 0.078F});
+  builder.rect({0.13F, 0.25F}, {0.115F, 0.070F}, 0.55F);
+  builder.rect({0.33F, 0.09F}, {0.070F, 0.055F}, -0.75F);
   builder.end_glyph(k_glyph_extrusion);
+}
+
+void add_axe(GlyphBuilder& builder) {
+  const std::array<QVector2D, 5> bit = {{
+      {0.06F, 0.345F},
+      {0.30F, 0.325F},
+      {0.44F, 0.20F},
+      {0.42F, 0.02F},
+      {0.06F, 0.19F},
+  }};
+
+  builder.bar({0.0F, 0.32F}, {0.0F, -0.38F}, 0.092F);
+  builder.rect({0.005F, 0.25F}, {0.075F, 0.095F});
+  builder.convex(bit);
 }
 
 void build_chop_wood(GlyphBuilder& builder) {
-  const std::array<QVector2D, 5> blade = {{
-      {0.00F, 0.34F},
-      {0.20F, 0.36F},
-      {0.34F, 0.16F},
-      {0.30F, -0.04F},
-      {0.10F, 0.00F},
-  }};
   builder.begin_glyph();
-  builder.bar({-0.20F, -0.34F}, {0.08F, 0.26F}, 0.105F);
-  builder.convex(blade);
+  builder.set_transform({-0.03F, 0.0F}, 0.30F);
+  add_axe(builder);
+  builder.reset_transform();
   builder.end_glyph(k_glyph_extrusion);
 }
 
+void add_pickaxe(GlyphBuilder& builder) {
+
+  builder.bar({0.0F, 0.24F}, {0.0F, -0.38F}, 0.092F);
+
+  for (int side = 0; side < 2; ++side) {
+    float const sign = side == 0 ? -1.0F : 1.0F;
+    builder.quad(
+        {0.0F, 0.30F}, {sign * 0.19F, 0.245F}, {sign * 0.17F, 0.120F}, {0.0F, 0.165F});
+    builder.quad({sign * 0.19F, 0.245F},
+                 {sign * 0.34F, 0.135F},
+                 {sign * 0.29F, 0.020F},
+                 {sign * 0.17F, 0.120F});
+    builder.tri({sign * 0.34F, 0.135F}, {sign * 0.45F, -0.10F}, {sign * 0.29F, 0.020F});
+  }
+}
+
 void build_mine_stone(GlyphBuilder& builder) {
-  const std::array<QVector2D, 5> head = {{
-      {-0.40F, -0.08F},
-      {-0.22F, 0.16F},
-      {0.00F, 0.24F},
-      {0.22F, 0.16F},
-      {0.40F, -0.08F},
-  }};
   builder.begin_glyph();
-  builder.bar({0.0F, 0.22F}, {0.0F, -0.38F}, 0.105F);
-  builder.polyline(head, 0.100F);
+
+  builder.set_transform({0.0F, -0.02F}, -0.34F);
+  add_pickaxe(builder);
+  builder.reset_transform();
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_mine_iron(GlyphBuilder& builder) {
   const std::array<QVector2D, 4> lower = {{
-      {-0.38F, -0.30F},
-      {0.38F, -0.30F},
-      {0.27F, -0.04F},
-      {-0.27F, -0.04F},
+      {-0.40F, -0.32F},
+      {0.36F, -0.32F},
+      {0.28F, -0.11F},
+      {-0.32F, -0.11F},
   }};
   const std::array<QVector2D, 4> upper = {{
-      {-0.25F, -0.01F},
-      {0.25F, -0.01F},
-      {0.15F, 0.25F},
-      {-0.15F, 0.25F},
+      {-0.14F, -0.03F},
+      {0.42F, -0.03F},
+      {0.34F, 0.18F},
+      {-0.06F, 0.18F},
   }};
   builder.begin_glyph();
   builder.convex(lower);
   builder.convex(upper);
   builder.end_glyph(k_glyph_extrusion);
+
+  builder.set_layer(GlyphLayer::Accent);
+  builder.set_depth(k_glyph_detail_depth);
+  builder.bar({0.04F, 0.115F}, {0.22F, 0.115F}, 0.036F);
+  builder.bar({-0.22F, -0.175F}, {0.04F, -0.175F}, 0.036F);
 }
 
 void build_auto_gather(GlyphBuilder& builder) {
-
+  const std::array<QVector2D, 4> pile = {{
+      {-0.26F, -0.36F},
+      {0.26F, -0.36F},
+      {0.16F, -0.14F},
+      {-0.16F, -0.14F},
+  }};
   builder.begin_glyph();
-  builder.ring({0.0F, 0.02F}, 0.185F, 0.310F, 26, 0.55F, 4.90F);
-  builder.arrow_head({0.30F, 0.22F}, {0.30F, 0.95F}, 0.20F, 0.155F);
+  builder.convex(pile);
+  for (int side = 0; side < 2; ++side) {
+    float const sign = side == 0 ? -1.0F : 1.0F;
+    builder.bar({sign * 0.35F, 0.38F}, {sign * 0.22F, 0.14F}, 0.086F);
+    builder.arrow_head(
+        {sign * 0.129F, -0.027F}, {-sign * 0.478F, -0.878F}, 0.20F, 0.150F);
+  }
+  builder.end_glyph(k_glyph_extrusion);
+}
+
+void build_deliver(GlyphBuilder& builder) {
+  const std::array<QVector2D, 4> crate = {{
+      {-0.28F, -0.34F},
+      {0.28F, -0.34F},
+      {0.24F, -0.05F},
+      {-0.24F, -0.05F},
+  }};
+  builder.begin_glyph();
+  builder.convex(crate);
+  builder.rect({0.0F, 0.005F}, {0.30F, 0.058F});
+  builder.bar({0.0F, 0.42F}, {0.0F, 0.24F}, 0.100F);
+  builder.arrow_head({0.0F, 0.11F}, {0.0F, -1.0F}, 0.16F, 0.145F);
   builder.end_glyph(k_glyph_extrusion);
 
   builder.set_layer(GlyphLayer::Accent);
   builder.set_depth(k_glyph_detail_depth);
-  builder.disc({0.0F, 0.02F}, 0.098F, 16);
-}
-
-void build_deliver(GlyphBuilder& builder) {
-  builder.begin_glyph();
-  builder.rect({0.0F, -0.22F}, {0.26F, 0.17F});
-  builder.rect({0.0F, 0.00F}, {0.32F, 0.065F});
-  builder.bar({0.0F, 0.42F}, {0.0F, 0.22F}, 0.115F);
-  builder.arrow_head({0.0F, 0.11F}, {0.0F, -1.0F}, 0.16F, 0.155F);
-  builder.end_glyph(k_glyph_extrusion);
-
-  builder.set_layer(GlyphLayer::Outline);
-  builder.set_depth(k_glyph_detail_depth);
-  builder.bar({0.0F, -0.36F}, {0.0F, -0.10F}, 0.080F);
+  builder.bar({-0.17F, -0.21F}, {0.17F, -0.21F}, 0.044F);
 }
 
 void build_heal(GlyphBuilder& builder) {
   builder.begin_glyph();
-  builder.bar({0.0F, -0.28F}, {0.0F, 0.28F}, 0.155F);
-  builder.bar({-0.28F, 0.0F}, {0.28F, 0.0F}, 0.155F);
+  builder.bar({0.0F, -0.30F}, {0.0F, 0.30F}, 0.170F);
+  builder.bar({-0.29F, 0.0F}, {0.29F, 0.0F}, 0.160F);
   builder.end_glyph(k_glyph_extrusion);
 }
 
 void build_train(GlyphBuilder& builder) {
-  const std::array<QVector2D, 3> upper = {{
-      {-0.19F, 0.24F},
-      {0.19F, 0.24F},
-      {0.00F, 0.01F},
+  const std::array<QVector2D, 4> upper = {{
+      {-0.20F, 0.22F},
+      {0.20F, 0.22F},
+      {0.035F, -0.025F},
+      {-0.035F, -0.025F},
   }};
-  const std::array<QVector2D, 3> lower = {{
-      {-0.19F, -0.24F},
-      {0.19F, -0.24F},
-      {0.00F, -0.01F},
+  const std::array<QVector2D, 4> lower = {{
+      {-0.20F, -0.22F},
+      {0.20F, -0.22F},
+      {0.035F, 0.025F},
+      {-0.035F, 0.025F},
   }};
   builder.begin_glyph();
   builder.convex(upper);
   builder.convex(lower);
-  builder.rect({0.0F, 0.30F}, {0.27F, 0.065F});
-  builder.rect({0.0F, -0.30F}, {0.27F, 0.065F});
+  builder.rect({0.0F, 0.29F}, {0.26F, 0.070F});
+  builder.rect({0.0F, -0.29F}, {0.26F, 0.070F});
   builder.end_glyph(k_glyph_extrusion);
 
   builder.set_layer(GlyphLayer::Accent);
   builder.set_depth(k_glyph_detail_depth);
-  builder.tri({-0.12F, -0.18F}, {0.12F, -0.18F}, {0.0F, -0.03F});
+  builder.tri({-0.115F, -0.175F}, {0.115F, -0.175F}, {0.0F, -0.035F});
 }
 
 void build_blocked(GlyphBuilder& builder) {
-  const std::array<QVector2D, 3> warning = {{
-      {0.00F, 0.31F},
-      {-0.30F, -0.24F},
-      {0.30F, -0.24F},
+  const std::array<QVector2D, 6> warning = {{
+      {-0.06F, 0.34F},
+      {0.06F, 0.34F},
+      {0.34F, -0.19F},
+      {0.29F, -0.27F},
+      {-0.29F, -0.27F},
+      {-0.34F, -0.19F},
   }};
   builder.begin_glyph();
   builder.convex(warning);
@@ -284,8 +343,8 @@ void build_blocked(GlyphBuilder& builder) {
 
   builder.set_layer(GlyphLayer::Outline);
   builder.set_depth(k_glyph_detail_depth);
-  builder.bar({0.0F, 0.15F}, {0.0F, -0.05F}, 0.098F);
-  builder.disc({0.0F, -0.14F}, 0.062F, 10);
+  builder.bar({0.0F, 0.17F}, {0.0F, -0.04F}, 0.094F);
+  builder.disc({0.0F, -0.14F}, 0.060F, 12);
 }
 
 void build_idle(GlyphBuilder& builder) {

--- a/render/geom/mode_indicator.h
+++ b/render/geom/mode_indicator.h
@@ -20,7 +20,8 @@ inline constexpr std::size_t k_indicator_kind_count =
     static_cast<std::size_t>(IndicatorKind::Blocked) + 1U;
 
 constexpr float k_indicator_height_base = 2.05F;
-constexpr float k_indicator_alpha = 0.95F;
+
+constexpr float k_indicator_alpha = 1.0F;
 constexpr float k_indicator_height_multiplier = 1.35F;
 constexpr float k_indicator_render_scale_height_multiplier = 2.2F;
 constexpr float k_indicator_head_gap = 0.45F;

--- a/render/ground/olive_renderer.cpp
+++ b/render/ground/olive_renderer.cpp
@@ -115,8 +115,8 @@ void OliveRenderer::append_world_prop_olives() {
                                        static_cast<int>(std::round(prop.z)),
                                        m_noise_seed ^ 0x7B3E5F1CU);
       const float color_var = rand_01(var_state);
-      const QVector3D base_color(0.17F, 0.25F, 0.17F);
-      const QVector3D var_color(0.40F, 0.45F, 0.34F);
+      const QVector3D base_color(0.215F, 0.290F, 0.185F);
+      const QVector3D var_color(0.480F, 0.570F, 0.340F);
       QVector3D tint = base_color * (1.0F - color_var) + var_color * color_var;
 
       tint *= remap(rand_01(var_state), 0.82F, 1.20F);
@@ -200,17 +200,17 @@ void OliveRenderer::generate_procedural_olives(
 
     float const color_var = remap(rand_01(state), 0.0F, 1.0F);
 
-    QVector3D const base_color(0.14F + scene.dryness * 0.05F,
-                               0.21F + scene.rockiness * 0.03F,
-                               0.15F + scene.dryness * 0.03F);
-    QVector3D const var_color(0.44F + scene.cluster_bias * 0.05F,
-                              0.50F + scene.rockiness * 0.05F,
-                              0.37F + scene.cluster_bias * 0.04F);
+    QVector3D const base_color(0.160F + scene.dryness * 0.05F,
+                               0.245F + scene.rockiness * 0.04F,
+                               0.170F + scene.dryness * 0.03F);
+    QVector3D const var_color(0.495F + scene.cluster_bias * 0.05F,
+                              0.605F + scene.rockiness * 0.05F,
+                              0.355F + scene.cluster_bias * 0.04F);
     QVector3D tint_color = base_color * (1.0F - color_var) + var_color * color_var;
 
     float const gray_mix = remap(
         rand_01(state), 0.08F + scene.rockiness * 0.04F, 0.18F + scene.dryness * 0.08F);
-    QVector3D const gray_tint(0.44F, 0.47F, 0.43F);
+    QVector3D const gray_tint(0.530F, 0.560F, 0.500F);
     tint_color = tint_color * (1.0F - gray_mix) + gray_tint * gray_mix;
 
     tint_color *= remap(rand_01(state), 0.80F, 1.22F);

--- a/render/ground/pine_renderer.cpp
+++ b/render/ground/pine_renderer.cpp
@@ -115,8 +115,8 @@ void PineRenderer::append_world_prop_pines() {
                                        static_cast<int>(std::round(prop.z)),
                                        m_noise_seed ^ 0x4A7F2C9EU);
       const float color_var = rand_01(var_state);
-      const QVector3D base_color(0.09F, 0.20F, 0.13F);
-      const QVector3D var_color(0.28F, 0.42F, 0.23F);
+      const QVector3D base_color(0.115F, 0.245F, 0.150F);
+      const QVector3D var_color(0.330F, 0.520F, 0.270F);
       QVector3D tint = base_color * (1.0F - color_var) + var_color * color_var;
 
       tint *= remap(rand_01(var_state), 0.80F, 1.22F);
@@ -202,17 +202,17 @@ void PineRenderer::generate_procedural_pines(std::vector<TreeInstanceGpu>& out) 
                         tile_safe * scatter_scale_bias(ScatterRuleSpecies::Pine, scene);
 
     float const color_var = remap(rand_01(state), 0.0F, 1.0F);
-    QVector3D const base_color(0.07F + scene.shelter * 0.03F,
-                               0.16F + scene.shelter * 0.07F,
-                               0.13F + scene.shelter * 0.04F);
-    QVector3D const var_color(0.33F + scene.cluster_bias * 0.05F,
-                              0.49F + scene.shelter * 0.07F,
-                              0.25F + scene.cluster_bias * 0.04F);
+    QVector3D const base_color(0.095F + scene.shelter * 0.03F,
+                               0.200F + scene.shelter * 0.08F,
+                               0.150F + scene.shelter * 0.04F);
+    QVector3D const var_color(0.345F + scene.cluster_bias * 0.05F,
+                              0.545F + scene.shelter * 0.08F,
+                              0.285F + scene.cluster_bias * 0.04F);
     QVector3D tint_color = base_color * (1.0F - color_var) + var_color * color_var;
 
     float const brown_mix = remap(
         rand_01(state), 0.03F + scene.dryness * 0.05F, 0.10F + scene.rockiness * 0.06F);
-    QVector3D const brown_tint(0.27F, 0.25F, 0.19F);
+    QVector3D const brown_tint(0.34F, 0.31F, 0.23F);
     tint_color = tint_color * (1.0F - brown_mix) + brown_tint * brown_mix;
 
     tint_color *= remap(rand_01(state), 0.78F, 1.24F);


### PR DESCRIPTION
Rework the activity indicator shading so its outline, layered surfaces, sheen, and rim response produce clearer silhouettes and more readable depth across the indicator stack.

Update olive and pine foliage shaders with directional ambient and sun illumination, improved foliage-normal treatment, stronger color variation, canopy occlusion, translucency, specular response, and sky-colored rim lighting. Adjust the procedural renderer tints to complement the brighter, more varied foliage palette.

Refine the mode indicator glyph library with cleaner silhouettes and more legible attack, guard, hold, patrol, construction, repair, dismantle, mining, gathering, delivery, train, and blocked symbols. Increase rounded geometry detail, use the shared indicator alpha for attack markers, and tune the indicator extrusion proportions and opacity for a more consistent presentation.