### PR TITLE
Commanders authored in maps

### DIFF
--- a/app/core/mission_commander_setup.cpp
+++ b/app/core/mission_commander_setup.cpp
@@ -1,12 +1,17 @@
 #include "mission_commander_setup.h"
 
+#include <QDebug>
+
 #include <algorithm>
 #include <limits>
 
+#include "game/map/map_loader.h"
 #include "game/map/spawn_cluster.h"
 #include "game/systems/nation_id.h"
 #include "game/units/commander_catalog.h"
 #include "game/units/spawn_type.h"
+#include "game/units/troop_type.h"
+#include "utils/resource_utils.h"
 
 namespace App::Core {
 namespace {
@@ -85,6 +90,35 @@ auto resolve_commander_troop(const QString& nation,
   return Game::Units::troop_typeToQString(
       Game::Units::default_commander_troop_for_nation(
           parsed_nation ? nation_id : Game::Systems::NationID::RomanRepublic));
+}
+
+auto commander_troops_by_owner(const Game::Map::MapDefinition& map)
+    -> std::map<int, QString> {
+  std::map<int, QString> by_owner;
+  for (const auto& spawn : map.spawns) {
+    const auto troop_type = Game::Units::spawn_typeToTroopType(spawn.type);
+    if (!troop_type.has_value() || !Game::Units::is_commander_troop(*troop_type)) {
+      continue;
+    }
+    const QString troop = Game::Units::troop_typeToQString(*troop_type);
+    const auto [it, inserted] = by_owner.emplace(spawn.player_id, troop);
+    if (!inserted) {
+      qWarning() << "Map authors more than one commander for owner" << spawn.player_id
+                 << "- keeping" << it->second << "and ignoring" << troop;
+    }
+  }
+  return by_owner;
+}
+
+auto commander_troops_for_map(const QString& map_path) -> std::map<int, QString> {
+  Game::Map::MapDefinition map;
+  QString error;
+  const QString resolved = Utils::Resources::resolve_resource_path(map_path);
+  if (!Game::Map::MapLoader::load_from_json_file(resolved, map, &error)) {
+    qWarning() << "Commander lookup: failed to load map" << map_path << "-" << error;
+    return {};
+  }
+  return commander_troops_by_owner(map);
 }
 
 auto resolve_commander_position(

--- a/app/core/mission_commander_setup.h
+++ b/app/core/mission_commander_setup.h
@@ -2,9 +2,11 @@
 
 #include <QString>
 
+#include <map>
 #include <optional>
 #include <vector>
 
+#include "game/map/map_definition.h"
 #include "game/map/mission_definition.h"
 
 namespace App::Core {
@@ -27,6 +29,12 @@ struct ResolvedCommanderPosition {
 [[nodiscard]] auto
 resolve_commander_troop(const QString& nation,
                         const std::optional<QString>& configured_commander) -> QString;
+
+[[nodiscard]] auto commander_troops_by_owner(const Game::Map::MapDefinition& map)
+    -> std::map<int, QString>;
+
+[[nodiscard]] auto
+commander_troops_for_map(const QString& map_path) -> std::map<int, QString>;
 
 [[nodiscard]] auto resolve_commander_position(
     const std::vector<Game::Mission::UnitSetup>& units,

--- a/app/core/mission_definition_view.cpp
+++ b/app/core/mission_definition_view.cpp
@@ -13,6 +13,9 @@
 
 namespace {
 
+constexpr int k_local_owner_id = 1;
+constexpr int k_first_ai_owner_id = 2;
+
 auto resolve_mission_file_path(const QString& mission_id) -> QString {
   const QStringList search_paths = {QStringLiteral("assets/missions/%1.json"),
                                     QStringLiteral("../assets/missions/%1.json"),
@@ -208,18 +211,26 @@ auto build_commander_map(const QString& commander_troop) -> QVariantMap {
   return map;
 }
 
-auto build_player_setup_map(const Game::Mission::PlayerSetup& setup) -> QVariantMap {
+void apply_map_commander(QVariantMap& map,
+                         const std::map<int, QString>& map_commanders,
+                         int owner_id) {
+  const auto it = map_commanders.find(owner_id);
+  if (it == map_commanders.end() || it->second.isEmpty()) {
+    return;
+  }
+  map["commander_troop"] = it->second;
+  map["commander"] = build_commander_map(it->second);
+}
+
+auto build_player_setup_map(const Game::Mission::PlayerSetup& setup,
+                            const std::map<int, QString>& map_commanders)
+    -> QVariantMap {
   QVariantMap map;
   map["nation"] = setup.nation;
   map["faction"] = setup.faction;
   map["color"] = setup.color;
 
-  const QString commander_troop =
-      App::Core::resolve_commander_troop(setup.nation, setup.commander_troop);
-  if (!commander_troop.isEmpty()) {
-    map["commander_troop"] = commander_troop;
-    map["commander"] = build_commander_map(commander_troop);
-  }
+  apply_map_commander(map, map_commanders, k_local_owner_id);
 
   map["starting_units"] = build_unit_setup_list(setup.starting_units);
   map["starting_buildings"] = build_building_setup_list(setup.starting_buildings);
@@ -234,7 +245,9 @@ auto build_player_setup_map(const Game::Mission::PlayerSetup& setup) -> QVariant
   return map;
 }
 
-auto build_ai_setup_map(const Game::Mission::AISetup& setup) -> QVariantMap {
+auto build_ai_setup_map(const Game::Mission::AISetup& setup,
+                        const std::map<int, QString>& map_commanders,
+                        int owner_id) -> QVariantMap {
   QVariantMap map;
   map["id"] = setup.id;
   map["nation"] = setup.nation;
@@ -242,12 +255,7 @@ auto build_ai_setup_map(const Game::Mission::AISetup& setup) -> QVariantMap {
   map["color"] = setup.color;
   map["difficulty"] = setup.difficulty;
 
-  const QString commander_troop =
-      App::Core::resolve_commander_troop(setup.nation, setup.commander_troop);
-  if (!commander_troop.isEmpty()) {
-    map["commander_troop"] = commander_troop;
-    map["commander"] = build_commander_map(commander_troop);
-  }
+  apply_map_commander(map, map_commanders, owner_id);
   if (setup.team_id.has_value()) {
     map["team_id"] = setup.team_id.value();
   }
@@ -264,7 +272,6 @@ auto build_ai_setup_map(const Game::Mission::AISetup& setup) -> QVariantMap {
 }
 
 auto build_campaign_player_config(const QString& nation,
-                                  const std::optional<QString>& commander_troop,
                                   int player_id,
                                   int color_index,
                                   int team_id,
@@ -275,8 +282,6 @@ auto build_campaign_player_config(const QString& nation,
   player["colorIndex"] = color_index;
   player["team_id"] = team_id;
   player["nationId"] = nation;
-  player["commanderTroop"] =
-      App::Core::resolve_commander_troop(nation, commander_troop);
   player["isHuman"] = is_human;
   return player;
 }
@@ -307,11 +312,14 @@ auto build_mission_definition_map(const Game::Mission::MissionDefinition& missio
     result["terrain_type"] = mission.terrain_type.value();
   }
 
-  result["player_setup"] = build_player_setup_map(mission.player_setup);
+  const auto map_commanders = App::Core::commander_troops_for_map(mission.map_path);
+  result["player_setup"] = build_player_setup_map(mission.player_setup, map_commanders);
 
   QVariantList ai_setups;
+  int owner_id = k_first_ai_owner_id;
   for (const auto& ai_setup : mission.ai_setups) {
-    ai_setups.append(build_ai_setup_map(ai_setup));
+    ai_setups.append(build_ai_setup_map(ai_setup, map_commanders, owner_id));
+    ++owner_id;
   }
   result["ai_setups"] = ai_setups;
 
@@ -339,25 +347,16 @@ auto build_mission_objectives_map(const Game::Mission::MissionDefinition& missio
 auto build_campaign_player_configs(const Game::Mission::MissionDefinition& mission)
     -> QVariantList {
   QVariantList player_configs;
-  player_configs.append(
-      build_campaign_player_config(mission.player_setup.nation,
-                                   mission.player_setup.commander_troop,
-                                   1,
-                                   0,
-                                   0,
-                                   true));
+  player_configs.append(build_campaign_player_config(
+      mission.player_setup.nation, k_local_owner_id, 0, 0, true));
 
-  int player_id = 2;
+  int player_id = k_first_ai_owner_id;
   int default_team_id = 1;
   for (const auto& ai_setup : mission.ai_setups) {
     const int team_id =
         ai_setup.team_id.has_value() ? ai_setup.team_id.value() : default_team_id++;
-    player_configs.append(build_campaign_player_config(ai_setup.nation,
-                                                       ai_setup.commander_troop,
-                                                       player_id,
-                                                       player_id - 1,
-                                                       team_id,
-                                                       false));
+    player_configs.append(build_campaign_player_config(
+        ai_setup.nation, player_id, player_id - 1, team_id, false));
     ++player_id;
   }
 

--- a/app/core/mission_setup_coordinator.cpp
+++ b/app/core/mission_setup_coordinator.cpp
@@ -548,77 +548,27 @@ auto MissionSetupCoordinator::apply_mission_setup(
     }
   };
 
-  auto spawn_commander_for_owner =
-      [&](int owner_id,
-          const Game::Systems::NationID nation_id,
-          const QString& commander_troop,
-          const App::Core::ResolvedCommanderPosition& position) {
-        if (commander_troop.trimmed().isEmpty()) {
-          return;
-        }
-        const auto spawn_type =
-            Game::Units::spawn_typeFromString(commander_troop.trimmed().toStdString());
-        if (!spawn_type.has_value()) {
-          qWarning() << "Mission setup: unknown commander troop" << commander_troop;
-          return;
-        }
-        const auto troop_type = Game::Units::spawn_typeToTroopType(*spawn_type);
-        if (!troop_type.has_value() || !Game::Units::is_commander_troop(*troop_type)) {
-          qWarning() << "Mission setup: non-commander troop configured as commander"
-                     << commander_troop;
-          return;
-        }
-        for (auto* entity :
-             ctx.world.get_entities_with<Engine::Core::CommanderComponent>()) {
-          if (entity == nullptr) {
-            continue;
-          }
-          const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
-          if (unit != nullptr && unit->owner_id == owner_id && unit->health > 0) {
-            return;
-          }
-        }
-        Game::Units::SpawnParams sp;
-        if (position.space == App::Core::CommanderPositionSpace::World) {
-          sp.position = QVector3D(position.position.x, 0.0F, position.position.z);
-        } else {
-          sp.position = mission_position_to_world(position.position);
-        }
-        sp.player_id = owner_id;
-        sp.spawn_type = *spawn_type;
-        sp.ai_controlled = owner_registry.is_ai(owner_id);
-        sp.nation_id = nation_id;
-        auto unit = reg->create(sp.spawn_type, ctx.world, sp);
-        if (!unit) {
-          qWarning() << "Mission setup: failed to spawn commander" << commander_troop
-                     << "for owner" << owner_id;
-          return;
-        }
-        apply_team_color(ctx.world.get_entity(unit->id()), owner_id);
-      };
+  const auto map_commanders = App::Core::commander_troops_by_owner(map_def);
 
-  auto existing_owner_spawn_anchors = [&](int owner_id) {
-    std::vector<App::Core::ExistingOwnerSpawnAnchor> anchors;
-    auto entities = ctx.world.get_entities_with<Engine::Core::UnitComponent>();
-    anchors.reserve(entities.size());
-    for (auto* entity : entities) {
+  auto verify_owner_commander = [&](int owner_id, const QString& force_label) {
+    for (auto* entity :
+         ctx.world.get_entities_with<Engine::Core::CommanderComponent>()) {
       if (entity == nullptr) {
         continue;
       }
-
       const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
-      const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
-      if (unit == nullptr || transform == nullptr || unit->owner_id != owner_id ||
-          unit->health <= 0) {
-        continue;
+      if (unit != nullptr && unit->owner_id == owner_id && unit->health > 0) {
+        return;
       }
-
-      App::Core::ExistingOwnerSpawnAnchor anchor;
-      anchor.position = {transform->position.x, transform->position.z};
-      anchor.is_building = Game::Units::is_building_spawn(unit->spawn_type);
-      anchors.push_back(anchor);
     }
-    return anchors;
+    if (map_commanders.find(owner_id) == map_commanders.end()) {
+      qWarning() << "Mission setup:" << ctx.level.map_path << "authors no commander for"
+                 << force_label << "(owner" << owner_id
+                 << ") - that force starts headless";
+      return;
+    }
+    qWarning() << "Mission setup: map commander for" << force_label << "(owner"
+               << owner_id << ") failed to spawn";
   };
 
   auto spawn_buildings_for_owner =
@@ -670,15 +620,7 @@ auto MissionSetupCoordinator::apply_mission_setup(
   nation_registry.set_player_nation(local_owner_id, player_nation_id);
   apply_owner_color(local_owner_id, mission.player_setup.color);
 
-  const QString player_commander_troop = App::Core::resolve_commander_troop(
-      mission.player_setup.nation, mission.player_setup.commander_troop);
-  const auto player_commander_pos = App::Core::resolve_commander_position(
-      mission.player_setup.starting_units,
-      mission.player_setup.starting_buildings,
-      existing_owner_spawn_anchors(local_owner_id),
-      {68.0F, 70.0F});
-  spawn_commander_for_owner(
-      local_owner_id, player_nation_id, player_commander_troop, player_commander_pos);
+  verify_owner_commander(local_owner_id, QStringLiteral("the player"));
   spawn_units_for_owner(
       local_owner_id, player_nation_id, mission.player_setup.starting_units);
   spawn_buildings_for_owner(
@@ -713,15 +655,7 @@ auto MissionSetupCoordinator::apply_mission_setup(
     nation_registry.set_player_nation(ai_owner_id, ai_nation_id);
     apply_owner_color(ai_owner_id, ai_setup.color);
 
-    const QString ai_commander_troop =
-        App::Core::resolve_commander_troop(ai_setup.nation, ai_setup.commander_troop);
-    const auto ai_commander_pos =
-        App::Core::resolve_commander_position(ai_setup.starting_units,
-                                              ai_setup.starting_buildings,
-                                              existing_owner_spawn_anchors(ai_owner_id),
-                                              {132.0F, 80.0F});
-    spawn_commander_for_owner(
-        ai_owner_id, ai_nation_id, ai_commander_troop, ai_commander_pos);
+    verify_owner_commander(ai_owner_id, ai_setup.id);
     spawn_units_for_owner(ai_owner_id, ai_nation_id, ai_setup.starting_units);
     spawn_buildings_for_owner(ai_owner_id, ai_nation_id, ai_setup.starting_buildings);
 

--- a/assets/maps/map_battle_cannae.json
+++ b/assets/maps/map_battle_cannae.json
@@ -1828,6 +1828,38 @@
             "type": "archer",
             "x": 142,
             "z": 606
+        },
+        {
+            "max_population": -1,
+            "nation": "carthage",
+            "player_id": 1,
+            "type": "carthage_sword_commander",
+            "x": 191.01,
+            "z": 270.69
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 2,
+            "type": "roman_field_commander",
+            "x": 294.0,
+            "z": 346.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 3,
+            "type": "roman_legion_organizer",
+            "x": 520.0,
+            "z": 114.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 4,
+            "type": "roman_veteran_consul",
+            "x": 140.0,
+            "z": 606.0
         }
     ],
     "starting_resources": {

--- a/assets/maps/map_battle_ticino.json
+++ b/assets/maps/map_battle_ticino.json
@@ -2527,6 +2527,30 @@
             "type": "archer",
             "x": 254,
             "z": 56
+        },
+        {
+            "max_population": -1,
+            "nation": "carthage",
+            "player_id": 1,
+            "type": "carthage_sword_commander",
+            "x": 104.19,
+            "z": 240.37
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 2,
+            "type": "roman_veteran_consul",
+            "x": 238.59,
+            "z": 191.92
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 3,
+            "type": "roman_field_commander",
+            "x": 548.0,
+            "z": 200.0
         }
     ],
     "starting_resources": {

--- a/assets/maps/map_battle_trasimene.json
+++ b/assets/maps/map_battle_trasimene.json
@@ -1816,6 +1816,30 @@
             "type": "archer",
             "x": 500,
             "z": 464
+        },
+        {
+            "max_population": -1,
+            "nation": "carthage",
+            "player_id": 1,
+            "type": "carthage_sword_commander",
+            "x": 131.0,
+            "z": 270.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 2,
+            "type": "roman_legion_organizer",
+            "x": 220.0,
+            "z": 426.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 3,
+            "type": "roman_veteran_consul",
+            "x": 444.67,
+            "z": 300.0
         }
     ],
     "starting_resources": {

--- a/assets/maps/map_battle_trebia.json
+++ b/assets/maps/map_battle_trebia.json
@@ -2536,6 +2536,30 @@
             "type": "archer",
             "x": 302,
             "z": 290
+        },
+        {
+            "max_population": -1,
+            "nation": "carthage",
+            "player_id": 1,
+            "type": "carthage_sword_commander",
+            "x": 280.11,
+            "z": 445.39
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 2,
+            "type": "roman_field_commander",
+            "x": 300.0,
+            "z": 290.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 3,
+            "type": "roman_legion_organizer",
+            "x": 383.6,
+            "z": 268.0
         }
     ],
     "starting_resources": {

--- a/assets/maps/map_battle_zama.json
+++ b/assets/maps/map_battle_zama.json
@@ -2159,6 +2159,46 @@
             "type": "archer",
             "x": 87.16,
             "z": 316.11
+        },
+        {
+            "max_population": -1,
+            "nation": "carthage",
+            "player_id": 1,
+            "type": "carthage_sword_commander",
+            "x": 283.85,
+            "z": 434.14
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 2,
+            "type": "roman_veteran_consul",
+            "x": 423.67,
+            "z": 276.72
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 3,
+            "type": "roman_field_commander",
+            "x": 560.0,
+            "z": 194.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 4,
+            "type": "roman_legion_organizer",
+            "x": 548.0,
+            "z": 596.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 5,
+            "type": "roman_field_commander",
+            "x": 100.0,
+            "z": 472.0
         }
     ],
     "starting_resources": {

--- a/assets/maps/map_campania_campaign.json
+++ b/assets/maps/map_campania_campaign.json
@@ -2195,6 +2195,38 @@
             "type": "spearman",
             "x": 154,
             "z": 404
+        },
+        {
+            "max_population": -1,
+            "nation": "carthage",
+            "player_id": 1,
+            "type": "carthage_sword_commander",
+            "x": 322.0,
+            "z": 238.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 2,
+            "type": "roman_legion_organizer",
+            "x": 120.0,
+            "z": 78.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 3,
+            "type": "roman_veteran_consul",
+            "x": 392.0,
+            "z": 546.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 4,
+            "type": "roman_field_commander",
+            "x": 582.0,
+            "z": 284.0
         }
     ],
     "starting_resources": {

--- a/assets/maps/map_crossing_alps.json
+++ b/assets/maps/map_crossing_alps.json
@@ -1546,6 +1546,38 @@
             "type": "archer",
             "x": 62,
             "z": 226
+        },
+        {
+            "max_population": -1,
+            "nation": "carthage",
+            "player_id": 1,
+            "type": "carthage_sword_commander",
+            "x": 44.0,
+            "z": 58.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 2,
+            "type": "roman_field_commander",
+            "x": 60.0,
+            "z": 226.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 3,
+            "type": "roman_legion_organizer",
+            "x": 286.0,
+            "z": 520.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 4,
+            "type": "roman_veteran_consul",
+            "x": 417.34,
+            "z": 564.48
         }
     ],
     "starting_resources": {

--- a/assets/maps/map_crossing_rhone.json
+++ b/assets/maps/map_crossing_rhone.json
@@ -4925,6 +4925,22 @@
             "type": "spearman",
             "x": 306,
             "z": 176
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 2,
+            "type": "roman_legion_organizer",
+            "x": 282.25,
+            "z": 87.0
+        },
+        {
+            "max_population": -1,
+            "nation": "roman_republic",
+            "player_id": 3,
+            "type": "roman_veteran_consul",
+            "x": 416.55,
+            "z": 601.0
         }
     ],
     "starting_resources": {

--- a/assets/missions/battle_of_cannae.json
+++ b/assets/missions/battle_of_cannae.json
@@ -16,8 +16,7 @@
     "starting_resources": {
       "gold": 750,
       "food": 600
-    },
-    "commander_troop": "carthage_sword_commander"
+    }
   },
   "ai_setups": [
     {
@@ -74,8 +73,7 @@
             "z": 296
           }
         }
-      ],
-      "commander_troop": "roman_field_commander"
+      ]
     },
     {
       "id": "roman_reserve_wing",
@@ -135,8 +133,7 @@
             "z": 152
           }
         }
-      ],
-      "commander_troop": "roman_legion_organizer"
+      ]
     },
     {
       "id": "roman_allied_wing",
@@ -188,8 +185,7 @@
             "z": 430
           }
         }
-      ],
-      "commander_troop": "roman_field_commander"
+      ]
     }
   ],
   "victory_conditions": [

--- a/assets/missions/battle_of_ticino.json
+++ b/assets/missions/battle_of_ticino.json
@@ -16,8 +16,7 @@
     "starting_resources": {
       "gold": 550,
       "food": 450
-    },
-    "commander_troop": "carthage_sword_commander"
+    }
   },
   "ai_setups": [
     {
@@ -78,8 +77,7 @@
             "z": 330
           }
         }
-      ],
-      "commander_troop": "roman_veteran_consul"
+      ]
     },
     {
       "id": "roman_reserve",
@@ -139,8 +137,7 @@
             "z": 232
           }
         }
-      ],
-      "commander_troop": "roman_field_commander"
+      ]
     }
   ],
   "victory_conditions": [

--- a/assets/missions/battle_of_trasimene.json
+++ b/assets/missions/battle_of_trasimene.json
@@ -16,8 +16,7 @@
     "starting_resources": {
       "gold": 360,
       "food": 280
-    },
-    "commander_troop": "carthage_sword_commander"
+    }
   },
   "ai_setups": [
     {
@@ -74,8 +73,7 @@
             "z": 172
           }
         }
-      ],
-      "commander_troop": "roman_legion_organizer"
+      ]
     },
     {
       "id": "roman_escape_force",
@@ -110,8 +108,7 @@
             "z": 152
           }
         }
-      ],
-      "commander_troop": "roman_veteran_consul"
+      ]
     }
   ],
   "victory_conditions": [

--- a/assets/missions/battle_of_trebia.json
+++ b/assets/missions/battle_of_trebia.json
@@ -16,8 +16,7 @@
     "starting_resources": {
       "gold": 500,
       "food": 380
-    },
-    "commander_troop": "carthage_sword_commander"
+    }
   },
   "ai_setups": [
     {
@@ -136,8 +135,7 @@
             }
           ]
         }
-      ],
-      "commander_troop": "roman_field_commander"
+      ]
     },
     {
       "id": "roman_west_reserve",
@@ -221,8 +219,7 @@
           "grace_seconds": 40.0,
           "warning_seconds": 18.0
         }
-      ],
-      "commander_troop": "roman_legion_organizer"
+      ]
     }
   ],
   "victory_conditions": [

--- a/assets/missions/battle_of_zama.json
+++ b/assets/missions/battle_of_zama.json
@@ -16,8 +16,7 @@
     "starting_resources": {
       "gold": 650,
       "food": 520
-    },
-    "commander_troop": "carthage_sword_commander"
+    }
   },
   "ai_setups": [
     {
@@ -74,8 +73,7 @@
             "z": 420
           }
         }
-      ],
-      "commander_troop": "roman_veteran_consul"
+      ]
     },
     {
       "id": "roman_numidian_allies",
@@ -131,8 +129,7 @@
             "z": 252
           }
         }
-      ],
-      "commander_troop": "roman_field_commander"
+      ]
     },
     {
       "id": "roman_rear_guard",
@@ -175,8 +172,7 @@
             "z": 596
           }
         }
-      ],
-      "commander_troop": "roman_legion_organizer"
+      ]
     },
     {
       "id": "roman_northern_camp",
@@ -228,8 +224,7 @@
             "z": 240
           }
         }
-      ],
-      "commander_troop": "roman_field_commander"
+      ]
     }
   ],
   "victory_mode": "all",

--- a/assets/missions/campania_campaign.json
+++ b/assets/missions/campania_campaign.json
@@ -11,7 +11,6 @@
     "nation": "carthage",
     "faction": "carthaginian",
     "color": "brown",
-    "commander_troop": "carthage_sword_commander",
     "starting_units": [],
     "starting_buildings": [
       {
@@ -216,7 +215,6 @@
           ]
         }
       ],
-      "commander_troop": "roman_legion_organizer",
       "wave_escalation": 0.12
     },
     {
@@ -345,7 +343,6 @@
           "label": "The allied wing"
         }
       ],
-      "commander_troop": "roman_veteran_consul",
       "wave_escalation": 0.12
     },
     {
@@ -461,7 +458,6 @@
           "label": "The siege column"
         }
       ],
-      "commander_troop": "roman_field_commander",
       "wave_escalation": 0.12
     }
   ],

--- a/assets/missions/crossing_the_alps.json
+++ b/assets/missions/crossing_the_alps.json
@@ -25,8 +25,7 @@
     "starting_resources": {
       "gold": 450,
       "food": 650
-    },
-    "commander_troop": "carthage_sword_commander"
+    }
   },
   "ai_setups": [
     {
@@ -79,8 +78,7 @@
             "z": 216
           }
         }
-      ],
-      "commander_troop": "roman_field_commander"
+      ]
     },
     {
       "id": "mountain_tribes_pass_two",
@@ -132,8 +130,7 @@
             "z": 336
           }
         }
-      ],
-      "commander_troop": "roman_legion_organizer"
+      ]
     },
     {
       "id": "mountain_tribes_final_pass",
@@ -193,8 +190,7 @@
             "z": 536
           }
         }
-      ],
-      "commander_troop": "roman_veteran_consul"
+      ]
     }
   ],
   "victory_conditions": [

--- a/assets/missions/crossing_the_rhone.json
+++ b/assets/missions/crossing_the_rhone.json
@@ -16,8 +16,7 @@
     "starting_resources": {
       "gold": 300,
       "food": 200
-    },
-    "commander_troop": "carthage_sword_commander"
+    }
   },
   "ai_setups": [
     {
@@ -34,8 +33,7 @@
         "harassment": 0.2
       },
       "starting_units": [],
-      "starting_buildings": [],
-      "commander_troop": "roman_legion_organizer"
+      "starting_buildings": []
     },
     {
       "id": "roman_patrol_forces",
@@ -52,7 +50,6 @@
       },
       "starting_units": [],
       "starting_buildings": [],
-      "commander_troop": "roman_veteran_consul",
       "waves": [
         {
           "timing": 15.0,

--- a/assets/missions/iron_sepulcher_watch.json
+++ b/assets/missions/iron_sepulcher_watch.json
@@ -7,7 +7,6 @@
     "nation": "roman_republic",
     "faction": "roman",
     "color": "red",
-    "commander_troop": "roman_field_commander",
     "starting_units": [],
     "starting_buildings": [],
     "starting_resources": {

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -418,8 +418,7 @@ Mission files are the current authoring surface for AI setup. The loader reads `
             "count": 2,
             "position": { "x": 134, "z": 82 }
         }
-    ],
-    "commander_troop": "roman_field_commander"
+    ]
 }
 ```
 

--- a/docs/CAMPAIGN_MISSIONS.md
+++ b/docs/CAMPAIGN_MISSIONS.md
@@ -57,9 +57,10 @@ death its barracks fall to the neutral owner, its other works come down and its
 troops leave the field. That makes decapitation the shortest route to a capture
 objective rather than a way around one — a neutral camp is still a camp you have
 to walk into. `MissionAssetRulesTest.DecapitationObjectivesHaveCommandersToKill`
-fails the build if any AI setup ships without a `commander_troop`, because the
-rule only arms once an enemy commander has been seen and an unarmed rule would
-make the mission unwinnable.
+fails the build if any AI force ships without a commander spawn in its map, because
+the rule only arms once an enemy commander has been seen and an unarmed rule would
+make the mission unwinnable. Commanders are authored in the map's `spawns[]`; see
+[MISSION_FRAMEWORK.md](MISSION_FRAMEWORK.md).
 
 _Trasimene is the only mission that can be lost to the clock._ Every other timer
 is an optional objective or a wave schedule.

--- a/docs/MISSION_FRAMEWORK.md
+++ b/docs/MISSION_FRAMEWORK.md
@@ -74,6 +74,57 @@ Defines the human player's starting configuration:
 }
 ```
 
+### Commanders
+
+**Commanders are authored in the map, never in the mission.** A commander reaches
+the field as an ordinary entry in the map's `spawns[]` whose `type` is a commander
+troop, carrying the owning `player_id` and that force's `nation`:
+
+```json
+{
+    "type": "carthage_sword_commander",
+    "player_id": 1,
+    "nation": "carthage",
+    "x": 283.85,
+    "z": 434.14,
+    "max_population": -1
+}
+```
+
+Every force a mission declares — the player as owner 1, then each entry of
+`ai_setups` as owners 2, 3, … in order — needs exactly one such spawn. Mission
+setup no longer invents a commander for a force that lacks one; it warns and that
+force starts headless, which will lose it the mission to `no_commander`.
+
+This used to be a `commander_troop` field on `player_setup` and each AI setup, which
+made two sources of truth: a map that authored a commander silently won, because the
+map's units are already in the world when mission setup runs. The field is gone.
+`MissionLoader` warns if it finds one and `MissionLoaderTest.ShippedMissionsDoNotAuthorCommanders`
+fails the build, so the dead field cannot creep back in.
+
+The map is also what fixes the commander's **position**. Before, position was derived
+from the densest cluster of a force's units, and a force with no authored units landed
+on a hardcoded fallback far from its camp — `battle_of_ticino`'s reserve, `campania_campaign`'s
+siege column and `battle_of_zama`'s rear guard all did. Authoring the spawn puts each
+commander exactly where the author wants it.
+
+Two rules are pinned by tests over the shipped campaign:
+
+- **Coverage** — every force has exactly one commander, of its own nation.
+  `MissionCommanderSetupTest.EveryCampaignForceHasExactlyOneMapCommander` and
+  `CampaignCommandersMatchTheirForcesNation` check the data;
+  `CampaignWaveAssaultTest.EveryCampaignForceLoadsWithExactlyOneCommander` loads every
+  mission for real and counts the live commanders per owner.
+- **Distinctness** — no two forces in one mission share a commander, until a nation
+  fields more forces than it has commanders. Each nation has three, so
+  `battle_of_zama`'s four Roman forces must repeat exactly one; every other mission
+  must be fully distinct.
+  `MissionCommanderSetupTest.CampaignCommandersAreUniqueUntilThePoolRunsOut` enforces
+  the `min(forces, pool)` rule.
+
+In the map editor, a force whose commander the map has forgotten draws as a red crossed
+ring naming the nation-appropriate commander to place — never as a phantom commander badge.
+
 ### AI Setup
 
 Defines AI opponents with personality and behavior:
@@ -88,7 +139,6 @@ Defines AI opponents with personality and behavior:
     "difficulty": "hard",
     "strategy": "aggressive",
     "team_id": 1,
-    "commander_troop": "carthage_war_leader",
     "personality": {
       "aggression": 0.7,
       "defense": 0.3,
@@ -138,7 +188,6 @@ Defines AI opponents with personality and behavior:
 | `difficulty`         | No       | Execution tuning, and a wave-size multiplier; omitted means normal  |
 | `strategy`           | No       | Base strategic preset; omitted falls back to `balanced`             |
 | `team_id`            | No       | Allies AIs with the same team and prevents them fighting each other |
-| `commander_troop`    | No       | Explicit commander troop override                                   |
 | `personality`        | No       | Fine-tunes aggression / defense / harassment on top of the strategy |
 | `starting_units`     | No       | Spawns the AI with units at mission start                           |
 | `starting_buildings` | No       | Spawns the AI with structures at mission start                      |
@@ -466,8 +515,8 @@ satisfied once no enemy commander is left alive.
 The rule **arms** only after an enemy commander has been seen. At mission start the
 roster has not spawned and the count is legitimately zero; without arming, the mission
 would be won on its first evaluated frame. The consequence for authors is that every AI
-setup in a mission carrying this condition needs a `commander_troop` — an AI without one
-can never arm the rule, which makes the mission unwinnable.
+force in a mission carrying this condition needs a commander spawn in the map — an AI
+without one can never arm the rule, which makes the mission unwinnable.
 `MissionAssetRulesTest.DecapitationObjectivesHaveCommandersToKill` fails the build if that
 happens. Iron Sepulcher units are excluded from the count: the dead have no commander, so
 a Sepulcher zone can never block the objective.

--- a/game/map/mission_definition.h
+++ b/game/map/mission_definition.h
@@ -43,7 +43,6 @@ struct PlayerSetup {
   QString nation;
   QString faction;
   QString color;
-  std::optional<QString> commander_troop;
   std::vector<UnitSetup> starting_units;
   std::vector<BuildingSetup> starting_buildings;
   Resources starting_resources;
@@ -98,7 +97,6 @@ struct AISetup {
   QString faction;
   QString color;
   QString difficulty;
-  std::optional<QString> commander_troop;
   std::optional<int> team_id;
   std::optional<QString> strategy;
   AIPersonality personality;

--- a/game/map/mission_loader.cpp
+++ b/game/map/mission_loader.cpp
@@ -1,5 +1,6 @@
 #include "mission_loader.h"
 
+#include <QDebug>
 #include <QFile>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -59,14 +60,23 @@ auto MissionLoader::parse_resources(const QJsonObject& obj) -> Resources {
   return res;
 }
 
+namespace {
+
+void warn_on_authored_commander(const QJsonObject& obj, const QString& force_label) {
+  if (obj.contains("commander_troop")) {
+    qWarning() << "MissionLoader: ignoring 'commander_troop' on" << force_label
+               << "- commanders are authored in the map's spawns[]";
+  }
+}
+
+} // namespace
+
 auto MissionLoader::parse_player_setup(const QJsonObject& obj) -> PlayerSetup {
   PlayerSetup setup;
   setup.nation = obj["nation"].toString();
   setup.faction = obj["faction"].toString();
   setup.color = obj["color"].toString();
-  if (obj.contains("commander_troop")) {
-    setup.commander_troop = obj["commander_troop"].toString();
-  }
+  warn_on_authored_commander(obj, QStringLiteral("player_setup"));
 
   const QJsonArray units = obj["starting_units"].toArray();
   for (const auto& unit_val : units) {
@@ -151,9 +161,7 @@ auto MissionLoader::parse_ai_setup(const QJsonObject& obj) -> AISetup {
   setup.faction = obj["faction"].toString();
   setup.color = obj["color"].toString();
   setup.difficulty = obj["difficulty"].toString();
-  if (obj.contains("commander_troop")) {
-    setup.commander_troop = obj["commander_troop"].toString();
-  }
+  warn_on_authored_commander(obj, setup.id);
 
   if (obj.contains("team_id")) {
     setup.team_id = obj["team_id"].toInt();

--- a/tests/core/campaign_wave_assault_test.cpp
+++ b/tests/core/campaign_wave_assault_test.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <limits>
+#include <map>
 #include <vector>
 
 #include "app/core/campaign_manager.h"
@@ -19,6 +21,7 @@
 #include "game/systems/nation_registry.h"
 #include "game/systems/owner_registry.h"
 #include "game/systems/runtime_system_registry.h"
+#include "game/units/spawn_type.h"
 #include "render/scene_renderer.h"
 #include "scene/camera.h"
 
@@ -176,6 +179,28 @@ public:
     return m_spawned;
   }
 
+  [[nodiscard]] auto
+  living_commanders_by_owner() -> std::map<int, std::vector<QString>> {
+    std::map<int, std::vector<QString>> by_owner;
+    for (auto* entity : m_world.get_entities_with<Engine::Core::CommanderComponent>()) {
+      if (entity == nullptr) {
+        continue;
+      }
+      const auto* unit = entity->get_component<UnitComponent>();
+      if (unit == nullptr || unit->health <= 0) {
+        continue;
+      }
+      by_owner[unit->owner_id].push_back(
+          Game::Units::spawn_typeToQString(unit->spawn_type));
+    }
+    return by_owner;
+  }
+
+  [[nodiscard]] auto force_count() const -> std::size_t {
+    const auto& mission = m_campaign.current_mission_definition();
+    return mission.has_value() ? 1 + mission->ai_setups.size() : 0;
+  }
+
 private:
   struct Engagement {
 
@@ -292,5 +317,33 @@ TEST_F(CampaignWaveAssaultTest, EveryCampaignMissionWaveClosesOnThePlayerCamp) {
         << march.closest_approach;
     EXPECT_LT(march.furthest_from_camp, march.spawn_distance + 10.0F)
         << "the wave drifted away from the camp instead of marching on it";
+  }
+}
+
+TEST_F(CampaignWaveAssaultTest, EveryCampaignForceLoadsWithExactlyOneCommander) {
+  const auto ids = campaign_mission_ids();
+  ASSERT_FALSE(ids.empty()) << "the campaign must list its missions";
+
+  for (const auto& mission_id : ids) {
+    SCOPED_TRACE(mission_id.toStdString());
+
+    MissionUnderTest mission;
+    ASSERT_TRUE(mission.load(mission_id)) << mission.error().toStdString();
+
+    const auto commanders = mission.living_commanders_by_owner();
+    const std::size_t forces = mission.force_count();
+    ASSERT_GT(forces, 0U);
+
+    for (std::size_t index = 0; index < forces; ++index) {
+      const int owner_id = static_cast<int>(index) + 1;
+      const auto it = commanders.find(owner_id);
+      ASSERT_NE(it, commanders.end())
+          << "owner " << owner_id << " went into battle with no commander";
+      EXPECT_EQ(it->second.size(), 1U) << "owner " << owner_id << " fielded "
+                                       << it->second.size() << " commanders at once";
+    }
+
+    EXPECT_EQ(commanders.size(), forces)
+        << "the world holds commanders for owners the mission never declared";
   }
 }

--- a/tests/core/mission_commander_setup_test.cpp
+++ b/tests/core/mission_commander_setup_test.cpp
@@ -1,8 +1,16 @@
+#include <algorithm>
 #include <gtest/gtest.h>
+#include <map>
+#include <set>
+#include <vector>
 
 #include "app/core/mission_commander_setup.h"
+#include "game/map/campaign_loader.h"
+#include "game/map/mission_loader.h"
+#include "game/systems/nation_id.h"
 #include "game/units/commander_catalog.h"
 #include "game/units/troop_type.h"
+#include "utils/resource_utils.h"
 
 TEST(MissionCommanderSetupTest, FallsBackToHannibalForCarthage) {
   EXPECT_EQ(App::Core::resolve_commander_troop("carthage", std::nullopt),
@@ -89,5 +97,124 @@ TEST(MissionCommanderSetupTest, NationDefaultsResolveToCatalogCommanders) {
     const auto* definition = Game::Units::commander_definition(troop);
     ASSERT_NE(definition, nullptr);
     EXPECT_EQ(definition->nation_id, nation);
+  }
+}
+
+namespace {
+
+auto campaign_missions() -> std::vector<Game::Mission::MissionDefinition> {
+  Game::Campaign::CampaignDefinition campaign;
+  QString error;
+  EXPECT_TRUE(Game::Campaign::CampaignLoader::load_from_json_file(
+      Utils::Resources::resolve_resource_path(
+          QStringLiteral(":/assets/campaigns/second_punic_war.json")),
+      campaign,
+      &error))
+      << error.toStdString();
+
+  std::vector<Game::Mission::MissionDefinition> missions;
+  for (const auto& entry : campaign.missions) {
+    Game::Mission::MissionDefinition mission;
+    QString mission_error;
+    EXPECT_TRUE(Game::Mission::MissionLoader::load_from_json_file(
+        Utils::Resources::resolve_resource_path(
+            QStringLiteral(":/assets/missions/%1.json").arg(entry.mission_id)),
+        mission,
+        &mission_error))
+        << entry.mission_id.toStdString() << ": " << mission_error.toStdString();
+    missions.push_back(std::move(mission));
+  }
+  return missions;
+}
+
+auto commander_pool_size(Game::Systems::NationID nation) -> std::size_t {
+  std::size_t count = 0;
+  for (const auto& definition : Game::Units::all_commander_definitions()) {
+    if (definition.nation_id == nation) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+} // namespace
+
+TEST(MissionCommanderSetupTest, EveryCampaignForceHasExactlyOneMapCommander) {
+  const auto missions = campaign_missions();
+  ASSERT_FALSE(missions.empty());
+
+  for (const auto& mission : missions) {
+    const auto commanders = App::Core::commander_troops_for_map(mission.map_path);
+    const std::size_t force_count = 1 + mission.ai_setups.size();
+
+    for (std::size_t index = 0; index < force_count; ++index) {
+      const int owner_id = static_cast<int>(index) + 1;
+      const auto it = commanders.find(owner_id);
+      ASSERT_NE(it, commanders.end())
+          << mission.id.toStdString() << ": " << mission.map_path.toStdString()
+          << " authors no commander for owner " << owner_id;
+      EXPECT_FALSE(it->second.trimmed().isEmpty())
+          << mission.id.toStdString() << " owner " << owner_id;
+    }
+  }
+}
+
+TEST(MissionCommanderSetupTest, CampaignCommandersMatchTheirForcesNation) {
+  for (const auto& mission : campaign_missions()) {
+    const auto commanders = App::Core::commander_troops_for_map(mission.map_path);
+
+    std::vector<QString> nations{mission.player_setup.nation};
+    for (const auto& ai_setup : mission.ai_setups) {
+      nations.push_back(ai_setup.nation);
+    }
+
+    for (std::size_t index = 0; index < nations.size(); ++index) {
+      const int owner_id = static_cast<int>(index) + 1;
+      const auto it = commanders.find(owner_id);
+      if (it == commanders.end()) {
+        continue;
+      }
+      Game::Units::TroopType troop_type{};
+      ASSERT_TRUE(Game::Units::try_parse_troop_type(it->second, troop_type))
+          << mission.id.toStdString() << " owner " << owner_id;
+      const auto* definition = Game::Units::commander_definition(troop_type);
+      ASSERT_NE(definition, nullptr) << mission.id.toStdString();
+
+      Game::Systems::NationID expected{};
+      ASSERT_TRUE(Game::Systems::try_parse_nation_id(nations[index], expected))
+          << nations[index].toStdString();
+      EXPECT_EQ(definition->nation_id, expected)
+          << mission.id.toStdString() << " owner " << owner_id << " fields "
+          << it->second.toStdString() << " under the wrong flag";
+    }
+  }
+}
+
+TEST(MissionCommanderSetupTest, CampaignCommandersAreUniqueUntilThePoolRunsOut) {
+  for (const auto& mission : campaign_missions()) {
+    const auto commanders = App::Core::commander_troops_for_map(mission.map_path);
+
+    std::map<Game::Systems::NationID, std::vector<QString>> by_nation;
+    for (const auto& [owner_id, troop] : commanders) {
+      Game::Units::TroopType troop_type{};
+      if (!Game::Units::try_parse_troop_type(troop, troop_type)) {
+        continue;
+      }
+      const auto* definition = Game::Units::commander_definition(troop_type);
+      if (definition == nullptr) {
+        continue;
+      }
+      by_nation[definition->nation_id].push_back(troop);
+    }
+
+    for (const auto& [nation, troops] : by_nation) {
+      std::set<QString> distinct(troops.begin(), troops.end());
+      const std::size_t pool = commander_pool_size(nation);
+      const std::size_t expected = std::min(troops.size(), pool);
+      EXPECT_EQ(distinct.size(), expected)
+          << mission.id.toStdString() << " fields " << troops.size()
+          << " forces for one nation using only " << distinct.size()
+          << " distinct commanders, though " << pool << " exist";
+    }
   }
 }

--- a/tests/core/mission_definition_view_test.cpp
+++ b/tests/core/mission_definition_view_test.cpp
@@ -9,10 +9,11 @@
 #include "app/core/mission_definition_view.h"
 #include "game/map/campaign_loader.h"
 
-TEST(MissionDefinitionViewTest, ResolvesFallbackPlayerCommanderForCarthage) {
+TEST(MissionDefinitionViewTest, ReadsPlayerCommanderFromTheMissionMap) {
   Game::Mission::MissionDefinition mission;
   mission.id = "campania_campaign";
   mission.title = "Campania Campaign";
+  mission.map_path = ":/assets/maps/map_campania_campaign.json";
   mission.player_setup.nation = "carthage";
   mission.player_setup.faction = "carthaginian";
   mission.player_setup.color = "brown";
@@ -32,6 +33,7 @@ TEST(MissionDefinitionViewTest, ResolvesFallbackPlayerCommanderForCarthage) {
 
 TEST(MissionDefinitionViewTest, IncludesEveryEnemySetupAndCommanderDetails) {
   Game::Mission::MissionDefinition mission;
+  mission.map_path = ":/assets/maps/map_campania_campaign.json";
   mission.player_setup.nation = "roman_republic";
   mission.player_setup.faction = "roman";
   mission.player_setup.color = "red";
@@ -42,7 +44,6 @@ TEST(MissionDefinitionViewTest, IncludesEveryEnemySetupAndCommanderDetails) {
   northern_force.faction = "roman";
   northern_force.color = "red";
   northern_force.difficulty = "hard";
-  northern_force.commander_troop = QStringLiteral("roman_legion_organizer");
 
   Game::Mission::AISetup southern_force;
   southern_force.id = "south";
@@ -50,7 +51,6 @@ TEST(MissionDefinitionViewTest, IncludesEveryEnemySetupAndCommanderDetails) {
   southern_force.faction = "roman";
   southern_force.color = "orange";
   southern_force.difficulty = "hard";
-  southern_force.commander_troop = QStringLiteral("roman_veteran_consul");
 
   mission.ai_setups = {northern_force, southern_force};
 

--- a/tests/map/mission_asset_rules_test.cpp
+++ b/tests/map/mission_asset_rules_test.cpp
@@ -17,6 +17,9 @@
 #include "game/map/mission_loader.h"
 #include "game/map/terrain.h"
 #include "game/systems/building_collision_registry.h"
+#include "game/units/spawn_type.h"
+#include "game/units/troop_type.h"
+#include "utils/resource_utils.h"
 
 namespace {
 
@@ -349,10 +352,27 @@ TEST(MissionAssetRulesTest, DecapitationObjectivesHaveCommandersToKill) {
     ASSERT_FALSE(mission.ai_setups.empty())
         << entry.mission_id.toStdString()
         << " asks the player to kill commanders but ships no opponents";
-    for (const auto& ai_setup : mission.ai_setups) {
-      EXPECT_TRUE(ai_setup.commander_troop.has_value() &&
-                  !ai_setup.commander_troop->trimmed().isEmpty())
-          << entry.mission_id.toStdString() << " AI " << ai_setup.id.toStdString()
+    Game::Map::MapDefinition map;
+    QString map_error;
+    ASSERT_TRUE(Game::Map::MapLoader::load_from_json_file(
+        Utils::Resources::resolve_resource_path(mission.map_path), map, &map_error))
+        << mission.map_path.toStdString() << ": " << map_error.toStdString();
+
+    for (std::size_t index = 0; index < mission.ai_setups.size(); ++index) {
+      const int owner_id = static_cast<int>(index) + 2;
+      const bool has_commander = std::any_of(
+          map.spawns.begin(),
+          map.spawns.end(),
+          [owner_id](const Game::Map::UnitSpawn& spawn) {
+            if (spawn.player_id != owner_id) {
+              return false;
+            }
+            const auto troop = Game::Units::spawn_typeToTroopType(spawn.type);
+            return troop.has_value() && Game::Units::is_commander_troop(*troop);
+          });
+      EXPECT_TRUE(has_commander)
+          << entry.mission_id.toStdString() << " AI "
+          << mission.ai_setups[index].id.toStdString()
           << " has no commander to kill, so eliminate_commanders can never arm";
     }
   }

--- a/tests/map/mission_loader_test.cpp
+++ b/tests/map/mission_loader_test.cpp
@@ -1,5 +1,9 @@
 #include <QCoreApplication>
 #include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QTemporaryFile>
 
 #include <algorithm>
@@ -34,7 +38,6 @@ protected:
         "nation": "roman_republic",
         "faction": "roman",
         "color": "red",
-        "commander_troop": "roman_veteran_consul",
         "starting_units": [
           {
             "type": "spearman",
@@ -63,7 +66,6 @@ protected:
           "nation": "carthage",
           "faction": "carthaginian",
           "color": "blue",
-          "commander_troop": "carthage_sword_commander",
           "difficulty": "medium",
           "personality": {
             "aggression": 0.7,
@@ -139,8 +141,6 @@ TEST_F(MissionLoaderTest, ParsesPlayerSetup) {
   EXPECT_EQ(mission.player_setup.nation, "roman_republic");
   EXPECT_EQ(mission.player_setup.faction, "roman");
   EXPECT_EQ(mission.player_setup.color, "red");
-  ASSERT_TRUE(mission.player_setup.commander_troop.has_value());
-  EXPECT_EQ(*mission.player_setup.commander_troop, "roman_veteran_consul");
   EXPECT_EQ(mission.player_setup.starting_units.size(), 1);
   EXPECT_EQ(mission.player_setup.starting_buildings.size(), 1);
   EXPECT_EQ(
@@ -169,8 +169,6 @@ TEST_F(MissionLoaderTest, ParsesAISetups) {
   ASSERT_EQ(mission.ai_setups.size(), 1);
   EXPECT_EQ(mission.ai_setups[0].id, "enemy_1");
   EXPECT_EQ(mission.ai_setups[0].nation, "carthage");
-  ASSERT_TRUE(mission.ai_setups[0].commander_troop.has_value());
-  EXPECT_EQ(*mission.ai_setups[0].commander_troop, "carthage_sword_commander");
   EXPECT_EQ(mission.ai_setups[0].difficulty, "medium");
   EXPECT_FLOAT_EQ(mission.ai_setups[0].personality.aggression, 0.7F);
   EXPECT_EQ(mission.ai_setups[0].waves.size(), 1);
@@ -343,7 +341,6 @@ TEST_F(MissionLoaderTest, ParsesAuthoredUnitPatrolBehavior) {
       "nation": "roman_republic",
       "faction": "roman",
       "color": "red",
-      "commander_troop": "roman_veteran_consul",
       "starting_units": [],
       "starting_buildings": []
     },
@@ -353,7 +350,6 @@ TEST_F(MissionLoaderTest, ParsesAuthoredUnitPatrolBehavior) {
         "nation": "carthage",
         "faction": "carthaginian",
         "color": "blue",
-        "commander_troop": "carthage_sword_commander",
         "difficulty": "medium",
         "starting_units": [
           {
@@ -390,29 +386,26 @@ TEST_F(MissionLoaderTest, ParsesAuthoredUnitPatrolBehavior) {
   EXPECT_FLOAT_EQ(unit.patrol_waypoints[1].z, 48.0F);
 }
 
-TEST_F(MissionLoaderTest, ShippedMissionsAuthorCommandersForPlayerAndAiSetups) {
+TEST_F(MissionLoaderTest, ShippedMissionsDoNotAuthorCommanders) {
   const QDir mission_dir = assetMissionDirectory();
   const QStringList mission_files =
       mission_dir.entryList(QStringList() << QStringLiteral("*.json"), QDir::Files);
   ASSERT_FALSE(mission_files.isEmpty());
 
   for (const QString& file_name : mission_files) {
-    MissionDefinition mission;
-    QString error;
-    ASSERT_TRUE(MissionLoader::load_from_json_file(
-        mission_dir.absoluteFilePath(file_name), mission, &error))
-        << file_name.toStdString() << ": " << error.toStdString();
+    QFile file(mission_dir.absoluteFilePath(file_name));
+    ASSERT_TRUE(file.open(QIODevice::ReadOnly)) << file_name.toStdString();
+    const QJsonObject root = QJsonDocument::fromJson(file.readAll()).object();
 
-    ASSERT_TRUE(mission.player_setup.commander_troop.has_value())
-        << file_name.toStdString();
-    EXPECT_FALSE(mission.player_setup.commander_troop->trimmed().isEmpty())
-        << file_name.toStdString();
+    EXPECT_FALSE(root.value("player_setup").toObject().contains("commander_troop"))
+        << file_name.toStdString()
+        << ": player_setup must not author a commander; use the map's spawns[]";
 
-    for (std::size_t index = 0; index < mission.ai_setups.size(); ++index) {
-      ASSERT_TRUE(mission.ai_setups[index].commander_troop.has_value())
-          << file_name.toStdString() << " ai index " << index;
-      EXPECT_FALSE(mission.ai_setups[index].commander_troop->trimmed().isEmpty())
-          << file_name.toStdString() << " ai index " << index;
+    const QJsonArray ai_setups = root.value("ai_setups").toArray();
+    for (qsizetype index = 0; index < ai_setups.size(); ++index) {
+      EXPECT_FALSE(ai_setups[index].toObject().contains("commander_troop"))
+          << file_name.toStdString() << " ai index " << index
+          << ": must not author a commander; use the map's spawns[]";
     }
   }
 }

--- a/tests/tools/map_editor_commander_preview_test.cpp
+++ b/tests/tools/map_editor_commander_preview_test.cpp
@@ -38,7 +38,7 @@ auto commander_for_owner(const QVector<MapEditor::DerivedCommander>& commanders,
 
 } // namespace
 
-TEST(MapEditorCommanderPreviewTest, ConfiguredCommandersWinOverNationDefaults) {
+TEST(MapEditorCommanderPreviewTest, SuggestsNationAppropriateCommanders) {
   EXPECT_EQ(MapEditor::resolve_commander_troop("carthage", ""),
             QStringLiteral("carthage_sword_commander"));
   EXPECT_EQ(MapEditor::resolve_commander_troop("roman_republic", ""),
@@ -53,7 +53,7 @@ TEST(MapEditorCommanderPreviewTest, ConfiguredCommandersWinOverNationDefaults) {
       QStringLiteral("roman_veteran_consul"));
 }
 
-TEST(MapEditorCommanderPreviewTest, RhoneMissionExposesOneCommanderPerOwner) {
+TEST(MapEditorCommanderPreviewTest, RhoneMapAuthorsOneCommanderPerOwner) {
   const QString root = repo_root();
   MapEditor::MapData map;
   QString error;
@@ -75,32 +75,42 @@ TEST(MapEditorCommanderPreviewTest, RhoneMissionExposesOneCommanderPerOwner) {
   const auto* first_ai = commander_for_owner(commanders, 2);
   ASSERT_NE(first_ai, nullptr);
   EXPECT_EQ(first_ai->troop_type, QStringLiteral("roman_legion_organizer"));
-  EXPECT_FALSE(first_ai->authored_in_map);
+  EXPECT_TRUE(first_ai->authored_in_map);
 
   const auto* second_ai = commander_for_owner(commanders, 3);
   ASSERT_NE(second_ai, nullptr);
   EXPECT_EQ(second_ai->troop_type, QStringLiteral("roman_veteran_consul"));
-  EXPECT_FALSE(second_ai->authored_in_map);
+  EXPECT_TRUE(second_ai->authored_in_map);
+}
+
+TEST(MapEditorCommanderPreviewTest, ForcesWithoutAMapCommanderReadBackAsMissing) {
+  MapEditor::MapData map;
+  MapEditor::TroopSpawnElement archer;
+  archer.type = QStringLiteral("archer");
+  archer.player_id = 2;
+  archer.x = 40.0F;
+  archer.z = 40.0F;
+  map.add_troop_spawn(archer);
+
+  const QJsonObject mission = QJsonDocument::fromJson(R"({
+    "player_setup": {"nation": "carthage"},
+    "ai_setups": [{"id": "roman_screen", "nation": "roman_republic"}]
+  })")
+                                  .object();
+
+  const QVector<MapEditor::DerivedCommander> commanders =
+      MapEditor::derive_mission_commanders(map, mission);
+  ASSERT_EQ(commanders.size(), 2);
 
   for (const auto& commander : commanders) {
-    if (commander.authored_in_map) {
-      continue;
-    }
-    bool near_owner_spawn = false;
-    for (const auto& spawn : map.troop_spawns()) {
-      if (spawn.player_id != commander.owner_id) {
-        continue;
-      }
-      const double dx = spawn.x - commander.position.x();
-      const double dz = spawn.z - commander.position.y();
-      if ((dx * dx) + (dz * dz) <= 12.0 * 12.0) {
-        near_owner_spawn = true;
-        break;
-      }
-    }
-    EXPECT_TRUE(near_owner_spawn)
-        << "owner " << commander.owner_id << " commander is placed away from its army";
+    EXPECT_FALSE(commander.authored_in_map) << "owner " << commander.owner_id;
+    EXPECT_TRUE(commander.troop_type.isEmpty()) << "owner " << commander.owner_id;
   }
+
+  EXPECT_EQ(commander_for_owner(commanders, 1)->suggested_troop_type,
+            QStringLiteral("carthage_sword_commander"));
+  EXPECT_EQ(commander_for_owner(commanders, 2)->suggested_troop_type,
+            QStringLiteral("roman_veteran_consul"));
 }
 
 TEST(MapEditorCommanderPreviewTest, OnlyOneCommanderPerOwnerIsTracked) {

--- a/tools/map_editor/commander_preview.cpp
+++ b/tools/map_editor/commander_preview.cpp
@@ -86,9 +86,6 @@ auto append_commander(const MapData& map,
   DerivedCommander commander;
   commander.owner_id = owner_id;
   commander.label = label;
-  commander.troop_type = resolve_commander_troop(
-      setup.value(QStringLiteral("nation")).toString(),
-      setup.value(QStringLiteral("commander_troop")).toString());
 
   const int authored_index = map.commander_spawn_index_for_player(owner_id);
   if (authored_index >= 0) {
@@ -97,6 +94,8 @@ auto append_commander(const MapData& map,
     commander.troop_type = spawn.type;
     commander.position = QPointF(spawn.x, spawn.z);
   } else {
+    commander.suggested_troop_type =
+        resolve_commander_troop(setup.value(QStringLiteral("nation")).toString(), {});
     commander.position = resolve_position(map, setup, owner_id);
   }
 

--- a/tools/map_editor/commander_preview.h
+++ b/tools/map_editor/commander_preview.h
@@ -15,6 +15,7 @@ inline constexpr int k_first_ai_owner_id = 2;
 struct DerivedCommander {
   int owner_id = k_local_owner_id;
   QString troop_type;
+  QString suggested_troop_type;
   QString label;
   QPointF position;
   bool authored_in_map = false;

--- a/tools/map_editor/map_canvas.cpp
+++ b/tools/map_editor/map_canvas.cpp
@@ -1679,20 +1679,20 @@ void MapCanvas::draw_derived_commanders(QPainter& painter) {
 
     const QPoint pos = grid_to_widget(static_cast<float>(commander.position.x()),
                                       static_cast<float>(commander.position.y()));
-    draw_troop_marker(
-        painter, pos, commander.troop_type, commander.owner_id, badge_size);
 
     painter.setBrush(Qt::NoBrush);
-    painter.setPen(QPen(QColor(255, 214, 120, 220), 2, Qt::DashLine));
+    painter.setPen(QPen(QColor(255, 96, 96, 230), 2, Qt::DashLine));
     const int ring = static_cast<int>(badge_size * 0.5F) + 5;
     painter.drawEllipse(pos, ring, ring);
+    painter.drawLine(pos.x() - ring, pos.y() - ring, pos.x() + ring, pos.y() + ring);
+    painter.drawLine(pos.x() - ring, pos.y() + ring, pos.x() + ring, pos.y() - ring);
 
     if (labels_visible()) {
-      painter.setPen(QColor(255, 226, 168));
-      painter.drawText(QRect(pos.x() - 80, pos.y() + ring + 2, 160, 16),
+      painter.setPen(QColor(255, 150, 150));
+      painter.drawText(QRect(pos.x() - 90, pos.y() + ring + 2, 180, 16),
                        Qt::AlignHCenter | Qt::AlignTop,
-                       QStringLiteral("%1 commander (auto): %2")
-                           .arg(commander.label, commander.troop_type));
+                       QStringLiteral("%1 has no commander - place %2")
+                           .arg(commander.label, commander.suggested_troop_type));
     }
   }
   painter.restore();

--- a/tools/map_editor/mission_panel.cpp
+++ b/tools/map_editor/mission_panel.cpp
@@ -123,9 +123,6 @@ auto edit_ai_dialog(const QJsonObject& initial,
   auto* strategy = combo(MissionData::supported_strategies(), &dialog);
   auto* team = int_box(-1, 32, initial.value("team_id").toInt(-1), &dialog);
   team->setSpecialValueText(QStringLiteral("Independent"));
-  auto* commander =
-      combo(QStringList{QStringLiteral("(default)")} + MissionData::supported_troops(),
-            &dialog);
   const QJsonObject personality = initial.value("personality").toObject();
   auto* aggression =
       double_box(0.0, 1.0, personality.value("aggression").toDouble(0.5), &dialog);
@@ -139,7 +136,6 @@ auto edit_ai_dialog(const QJsonObject& initial,
   select_value(color, initial.value("color").toString("blue"));
   select_value(difficulty, initial.value("difficulty").toString("normal"));
   select_value(strategy, initial.value("strategy").toString("balanced"));
-  select_value(commander, initial.value("commander_troop").toString("(default)"));
 
   form->addRow(QStringLiteral("ID"), id);
   form->addRow(QStringLiteral("Nation"), nation);
@@ -148,7 +144,6 @@ auto edit_ai_dialog(const QJsonObject& initial,
   form->addRow(QStringLiteral("Difficulty"), difficulty);
   form->addRow(QStringLiteral("Strategy"), strategy);
   form->addRow(QStringLiteral("Team"), team);
-  form->addRow(QStringLiteral("Commander"), commander);
   form->addRow(QStringLiteral("Aggression"), aggression);
   form->addRow(QStringLiteral("Defense"), defense);
   form->addRow(QStringLiteral("Harassment"), harassment);
@@ -169,11 +164,7 @@ auto edit_ai_dialog(const QJsonObject& initial,
   } else {
     result.remove("team_id");
   }
-  if (commander->currentIndex() > 0) {
-    result["commander_troop"] = commander->currentText();
-  } else {
-    result.remove("commander_troop");
-  }
+  result.remove("commander_troop");
   result["personality"] = QJsonObject{{"aggression", aggression->value()},
                                       {"defense", defense->value()},
                                       {"harassment", harassment->value()}};
@@ -590,9 +581,6 @@ void MissionPanel::setup_ui() {
   m_player_nation = combo(MissionData::supported_nations(), player_group);
   m_player_faction = combo({"roman", "carthaginian", "iron_sepulcher"}, player_group);
   m_player_color = combo(MissionData::supported_colors(), player_group);
-  m_player_commander =
-      combo(QStringList{QStringLiteral("(default)")} + MissionData::supported_troops(),
-            player_group);
   m_player_gold = int_box(0, 1000000, 500, player_group);
   m_player_food = int_box(0, 1000000, 500, player_group);
   m_ambient_undead =
@@ -600,7 +588,6 @@ void MissionPanel::setup_ui() {
   player_form->addRow(QStringLiteral("Nation"), m_player_nation);
   player_form->addRow(QStringLiteral("Faction"), m_player_faction);
   player_form->addRow(QStringLiteral("Color"), m_player_color);
-  player_form->addRow(QStringLiteral("Commander"), m_player_commander);
   player_form->addRow(QStringLiteral("Gold"), m_player_gold);
   player_form->addRow(QStringLiteral("Food"), m_player_food);
   player_layout->addLayout(player_form);
@@ -616,10 +603,6 @@ void MissionPanel::setup_ui() {
           &MissionPanel::sync_player);
   connect(
       m_player_color, &QComboBox::currentTextChanged, this, &MissionPanel::sync_player);
-  connect(m_player_commander,
-          &QComboBox::currentTextChanged,
-          this,
-          &MissionPanel::sync_player);
   connect(m_player_gold, &QSpinBox::valueChanged, this, [this](int) { sync_player(); });
   connect(m_player_food, &QSpinBox::valueChanged, this, [this](int) { sync_player(); });
   connect(m_ambient_undead, &QCheckBox::toggled, this, [this](bool checked) {
@@ -817,8 +800,6 @@ void MissionPanel::refresh() {
   select_value(m_player_nation, player.value("nation").toString());
   select_value(m_player_faction, player.value("faction").toString());
   select_value(m_player_color, player.value("color").toString());
-  select_value(m_player_commander,
-               player.value("commander_troop").toString("(default)"));
   const QJsonObject resources = player.value("starting_resources").toObject();
   m_player_gold->setValue(resources.value("gold").toInt());
   m_player_food->setValue(resources.value("food").toInt());
@@ -861,11 +842,7 @@ void MissionPanel::sync_player() {
   player["nation"] = m_player_nation->currentText();
   player["faction"] = m_player_faction->currentText();
   player["color"] = m_player_color->currentText();
-  if (m_player_commander->currentIndex() > 0) {
-    player["commander_troop"] = m_player_commander->currentText();
-  } else {
-    player.remove("commander_troop");
-  }
+  player.remove("commander_troop");
   QJsonObject resources = player.value("starting_resources").toObject();
   resources["gold"] = m_player_gold->value();
   resources["food"] = m_player_food->value();

--- a/tools/map_editor/mission_panel.h
+++ b/tools/map_editor/mission_panel.h
@@ -66,7 +66,6 @@ private:
   QComboBox* m_player_nation = nullptr;
   QComboBox* m_player_faction = nullptr;
   QComboBox* m_player_color = nullptr;
-  QComboBox* m_player_commander = nullptr;
   QSpinBox* m_player_gold = nullptr;
   QSpinBox* m_player_food = nullptr;
   QCheckBox* m_ambient_undead = nullptr;


### PR DESCRIPTION
Commanders had two sources of truth. The level loads before mission setup, so a map that spawned a commander left spawn_commander_for_owner seeing a live CommanderComponent and returning early: the map silently won. Only two of the thirty-two campaign forces were authored that way, so mission JSON supplied the rest, and the same commander could be declared in two places with the map quietly overriding.

Make the map's spawns[] the only source. Remove commander_troop from PlayerSetup and AISetup, the mission loader, all nine mission JSONs, the campaign player configs and the editor's two commander dropdowns. Mission setup no longer spawns a commander at all; it verifies each declared owner has one and warns when a force would go into battle headless. A leftover commander_troop now logs a warning and fails the shipped-mission test.

Author all thirty-two commanders into the maps at the positions they already occupied, so nothing moved. Three forces had no map spawns at all and were landing on a hardcoded (132, 80) fallback in a far corner of the map: ticino's roman_reserve, campania's eastern_siege_column and zama's roman_rear_guard now stand at their wave entry points.

Fix Cannae's avoidable duplicate. It fielded three Roman forces from a pool of three commanders but gave Marcellus to both the consular line and the allied wing, leaving Scipio unused; the allied wing is now Scipio. Zama still repeats Marcellus because four Roman forces exceed the three-commander pool, which is the only case where a repeat is forced.

The briefing panel and the editor preview read the map too. A force whose commander the map has forgotten now draws as a red crossed ring naming the commander to place, instead of a phantom badge for one that will never spawn.

Guard both rules over the shipped campaign: every force has exactly one commander of its own nation, and commanders are distinct within a mission until a nation fields more forces than it has commanders. Coverage is also checked end to end by loading every campaign mission through SkirmishLoader and MissionSetupCoordinator and counting the live commanders per owner.