### PR TITLE
Add cross-platform portability gates and release safety fixes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -91,6 +91,24 @@ jobs:
           cmake --build build --parallel \
             --target soi_test_binaries content_validator
 
+      # macOS ships AppleClang and libc++; this runner is GCC and libstdc++.
+      # libstdc++ pulls in far more transitively than libc++ does, so a missing
+      # include builds here and fails on macOS, and Clang diagnoses several
+      # things GCC is silent about. Reparsing the translation units the build
+      # just configured turns a macOS-only build failure into a Linux one for
+      # the cost of a syntax-only pass -- nothing is linked, so Qt being built
+      # against libstdc++ does not matter.
+      #
+      # This runs here rather than in build-linux.yml because that job is on
+      # ubuntu-22.04 for AppImage glibc reasons, and -Wnan-infinity-disabled
+      # needs Clang 18. Without it the fast-math guard would go unenforced.
+      - name: Portability (macOS toolchain)
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y --no-install-recommends clang libc++-dev
+          python3 scripts/check-portability.py --only apple --require-all \
+            --build-dir build
+
       - name: Unit tests
         env:
           QT_QPA_PLATFORM: offscreen

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -84,3 +84,31 @@ jobs:
         run: |
           python scripts/validate_shader_uniforms.py
           python scripts/validate_opengl_requirements.py
+
+  # The two portability passes that need no compiler and no Qt. The third one
+  # (Clang + libc++ over every translation unit) needs a configured build tree,
+  # so it lives in build-linux.yml where one already exists.
+  portability:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install glslang
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends glslang-tools
+
+      # Mesa accepts GLSL that Apple's front end rejects, and a shader that
+      # fails to compile on macOS is a silently missing object rather than a
+      # crash. --require-all means a missing glslangValidator fails the job
+      # instead of quietly skipping the pass.
+      - name: Portability (GLSL and Windows)
+        run: python scripts/check-portability.py --only glsl,windows --require-all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,38 @@ than as something you compile yourself.
 - The renderer now asserts at startup that the driver actually granted an OpenGL
   3.3 Core context, rather than assuming the one it asked for. All three release
   workflows fail if it did not.
+- The macOS and Windows toolchains are now exercised from Linux, where the
+  project is actually developed: every translation unit is reparsed with Clang
+  and libc++, every shader is compiled by a spec-literal GLSL front end, and
+  the sources are scanned for what MSVC and NTFS reject. `make portability`
+  runs it locally; CI runs it on every pull request and every build. The
+  entries under **Fixed** below are what it found on its first run.
 
 ### Fixed
 
+- **Optimised builds had deleted every NaN and infinity check in the game.**
+  `-ffast-math` (and MSVC's `/fp:fast`) licenses the compiler to assume no
+  operand is ever NaN or infinite, so `std::isfinite` folds to `true` and the
+  clamp behind it disappears — verified on the project's own release flags.
+  Around forty guards were affected, on volumes read back from the settings
+  file, camera angles and impact geometry, and so was every use of
+  `infinity()` as a sentinel in pathfinding, AI target selection and bounding
+  boxes. Debug builds were unaffected, which is why it never showed in
+  development, and the three shipped platforms did not agree on the outcome.
+  Linux and macOS now build with `-fno-finite-math-only` and Windows with
+  `/fp:precise`.
+- Two places computed a value from a variable and incremented it in the same
+  function call, where the order is unspecified and compilers differ: the
+  Roman market stall's produce, and the balance simulator's spawn jitter — the
+  latter meaning a seeded simulation did not have to produce the same
+  battle on Windows as on Linux.
+- `stone_instanced.frag` declared a function named `noise3`, which is a GLSL
+  built-in with a different return type. Mesa does not declare the built-in so
+  it compiled here; a spec-literal front end rejects the shader, and a shader
+  that fails to compile is a silently missing object rather than a crash.
+- Eight files used `M_PI`, which MSVC's `<cmath>` does not define. They
+  compiled on Windows only because Qt's `qmath.h` defines it as a fallback and
+  happened to be included first; they now use `std::numbers`.
 - **A crash on drivers that advertise compute shaders on a context below 4.3.**
   The GPU crowd-culling path is guarded by a capability probe that accepted an
   extension string, but its shaders are `#version 430` and need OpenGL 4.3 to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,13 +105,31 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(STATUS "Building in DEBUG mode with GDB support")
 else()
     # Release/RelWithDebInfo: optimize for performance
+    # ---- Floating point ----
+    # The codebase guards roughly forty inputs with std::isfinite: volumes read
+    # back from the settings file, camera angles, impact geometry. Those guards
+    # only exist if the compiler is not allowed to assume operands are finite.
+    #
+    # Both -ffast-math and MSVC's /fp:fast grant exactly that permission, so an
+    # optimised build folds every one of those checks to "true" and the clamp
+    # behind it disappears. It is invisible in development because Debug builds
+    # do not use these flags, and it diverges per platform, which is worse than
+    # being uniformly wrong. Clang says so out loud (-Wnan-infinity-disabled);
+    # GCC and MSVC do it silently.
+    #
+    # GCC and Clang can keep the rest of fast math and give the finiteness
+    # assumption back with -fno-finite-math-only. MSVC has no such sub-switch,
+    # so Windows uses /fp:precise -- the same reasoning, and the only setting
+    # there that keeps the guards alive.
     if(MSVC)
         # MSVC Release flags
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2 /Oi /Ot /GL /fp:fast")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2 /Oi /Ot /GL /fp:precise")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
     else()
         # GCC/Clang Release flags
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ffast-math -funroll-loops -ftree-vectorize")
+        set(CMAKE_CXX_FLAGS
+            "${CMAKE_CXX_FLAGS} -O3 -ffast-math -fno-finite-math-only -funroll-loops -ftree-vectorize"
+        )
         # Keep release artifacts on the compiler's portable architecture
         # baseline. CI-runner-specific -march flags can make packaged builds
         # crash on otherwise supported user CPUs.
@@ -133,6 +151,90 @@ else()
         endif()
     endif()
     message(STATUS "Building in RELEASE mode with optimizations")
+endif()
+
+# ---- Portability warnings ----
+# The game is developed on Linux/GCC and shipped on macOS/AppleClang and
+# Windows/MSVC. This option turns on the warnings that catch, on Linux, the
+# constructs that behave differently on those other two toolchains. It is OFF
+# by default so a normal build stays quiet; CI turns it on (see `make
+# portability` and the portability job in quality.yml).
+#
+# The set is split in two deliberately:
+#
+#   * ERRORS are the diagnostics that indicate real divergence between
+#     compilers -- unspecified evaluation order, dangling references, missing
+#     returns, disabled NaN handling. Every one of these is at zero, so the
+#     gate is meaningful: a new hit is a regression, not a backlog item.
+#   * The rest stay warnings. There are ~2,700 of them (mostly -Wswitch and
+#     -Wmissing-field-initializers) and they are stylistic, not portability
+#     signal. Promoting them would drown the ones that matter.
+#
+# Anything suppressed here is suppressed because it is noise, never because a
+# real finding was inconvenient.
+option(SOI_STRICT_WARNINGS "Compile with the cross-platform portability warning set" OFF)
+if(SOI_STRICT_WARNINGS)
+    if(MSVC)
+        add_compile_options(
+            /W4
+            /permissive- # Reject the Microsoft language extensions
+            /we4715 # Not all control paths return a value
+            /we4172 # Returning the address of a local
+            /we4239 # Non-standard binding of a temporary to a reference
+            /wd4100 # Unreferenced formal parameter
+            /wd4189 # Local variable initialised but not referenced
+            /wd4244 # Narrowing conversion
+            /wd4267 # size_t narrowing
+            /wd4505 # Unreferenced local function
+        )
+    else()
+        add_compile_options(-Wall -Wextra)
+        # -Werror=unused-result belongs to this set on merit but cannot live
+        # here: moc emits `_t->some_getter();` for every invokable, so a
+        # [[nodiscard]] getter on a Q_OBJECT fails the build from generated
+        # code we do not own, and 42 headers have that shape. It is enforced in
+        # scripts/check-portability.py instead, which only sees our own
+        # translation units.
+        add_compile_options(
+            -Werror=return-type
+            -Werror=sign-compare
+            -Werror=range-loop-construct
+            -Wno-switch
+            -Wno-missing-field-initializers
+            -Wno-unused-parameter
+            -Wno-unused-variable
+            -Wno-unused-function
+        )
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            add_compile_options(
+                # The Apple toolchain is Clang, so these are the ones that
+                # speak for macOS.
+                -Werror=unsequenced
+                -Werror=dangling-gsl
+                -Werror=inconsistent-missing-override
+                # Fires if anyone reinstates -ffast-math without
+                # -fno-finite-math-only and silently deletes the isfinite
+                # guards again. See the floating point note above.
+                -Werror=nan-infinity-disabled
+                -Wno-unused-private-field
+                -Wno-unused-lambda-capture
+                -Wno-unused-local-typedef
+                -Wno-mismatched-tags
+                -Wno-shadow-field
+                -Wno-range-loop-bind-reference
+            )
+        else()
+            add_compile_options(
+                -Werror=sequence-point
+                -Wno-unused-but-set-variable
+                -Wno-unused-local-typedefs
+            )
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+                add_compile_options(-Werror=dangling-reference)
+            endif()
+        endif()
+    endif()
+    message(STATUS "Portability warning set enabled (SOI_STRICT_WARNINGS)")
 endif()
 
 # ---- Qt ----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ differs from the pin; a minor/patch difference is reported as drift.
 | `make lint-changed`         | Lint only what changed (includes changed-file clang-tidy)          |
 | `make quality`              | `format-check` + `lint` + quality-marker scan                      |
 | `make validate`             | `quality` + build + tests + content validation                     |
+| `make portability`          | macOS and Windows checks, run from Linux (see below)               |
 | `make strip-comments`       | **Destructive**: delete comments. Needs `STRIP_COMMENTS_CONFIRM=1` |
 
 `FORMAT_BASE` defaults to `origin/main`:
@@ -105,6 +106,50 @@ sudo apt-get install qtdeclarative5-dev-tools    # Ubuntu/Debian (Qt5)
 They land in `/usr/lib/qt6/bin/` or `/usr/lib/qt5/bin/`; the driver searches
 those paths automatically, and `QMLFORMAT` / `QMLLINT` override the lookup.
 
+### Catching macOS and Windows problems from Linux
+
+Almost all development happens on Linux, with GCC, libstdc++ and Mesa. The game
+ships on macOS (AppleClang, libc++, Apple's GL front end) and Windows (MSVC).
+Those toolchains reject things this one accepts, and without help you find out
+at the point a release tag is already cut.
+
+Two targets close most of that gap without leaving Linux:
+
+```bash
+make portability-lint    # three static passes, a couple of minutes
+make portability-build   # full compile with the warnings promoted to errors
+```
+
+`make portability-lint` runs `scripts/check-portability.py`, which is three
+passes:
+
+| Pass      | Stands in for          | Finds                                                                                               |
+| --------- | ---------------------- | --------------------------------------------------------------------------------------------------- |
+| `apple`   | AppleClang + libc++    | Includes that only libstdc++ provides transitively; unsequenced modification; dangling references   |
+| `glsl`    | Apple's GLSL front end | Shaders Mesa accepts and a spec-literal compiler rejects - a missing object on screen, not a crash  |
+| `windows` | MSVC and NTFS          | Math constants MSVC's `<cmath>` hides; filenames Windows cannot create; `MAX_PATH`; case collisions |
+
+It needs `clang`, `libc++-dev` and `glslang-tools`. Passes whose tool is
+missing are skipped locally; CI passes `--require-all`, so there a missing
+tool is a failure rather than a silent gap.
+
+`make portability-build` configures a separate `build-strict/` tree with
+`-DSOI_STRICT_WARNINGS=ON`. That option is defined in `CMakeLists.txt` and
+splits its diagnostics deliberately: the ones that indicate genuine divergence
+between compilers are **errors** and are all at zero, so a new hit is a
+regression; the roughly 2,700 stylistic warnings (mostly `-Wswitch` and
+`-Wmissing-field-initializers`) stay warnings, because promoting them would
+bury the signal.
+
+In CI, `glsl` and `windows` run in the `portability` job of `quality.yml`, which
+needs no compiler. `apple` runs in the pull-request test job, which already has
+a configured tree - and specifically there rather than in `build-linux.yml`,
+because that job is on ubuntu-22.04 for AppImage glibc reasons and
+`-Wnan-infinity-disabled` needs Clang 18. An unknown `-Werror=` name is only a
+warning to Clang, so on an older one the fast-math guard would appear to pass
+without ever being checked; `check-portability.py` refuses to run rather than
+report a green it did not earn.
+
 ## Continuous Integration
 
 CI runs in three tiers of increasing thoroughness. Pull requests stay cheap so
@@ -114,7 +159,10 @@ the point at which every supported platform must actually ship.
 **Pull requests** (`.github/workflows/pr.yml`) run two jobs in parallel:
 
 - `quality` - formatting, linting, quality markers and the static content
-  validators. No compiler, fails in about a minute.
+  validators, plus the compiler-free half of the portability gate (GLSL and
+  Windows). No compiler, fails in about a minute.
+- The `test` job below also runs the `apple` portability pass, reparsing every
+  translation unit with Clang and libc++.
 - `test` - Linux configure and build of the test targets only
   (`soi_test_binaries`, `content_validator`), then unit tests, content
   validation, the validator integration tests, and advisory clang-tidy over

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ help:
 	@echo "  $(GREEN)lint-changed$(RESET)  - Lint only files changed vs FORMAT_BASE"
 	@echo "  $(GREEN)quality$(RESET)       - lint + format-check + quality markers"
 	@echo "  $(GREEN)validate$(RESET)      - quality + build + test + content validation"
+	@echo "  $(GREEN)portability$(RESET)   - macOS/Windows checks run from Linux"
 	@echo "  $(GREEN)hooks-install$(RESET) - Install the pre-commit git hooks"
 	@echo "  $(GREEN)tidy$(RESET)          - Run clang-tidy fixes on changed files"
 	@echo "  $(GREEN)tidy-all$(RESET)      - Run clang-tidy fixes on the whole project"
@@ -559,6 +560,39 @@ translations-check:
 		exit 1; \
 	fi
 	@echo "$(GREEN)✓ Every UI string is translated$(RESET)"
+
+# ---- Cross-platform portability ----
+#
+# The game is developed on Linux/GCC/Mesa and shipped on macOS/AppleClang and
+# Windows/MSVC. These two targets look, from Linux, for the constructs that
+# only the other two toolchains reject.
+#
+# portability-lint needs clang, libc++-dev and glslang-tools. Without them the
+# passes skip; CI passes --require-all so a missing tool fails there instead.
+#
+# portability-build is the same warning set applied to a real compile, which is
+# the only way to reach code behind #ifdefs and templates that the lint's
+# syntax-only pass still covers but a reader might doubt. It builds into
+# BUILD_STRICT_DIR so it never disturbs the incremental build in build/.
+.PHONY: portability portability-lint portability-build
+
+BUILD_STRICT_DIR := build-strict
+
+## Run the macOS (clang + libc++), GLSL and Windows portability passes.
+portability-lint:
+	@echo "$(BOLD)$(BLUE)Checking cross-platform portability...$(RESET)"
+	@$(PYTHON) scripts/check-portability.py --build-dir $(BUILD_DIR)
+
+## Compile the whole project with the portability warning set promoted to errors.
+portability-build:
+	@echo "$(BOLD)$(BLUE)Building with SOI_STRICT_WARNINGS...$(RESET)"
+	@cmake -S . -B $(BUILD_STRICT_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Release \
+		-DSOI_STRICT_WARNINGS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+	@cmake --build $(BUILD_STRICT_DIR) -j$$(nproc)
+	@echo "$(GREEN)✓ Strict build clean$(RESET)"
+
+## Both portability gates.
+portability: portability-lint portability-build
 
 # ---- Aggregate gates ----
 .PHONY: quality validate hooks-install

--- a/assets/shaders/stone_instanced.frag
+++ b/assets/shaders/stone_instanced.frag
@@ -17,7 +17,7 @@ float hash31(vec3 p) {
   return fract((p.x + p.y) * p.z);
 }
 
-float noise3(vec3 p) {
+float stone_noise3(vec3 p) {
   vec3 i = floor(p);
   vec3 f = fract(p);
   f = f * f * (3.0 - 2.0 * f);
@@ -38,8 +38,8 @@ void main() {
   vec3 H = normalize(L + V);
 
   vec3 p = v_local_pos;
-  float broad = noise3(p * 3.2 + vec3(1.7, 5.1, 2.3));
-  float grain = noise3(p * 13.0 + v_world_pos * 0.12);
+  float broad = stone_noise3(p * 3.2 + vec3(1.7, 5.1, 2.3));
+  float grain = stone_noise3(p * 13.0 + v_world_pos * 0.12);
   float strata = 0.5 + 0.5 * sin(p.y * 22.0 + p.x * 4.0 + broad * 3.2);
   float fissure_field = abs(sin(p.x * 13.0 - p.z * 9.0 + p.y * 6.0 + broad * 4.0));
   float fissures = 1.0 - smoothstep(0.035, 0.14, fissure_field);
@@ -49,13 +49,13 @@ void main() {
   stone = mix(stone, stone * vec3(0.55, 0.58, 0.60), fissures * 0.72);
 
   float upward = smoothstep(0.28, 0.86, N.y);
-  float lichen_noise = noise3(v_world_pos * 1.8 + vec3(3.0, 8.0, 1.0));
+  float lichen_noise = stone_noise3(v_world_pos * 1.8 + vec3(3.0, 8.0, 1.0));
   float lichen = upward * smoothstep(0.58, 0.82, lichen_noise) * 0.34;
   vec3 lichen_color = vec3(0.24, 0.28, 0.20);
   stone = mix(stone, lichen_color, lichen);
 
   float ground_damp = (1.0 - smoothstep(0.02, 0.24, p.y)) *
-                      smoothstep(0.28, 0.72, noise3(v_world_pos * 0.9));
+                      smoothstep(0.28, 0.72, stone_noise3(v_world_pos * 0.9));
   stone = mix(stone, stone * vec3(0.52, 0.58, 0.60), ground_damp * 0.58);
 
   float ndotl = max(dot(N, L), 0.0);

--- a/game/map/terrain.cpp
+++ b/game/map/terrain.cpp
@@ -986,7 +986,7 @@ auto TerrainHeightMap::calculateFeatureHeight(const TerrainFeature& feature,
   }
 
   float const t = dist / feature.radius;
-  float const height_factor = (std::cos(t * M_PI) + 1.0F) * 0.5F;
+  float const height_factor = (std::cos(t * std::numbers::pi) + 1.0F) * 0.5F;
 
   return feature.height * height_factor;
 }

--- a/render/entity/mounted_humanoid_renderer_base.h
+++ b/render/entity/mounted_humanoid_renderer_base.h
@@ -19,7 +19,7 @@ public:
 
   auto uses_mounted_pipeline() const noexcept -> bool override { return true; }
 
-  virtual auto get_mount_scale() const -> float = 0;
+  auto get_mount_scale() const -> float override = 0;
 
   void set_mount_visual(Render::Creature::ArchetypeId id, std::string_view debug_name) {
     m_mount_archetype_id = id;

--- a/render/entity/nations/roman/marketplace_renderer.cpp
+++ b/render/entity/nations/roman/marketplace_renderer.cpp
@@ -116,12 +116,17 @@ void add_produce_basket(BuildingArchetypeDesc& desc,
   for (float const x : {-0.055F, 0.0F, 0.055F}) {
     for (float const z : {-0.040F, 0.040F}) {
       QVector3D const fruit_base = base + QVector3D(x, 0.10F, z);
+      QVector3D const fruit_tip =
+          fruit_base +
+          QVector3D(0.0F, 0.055F + 0.008F * static_cast<float>(index), 0.0F);
+      QVector3D const& fruit_colour = (index % 2 == 0) ? produce_a : produce_b;
       desc.add_cone(fruit_base,
-                    fruit_base + QVector3D(0.0F, 0.055F + 0.008F * index, 0.0F),
+                    fruit_tip,
                     0.035F,
-                    (index++ % 2 == 0) ? produce_a : produce_b,
+                    fruit_colour,
                     BuildingStateMask::Normal,
                     BuildingLODMask::Full);
+      ++index;
     }
   }
 }

--- a/scripts/check-portability.py
+++ b/scripts/check-portability.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Catch macOS and Windows build failures from a Linux machine.
+
+The game is developed on Linux/GCC and shipped on macOS/AppleClang and
+Windows/MSVC, so most of what breaks the other two toolchains is discovered by
+a release build that has already been tagged.  Everything here runs on Linux
+and looks for a class of problem that Linux/GCC/Mesa happens to accept.
+
+Three passes:
+
+  apple   Re-parses every first-party translation unit with Clang and libc++ —
+          the macOS toolchain, near enough.  libstdc++ includes far more
+          transitively than libc++ does, so a missing '#include <cstdint>'
+          builds here and fails there; Clang also diagnoses several things GCC
+          is silent about (unsequenced modification, dangling references,
+          missing 'override').  Syntax-only, so no Qt-against-libc++ ABI
+          question arises: nothing is linked.
+
+  glsl    Runs every shader through glslangValidator after resolving the
+          engine's own '#include' directives the way render/gl/shader.cpp
+          resolves them.  Mesa's GLSL front end is permissive; Apple's is
+          close to the letter of the spec, and a shader that fails to compile
+          there is not a crash, it is a silently missing object on screen.
+
+  windows Static checks for the constructs MSVC and NTFS reject: math
+          constants that MSVC's <cmath> does not define, filenames Windows
+          cannot create, and paths that overflow MAX_PATH once unpacked.
+
+The compiler warning set that belongs to a real build lives in CMakeLists.txt
+behind SOI_STRICT_WARNINGS, not here, so that `make portability` and CI agree
+with what an actual strict build enforces.
+
+Usage:
+    python3 scripts/check-portability.py [--build-dir build] [--require-all]
+                                         [--only apple,glsl,windows]
+
+--require-all turns a missing clang/libc++/glslangValidator into a failure
+instead of a skip.  CI passes it; a developer running this locally without the
+tools installed gets the passes it can run.
+"""
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SKIP_PREFIXES = ("third_party", "build")
+
+CLANG_FLAGS = [
+    "-fsyntax-only",
+    "-Wall",
+    "-Wextra",
+    "-Werror=return-type",
+    "-Werror=unused-result",
+    "-Werror=sign-compare",
+    "-Werror=range-loop-construct",
+    "-Werror=unsequenced",
+    "-Werror=dangling-gsl",
+    "-Werror=inconsistent-missing-override",
+    "-Werror=nan-infinity-disabled",
+    "-Wno-switch",
+    "-Wno-missing-field-initializers",
+    "-Wno-unused-parameter",
+    "-Wno-unused-variable",
+    "-Wno-unused-function",
+    "-Wno-unused-private-field",
+    "-Wno-unused-lambda-capture",
+    "-Wno-unused-local-typedef",
+    "-Wno-mismatched-tags",
+    "-Wno-shadow-field",
+    "-Wno-range-loop-bind-reference",
+    "-Wno-unknown-warning-option",
+    "-Wno-unused-command-line-argument",
+]
+
+GCC_ONLY_FLAGS = {
+    "-ftree-vectorize",
+    "-fno-optimize-sibling-calls",
+    "-ggdb3",
+    "-fprofile-update=atomic",
+}
+
+MSVC_UNDEFINED_MATH = (
+    "M_PI",
+    "M_PI_2",
+    "M_PI_4",
+    "M_E",
+    "M_SQRT2",
+    "M_LN2",
+    "M_LN10",
+    "M_1_PI",
+    "M_2_PI",
+)
+
+WINDOWS_RESERVED = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
+WINDOWS_FORBIDDEN_CHARS = set('<>:"|?*\\')
+
+MAX_PATH = 260
+
+MIN_CLANG_MAJOR = 18
+
+
+def clang_major(clang):
+    """Major version of the given clang, or None if it cannot be read."""
+    proc = subprocess.run([clang, "--version"], capture_output=True, text=True)
+    match = re.search(r"clang version (\d+)", proc.stdout)
+    return int(match.group(1)) if match else None
+
+
+def tracked_files():
+    """Every file git knows about, as repo-relative POSIX paths."""
+    out = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [p for p in out.split("\0") if p]
+
+
+def find_libcxx(clang):
+    """Locate a libc++ header directory next to the given clang binary."""
+    bindir = Path(clang).resolve().parent
+    candidates = [
+        bindir.parent / "include" / "c++" / "v1",
+        Path("/usr/include/c++/v1"),
+    ]
+    candidates += sorted(Path("/usr/lib").glob("llvm-*/include/c++/v1"), reverse=True)
+    for c in candidates:
+        if (c / "vector").exists():
+            return c
+    return None
+
+
+def resolve_shader_includes(source, include_dir, already):
+    """Mirror resolve_shader_includes() in render/gl/shader.cpp.
+
+    Same rules: the name is looked up in assets/shaders/include, each header is
+    pasted at most once per shader, and resolution recurses.  If this ever
+    drifts from the C++ the validator stops describing what the game compiles.
+    """
+    out = []
+    for line in source.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("#include"):
+            match = re.search(r'["<]([^">]+)[">]', stripped)
+            if match:
+                name = match.group(1)
+                if name in already:
+                    continue
+                header = include_dir / name
+                if header.exists():
+                    already.add(name)
+                    out.append(
+                        resolve_shader_includes(
+                            header.read_text(encoding="utf-8"), include_dir, already
+                        )
+                    )
+                    continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def check_apple(build_dir, require):
+    """Reparse every first-party TU with Clang and libc++."""
+    clang = shutil.which("clang++") or shutil.which("clang++-18")
+    if clang is None:
+        msg = "clang++ not found (install clang)"
+        return ([f"{msg}"], []) if require else ([], [f"SKIP {msg}"])
+
+    libcxx = find_libcxx(clang)
+    if libcxx is None:
+        msg = "libc++ headers not found (install libc++-dev)"
+        return ([f"{msg}"], []) if require else ([], [f"SKIP {msg}"])
+
+    version = clang_major(clang)
+    if version is not None and version < MIN_CLANG_MAJOR:
+        msg = (
+            f"clang {version} is too old: -Wnan-infinity-disabled arrived in "
+            f"{MIN_CLANG_MAJOR}, and an unknown -Werror= name is only a warning, "
+            "so the fast-math guard would pass without being checked"
+        )
+        return ([msg], []) if require else ([], [f"SKIP {msg}"])
+
+    db_path = ROOT / build_dir / "compile_commands.json"
+    if not db_path.exists():
+        return (
+            [f"{db_path} missing — configure with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"],
+            [],
+        )
+
+    database = json.loads(db_path.read_text(encoding="utf-8"))
+    seen, units = set(), []
+    for entry in database:
+        path = Path(entry["file"])
+        try:
+            rel = path.relative_to(ROOT).as_posix()
+        except ValueError:
+            continue
+        if rel.startswith(SKIP_PREFIXES) or "_autogen" in rel or entry["file"] in seen:
+            continue
+        seen.add(entry["file"])
+        units.append(entry)
+
+    def compile_one(entry):
+        args, skip_next = [], False
+        for arg in shlex.split(entry["command"])[1:]:
+            if skip_next:
+                skip_next = False
+                continue
+            if arg == "-o":
+                skip_next = True
+                continue
+            if arg == "-c" or arg in GCC_ONLY_FLAGS:
+                continue
+            args.append(arg)
+        cmd = [clang, "-nostdinc++", "-isystem", str(libcxx)]
+        cmd += CLANG_FLAGS + args + [entry["file"]]
+        proc = subprocess.run(
+            cmd, cwd=entry["directory"], capture_output=True, text=True
+        )
+        return proc.returncode, proc.stderr
+
+    errors = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count() or 4) as pool:
+        for entry, (code, err) in zip(units, pool.map(compile_one, units), strict=True):
+            if code != 0:
+                rel = Path(entry["file"]).relative_to(ROOT).as_posix()
+                first = next(
+                    (ln for ln in err.split("\n") if "error:" in ln), err.split("\n")[0]
+                )
+                errors.append(f"{rel}: {first.strip()}")
+    return errors, [f"{len(units)} translation units reparsed with Clang + libc++"]
+
+
+def check_glsl(require):
+    """Compile every shader with glslang after resolving engine includes."""
+    glslang = shutil.which("glslangValidator") or shutil.which("glslang")
+    if glslang is None:
+        msg = "glslangValidator not found (install glslang-tools)"
+        return ([f"{msg}"], []) if require else ([], [f"SKIP {msg}"])
+
+    shader_dir = ROOT / "assets" / "shaders"
+    include_dir = shader_dir / "include"
+    shaders = sorted(
+        p for p in shader_dir.iterdir() if p.suffix in (".vert", ".frag", ".comp")
+    )
+
+    errors = []
+    for shader in shaders:
+        resolved = resolve_shader_includes(
+            shader.read_text(encoding="utf-8"), include_dir, set()
+        )
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=shader.suffix, delete=False, encoding="utf-8"
+        ) as handle:
+            handle.write(resolved)
+            tmp = handle.name
+        try:
+            proc = subprocess.run([glslang, tmp], capture_output=True, text=True)
+        finally:
+            os.unlink(tmp)
+        if proc.returncode != 0:
+            detail = [
+                ln.strip()
+                for ln in (proc.stdout + proc.stderr).split("\n")
+                if ln.startswith("ERROR:") and "compilation terminated" not in ln
+            ]
+            errors.append(
+                f"{shader.name}: {detail[0] if detail else 'failed to compile'}"
+            )
+    return errors, [f"{len(shaders)} shaders compiled by glslang"]
+
+
+def check_windows():
+    """Static checks for what MSVC and NTFS reject."""
+    errors = []
+    files = tracked_files()
+
+    sources = [
+        f
+        for f in files
+        if f.endswith((".cpp", ".h", ".hpp", ".cc")) and not f.startswith(SKIP_PREFIXES)
+    ]
+    pattern = re.compile(r"\b(" + "|".join(MSVC_UNDEFINED_MATH) + r")\b")
+    for rel in sources:
+        text = (ROOT / rel).read_text(encoding="utf-8", errors="replace")
+        if "_USE_MATH_DEFINES" in text:
+            continue
+        for number, line in enumerate(text.split("\n"), start=1):
+            if line.lstrip().startswith("#"):
+                continue
+            match = pattern.search(line)
+            if match:
+                errors.append(
+                    f"{rel}:{number}: {match.group(1)} is not defined by MSVC's "
+                    "<cmath> unless _USE_MATH_DEFINES is defined first; use a "
+                    "constant of your own or std::numbers"
+                )
+
+    for rel in files:
+        name = Path(rel).name
+        stem = name.split(".")[0].upper()
+        if stem in WINDOWS_RESERVED:
+            errors.append(f"{rel}: '{stem}' is a reserved device name on Windows")
+        if WINDOWS_FORBIDDEN_CHARS & set(name):
+            bad = "".join(sorted(WINDOWS_FORBIDDEN_CHARS & set(name)))
+            errors.append(f"{rel}: filename contains {bad!r}, which Windows forbids")
+        if name.endswith((".", " ")):
+            errors.append(f"{rel}: Windows strips trailing dots and spaces from names")
+        if len(rel) > MAX_PATH - len("C:\\standard_of_iron\\"):
+            errors.append(
+                f"{rel}: path is {len(rel)} chars; risks MAX_PATH once unpacked"
+            )
+
+    by_directory = {}
+    for rel in files:
+        directory, _, name = rel.rpartition("/")
+        by_directory.setdefault(directory, {}).setdefault(name.lower(), []).append(name)
+    for directory, names in by_directory.items():
+        for variants in names.values():
+            if len(variants) > 1:
+                joined = ", ".join(sorted(variants))
+                where = directory or "."
+                errors.append(
+                    f"{where}: {joined} differ only by case and cannot coexist on "
+                    "macOS or Windows"
+                )
+
+    return errors, [
+        f"{len(sources)} sources scanned for MSVC-only math constants",
+        f"{len(files)} tracked paths checked against Windows filename rules",
+    ]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--require-all", action="store_true")
+    parser.add_argument("--only", default="apple,glsl,windows")
+    args = parser.parse_args()
+
+    selected = {name.strip() for name in args.only.split(",") if name.strip()}
+    failures = 0
+
+    if "apple" in selected:
+        print("[apple]   Clang + libc++ reparse  (macOS toolchain)")
+        errors, notes = check_apple(args.build_dir, args.require_all)
+        failures += report(errors, notes)
+
+    if "glsl" in selected:
+        print("[glsl]    glslang shader compile  (Apple GLSL strictness)")
+        errors, notes = check_glsl(args.require_all)
+        failures += report(errors, notes)
+
+    if "windows" in selected:
+        print("[windows] MSVC and NTFS source lint")
+        errors, notes = check_windows()
+        failures += report(errors, notes)
+
+    print()
+    if failures:
+        print(f"PORTABILITY=fail — {failures} error(s).")
+        return 1
+    print("PORTABILITY=pass")
+    return 0
+
+
+def report(errors, notes):
+    for note in notes:
+        print(f"  {note}" if note.startswith("SKIP") else f"  OK   {note}")
+    for error in errors:
+        print(f"  FAIL {error}")
+    return len(errors)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/core/audio_backend_test.cpp
+++ b/tests/core/audio_backend_test.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <numbers>
 #include <vector>
 
 #include "game/audio/miniaudio_backend.h"
@@ -34,7 +35,7 @@ auto write_tone_wav(const QString& path, float amplitude) -> bool {
   stream.writeRawData("data", 4);
   stream << payload;
   for (int frame = 0; frame < TONE_FRAMES; ++frame) {
-    const double phase = 2.0 * M_PI * 440.0 * frame / SAMPLE_RATE;
+    const double phase = 2.0 * std::numbers::pi * 440.0 * frame / SAMPLE_RATE;
     const auto value = static_cast<std::int16_t>(amplitude * std::sin(phase) * 32000.0);
     stream << value << value;
   }
@@ -62,7 +63,7 @@ auto write_unclosed_bed_wav(const QString& path, int frames, float amplitude) ->
   stream << payload;
   const double cycles = 200.25;
   for (int frame = 0; frame < frames; ++frame) {
-    const double phase = 2.0 * M_PI * cycles * frame / frames;
+    const double phase = 2.0 * std::numbers::pi * cycles * frame / frames;
     const auto value = static_cast<std::int16_t>(amplitude * std::sin(phase) * 32000.0);
     stream << value << value;
   }

--- a/tests/core/commander_control_controller_test.cpp
+++ b/tests/core/commander_control_controller_test.cpp
@@ -127,7 +127,8 @@ TEST_F(CommanderControlControllerTest, WalkingAsksForAFootstepOnEveryStride) {
   Render::GL::Camera camera;
   for (int frame = 0; frame < 90; ++frame) {
     controller.input().forward = true;
-    controller.update(world, commander->get_id(), 1, camera, 1.0F / 30.0F);
+    static_cast<void>(
+        controller.update(world, commander->get_id(), 1, camera, 1.0F / 30.0F));
   }
 
   const std::vector<std::string> asked = registry.silent_cues();

--- a/tests/map/terrain_service_test.cpp
+++ b/tests/map/terrain_service_test.cpp
@@ -752,7 +752,7 @@ TEST_F(TerrainServiceTest, HillFootprintOnlyExtendsAtItsWalkableEntranceApron) {
   };
   height_map.build_from_features({hill});
 
-  for (auto const [x, z] : {std::pair{30, 19}, std::pair{41, 30}, std::pair{30, 41}}) {
+  for (auto const& [x, z] : {std::pair{30, 19}, std::pair{41, 30}, std::pair{30, 41}}) {
     EXPECT_FLOAT_EQ(height_map.get_height_at_grid(x, z), 0.0F);
     EXPECT_EQ(height_map.getTerrainType(x, z), Game::Map::TerrainType::Flat);
     EXPECT_TRUE(height_map.is_walkable(x, z));

--- a/tests/render/elephant/elephant_source_asset_test.cpp
+++ b/tests/render/elephant/elephant_source_asset_test.cpp
@@ -226,8 +226,8 @@ TEST(ElephantSourceAssetTest, SynthesisedGaitKeepsTheLegsUnderTheBody) {
       ASSERT_TRUE(Render::Elephant::elephant_source_sample_clip(clip, phase, pose))
           << clip;
 
-      for (auto const pair : {std::pair{k_foot_front_left, k_foot_front_right},
-                              std::pair{k_foot_rear_left, k_foot_rear_right}}) {
+      for (auto const& pair : {std::pair{k_foot_front_left, k_foot_front_right},
+                               std::pair{k_foot_rear_left, k_foot_rear_right}}) {
         float const spread = std::abs(pose[pair.first].column(3).toVector3D().z() -
                                       pose[pair.second].column(3).toVector3D().z());
         widest_pair = std::max(widest_pair, spread);

--- a/tests/tools/map_editor_element_ops_test.cpp
+++ b/tests/tools/map_editor_element_ops_test.cpp
@@ -72,7 +72,8 @@ TEST(MapEditorElementOpsTest, LinearElementAnchorIsItsCentre) {
 TEST(MapEditorElementOpsTest, SnapToGridRoundsEveryCoordinate) {
   const ElementSnapshot snap =
       ElementSnapshot{make_linear(QVector2D(1.4F, 2.6F), QVector2D(8.5F, 3.2F))};
-  const auto& snapped = std::get<MapEditor::LinearElement>(Ops::snapped_to_grid(snap));
+  const ElementSnapshot snapped_snapshot = Ops::snapped_to_grid(snap);
+  const auto& snapped = std::get<MapEditor::LinearElement>(snapped_snapshot);
 
   EXPECT_FLOAT_EQ(snapped.start.x(), 1.0F);
   EXPECT_FLOAT_EQ(snapped.start.y(), 3.0F);

--- a/tools/arena/promo_runner.cpp
+++ b/tools/arena/promo_runner.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <functional>
 #include <memory>
+#include <numbers>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -80,12 +81,13 @@ void paint_rpg_bow_hud(QImage& frame, const ArenaViewport::RpgBowHudState& state
   if (state.bow_stance) {
 
     const double half_fov =
-        std::clamp(static_cast<double>(state.fov_degrees), 20.0, 110.0) * M_PI / 360.0;
+        std::clamp(static_cast<double>(state.fov_degrees), 20.0, 110.0) *
+        std::numbers::pi / 360.0;
     const double focal = (height * 0.5) / std::tan(half_fov);
     const double spread = std::min(
         height * 0.14,
         focal * std::tan(std::min(14.0, static_cast<double>(state.spread_degrees)) *
-                         M_PI / 180.0));
+                         std::numbers::pi / 180.0));
 
     QColor reticle(243, 239, 230, 245);
     if (state.strained) {

--- a/tools/balance_sim/battle_simulation.cpp
+++ b/tools/balance_sim/battle_simulation.cpp
@@ -138,11 +138,13 @@ auto plan_side(const FixtureSide& side,
       const float depth =
           -static_cast<float>(row + row_offset) * rank_spacing * enemy_direction;
 
+      const float depth_jitter = jitter(seed, salt++, jitter_magnitude);
+      const float lateral_jitter = jitter(seed, salt++, jitter_magnitude);
+
       Game::Units::SpawnParams params;
-      params.position =
-          QVector3D(centre.x() + depth + jitter(seed, salt++, jitter_magnitude),
-                    0.0F,
-                    centre.z() + lateral + jitter(seed, salt++, jitter_magnitude));
+      params.position = QVector3D(centre.x() + depth + depth_jitter,
+                                  0.0F,
+                                  centre.z() + lateral + lateral_jitter);
 
       params.rotation_y = enemy_direction > 0.0F ? 90.0F : 270.0F;
       params.player_id = owner_id;

--- a/tools/map_editor/map_canvas.cpp
+++ b/tools/map_editor/map_canvas.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <numbers>
 #include <optional>
 #include <vector>
 
@@ -2076,8 +2077,9 @@ void MapCanvas::draw_world_prop_icon(QPainter& painter,
     const float inner_r = sr * 0.45F;
     QPolygonF star;
     for (int k = 0; k < points * 2; ++k) {
-      const float angle =
-          static_cast<float>(k) * M_PI / static_cast<float>(points) - M_PI_2;
+      const float angle = static_cast<float>(k) * std::numbers::pi_v<float> /
+                              static_cast<float>(points) -
+                          std::numbers::pi_v<float> * 0.5F;
       const float r = (k % 2 == 0) ? sr : inner_r;
       star << QPointF(r * std::cos(angle), r * std::sin(angle));
     }

--- a/tools/map_editor/mission_data.cpp
+++ b/tools/map_editor/mission_data.cpp
@@ -280,7 +280,9 @@ QStringList MissionData::validate() const {
       errors.append(context + QStringLiteral(" has an unsupported difficulty."));
     }
     const QJsonObject personality = ai.value("personality").toObject();
-    for (const QString& field : {"aggression", "defense", "harassment"}) {
+    for (const QString& field : {QStringLiteral("aggression"),
+                                 QStringLiteral("defense"),
+                                 QStringLiteral("harassment")}) {
       const double score = personality.value(field).toDouble(0.5);
       if (score < 0.0 || score > 1.0) {
         errors.append(context +

--- a/ui/campaign_map_view.cpp
+++ b/ui/campaign_map_view.cpp
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <numbers>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -2256,8 +2257,8 @@ void main() {
     if (hovered) {
       const qint64 elapsed = QDateTime::currentMSecsSinceEpoch() - m_hover_start_time;
       const float pulse_cycle = 1400.0F;
-      pulse = 0.5F + 0.5F * std::sin(static_cast<float>(elapsed) * 2.0F * float(M_PI) /
-                                     pulse_cycle);
+      pulse = 0.5F + 0.5F * std::sin(static_cast<float>(elapsed) * 2.0F *
+                                     std::numbers::pi_v<float> / pulse_cycle);
       wash(0.72F, 0.44F + 0.08F * pulse);
     } else {
       wash(0.38F, 0.30F);
@@ -2295,7 +2296,7 @@ void main() {
 
     glStencilFunc(GL_NOTEQUAL, 1, 0xFF);
     for (int i = 0; i < k_outline_steps; ++i) {
-      const float angle = 2.0F * float(M_PI) * static_cast<float>(i) /
+      const float angle = 2.0F * std::numbers::pi_v<float> * static_cast<float>(i) /
                           static_cast<float>(k_outline_steps);
       const QVector2D offset(2.0F * radius_px * std::cos(angle) / width_px,
                              2.0F * radius_px * std::sin(angle) / height_px);

--- a/ui/input_bindings.cpp
+++ b/ui/input_bindings.cpp
@@ -739,7 +739,7 @@ auto InputBindings::format(const Chord& chord) -> QString {
 
   if (chord.mouse_button != 0) {
     for (const auto& entry : k_button_names) {
-      if (chord.mouse_button == entry.button) {
+      if (chord.mouse_button == static_cast<int>(entry.button)) {
         return modifiers_to_string(chord.modifiers) + QString::fromLatin1(entry.name);
       }
     }
@@ -805,7 +805,7 @@ auto InputBindings::describe(const QString& shortcut) -> QString {
   }
   if (chord.mouse_button != 0) {
     for (const auto& entry : k_button_names) {
-      if (chord.mouse_button == entry.button) {
+      if (chord.mouse_button == static_cast<int>(entry.button)) {
         return modifiers_to_string(chord.modifiers) + tr(entry.name);
       }
     }


### PR DESCRIPTION
Introduce a repository-wide portability checker with AppleClang/libc++ syntax coverage, strict GLSL validation, and Windows/MSVC and NTFS compatibility checks. Expose the checks through Make targets and run the compiler-free and toolchain-specific lanes in CI with required-tool enforcement.

Make optimized builds preserve the finiteness checks relied on by gameplay and rendering code, use precise floating-point behavior on MSVC, and enable a focused strict warning set for cross-platform diagnostics. Fix the portability findings in shaders, math constants, evaluation order, range-loop bindings, abstract overrides, ignored results, and enum comparisons, then document the workflow and record the fixes in the changelog.

The branch was formatted with make format and rebased by fast-forwarding from the latest origin/main before this commit.