### PR TITLE
Overhaul wildlife behavior and creature animation previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,34 @@ may change in any release — see [Save compatibility](#save-compatibility).
 
 ### Changed
 
+- **Infantry no longer skate.** The walk clip drew the planted foot 1.08 m under
+  the body per cycle and was played at a cadence of about 0.9 s whatever the
+  unit's speed, which is a walk for someone travelling 1.2 m/s. Infantry travel
+  2.0–2.5 m/s, so nearly half of every step was the foot sliding across the
+  ground — the single largest reason the walk read as gliding rather than
+  walking. The stride and the cadence are now derived from one number, the
+  distance the body
+  covers in a cycle: the clip takes a 0.79 m step and the cycle time is that
+  distance divided by the actual ground speed, so the foot that is down stays
+  where it was put at any speed a unit is given. The same rule drives the run.
+  Two tests measure the retreat of the planted foot against `speed × cycle_time`
+  and fail if they drift apart.
+- The rest of the walk was rebuilt around the longer stride: the feet track near
+  the midline instead of under the shoulders (0.17 m apart, not 0.40 m), the
+  pelvis leans over the leg that is carrying the weight instead of away from it,
+  the shoulders and pelvis counter-rotate in time with the arms rather than a
+  quarter cycle out of phase, the pelvis drops on the swing side, the heel
+  leaves the ground halfway through the stance instead of in the last third, and
+  the ankle now peaks early in the swing while the knee is folded. The arms
+  swing on an arc around the shoulder: driving the hand fore and aft used to
+  push it past the arm's reach limit, where the clamp locked the elbow straight
+  and ate most of the swing.
+- The first-person camera bob and its footstep cue are derived from the walk
+  clip's stride distance, so the step you hear is the step the legs take.
+- `humanoid_preview --report` measures a gait as well as drawing it: stride
+  travel, the retreat of the planted foot per cycle, foot lift, hand swing,
+  pelvis bob and sway, shoulder twist and step width, plus the ground speed each
+  clip is skate-free at for a given cycle time.
 - The scheduled workflow is called **Weekly** and its jobs, cache keys and
   documentation say so. The cron moved to Mondays some time ago; only the name
   had gone on claiming otherwise.

--- a/animation/clip_manifest.cpp
+++ b/animation/clip_manifest.cpp
@@ -332,6 +332,8 @@ auto requested_humanoid_clip_variant(const HumanoidClipVariantInputs& inputs) no
   case StateId::RpgSwordOverhead:
   case StateId::RpgSwordThrust:
   case StateId::RpgSwordFinisher:
+  case StateId::WildlifeTense:
+  case StateId::WildlifeStartle:
   case StateId::Count:
     break;
   }

--- a/animation/clip_manifest.h
+++ b/animation/clip_manifest.h
@@ -97,6 +97,9 @@ enum class StateId : std::uint8_t {
   RpgSwordThrust = 19,
   RpgSwordFinisher = 20,
 
+  WildlifeTense = 21,
+  WildlifeStartle = 22,
+
   Count
 };
 
@@ -211,6 +214,8 @@ inline constexpr std::uint16_t k_sheep_walk_clip = 2U;
 inline constexpr std::uint16_t k_sheep_run_clip = 3U;
 inline constexpr std::uint16_t k_sheep_die_clip = 4U;
 inline constexpr std::uint16_t k_sheep_dead_clip = 5U;
+inline constexpr std::uint16_t k_sheep_startle_clip = 6U;
+inline constexpr std::uint16_t k_sheep_alert_clip = 7U;
 
 inline constexpr std::uint16_t k_wolf_idle_clip = 0U;
 inline constexpr std::uint16_t k_wolf_stalk_clip = 1U;
@@ -219,6 +224,7 @@ inline constexpr std::uint16_t k_wolf_run_clip = 3U;
 inline constexpr std::uint16_t k_wolf_bite_clip = 4U;
 inline constexpr std::uint16_t k_wolf_die_clip = 5U;
 inline constexpr std::uint16_t k_wolf_dead_clip = 6U;
+inline constexpr std::uint16_t k_wolf_crouch_clip = 7U;
 
 struct ClipManifest {
   std::array<std::uint16_t, state_count()> clips{};
@@ -412,6 +418,8 @@ sheep_clip_table() noexcept -> std::array<std::uint16_t, state_count()> {
   t[state_index(StateId::Run)] = k_sheep_run_clip;
   t[state_index(StateId::Die)] = k_sheep_die_clip;
   t[state_index(StateId::Dead)] = k_sheep_dead_clip;
+  t[state_index(StateId::WildlifeStartle)] = k_sheep_startle_clip;
+  t[state_index(StateId::WildlifeTense)] = k_sheep_alert_clip;
   return t;
 }
 
@@ -432,6 +440,7 @@ wolf_clip_table() noexcept -> std::array<std::uint16_t, state_count()> {
   t[state_index(StateId::AttackMelee)] = k_wolf_bite_clip;
   t[state_index(StateId::Die)] = k_wolf_die_clip;
   t[state_index(StateId::Dead)] = k_wolf_dead_clip;
+  t[state_index(StateId::WildlifeTense)] = k_wolf_crouch_clip;
   return t;
 }
 

--- a/animation/locomotion_manifest.cpp
+++ b/animation/locomotion_manifest.cpp
@@ -19,10 +19,29 @@ constexpr float k_arm_forward_bias = 0.86F;
 constexpr float k_arm_backward_bias = 1.18F;
 
 constexpr float k_reverse_stride_scale = 0.74F;
-constexpr float k_arm_back_lift_ratio = 0.35F;
 
 constexpr float k_foot_toe_length = 0.165F;
 constexpr float k_foot_heel_length = 0.060F;
+
+constexpr float k_walk_planted_fraction = 0.60F;
+constexpr float k_walk_stance_travel = 0.95F;
+constexpr float k_walk_cycle_distance = k_walk_stance_travel / k_walk_planted_fraction;
+static_assert(k_walk_cycle_distance > k_humanoid_walk_cycle_distance - 0.001F &&
+              k_walk_cycle_distance < k_humanoid_walk_cycle_distance + 0.001F);
+
+constexpr float k_run_planted_fraction = 0.36F;
+constexpr float k_run_stance_travel = 1.02F;
+constexpr float k_run_cycle_distance = k_run_stance_travel / k_run_planted_fraction;
+static_assert(k_run_cycle_distance > k_humanoid_run_cycle_distance - 0.001F &&
+              k_run_cycle_distance < k_humanoid_run_cycle_distance + 0.001F);
+
+constexpr float k_min_cycle_time = 0.52F;
+constexpr float k_max_cycle_time = 1.30F;
+constexpr float k_min_cadence_speed = 0.35F;
+
+constexpr float k_stance_forward_fraction = 0.42F;
+
+constexpr float k_walk_track_ratio = 0.45F;
 
 [[nodiscard]] auto ankle_lift_for_pitch(float pitch) noexcept -> float {
   return (pitch < 0.0F) ? (k_foot_toe_length * -std::sin(pitch))
@@ -117,13 +136,14 @@ struct LocomotionPoseProfile {
   float step_height{0.0F};
   float vertical_bob{0.0F};
   float hip_sway{0.0F};
-  float shoulder_counter_sway{0.0F};
+  float shoulder_sway{0.0F};
   float shoulder_twist{0.0F};
+  float pelvis_twist{0.0F};
   float forward_lean{0.0F};
   float lateral_foot_shift{0.0F};
   float arm_swing{0.0F};
   float max_arm_displacement{0.0F};
-  float arm_lift_scale{0.0F};
+  float elbow_flex{0.0F};
   float arm_counter_shift{0.0F};
   float weight_shift{0.0F};
   float pelvis_drop{0.0F};
@@ -148,13 +168,14 @@ struct LocomotionPoseProfile {
   out.step_height = mix(a.step_height, b.step_height);
   out.vertical_bob = mix(a.vertical_bob, b.vertical_bob);
   out.hip_sway = mix(a.hip_sway, b.hip_sway);
-  out.shoulder_counter_sway = mix(a.shoulder_counter_sway, b.shoulder_counter_sway);
+  out.shoulder_sway = mix(a.shoulder_sway, b.shoulder_sway);
   out.shoulder_twist = mix(a.shoulder_twist, b.shoulder_twist);
+  out.pelvis_twist = mix(a.pelvis_twist, b.pelvis_twist);
   out.forward_lean = mix(a.forward_lean, b.forward_lean);
   out.lateral_foot_shift = mix(a.lateral_foot_shift, b.lateral_foot_shift);
   out.arm_swing = mix(a.arm_swing, b.arm_swing);
   out.max_arm_displacement = mix(a.max_arm_displacement, b.max_arm_displacement);
-  out.arm_lift_scale = mix(a.arm_lift_scale, b.arm_lift_scale);
+  out.elbow_flex = mix(a.elbow_flex, b.elbow_flex);
   out.arm_counter_shift = mix(a.arm_counter_shift, b.arm_counter_shift);
   out.weight_shift = mix(a.weight_shift, b.weight_shift);
   out.pelvis_drop = mix(a.pelvis_drop, b.pelvis_drop);
@@ -171,21 +192,22 @@ struct LocomotionPoseProfile {
                                 const HumanoidLocomotionPoseInputs& inputs) noexcept
     -> LocomotionPoseProfile {
   LocomotionPoseProfile profile{};
-  profile.planted_fraction = 0.60F;
-  profile.stride_length =
-      0.640F * inputs.walk_speed_multiplier * (0.88F + 0.14F * speed_factor);
+  profile.planted_fraction = k_walk_planted_fraction;
+  profile.stride_length = k_walk_stance_travel * inputs.walk_speed_multiplier *
+                          (0.90F + 0.10F * speed_factor);
   profile.step_height = 0.090F * (0.92F + 0.10F * speed_factor);
   profile.vertical_bob = 0.022F * speed_factor;
-  profile.hip_sway = 0.028F * inputs.stance_width;
-  profile.shoulder_counter_sway = 0.032F;
-  profile.shoulder_twist = 0.030F;
+  profile.hip_sway = 0.022F * inputs.stance_width;
+  profile.shoulder_sway = 0.013F;
+  profile.shoulder_twist = 0.034F;
+  profile.pelvis_twist = 0.030F;
   profile.forward_lean = 0.026F + (speed_factor - 1.0F) * 0.012F;
   profile.lateral_foot_shift = 0.010F;
-  profile.arm_swing = 0.195F * inputs.arm_swing_amplitude;
-  profile.max_arm_displacement = 0.205F;
-  profile.arm_lift_scale = 0.17F;
+  profile.arm_swing = 0.215F * inputs.arm_swing_amplitude;
+  profile.max_arm_displacement = 0.230F;
+  profile.elbow_flex = 0.035F;
   profile.arm_counter_shift = 0.13F;
-  profile.weight_shift = 0.026F;
+  profile.weight_shift = 0.012F;
   profile.pelvis_drop = 0.016F;
   profile.head_stabilization = 0.72F;
   profile.contact_lift = 0.003F;
@@ -201,21 +223,22 @@ struct LocomotionPoseProfile {
                                const HumanoidLocomotionPoseInputs& inputs) noexcept
     -> LocomotionPoseProfile {
   LocomotionPoseProfile profile{};
-  profile.planted_fraction = 0.36F;
-  profile.stride_length =
-      0.980F * inputs.walk_speed_multiplier * (0.90F + 0.14F * speed_factor);
+  profile.planted_fraction = k_run_planted_fraction;
+  profile.stride_length = k_run_stance_travel * inputs.walk_speed_multiplier *
+                          (0.92F + 0.08F * speed_factor);
   profile.step_height = 0.165F * (0.88F + 0.18F * speed_factor);
   profile.vertical_bob = 0.038F * speed_factor;
-  profile.hip_sway = 0.016F * inputs.stance_width;
-  profile.shoulder_counter_sway = 0.040F;
-  profile.shoulder_twist = 0.050F;
+  profile.hip_sway = 0.014F * inputs.stance_width;
+  profile.shoulder_sway = 0.010F;
+  profile.shoulder_twist = 0.054F;
+  profile.pelvis_twist = 0.046F;
   profile.forward_lean = 0.108F + (speed_factor - 1.0F) * 0.020F;
   profile.lateral_foot_shift = 0.011F;
-  profile.arm_swing = 0.290F * inputs.arm_swing_amplitude;
-  profile.max_arm_displacement = 0.300F;
-  profile.arm_lift_scale = 0.245F;
+  profile.arm_swing = 0.300F * inputs.arm_swing_amplitude;
+  profile.max_arm_displacement = 0.320F;
+  profile.elbow_flex = 0.075F;
   profile.arm_counter_shift = 0.16F;
-  profile.weight_shift = 0.014F;
+  profile.weight_shift = 0.008F;
   profile.pelvis_drop = 0.012F;
   profile.head_stabilization = 0.88F;
   profile.contact_lift = 0.016F;
@@ -315,12 +338,13 @@ smooth_pulse(float t, float start, float peak, float end) noexcept -> float {
     float const heel_settle = smooth_pulse(t, 0.0F, 0.08F, 0.24F);
     float const mid_stance = smooth_pulse(t, 0.18F, 0.50F, 0.82F);
     float const toe_off = smooth_pulse(t, 0.72F, 0.88F, 1.0F);
-    z_pos = foot_stride_length * (0.50F - t + mid_stance * 0.03F);
+    z_pos = foot_stride_length * (k_stance_forward_fraction - t + mid_stance * 0.03F);
     foot_y += (heel_settle * 0.55F + toe_off) * profile.contact_lift * stride_scale;
     foot_y -= mid_stance * 0.0018F * stride_scale;
 
     float const heel_roll = 1.0F - smoothstep(std::clamp(t / 0.22F, 0.0F, 1.0F));
-    float const toe_roll = smoothstep(std::clamp((t - 0.66F) / 0.34F, 0.0F, 1.0F));
+
+    float const toe_roll = smoothstep(std::clamp((t - 0.52F) / 0.48F, 0.0F, 1.0F));
     pitch =
         (profile.heel_strike_pitch * heel_roll) + (profile.toe_off_pitch * toe_roll);
   } else {
@@ -329,9 +353,12 @@ smooth_pulse(float t, float start, float peak, float end) noexcept -> float {
                                0.0F,
                                1.0F);
     float const travel = swing_travel(t, planted_fraction);
-    float const lift_curve = std::sin(t * std::numbers::pi_v<float>);
+
+    float const lift_time = t * (1.0F + 0.55F * (1.0F - t));
+    float const lift_curve = std::sin(lift_time * std::numbers::pi_v<float>);
     float const landing_soften = smooth_pulse(t, 0.72F, 0.90F, 1.0F);
-    z_pos = -foot_stride_length * 0.50F + (foot_stride_length * 1.00F) * travel;
+    z_pos = -foot_stride_length * (1.0F - k_stance_forward_fraction) +
+            (foot_stride_length * 1.00F) * travel;
     foot_y +=
         lift_curve * foot_step_height +
         std::sin(t * std::numbers::pi_v<float>) * profile.knee_drive * step_scale +
@@ -348,8 +375,10 @@ smooth_pulse(float t, float start, float peak, float end) noexcept -> float {
 
   float const stance_turn_bias =
       turn_amount * lateral_sign * (0.014F + 0.006F * locomotion_blend);
+
+  float const track_x = base_foot.x * k_walk_track_ratio;
   float const target_x =
-      base_foot.x -
+      track_x -
       lateral_sign * std::abs(std::sin(phase * 2.0F * std::numbers::pi_v<float>)) *
           profile.lateral_foot_shift * stride_scale +
       turn_step_bias * lateral_sign + stance_turn_bias + weight_shift * lateral_sign;
@@ -397,10 +426,8 @@ build_targets(const HumanoidLocomotionInputs& inputs) noexcept -> LocomotionTarg
                                                inputs.locomotion_direction_z)
                      : 1.0F;
   if (has_locomotion) {
-    float const walk_cycle_time =
-        humanoid_walk_cycle_time_for_speed(targets.normalized_speed, inputs.tuning);
-    float const run_cycle_time =
-        humanoid_run_cycle_time_for_speed(targets.normalized_speed, inputs.tuning);
+    float const walk_cycle_time = humanoid_walk_cycle_time_for_speed(inputs.speed);
+    float const run_cycle_time = humanoid_run_cycle_time_for_speed(inputs.speed);
     targets.cycle_time = lerp(walk_cycle_time, run_cycle_time, targets.run_blend);
   } else {
     targets.cycle_time = inputs.tuning.idle_cycle_time;
@@ -428,26 +455,25 @@ auto wrap_locomotion_phase(float phase) noexcept -> float {
 auto humanoid_reference_cycle_time(HumanoidMotionState state,
                                    const HumanoidLocomotionTuning& tuning) noexcept
     -> float {
-  float const speed_multiplier = std::max(0.1F, tuning.walk_speed_multiplier);
   if (state == HumanoidMotionState::Run) {
-    return 0.56F / speed_multiplier;
+    return humanoid_run_cycle_time_for_speed(tuning.reference_run_speed);
   }
   if (state == HumanoidMotionState::Walk) {
-    return 0.92F / speed_multiplier;
+    return humanoid_walk_cycle_time_for_speed(tuning.reference_walk_speed);
   }
   return tuning.idle_cycle_time;
 }
 
-auto humanoid_walk_cycle_time_for_speed(
-    float normalized_speed, const HumanoidLocomotionTuning& tuning) noexcept -> float {
-  return lerp(1.08F, 0.90F, std::clamp(normalized_speed, 0.0F, 1.0F)) /
-         std::max(0.1F, tuning.walk_speed_multiplier);
+auto humanoid_walk_cycle_time_for_speed(float speed) noexcept -> float {
+  return std::clamp(k_walk_cycle_distance / std::max(k_min_cadence_speed, speed),
+                    k_min_cycle_time,
+                    k_max_cycle_time);
 }
 
-auto humanoid_run_cycle_time_for_speed(
-    float normalized_speed, const HumanoidLocomotionTuning& tuning) noexcept -> float {
-  return lerp(0.62F, 0.52F, std::clamp(normalized_speed, 0.0F, 1.0F)) /
-         std::max(0.1F, tuning.walk_speed_multiplier);
+auto humanoid_run_cycle_time_for_speed(float speed) noexcept -> float {
+  return std::clamp(k_run_cycle_distance / std::max(k_min_cadence_speed, speed),
+                    k_min_cycle_time,
+                    k_max_cycle_time);
 }
 
 auto resolve_humanoid_locomotion_sample(const HumanoidLocomotionInputs& inputs) noexcept
@@ -738,7 +764,7 @@ auto resolve_humanoid_locomotion_pose(
   float const planted_fraction =
       std::clamp(profile.planted_fraction + braking * 0.06F -
                      acceleration_push * 0.04F + turn_abs * 0.04F,
-                 0.38F,
+                 0.34F,
                  0.74F);
   float const bob_direction = 1.0F - 2.0F * run_blend;
   auto bob_at = [&](float phase_lag) {
@@ -750,13 +776,17 @@ auto resolve_humanoid_locomotion_pose(
   float const shoulder_bob = bob_at(k_shoulder_bob_lag_phase);
   float const neck_bob = bob_at(k_neck_bob_lag_phase);
   float const head_bob = bob_at(k_head_bob_lag_phase);
+
   float const sway_raw = std::sin(cycle_radians);
   float const sway_lagged =
       std::sin(cycle_radians - k_torso_lag_phase * 2.0F * std::numbers::pi_v<float>);
-  float const hip_sway = sway_raw * profile.hip_sway * stride_scale;
-  float const shoulder_counter_sway =
-      -sway_lagged * profile.shoulder_counter_sway * stride_scale;
-  float const shoulder_twist = sway_lagged * profile.shoulder_twist * stride_scale;
+  float const hip_sway = -sway_raw * profile.hip_sway * stride_scale;
+  float const shoulder_sway = -sway_lagged * profile.shoulder_sway * stride_scale;
+
+  float const torso_basis = std::sin((walk_phase - k_arm_swing_phase_shift) * 2.0F *
+                                     std::numbers::pi_v<float>);
+  float const shoulder_twist = torso_basis * profile.shoulder_twist * stride_scale;
+  float const pelvis_twist = -torso_basis * profile.pelvis_twist * stride_scale;
   float const acceleration_lean = acceleration * 0.006F;
   float const braking_sink = braking * 0.010F * locomotion_blend;
   float const forward_lean =
@@ -781,8 +811,6 @@ auto resolve_humanoid_locomotion_pose(
                             profile.pelvis_drop * step_scale;
   float const head_counter_bob =
       -vertical_bob * profile.head_stabilization * (0.45F + 0.10F * run_blend);
-  float const head_counter_sway =
-      -(hip_sway + weight_shift) * profile.head_stabilization * 0.42F;
 
   HumanoidLocomotionPoseSample sample{};
   sample.active = true;
@@ -850,13 +878,15 @@ auto resolve_humanoid_locomotion_pose(
                          acceleration_push * 0.003F * locomotion_blend +
                          head_counter_bob - stride_hip_drop;
 
-  sample.pelvis_delta.x += hip_sway + weight_shift + turn_lean * 0.55F;
-  sample.shoulder_l_delta.x += shoulder_counter_sway + weight_shift * 0.28F + turn_lean;
-  sample.shoulder_r_delta.x += shoulder_counter_sway + weight_shift * 0.28F + turn_lean;
-  sample.neck_delta.x +=
-      shoulder_counter_sway * 0.68F + weight_shift * 0.18F + head_counter_sway * 0.45F;
-  sample.head_delta.x += shoulder_counter_sway * 0.38F + weight_shift * 0.08F +
-                         head_counter_sway + turn_lean * 0.40F;
+  float const pelvis_lateral = hip_sway + weight_shift;
+  float const torso_lateral = shoulder_sway + weight_shift * 0.45F;
+  float const head_lateral = pelvis_lateral * (1.0F - profile.head_stabilization);
+
+  sample.pelvis_delta.x += pelvis_lateral + turn_lean * 0.55F;
+  sample.shoulder_l_delta.x += torso_lateral + turn_lean;
+  sample.shoulder_r_delta.x += torso_lateral + turn_lean;
+  sample.neck_delta.x += lerp(torso_lateral, head_lateral, 0.55F);
+  sample.head_delta.x += head_lateral + turn_lean * 0.40F;
 
   sample.pelvis_delta.z += forward_lean * 0.20F;
   sample.shoulder_l_delta.z += forward_lean + shoulder_twist + turn_twist;
@@ -864,20 +894,27 @@ auto resolve_humanoid_locomotion_pose(
   sample.neck_delta.z += forward_lean * 0.78F;
   sample.head_delta.z += forward_lean * 0.68F - braking * 0.004F * locomotion_blend;
 
-  auto arm_forward_swing = [&](float phase) {
+  sample.hip_l_delta.z += pelvis_twist;
+  sample.hip_r_delta.z -= pelvis_twist;
+  float const hip_list = profile.pelvis_drop * 0.90F * step_scale;
+  sample.hip_l_delta.y -= support_shift * hip_list * 0.5F;
+  sample.hip_r_delta.y += support_shift * hip_list * 0.5F;
+
+  float const arm_length = std::max(0.20F, inputs.arm_pendulum_length);
+  auto apply_arm_swing = [&](PoseVec3& hand_delta, float phase, float lateral_sign) {
     float const raw =
         std::sin((phase - k_arm_swing_phase_shift) * 2.0F * std::numbers::pi_v<float>);
     float const bias = (raw >= 0.0F) ? k_arm_forward_bias : k_arm_backward_bias;
-    return std::clamp(raw * bias * profile.arm_swing,
-                      -profile.max_arm_displacement * k_arm_backward_bias,
-                      profile.max_arm_displacement * k_arm_forward_bias) *
-           stride_scale;
-  };
-  auto apply_arm_swing = [&](PoseVec3& hand_delta, float phase, float lateral_sign) {
-    float const forward = arm_forward_swing(phase);
-    float const lift = (forward >= 0.0F) ? forward : -forward * k_arm_back_lift_ratio;
-    hand_delta.z += forward;
-    hand_delta.y += lift * profile.arm_lift_scale;
+    float const forward =
+        std::clamp(raw * bias * profile.arm_swing,
+                   -profile.max_arm_displacement * k_arm_backward_bias,
+                   profile.max_arm_displacement * k_arm_forward_bias) *
+        stride_scale;
+    float const angle = std::asin(std::clamp(forward / arm_length, -0.85F, 0.85F));
+    float const flex = profile.elbow_flex * (0.55F + 0.45F * std::max(0.0F, raw));
+    float const extension = arm_length * (1.0F - flex);
+    hand_delta.z += extension * std::sin(angle);
+    hand_delta.y += arm_length - extension * std::cos(angle);
     hand_delta.x -= lateral_sign * forward * profile.arm_counter_shift;
   };
   apply_arm_swing(sample.hand_l_delta, left_phase, -1.0F);

--- a/animation/locomotion_manifest.h
+++ b/animation/locomotion_manifest.h
@@ -12,6 +12,9 @@ enum class HumanoidMotionState {
   Attacking
 };
 
+inline constexpr float k_humanoid_walk_cycle_distance = 1.5833F;
+inline constexpr float k_humanoid_run_cycle_distance = 2.8333F;
+
 struct HumanoidLocomotionTuning {
   float reference_walk_speed{2.2F};
   float reference_run_speed{4.8F};
@@ -176,6 +179,7 @@ struct HumanoidLocomotionPoseInputs {
   PoseVec3 base_foot_l{};
   PoseVec3 base_foot_r{};
 
+  float arm_pendulum_length{0.55F};
   float pelvis_y{0.0F};
   float hip_lateral_offset{0.0F};
   float hip_vertical_offset{0.0F};
@@ -189,6 +193,8 @@ struct HumanoidLocomotionPoseSample {
   float foot_pitch_l{0.0F};
   float foot_pitch_r{0.0F};
   PoseVec3 pelvis_delta{};
+  PoseVec3 hip_l_delta{};
+  PoseVec3 hip_r_delta{};
   PoseVec3 shoulder_l_delta{};
   PoseVec3 shoulder_r_delta{};
   PoseVec3 neck_delta{};
@@ -205,13 +211,9 @@ struct HumanoidLocomotionPoseSample {
     HumanoidMotionState state,
     const HumanoidLocomotionTuning& tuning = {}) noexcept -> float;
 
-[[nodiscard]] auto humanoid_walk_cycle_time_for_speed(
-    float normalized_speed,
-    const HumanoidLocomotionTuning& tuning = {}) noexcept -> float;
+[[nodiscard]] auto humanoid_walk_cycle_time_for_speed(float speed) noexcept -> float;
 
-[[nodiscard]] auto humanoid_run_cycle_time_for_speed(
-    float normalized_speed,
-    const HumanoidLocomotionTuning& tuning = {}) noexcept -> float;
+[[nodiscard]] auto humanoid_run_cycle_time_for_speed(float speed) noexcept -> float;
 
 [[nodiscard]] auto resolve_humanoid_locomotion_sample(
     const HumanoidLocomotionInputs& inputs) noexcept -> HumanoidLocomotionSample;

--- a/animation/pose_manifest.h
+++ b/animation/pose_manifest.h
@@ -180,6 +180,8 @@ is_locomotion_pose_intent(PoseIntent intent) noexcept -> bool {
   case StateId::RidingCharge:
   case StateId::RidingReining:
   case StateId::RidingBowShot:
+  case StateId::WildlifeTense:
+  case StateId::WildlifeStartle:
   case StateId::Count:
     return false;
   }

--- a/app/core/commander_camera_rig.cpp
+++ b/app/core/commander_camera_rig.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <numbers>
 
+#include "animation/locomotion_manifest.h"
 #include "game/accessibility/motion_settings.h"
 #include "game/core/component.h"
 #include "game/map/terrain_service.h"
@@ -19,7 +20,9 @@ constexpr float k_deg2rad = 0.017453292519943295F;
 
 constexpr float k_focus_height = 1.45F;
 
-constexpr float k_bob_freq = 3.5F;
+constexpr float k_walk_bob_freq =
+    2.0F * k_pi / Animation::k_humanoid_walk_cycle_distance;
+constexpr float k_run_bob_freq = 2.0F * k_pi / Animation::k_humanoid_run_cycle_distance;
 constexpr float k_bob_vert_amp = 0.020F;
 constexpr float k_bob_run_mult = 1.35F;
 constexpr float k_bob_lat_amp = 0.013F;
@@ -150,7 +153,8 @@ auto CommanderCameraRig::update(Render::GL::Camera& camera,
   m_bob_amplitude += (bob_amp_target - m_bob_amplitude) * smooth_alpha(k_bob_decay, dt);
   float const previous_bob_phase = m_bob_phase;
   if (inputs.move_speed > 0.05F) {
-    m_bob_phase += inputs.move_speed * k_bob_freq * dt;
+    m_bob_phase += inputs.move_speed *
+                   (inputs.move_running ? k_run_bob_freq : k_walk_bob_freq) * dt;
   } else if (m_bob_amplitude < 0.01F) {
     m_bob_phase = 0.0F;
   }

--- a/docs/AMBIENT_WILDLIFE.md
+++ b/docs/AMBIENT_WILDLIFE.md
@@ -107,8 +107,14 @@ nearest person inside the detection radius, preferring livestock at equal distan
 civilians over soldiers, and declines a quarry that is standing behind enough strength to
 hurt the pack — which, since a person counts toward the strength around themself, is what
 reduces to "wolves take the isolated and leave the escorted alone". It also weighs how many
-wolves are already committed to a quarry, so a pack splits across a group of victims rather
-than putting eight animals on the nearest one.
+wolves are already committed to a quarry — but as a **pull**, not a push. A quarry one or
+two packmates are on scores _better_ than a free one, scaled by the pack's `aggression`,
+and a third wolf closes it off entirely. Pushing the pack apart (which is what the old
+squared penalty did) meant three wolves each picked their own sheep and a "hunt" was three
+separate one-on-ones; a kill has to look like a pack bringing something down. Three wolves
+share a target for 95% of `wildlife_wolf_hunt` now, against never before, while a lazy pack
+(`aggression` 0.15, as `wildlife_mixed_pasture` sets) keeps the old spread-out behaviour
+because the join bonus scales to nothing.
 
 Each wolf then claims a **slot** on a ring around its quarry: the pack members already
 focused on that prey are ordered by entity id, and the wolf takes the share of the circle
@@ -117,7 +123,23 @@ stand abreast, so eight wolves land eight abreast instead of inside one another.
 per-wolf angle at a fixed radius — which is what this used to be — puts several wolves on
 the same point, and a pack that reads as one clipping blob is the result. Inside bite range
 the wolf halts and turns to face the prey through `desired_yaw` so the bite lands along the
-muzzle. Committing to a person, rather than to a sheep, is what marks the wolf hostile.
+muzzle — but only while the bite itself is playing. **Between** bites it keeps its slot
+angle and adds `k_pack_orbit_step` to a per-wolf `orbit`, so a wolf waiting out its attack
+cooldown circles its prey at bite range instead of standing on the spot; that alone
+removed most of the frozen-wolf frames from a hunt. Committing to a person, rather than to a sheep, is what marks the wolf hostile.
+
+**An animal that is not deliberately holding still must be moving.** Half-second think
+ticks and a `k_move_reissue_epsilon` that suppresses near-identical orders combine badly
+at a map edge: a cornered animal can be handed the same unreachable goal forever and stand
+there. `release_if_stalled` watches every animal that is not grazing, mid-bite or
+mid-flinch, and after `k_stall_release_seconds` without measurable movement it stops the
+mover, clears the think cooldown and sets `stalled`. The behaviours read that flag on the
+next tick and pick a _different_ kind of target — the flee aims back at the home anchor
+instead of further into the corner, the drift re-anchors at home, and a wolf adds half a
+turn to its orbit. Flee headings also carry a per-animal arc jitter and fall back through
+±60° and ±110° veers when the straight-away target gains no ground, so a herd fans out
+rather than stacking on one escape point. Measured over `wildlife_wolf_hunt`, the longest
+run of frames where an active animal did not move fell from 3.9 s to 0.7 s.
 
 **Biting is not on the think tick.** `try_contact_bite` runs every frame for every wolf
 that has a `focus_id` within reach, and starts the bite on the animal's own attack
@@ -403,6 +425,35 @@ to be fed the locomotion phase, which is distance-driven — so a wolf that stop
 idle frozen on a single frame, and `wolf_gait_advance(Stand)` is zero anyway, so the
 cursor could not have advanced even if it had wanted to.
 
+**A stationary stalker needed a clip of its own.** Being on the clock is not enough if the
+clip itself is a stride: `Hold` maps to the wolf's `stalk` **walk cycle**, so a wolf
+holding station between bites either froze or skated. `crouch` is a looping three-second
+clip baked from the same crouched drive with no stride at all — panting breath, a head
+that tracks side to side, ear flicks and a low tail sway — and `resolve_gait` returns
+`Stand` below the walk threshold so a stalking wolf that has stopped selects it
+(`StateId::WildlifeTense`). The sheep maps the same state to `alert`: head up, ears
+forward, quick shallow breathing, weight shifting foot to foot. A frightened sheep that
+has run out of room now stands _tensely_ rather than dropping into the calm idle.
+
+**Every standing clip carries idle motion, so nothing is ever a statue.** `idle` was
+twenty-four frames of a one-centimetre bob. Both species' idles are ninety-six frames
+(four seconds) driven by the new `breath`, `head_turn`, `head_dip`, `ear_*`, `tail_*` and
+`weight_shift` fields, which `apply_idle_motion` turns into a rising ribcage, a head that
+looks around on the neck pivot, independent ear twitches and a lateral weight shift that
+keeps the feet planted. The drives are authored as **integer harmonics of the clip phase**
+plus `pulse()` bumps, because anything else does not loop.
+
+**A bite that no one flinches from reads as a nudge.** Two halves were missing. On the
+render side the jaw articulated 0.5 rad — barely a parted lip — and the lunge was a
+forward slide with the head low; the bite now coils, gapes at 1.05 rad, drives in with a
+`rear` that lifts the forequarters off the ground, clamps, then wrenches with a
+`head_roll` so the worry phase reads from any camera angle rather than only from above.
+On the simulation side nothing told the _victim_ it had been hit: `WildlifeComponent`
+now watches its own health, and any drop arms `flinch_timer`, which the sheep renderer
+plays as the one-shot `startle` clip — a lateral shy, a hop off the ground, the head
+thrown up and a twist away from the bite. It is armed by a health drop rather than by the
+bite itself, so a wolf shot by an archer flinches on the same path.
+
 **A clip's authored length is its playback length.** The bite is baked as 32 frames at
 30 fps and the game plays it over `k_bite_animation_seconds`; when those two disagreed the
 clip simply ran at the ratio between them — 1.08 s of animation crammed into 0.55 s, which
@@ -434,8 +485,8 @@ instead of assembled every frame:
   and the whole-mesh node graphs authored as `Quadruped::MeshNode` shapes.
 - `sheep_manifest.cpp` / `wolf_manifest.cpp` — clip descriptors and the bake callback.
 
-`tools/bpat_baker` walks both manifests and writes `sheep.bpat`/`wolf.bpat` (six and seven
-clips), the `*_full.bprm`/`*_minimal.bprm` bodies and the `*_minimal.bpsm` snapshots into
+`tools/bpat_baker` walks both manifests and writes `sheep.bpat`/`wolf.bpat` (eight clips
+each: the sheep adds `startle` and `alert`, the wolf adds `crouch`), the `*_full.bprm`/`*_minimal.bprm` bodies and the `*_minimal.bpsm` snapshots into
 `assets/creatures`, and `bake_creature_assets` lists them so a normal build regenerates
 them. The full body is 3024 triangles for the sheep and 3612 for the wolf, with minimal
 LODs at 1380 and 1600 — the same order as the horse's 2182. The minimal LODs carry the
@@ -462,7 +513,7 @@ a white fleece is what made a grazing herd read as plastic.
 
 ## Arena fixtures
 
-Ten scenarios cover the feature; run them with
+Eleven scenarios cover the feature; run them with
 `arena_app --batch --scenario <id>`:
 
 | Scenario                     | What it proves                                              |
@@ -472,6 +523,7 @@ Ten scenarios cover the feature; run them with
 | `wildlife_wolf_hunt`         | Pack stalking, bites, herd panic                            |
 | `wildlife_wolf_pack`         | Undisturbed prowl: wolf silhouette, coat and gait           |
 | `wildlife_wolf_ambush`       | A pack rushes a lone patrol; both sides take losses         |
+| `wildlife_pack_takedown`     | Close camera on a pack kill: bite, flinch, circling, death  |
 | `wildlife_bird_scatter`      | Resident flock cruise and burst under a marching column     |
 | `wildlife_bird_flyover`      | Empty sky, then a flock crosses it and leaves               |
 | `wildlife_mixed_pasture`     | Sheep, wolves and a passing flock in one frame              |
@@ -482,6 +534,16 @@ They assert through wildlife-specific expectations (`WildlifeGrazingObserved`,
 `WildlifeFleeObserved`, `WildlifeHuntObserved`, `WildlifeBirdsScattered`,
 `WildlifeBirdFlyoverObserved`, `WildlifePopulationHeld`,
 `WildlifeCasualtyObserved`) rather than by eye.
+
+A fixture answers _whether the fight happens_, not _what a clip looks like_ — an animal is
+a few dozen pixels at the gameplay camera, and a panicking herd leaves the shot within
+seconds. For the clips themselves use
+`wildlife_preview <wolf|sheep> [out_dir] [clip] [samples] [side|quarter|front]`, which
+skins each baked clip through `Render::Software::SoftwareRasterizer` and writes a labelled
+strip of phases. It needs no display and takes about a second, so it is the loop to
+iterate a pose in; the arena is where you then confirm the clip is actually _selected_.
+Sampling at 10% steps hides real motion between frames — take twenty samples before
+concluding a pose is broken.
 
 ## Authoring in the map editor
 

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -1850,11 +1850,21 @@ public:
 
   static constexpr float k_bite_animation_seconds = 1.08F;
   static constexpr float k_bite_impact_phase = 0.27F;
+  static constexpr float k_flinch_animation_seconds = 0.55F;
   float bite_timer{0.0F};
+  float flinch_timer{0.0F};
+  int watched_health{-1};
+
+  static constexpr float k_stall_release_seconds = 1.5F;
+  float stall_timer{0.0F};
+  float last_x{0.0F};
+  float last_z{0.0F};
+  bool stalled{false};
   EntityID bite_target_id{0};
   bool bite_impact_pending{false};
   EntityID focus_id{0};
   EntityID aggressor_id{0};
+  float orbit{0.0F};
   std::uint32_t rng_state{0U};
 
   [[nodiscard]] auto is_hostile() const noexcept -> bool {

--- a/game/systems/combat_system/damage_application.cpp
+++ b/game/systems/combat_system/damage_application.cpp
@@ -533,6 +533,11 @@ auto blood_stain_scale(const Engine::Core::UnitComponent* unit) -> float {
   if (is_mounted_spawn(unit->spawn_type)) {
     return 1.25F;
   }
+  if (unit->spawn_type == Game::Units::SpawnType::Sheep ||
+      unit->spawn_type == Game::Units::SpawnType::Wolf) {
+
+    return 0.42F;
+  }
   return 1.0F;
 }
 

--- a/game/wildlife/nature_ai.cpp
+++ b/game/wildlife/nature_ai.cpp
@@ -1,6 +1,7 @@
 #include "nature_ai.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
 #include "../core/component.h"
@@ -30,6 +31,11 @@ constexpr float k_pack_ring_reach_fraction = 0.82F;
 constexpr float k_pack_ring_min = 0.9F;
 constexpr float k_pack_ring_reach_margin = 0.92F;
 constexpr float k_pack_slot_jitter = 0.35F;
+constexpr float k_pack_orbit_step = 0.78F;
+constexpr float k_flee_arc_jitter = 0.55F;
+
+constexpr float k_flee_min_gain = 2.5F;
+constexpr std::array<float, 5> k_flee_veers{{0.0F, 1.05F, -1.05F, 1.95F, -1.95F}};
 constexpr float k_wolf_avoid_base_strength = 2.5F;
 constexpr float k_civilian_standoff = 3.0F;
 constexpr float k_sheep_flee_strength_threshold = 0.5F;
@@ -53,27 +59,61 @@ void bolt_away_from(const NatureContext& ctx,
                     float threat_z,
                     float scatter_radius) {
   auto& wildlife = *ctx.wildlife;
-  float const away_x = ctx.x - threat_x;
-  float const away_z = ctx.z - threat_z;
+
+  float away_x = ctx.x - threat_x;
+  float away_z = ctx.z - threat_z;
+  if (wildlife.stalled) {
+
+    wildlife.stalled = false;
+    away_x = wildlife.home_x - ctx.x;
+    away_z = wildlife.home_z - ctx.z;
+  }
   float const length = std::sqrt((away_x * away_x) + (away_z * away_z));
-  float const dir_x = length > 0.001F ? away_x / length : 1.0F;
-  float const dir_z = length > 0.001F ? away_z / length : 0.0F;
+  float const straight_x = length > 0.001F ? away_x / length : 1.0F;
+  float const straight_z = length > 0.001F ? away_z / length : 0.0F;
+
+  float const arc =
+      random_range(wildlife.rng_state, -k_flee_arc_jitter, k_flee_arc_jitter);
+  float const cos_arc = std::cos(arc);
+  float const sin_arc = std::sin(arc);
+  float const dir_x = (straight_x * cos_arc) - (straight_z * sin_arc);
+  float const dir_z = (straight_x * sin_arc) + (straight_z * cos_arc);
   float const distance =
       random_range(wildlife.rng_state, k_flee_distance_min, k_flee_distance_max);
 
   float target_x = ctx.x + (dir_x * distance);
   float target_z = ctx.z + (dir_z * distance);
-  float open_x = target_x;
-  float open_z = target_z;
-  if (actions.pick_open_point(wildlife.rng_state,
-                              target_x,
-                              target_z,
-                              0.0F,
-                              scatter_radius,
-                              open_x,
-                              open_z)) {
-    target_x = open_x;
-    target_z = open_z;
+
+  for (float const veer : k_flee_veers) {
+    float const cos_veer = std::cos(veer);
+    float const sin_veer = std::sin(veer);
+    float const veer_x = (dir_x * cos_veer) - (dir_z * sin_veer);
+    float const veer_z = (dir_x * sin_veer) + (dir_z * cos_veer);
+    float candidate_x = ctx.x + (veer_x * distance);
+    float candidate_z = ctx.z + (veer_z * distance);
+
+    float open_x = candidate_x;
+    float open_z = candidate_z;
+    if (actions.pick_open_point(wildlife.rng_state,
+                                candidate_x,
+                                candidate_z,
+                                0.0F,
+                                scatter_radius,
+                                open_x,
+                                open_z)) {
+      candidate_x = open_x;
+      candidate_z = open_z;
+    }
+
+    target_x = candidate_x;
+    target_z = candidate_z;
+
+    float const gained_x = candidate_x - ctx.x;
+    float const gained_z = candidate_z - ctx.z;
+    if ((gained_x * gained_x) + (gained_z * gained_z) >
+        k_flee_min_gain * k_flee_min_gain) {
+      break;
+    }
   }
 
   wildlife.target_x = target_x;
@@ -129,15 +169,36 @@ void close_and_bite(const NatureContext& ctx,
   wildlife.focus_id = prey.id;
   actions.set_travel_speed(ctx, true);
 
-  if (distance_to(ctx, prey) <= bite_reach(prey)) {
+  bool const in_reach = distance_to(ctx, prey) <= bite_reach(prey);
+  if (in_reach && wildlife.bite_timer <= 0.0F && wildlife.state_timer <= 0.0F) {
     actions.halt(ctx);
     actions.face_toward(ctx, prey.x, prey.z);
     actions.bite(ctx, prey);
     return;
   }
+  if (wildlife.bite_timer > 0.0F) {
+
+    actions.halt(ctx);
+    actions.face_toward(ctx, prey.x, prey.z);
+    return;
+  }
+
+  if (wildlife.stalled) {
+
+    wildlife.stalled = false;
+    wildlife.orbit += k_two_pi * 0.5F;
+  }
 
   PackSlot const slot = actions.claim_pack_slot(ctx, prey);
-  float const approach_angle = pack_slot_angle(ctx, slot);
+  if (in_reach) {
+
+    wildlife.orbit += k_pack_orbit_step;
+    if (wildlife.orbit > k_two_pi) {
+      wildlife.orbit -= k_two_pi;
+    }
+    actions.face_toward(ctx, prey.x, prey.z);
+  }
+  float const approach_angle = pack_slot_angle(ctx, slot) + wildlife.orbit;
   float const spacing = pack_ring_radius(prey, slot.count);
   float const approach_x = prey.x + (std::cos(approach_angle) * spacing);
   float const approach_z = prey.z + (std::sin(approach_angle) * spacing);
@@ -147,7 +208,14 @@ void close_and_bite(const NatureContext& ctx,
 }
 
 auto wander_anchor(const NatureContext& ctx, float& anchor_x, float& anchor_z) -> void {
-  const auto& wildlife = *ctx.wildlife;
+  auto& wildlife = *ctx.wildlife;
+  if (wildlife.stalled) {
+
+    wildlife.stalled = false;
+    anchor_x = wildlife.home_x;
+    anchor_z = wildlife.home_z;
+    return;
+  }
   anchor_x = ctx.herd.center_x;
   anchor_z = ctx.herd.center_z;
   float const home_dx = anchor_x - wildlife.home_x;

--- a/game/wildlife/wildlife_system.cpp
+++ b/game/wildlife/wildlife_system.cpp
@@ -47,7 +47,10 @@ constexpr float k_wolf_avoid_base_strength = 2.5F;
 constexpr float k_civilian_standoff = 3.0F;
 constexpr float k_civilian_threat_strength = 0.3F;
 constexpr float k_civilian_quarry_preference = 0.5F;
-constexpr float k_quarry_crowd_penalty = 9.0F;
+constexpr int k_pack_gang_size = 3;
+constexpr float k_pack_join_gain = 30.0F;
+constexpr float k_pack_second_join_gain = 9.0F;
+constexpr float k_quarry_crowd_penalty = 400.0F;
 constexpr float k_wolf_bite_recovery = 0.35F;
 constexpr float k_wolf_bite_flinch_seconds = 0.30F;
 constexpr float k_wolf_bite_blood_chance = 0.34F;
@@ -76,9 +79,20 @@ auto hash_unit_interval(std::uint32_t value) -> float {
   return static_cast<float>(value & 0xFFFFFFU) / 16777216.0F;
 }
 
-auto crowding_penalty(int attackers) -> float {
-  float const committed = static_cast<float>(std::max(attackers, 0));
-  return k_quarry_crowd_penalty * committed * committed;
+auto crowding_penalty(int attackers, float appetite) -> float {
+  int const committed = std::max(attackers, 0);
+  if (committed >= k_pack_gang_size) {
+
+    float const excess = static_cast<float>((committed - k_pack_gang_size) + 1);
+    return k_quarry_crowd_penalty * excess;
+  }
+  if (committed <= 0) {
+    return 0.0F;
+  }
+
+  float const gain =
+      committed == 1 ? k_pack_join_gain : k_pack_join_gain + k_pack_second_join_gain;
+  return -gain * std::clamp(appetite, 0.0F, 1.0F);
 }
 
 auto seed_for(std::uint32_t seed, Species species, int index) -> std::uint32_t {
@@ -586,6 +600,42 @@ void WildlifeSystem::try_contact_bite(Engine::Core::World& world,
   begin_bite(*animal.entity, wildlife, prey);
 }
 
+void WildlifeSystem::release_if_stalled(const AnimalRef& animal,
+                                        Engine::Core::WildlifeComponent& wildlife,
+                                        float delta_time) {
+  auto* movement = animal.entity->get_component<Engine::Core::MovementComponent>();
+  bool const meant_to_hold = wildlife.behavior == Behavior::Graze ||
+                             wildlife.bite_timer > 0.0F || wildlife.flinch_timer > 0.0F;
+  if (movement == nullptr || meant_to_hold) {
+
+    wildlife.stall_timer = 0.0F;
+    wildlife.last_x = animal.x;
+    wildlife.last_z = animal.z;
+    return;
+  }
+
+  float const dx = animal.x - wildlife.last_x;
+  float const dz = animal.z - wildlife.last_z;
+  wildlife.last_x = animal.x;
+  wildlife.last_z = animal.z;
+
+  if ((dx * dx) + (dz * dz) > k_stall_step_epsilon * k_stall_step_epsilon) {
+    wildlife.stall_timer = 0.0F;
+    return;
+  }
+
+  wildlife.stall_timer += delta_time;
+  if (wildlife.stall_timer < Engine::Core::WildlifeComponent::k_stall_release_seconds) {
+    return;
+  }
+
+  wildlife.stall_timer = 0.0F;
+  wildlife.stalled = true;
+  movement->stop();
+  wildlife.think_cooldown = 0.0F;
+  m_stats.stall_releases += 1U;
+}
+
 auto WildlifeSystem::attackers_on(Engine::Core::EntityID prey_id,
                                   Engine::Core::EntityID exclude_id) const -> int {
   if (prey_id == 0) {
@@ -632,8 +682,8 @@ auto WildlifeSystem::pack_slot_for(Engine::Core::EntityID prey_id,
 auto WildlifeSystem::nearest_prey(float world_x,
                                   float world_z,
                                   float radius,
-                                  Engine::Core::EntityID hunter_id) const
-    -> const AnimalRef* {
+                                  Engine::Core::EntityID hunter_id,
+                                  float appetite) const -> const AnimalRef* {
   const AnimalRef* best = nullptr;
   float best_score = 0.0F;
   for (const auto& animal : m_animals) {
@@ -647,7 +697,7 @@ auto WildlifeSystem::nearest_prey(float world_x,
       continue;
     }
     float const score =
-        distance_sq + crowding_penalty(attackers_on(animal.id, hunter_id));
+        distance_sq + crowding_penalty(attackers_on(animal.id, hunter_id), appetite);
     if (best != nullptr && score >= best_score) {
       continue;
     }
@@ -660,8 +710,8 @@ auto WildlifeSystem::nearest_prey(float world_x,
 auto WildlifeSystem::nearest_quarry(float world_x,
                                     float world_z,
                                     float radius,
-                                    Engine::Core::EntityID hunter_id) const
-    -> const QuarryRef* {
+                                    Engine::Core::EntityID hunter_id,
+                                    float appetite) const -> const QuarryRef* {
   const QuarryRef* best = nullptr;
   float best_score = 0.0F;
   for (const auto& quarry : m_quarry) {
@@ -673,7 +723,7 @@ auto WildlifeSystem::nearest_quarry(float world_x,
     }
     float const score =
         (distance_sq * (quarry.civilian ? k_civilian_quarry_preference : 1.0F)) +
-        crowding_penalty(attackers_on(quarry.id, hunter_id));
+        crowding_penalty(attackers_on(quarry.id, hunter_id), appetite);
     if (best != nullptr && score >= best_score) {
       continue;
     }
@@ -823,8 +873,8 @@ public:
   }
 
   auto nearest_prey(const NatureContext& ctx, float radius) -> PreyRef override {
-    const AnimalRef* found =
-        m_owner.nearest_prey(ctx.x, ctx.z, radius, ctx.entity->get_id());
+    const AnimalRef* found = m_owner.nearest_prey(
+        ctx.x, ctx.z, radius, ctx.entity->get_id(), ctx.config->aggression);
     if (found == nullptr) {
       return {};
     }
@@ -832,8 +882,8 @@ public:
   }
 
   auto nearest_quarry(const NatureContext& ctx, float radius) -> PreyRef override {
-    const QuarryRef* found =
-        m_owner.nearest_quarry(ctx.x, ctx.z, radius, ctx.entity->get_id());
+    const QuarryRef* found = m_owner.nearest_quarry(
+        ctx.x, ctx.z, radius, ctx.entity->get_id(), ctx.config->aggression);
     if (found == nullptr) {
       return {};
     }
@@ -978,6 +1028,15 @@ void WildlifeSystem::update(Engine::Core::World* world, float delta_time) {
 
     wildlife->state_timer = std::max(0.0F, wildlife->state_timer - delta_time);
     wildlife->alarm_timer = std::max(0.0F, wildlife->alarm_timer - delta_time);
+    wildlife->flinch_timer = std::max(0.0F, wildlife->flinch_timer - delta_time);
+    if (const auto* unit =
+            animal.entity->get_component<Engine::Core::UnitComponent>()) {
+      if (wildlife->watched_health >= 0 && unit->health < wildlife->watched_health) {
+        wildlife->flinch_timer =
+            Engine::Core::WildlifeComponent::k_flinch_animation_seconds;
+      }
+      wildlife->watched_health = unit->health;
+    }
     wildlife->hostile_timer = std::max(0.0F, wildlife->hostile_timer - delta_time);
     float const bite_timer_before = wildlife->bite_timer;
     wildlife->bite_timer = std::max(0.0F, wildlife->bite_timer - delta_time);
@@ -1031,6 +1090,8 @@ void WildlifeSystem::update(Engine::Core::World* world, float delta_time) {
     if (animal.species == Species::Wolf) {
       try_contact_bite(*world, animal, *wildlife);
     }
+
+    release_if_stalled(animal, *wildlife, delta_time);
 
     wildlife->think_cooldown -= delta_time;
     if (wildlife->think_cooldown > 0.0F) {

--- a/game/wildlife/wildlife_system.h
+++ b/game/wildlife/wildlife_system.h
@@ -47,6 +47,7 @@ struct WildlifeStats {
   std::uint64_t hunt_events{0U};
   std::uint64_t bites{0U};
   std::uint64_t respawns{0U};
+  std::uint64_t stall_releases{0U};
 
   void reset() noexcept { *this = WildlifeStats{}; }
 };
@@ -56,6 +57,7 @@ public:
   static constexpr float k_think_interval = 0.5F;
   static constexpr float k_far_think_multiplier = 4.0F;
   static constexpr float k_threat_refresh_interval = 0.35F;
+  static constexpr float k_stall_step_epsilon = 0.004F;
 
   WildlifeSystem();
   ~WildlifeSystem() override;
@@ -145,6 +147,10 @@ private:
                         const AnimalRef& animal,
                         Engine::Core::WildlifeComponent& wildlife);
 
+  void release_if_stalled(const AnimalRef& animal,
+                          Engine::Core::WildlifeComponent& wildlife,
+                          float delta_time);
+
   void alert_group(std::uint16_t group_id, float duration);
   void
   rally_pack(std::uint16_t group_id, Engine::Core::EntityID foe_id, float duration);
@@ -165,16 +171,16 @@ private:
                                      float max_radius,
                                      float& out_x,
                                      float& out_z) const -> bool;
-  [[nodiscard]] auto
-  nearest_prey(float world_x,
-               float world_z,
-               float radius,
-               Engine::Core::EntityID hunter_id) const -> const AnimalRef*;
-  [[nodiscard]] auto
-  nearest_quarry(float world_x,
-                 float world_z,
-                 float radius,
-                 Engine::Core::EntityID hunter_id) const -> const QuarryRef*;
+  [[nodiscard]] auto nearest_prey(float world_x,
+                                  float world_z,
+                                  float radius,
+                                  Engine::Core::EntityID hunter_id,
+                                  float appetite) const -> const AnimalRef*;
+  [[nodiscard]] auto nearest_quarry(float world_x,
+                                    float world_z,
+                                    float radius,
+                                    Engine::Core::EntityID hunter_id,
+                                    float appetite) const -> const QuarryRef*;
   [[nodiscard]] auto attackers_on(Engine::Core::EntityID prey_id,
                                   Engine::Core::EntityID exclude_id) const -> int;
   [[nodiscard]] auto pack_slot_for(Engine::Core::EntityID prey_id,

--- a/render/entity/wildlife/sheep_renderer.cpp
+++ b/render/entity/wildlife/sheep_renderer.cpp
@@ -17,8 +17,9 @@ namespace {
 
 constexpr float k_top_speed = 3.4F;
 constexpr float k_walk_threshold = 0.02F;
-constexpr float k_idle_period_seconds = 24.0F / 24.0F;
+constexpr float k_idle_period_seconds = 96.0F / 24.0F;
 constexpr float k_graze_period_seconds = 120.0F / 24.0F;
+constexpr float k_alert_period_seconds = 60.0F / 24.0F;
 constexpr float k_run_threshold = 0.42F;
 
 auto resolve_variant(const DrawState& state) -> Render::GL::WildlifeVariant {
@@ -84,8 +85,12 @@ auto state_for_gait(const DrawState& state, Render::Wildlife::SheepGait gait)
   case Render::Wildlife::SheepGait::Stand:
     break;
   }
-  return state.grazing ? Render::Creature::AnimationStateId::Hold
-                       : Render::Creature::AnimationStateId::Idle;
+  if (state.grazing) {
+    return Render::Creature::AnimationStateId::Hold;
+  }
+
+  return state.alert ? Render::Creature::AnimationStateId::WildlifeTense
+                     : Render::Creature::AnimationStateId::Idle;
 }
 
 void draw_sheep(const DrawContext& ctx, ISubmitter& out) {
@@ -105,14 +110,19 @@ void draw_sheep(const DrawContext& ctx, ISubmitter& out) {
   } else if (state.death_progress >= 0.0F) {
     inputs.state = Render::Creature::AnimationStateId::Die;
     inputs.phase = action_phase(state, state.death_progress);
+  } else if (state.flinch_progress >= 0.0F) {
+    inputs.state = Render::Creature::AnimationStateId::WildlifeStartle;
+    inputs.phase = action_phase(state, state.flinch_progress);
   } else {
     inputs.state = state_for_gait(state, gait);
     if (gait == Render::Wildlife::SheepGait::Stand) {
-      inputs.phase =
-          ambient_phase(state,
-                        inputs.state == Render::Creature::AnimationStateId::Hold
-                            ? k_graze_period_seconds
-                            : k_idle_period_seconds);
+      float period = k_idle_period_seconds;
+      if (inputs.state == Render::Creature::AnimationStateId::Hold) {
+        period = k_graze_period_seconds;
+      } else if (inputs.state == Render::Creature::AnimationStateId::WildlifeTense) {
+        period = k_alert_period_seconds;
+      }
+      inputs.phase = ambient_phase(state, period);
     } else {
       inputs.phase = gait_phase(state, Render::Wildlife::sheep_gait_advance(gait));
     }

--- a/render/entity/wildlife/wildlife_draw_state.cpp
+++ b/render/entity/wildlife/wildlife_draw_state.cpp
@@ -114,6 +114,12 @@ auto resolve_draw_state(const DrawContext& ctx, float top_speed) -> DrawState {
       state.bite_progress =
           std::clamp(1.0F - (wildlife->bite_timer / k_bite_seconds), 0.0F, 1.0F);
     }
+    if (wildlife->flinch_timer > 0.0F) {
+      constexpr float k_flinch_seconds =
+          Engine::Core::WildlifeComponent::k_flinch_animation_seconds;
+      state.flinch_progress =
+          std::clamp(1.0F - (wildlife->flinch_timer / k_flinch_seconds), 0.0F, 1.0F);
+    }
   }
 
   if (const auto* death =

--- a/render/entity/wildlife/wildlife_draw_state.h
+++ b/render/entity/wildlife/wildlife_draw_state.h
@@ -23,6 +23,7 @@ struct DrawState {
   Game::Wildlife::Behavior behavior{Game::Wildlife::Behavior::Graze};
 
   float bite_progress{-1.0F};
+  float flinch_progress{-1.0F};
   float death_progress{-1.0F};
   bool dead{false};
 };

--- a/render/entity/wildlife/wolf_renderer.cpp
+++ b/render/entity/wildlife/wolf_renderer.cpp
@@ -18,7 +18,8 @@ namespace {
 constexpr float k_top_speed = 4.6F;
 constexpr float k_run_threshold = 0.55F;
 constexpr float k_walk_threshold = 0.02F;
-constexpr float k_idle_period_seconds = 24.0F / 24.0F;
+constexpr float k_idle_period_seconds = 96.0F / 24.0F;
+constexpr float k_crouch_period_seconds = 72.0F / 24.0F;
 
 auto resolve_variant(const DrawState& state) -> Render::GL::WildlifeVariant {
   float const morph = hash_unit_float(state.seed, 31U);
@@ -55,13 +56,14 @@ auto resolve_gait(const DrawState& state,
   if (gait_ratio > k_run_threshold) {
     return Render::Wildlife::WolfGait::Run;
   }
+  if (gait_ratio <= k_walk_threshold) {
+
+    return Render::Wildlife::WolfGait::Stand;
+  }
   if (stalking) {
     return Render::Wildlife::WolfGait::Stalk;
   }
-  if (gait_ratio > k_walk_threshold) {
-    return Render::Wildlife::WolfGait::Walk;
-  }
-  return Render::Wildlife::WolfGait::Stand;
+  return Render::Wildlife::WolfGait::Walk;
 }
 
 auto state_for_gait(const DrawState& state, Render::Wildlife::WolfGait gait)
@@ -77,8 +79,8 @@ auto state_for_gait(const DrawState& state, Render::Wildlife::WolfGait gait)
     break;
   }
 
-  return state.behavior == Game::Wildlife::Behavior::Stalk
-             ? Render::Creature::AnimationStateId::Hold
+  return state.behavior == Game::Wildlife::Behavior::Stalk || state.alert
+             ? Render::Creature::AnimationStateId::WildlifeTense
              : Render::Creature::AnimationStateId::Idle;
 }
 
@@ -104,9 +106,17 @@ void draw_wolf(const DrawContext& ctx, ISubmitter& out) {
     inputs.phase = action_phase(state, state.bite_progress);
   } else {
     inputs.state = state_for_gait(state, gait);
-    inputs.phase = inputs.state == Render::Creature::AnimationStateId::Idle
-                       ? ambient_phase(state, k_idle_period_seconds)
-                       : gait_phase(state, Render::Wildlife::wolf_gait_advance(gait));
+    switch (inputs.state) {
+    case Render::Creature::AnimationStateId::Idle:
+      inputs.phase = ambient_phase(state, k_idle_period_seconds);
+      break;
+    case Render::Creature::AnimationStateId::WildlifeTense:
+      inputs.phase = ambient_phase(state, k_crouch_period_seconds);
+      break;
+    default:
+      inputs.phase = gait_phase(state, Render::Wildlife::wolf_gait_advance(gait));
+      break;
+    }
   }
 
   const ClipTransition transition =

--- a/render/humanoid/poser.cpp
+++ b/render/humanoid/poser.cpp
@@ -82,7 +82,12 @@ void HumanoidRendererBase::compute_locomotion_pose(uint32_t seed,
   pose.foot_pitch_l = 0.0F;
   pose.foot_pitch_r = 0.0F;
 
+  QVector3D hip_delta_l;
+  QVector3D hip_delta_r;
+
   if (is_moving) {
+    float const rest_arm_length = 0.5F * ((pose.hand_l - pose.shoulder_l).length() +
+                                          (pose.hand_r - pose.shoulder_r).length());
     auto const locomotion_pose = Animation::resolve_humanoid_locomotion_pose({
         .state = static_cast<Animation::HumanoidMotionState>(resolved_gait.state),
         .normalized_speed = resolved_gait.normalized_speed,
@@ -102,6 +107,7 @@ void HumanoidRendererBase::compute_locomotion_pose(uint32_t seed,
         .foot_y_offset = pose.foot_y_offset,
         .base_foot_l = base_pose.foot_l,
         .base_foot_r = base_pose.foot_r,
+        .arm_pendulum_length = rest_arm_length,
         .pelvis_y = pose.pelvis_pos.y(),
         .hip_lateral_offset = HP::HIP_LATERAL_OFFSET,
         .hip_vertical_offset = HP::HIP_VERTICAL_OFFSET,
@@ -119,6 +125,8 @@ void HumanoidRendererBase::compute_locomotion_pose(uint32_t seed,
       pose.head_pos += to_qvec(locomotion_pose.head_delta);
       pose.hand_l += to_qvec(locomotion_pose.hand_l_delta);
       pose.hand_r += to_qvec(locomotion_pose.hand_r_delta);
+      hip_delta_l = to_qvec(locomotion_pose.hip_l_delta);
+      hip_delta_r = to_qvec(locomotion_pose.hip_r_delta);
     }
 
     float const max_reach =
@@ -131,10 +139,10 @@ void HumanoidRendererBase::compute_locomotion_pose(uint32_t seed,
 
   QVector3D const hip_l =
       pose.pelvis_pos +
-      QVector3D(-HP::HIP_LATERAL_OFFSET, HP::HIP_VERTICAL_OFFSET, 0.0F);
+      QVector3D(-HP::HIP_LATERAL_OFFSET, HP::HIP_VERTICAL_OFFSET, 0.0F) + hip_delta_l;
   QVector3D const hip_r =
       pose.pelvis_pos +
-      QVector3D(HP::HIP_LATERAL_OFFSET, HP::HIP_VERTICAL_OFFSET, 0.0F);
+      QVector3D(HP::HIP_LATERAL_OFFSET, HP::HIP_VERTICAL_OFFSET, 0.0F) + hip_delta_r;
 
   auto solve_leg =
       [&](const QVector3D& hip, const QVector3D& foot, Side side) -> QVector3D {
@@ -156,8 +164,14 @@ void HumanoidRendererBase::compute_locomotion_pose(uint32_t seed,
   if (right_axis.x() < 0.0F) {
     right_axis = -right_axis;
   }
-  QVector3D const outward_l = -right_axis;
-  QVector3D const outward_r = right_axis;
+
+  constexpr float k_walking_elbow_backset = 0.45F;
+  QVector3D const elbow_backset =
+      is_moving ? QVector3D(0.0F, 0.0F, -1.0F) * k_walking_elbow_backset : QVector3D();
+  QVector3D const outward_l =
+      (-right_axis * (1.0F - (is_moving ? 0.35F : 0.0F))) + elbow_backset;
+  QVector3D const outward_r =
+      (right_axis * (1.0F - (is_moving ? 0.35F : 0.0F))) + elbow_backset;
 
   float const elbow_along_bias = (variation.bulk_scale - 1.0F) * 0.05F;
   pose.elbow_l =

--- a/render/wildlife/sheep_manifest.cpp
+++ b/render/wildlife/sheep_manifest.cpp
@@ -18,6 +18,13 @@ namespace Render::Wildlife {
 
 namespace {
 
+enum class SheepAmbient : std::uint8_t {
+  None = 0,
+  Resting,
+  Browsing,
+  Watchful,
+};
+
 struct SheepClipSpec {
   Render::Creature::BakeClipDescriptor desc;
   float graze{0.0F};
@@ -25,16 +32,65 @@ struct SheepClipSpec {
   float alert{0.0F};
   bool collapses{false};
   bool holds_collapsed{false};
+  bool startles{false};
   SheepGait gait{SheepGait::Stand};
+  SheepAmbient ambient{SheepAmbient::None};
 };
 
-constexpr std::array<SheepClipSpec, 6> k_sheep_clips{{
-    {{"idle", 24U, 24.0F, true}, 0.0F, 0.0F, 0.0F, false, false, SheepGait::Stand},
-    {{"graze", 120U, 24.0F, true}, 1.0F, 0.0F, 0.0F, false, false, SheepGait::Stand},
-    {{"walk", 28U, 28.0F, true}, 0.0F, 0.42F, 0.0F, false, false, SheepGait::Walk},
-    {{"run", 24U, 40.0F, true}, 0.0F, 1.0F, 1.0F, false, false, SheepGait::Run},
-    {{"die", 32U, 26.0F, false}, 0.0F, 0.0F, 1.0F, true, false, SheepGait::Stand},
-    {{"dead", 1U, 1.0F, true}, 0.0F, 0.0F, 1.0F, true, true, SheepGait::Stand},
+constexpr std::array<SheepClipSpec, 8> k_sheep_clips{{
+    {{"idle", 96U, 24.0F, true},
+     0.0F,
+     0.0F,
+     0.0F,
+     false,
+     false,
+     false,
+     SheepGait::Stand,
+     SheepAmbient::Resting},
+    {{"graze", 120U, 24.0F, true},
+     1.0F,
+     0.0F,
+     0.0F,
+     false,
+     false,
+     false,
+     SheepGait::Stand,
+     SheepAmbient::Browsing},
+    {{"walk", 28U, 28.0F, true},
+     0.0F,
+     0.42F,
+     0.0F,
+     false,
+     false,
+     false,
+     SheepGait::Walk},
+    {{"run", 24U, 40.0F, true}, 0.0F, 1.0F, 1.0F, false, false, false, SheepGait::Run},
+    {{"die", 32U, 26.0F, false},
+     0.0F,
+     0.0F,
+     1.0F,
+     true,
+     false,
+     false,
+     SheepGait::Stand},
+    {{"dead", 1U, 1.0F, true}, 0.0F, 0.0F, 1.0F, true, true, false, SheepGait::Stand},
+    {{"startle", 26U, 30.0F, false},
+     0.0F,
+     0.0F,
+     1.0F,
+     false,
+     false,
+     true,
+     SheepGait::Stand},
+    {{"alert", 60U, 24.0F, true},
+     0.0F,
+     0.0F,
+     1.0F,
+     false,
+     false,
+     false,
+     SheepGait::Stand,
+     SheepAmbient::Watchful},
 }};
 
 constexpr std::array<Render::Creature::BakeClipDescriptor, k_sheep_clips.size()>
@@ -45,7 +101,65 @@ constexpr std::array<Render::Creature::BakeClipDescriptor, k_sheep_clips.size()>
         k_sheep_clips[3].desc,
         k_sheep_clips[4].desc,
         k_sheep_clips[5].desc,
+        k_sheep_clips[6].desc,
+        k_sheep_clips[7].desc,
     }};
+
+constexpr float k_two_pi = 6.28318530718F;
+
+auto wave(float phase, float harmonic, float offset) -> float {
+  return std::sin((phase * harmonic * k_two_pi) + offset);
+}
+
+auto pulse(float phase, float centre, float width) -> float {
+  float const wrapped = phase - std::floor(phase);
+  float delta = std::fabs(wrapped - centre);
+  delta = std::min(delta, 1.0F - delta);
+  if (delta >= width) {
+    return 0.0F;
+  }
+  float const t = 1.0F - (delta / width);
+  return t * t * (3.0F - (2.0F * t));
+}
+
+void apply_ambient(SheepDrive& drive, SheepAmbient ambient, float phase) {
+  switch (ambient) {
+  case SheepAmbient::None:
+    return;
+  case SheepAmbient::Resting:
+
+    drive.breath = wave(phase, 2.0F, 0.0F);
+    drive.weight_shift = wave(phase, 1.0F, 1.1F) * 0.80F;
+    drive.head_turn =
+        (wave(phase, 1.0F, 2.4F) * 0.55F) + (wave(phase, 2.0F, 0.9F) * 0.18F);
+    drive.head_dip = wave(phase, 1.0F, 0.3F) * 0.50F;
+    drive.ear_flick =
+        (pulse(phase, 0.22F, 0.045F) * 1.0F) - (pulse(phase, 0.66F, 0.04F) * 0.8F);
+    drive.tail_flick =
+        (wave(phase, 2.0F, 0.0F) * 0.35F) + (pulse(phase, 0.48F, 0.06F) * 0.9F);
+    return;
+  case SheepAmbient::Browsing:
+
+    drive.breath = wave(phase, 5.0F, 0.0F) * 0.55F;
+    drive.weight_shift = wave(phase, 1.0F, 0.0F) * 0.65F;
+    drive.head_turn = wave(phase, 2.0F, 1.7F) * 0.42F;
+    drive.ear_flick = pulse(phase, 0.55F, 0.03F) * 0.9F;
+    drive.tail_flick = (wave(phase, 3.0F, 0.5F) * 0.30F) + pulse(phase, 0.18F, 0.04F);
+    return;
+  case SheepAmbient::Watchful:
+
+    drive.breath = wave(phase, 4.0F, 0.0F) * 0.75F;
+    drive.head_turn =
+        (wave(phase, 2.0F, 0.0F) * 0.85F) + (wave(phase, 5.0F, 1.3F) * 0.2F);
+    drive.head_dip = -0.55F + (wave(phase, 2.0F, 1.6F) * 0.25F);
+    drive.weight_shift = wave(phase, 2.0F, 2.6F) * 0.45F;
+    drive.ear_flick = (pulse(phase, 0.14F, 0.035F) * 1.0F) -
+                      (pulse(phase, 0.47F, 0.03F) * 0.9F) +
+                      (pulse(phase, 0.81F, 0.035F) * 0.8F);
+    drive.tail_flick = wave(phase, 4.0F, 0.9F) * 0.55F;
+    return;
+  }
+}
 
 void bake_sheep_clip_frame(std::size_t clip_index,
                            std::uint32_t frame_index,
@@ -65,6 +179,11 @@ void bake_sheep_clip_frame(std::size_t clip_index,
   drive.alert = clip.alert;
   drive.stride_phase = phase;
   drive.gait = clip.gait;
+  apply_ambient(drive, clip.ambient, phase);
+  if (clip.startles) {
+    drive.startle = phase;
+    drive.stride_phase = 0.0F;
+  }
   if (clip.collapses) {
     drive.collapse = clip.holds_collapsed ? 1.0F : phase;
     drive.stride_phase = 0.0F;

--- a/render/wildlife/sheep_spec.cpp
+++ b/render/wildlife/sheep_spec.cpp
@@ -229,6 +229,155 @@ void reattach_head(RigPose& pose, const HeadAttachment& held) {
   pose.ear_tip_r = pose.poll + held.ear_tip_r;
 }
 
+auto rotate_about_x(const QVector3D& point,
+                    const QVector3D& pivot,
+                    float radians) -> QVector3D {
+  QVector3D const d = point - pivot;
+  float const c = std::cos(radians);
+  float const s = std::sin(radians);
+  return pivot + QVector3D(d.x(), (d.y() * c) - (d.z() * s), (d.y() * s) + (d.z() * c));
+}
+
+auto rotate_about_y(const QVector3D& point,
+                    const QVector3D& pivot,
+                    float radians) -> QVector3D {
+  QVector3D const d = point - pivot;
+  float const c = std::cos(radians);
+  float const s = std::sin(radians);
+  return pivot + QVector3D((d.x() * c) + (d.z() * s), d.y(), (d.z() * c) - (d.x() * s));
+}
+
+auto head_chain(RigPose& pose) -> std::array<QVector3D*, 8> {
+  return {&pose.poll,
+          &pose.muzzle,
+          &pose.jaw_hinge,
+          &pose.jaw_tip,
+          &pose.ear_base_l,
+          &pose.ear_base_r,
+          &pose.ear_tip_l,
+          &pose.ear_tip_r};
+}
+
+void apply_idle_motion(RigPose& pose, const SheepDrive& drive) {
+  if (drive.breath == 0.0F && drive.head_turn == 0.0F && drive.head_dip == 0.0F &&
+      drive.ear_flick == 0.0F && drive.tail_flick == 0.0F &&
+      drive.weight_shift == 0.0F) {
+    return;
+  }
+
+  QVector3D const swell(0.0F, 0.011F * drive.breath, 0.0F);
+  float const shift = 0.016F * drive.weight_shift;
+
+  auto ride = [&](QVector3D& point, float swell_weight, float shift_weight) {
+    point += swell * swell_weight;
+    point.setX(point.x() + (shift * shift_weight));
+  };
+
+  ride(pose.root, 0.35F, 0.55F);
+  ride(pose.body_front, 1.0F, 0.72F);
+  ride(pose.body_rear, 0.70F, 1.0F);
+  ride(pose.withers, 0.90F, 0.72F);
+  for (std::size_t i = 0; i < k_leg_count; ++i) {
+    bool const hind = k_leg_plans[i].z < 0.0F;
+    ride(pose.legs[i].shoulder, hind ? 0.50F : 0.85F, hind ? 1.0F : 0.68F);
+    ride(pose.legs[i].knee, hind ? 0.20F : 0.34F, hind ? 0.44F : 0.28F);
+  }
+
+  QVector3D const neck = pose.withers;
+  float const yaw = 0.30F * drive.head_turn;
+  float const pitch = 0.17F * drive.head_dip;
+  float const flick = 0.55F * drive.ear_flick;
+  pose.ear_tip_l = rotate_about_y(pose.ear_tip_l, pose.ear_base_l, flick);
+  pose.ear_tip_r = rotate_about_y(pose.ear_tip_r, pose.ear_base_r, -flick);
+  for (auto* point : head_chain(pose)) {
+    *point += swell * 0.85F;
+    point->setX(point->x() + (shift * 0.74F));
+    *point = rotate_about_y(*point, neck, yaw);
+    *point = rotate_about_x(*point, neck, pitch);
+  }
+
+  ride(pose.tail_base, 0.60F, 1.0F);
+  pose.tail_mid += swell * 0.4F;
+  pose.tail_tip += swell * 0.3F;
+  pose.tail_mid.setX(pose.tail_mid.x() + (0.020F * drive.tail_flick) + shift);
+  pose.tail_tip.setX(pose.tail_tip.x() + (0.048F * drive.tail_flick) + shift);
+}
+
+void apply_startle(RigPose& pose, const SheepDrive& drive) {
+  float const phase = std::clamp(drive.startle, 0.0F, 1.0F);
+  if (phase <= 0.0F) {
+    return;
+  }
+
+  auto const smoother = [](float value) {
+    float const t = std::clamp(value, 0.0F, 1.0F);
+    return t * t * t * ((t * ((t * 6.0F) - 15.0F)) + 10.0F);
+  };
+  auto const window = [&](float from, float to) {
+    if (phase <= from) {
+      return 0.0F;
+    }
+    if (phase >= to) {
+      return 1.0F;
+    }
+    return smoother((phase - from) / (to - from));
+  };
+
+  float const flinch = window(0.0F, 0.14F) - window(0.30F, 0.62F);
+
+  float const hop = window(0.06F, 0.30F) - window(0.30F, 0.72F);
+
+  float const settle = 1.0F - window(0.62F, 1.0F);
+
+  float const away = 0.150F * flinch;
+  float const rise = 0.075F * hop;
+  float const twist = -0.42F * flinch;
+
+  float const throw_up = -0.46F * flinch;
+
+  QVector3D const pivot(0.0F, 0.240F, -0.120F);
+
+  auto shove = [&](QVector3D& point, float lateral, float lift) {
+    point.setX(point.x() + (away * lateral));
+    point.setY(point.y() + (rise * lift));
+    point = rotate_about_y(point, pivot, twist * lateral);
+  };
+
+  shove(pose.root, 0.80F, 0.85F);
+  shove(pose.body_rear, 1.00F, 1.00F);
+  shove(pose.body_front, 0.70F, 0.80F);
+  shove(pose.withers, 0.65F, 0.75F);
+
+  for (std::size_t i = 0; i < k_leg_count; ++i) {
+    bool const hind = k_leg_plans[i].z < 0.0F;
+
+    float const tuck = hind ? -0.070F : 0.048F;
+    float const kick = hind ? 0.090F : 0.030F;
+    pose.legs[i].knee += QVector3D(0.0F, 0.052F * hop, tuck * hop);
+    pose.legs[i].foot += QVector3D(0.0F, 0.086F * hop, (tuck - kick) * hop);
+    pose.legs[i].toe += QVector3D(0.0F, 0.094F * hop, (tuck - kick) * hop);
+    shove(pose.legs[i].shoulder, hind ? 1.0F : 0.7F, hind ? 1.0F : 0.8F);
+    shove(pose.legs[i].knee, hind ? 0.8F : 0.6F, hind ? 0.85F : 0.7F);
+    shove(pose.legs[i].foot, hind ? 0.5F : 0.4F, hind ? 0.6F : 0.5F);
+    shove(pose.legs[i].toe, hind ? 0.4F : 0.3F, hind ? 0.5F : 0.4F);
+  }
+
+  QVector3D const neck = pose.withers;
+  for (auto* point : head_chain(pose)) {
+    point->setY(point->y() + (rise * 0.9F));
+    *point = rotate_about_x(*point, neck, throw_up);
+    *point = rotate_about_y(*point, pivot, twist * 0.9F);
+  }
+
+  float const lash = 0.055F * flinch * settle;
+  pose.tail_base.setX(pose.tail_base.x() + (away * 0.9F));
+  pose.tail_base.setY(pose.tail_base.y() + (rise * 0.9F));
+  pose.tail_mid.setX(pose.tail_mid.x() + (away * 0.9F) - lash);
+  pose.tail_tip.setX(pose.tail_tip.x() + (away * 0.9F) - (lash * 2.2F));
+  pose.tail_mid.setY(pose.tail_mid.y() + (rise * 0.8F) + (0.030F * flinch));
+  pose.tail_tip.setY(pose.tail_tip.y() + (rise * 0.7F) + (0.048F * flinch));
+}
+
 void apply_collapse(RigPose& pose, const SheepDrive& drive) {
   float const phase = std::clamp(drive.collapse, 0.0F, 1.0F);
   if (phase <= 0.0F) {
@@ -331,6 +480,8 @@ auto make_pose(const SheepDrive& drive) -> RigPose {
   pose.tail_mid.setX(wag * 0.5F);
   pose.tail_tip.setX(wag);
 
+  apply_idle_motion(pose, drive);
+  apply_startle(pose, drive);
   apply_collapse(pose, drive);
   reattach_head(pose, head_attachment);
   enforce_skeleton_lengths(pose, skeleton);

--- a/render/wildlife/sheep_spec.h
+++ b/render/wildlife/sheep_spec.h
@@ -35,6 +35,15 @@ struct SheepDrive {
   float speed_ratio{0.0F};
   float alert{0.0F};
   float collapse{0.0F};
+
+  float breath{0.0F};
+  float head_turn{0.0F};
+  float head_dip{0.0F};
+  float ear_flick{0.0F};
+  float tail_flick{0.0F};
+  float weight_shift{0.0F};
+
+  float startle{0.0F};
   SheepGait gait{SheepGait::Stand};
 };
 

--- a/render/wildlife/wolf_manifest.cpp
+++ b/render/wildlife/wolf_manifest.cpp
@@ -19,6 +19,14 @@ namespace Render::Wildlife {
 
 namespace {
 
+constexpr float k_two_pi = 6.28318530718F;
+
+enum class WolfAmbient : std::uint8_t {
+  None = 0,
+  Resting,
+  Crouched,
+};
+
 struct WolfClipSpec {
   Render::Creature::BakeClipDescriptor desc;
   float speed_ratio{0.0F};
@@ -28,17 +36,19 @@ struct WolfClipSpec {
   bool collapses{false};
   bool holds_collapsed{false};
   WolfGait gait{WolfGait::Stand};
+  WolfAmbient ambient{WolfAmbient::None};
 };
 
-constexpr std::array<WolfClipSpec, 7> k_wolf_clips{{
-    {{"idle", 24U, 24.0F, true},
+constexpr std::array<WolfClipSpec, 8> k_wolf_clips{{
+    {{"idle", 96U, 24.0F, true},
      0.0F,
      0.0F,
      0.0F,
      false,
      false,
      false,
-     WolfGait::Stand},
+     WolfGait::Stand,
+     WolfAmbient::Resting},
     {{"stalk", 32U, 22.0F, true},
      0.30F,
      1.0F,
@@ -66,6 +76,15 @@ constexpr std::array<WolfClipSpec, 7> k_wolf_clips{{
      WolfGait::Stand},
     {{"die", 32U, 26.0F, false}, 0.0F, 0.0F, 1.0F, false, true, false, WolfGait::Stand},
     {{"dead", 1U, 1.0F, true}, 0.0F, 0.0F, 1.0F, false, true, true, WolfGait::Stand},
+    {{"crouch", 72U, 24.0F, true},
+     0.0F,
+     0.92F,
+     0.72F,
+     false,
+     false,
+     false,
+     WolfGait::Stand,
+     WolfAmbient::Crouched},
 }};
 
 constexpr std::array<Render::Creature::BakeClipDescriptor, k_wolf_clips.size()>
@@ -77,7 +96,52 @@ constexpr std::array<Render::Creature::BakeClipDescriptor, k_wolf_clips.size()>
         k_wolf_clips[4].desc,
         k_wolf_clips[5].desc,
         k_wolf_clips[6].desc,
+        k_wolf_clips[7].desc,
     }};
+
+auto wave(float phase, float harmonic, float offset) -> float {
+  return std::sin((phase * harmonic * k_two_pi) + offset);
+}
+
+auto pulse(float phase, float centre, float width) -> float {
+  float const wrapped = phase - std::floor(phase);
+  float delta = std::fabs(wrapped - centre);
+  delta = std::min(delta, 1.0F - delta);
+  if (delta >= width) {
+    return 0.0F;
+  }
+  float const t = 1.0F - (delta / width);
+  return t * t * (3.0F - (2.0F * t));
+}
+
+void apply_ambient(WolfDrive& drive, WolfAmbient ambient, float phase) {
+  switch (ambient) {
+  case WolfAmbient::None:
+    return;
+  case WolfAmbient::Resting:
+
+    drive.breath = wave(phase, 2.0F, 0.0F);
+    drive.weight_shift = wave(phase, 1.0F, 0.7F) * 0.85F;
+    drive.head_turn =
+        (wave(phase, 1.0F, 1.9F) * 0.62F) + (wave(phase, 2.0F, 0.4F) * 0.2F);
+    drive.head_dip = wave(phase, 1.0F, 3.1F) * 0.45F;
+    drive.ear_swivel =
+        (pulse(phase, 0.31F, 0.055F) * 0.9F) - (pulse(phase, 0.74F, 0.045F) * 0.7F);
+    drive.tail_sway =
+        (wave(phase, 1.0F, 0.0F) * 0.7F) + (wave(phase, 3.0F, 1.2F) * 0.22F);
+    return;
+  case WolfAmbient::Crouched:
+
+    drive.breath = wave(phase, 3.0F, 0.0F) * 0.85F;
+    drive.weight_shift = wave(phase, 1.0F, 2.2F) * 0.55F;
+    drive.head_turn = wave(phase, 1.0F, 0.0F) * 0.85F;
+    drive.head_dip = wave(phase, 2.0F, 1.4F) * 0.30F;
+    drive.ear_swivel =
+        (pulse(phase, 0.18F, 0.05F) * 0.8F) - (pulse(phase, 0.62F, 0.05F) * 0.8F);
+    drive.tail_sway = wave(phase, 2.0F, 0.6F) * 0.45F;
+    return;
+  }
+}
 
 void bake_wolf_clip_frame(std::size_t clip_index,
                           std::uint32_t frame_index,
@@ -97,43 +161,61 @@ void bake_wolf_clip_frame(std::size_t clip_index,
   drive.crouch = clip.crouch;
   drive.ear_pin = clip.ear_pin;
   drive.gait = clip.gait;
+  apply_ambient(drive, clip.ambient, phase);
   if (clip.bites) {
 
-    constexpr float k_gather_end = 0.20F;
-    constexpr float k_contact = 0.27F;
-    constexpr float k_worry_end = 0.84F;
+    constexpr float k_coil_end = 0.16F;
+    constexpr float k_contact = 0.28F;
+    constexpr float k_wrench_end = 0.56F;
+    constexpr float k_worry_end = 0.86F;
+    constexpr float k_pi = std::numbers::pi_v<float>;
 
     auto smoothstep = [](float value) {
       float const t = std::clamp(value, 0.0F, 1.0F);
       return t * t * (3.0F - (2.0F * t));
     };
 
-    if (phase < k_gather_end) {
+    if (phase < k_coil_end) {
 
-      float const t = phase / k_gather_end;
-      drive.lunge = -0.30F * smoothstep(t);
-      drive.jaw_open = smoothstep(t);
-      drive.crouch = 0.55F + (0.42F * smoothstep(t));
+      float const t = smoothstep(phase / k_coil_end);
+      drive.lunge = -0.34F * t;
+      drive.jaw_open = t;
+      drive.crouch = 0.55F + (0.45F * t);
+      drive.rear = 0.22F * t;
     } else if (phase < k_contact) {
 
-      float const t = (phase - k_gather_end) / (k_contact - k_gather_end);
-      drive.lunge = -0.30F + (1.30F * (t * t));
-      drive.jaw_open = 1.0F - (t * t);
-      drive.crouch = 0.97F - (0.72F * t);
+      float const t = (phase - k_coil_end) / (k_contact - k_coil_end);
+      drive.lunge = -0.34F + (1.34F * (t * t));
+      drive.jaw_open = 1.0F - (0.28F * t * t * t);
+      drive.crouch = 1.0F - (0.72F * t);
+      drive.rear = 0.22F + (0.78F * (t * t));
+    } else if (phase < k_wrench_end) {
+
+      float const t = (phase - k_contact) / (k_wrench_end - k_contact);
+      float const heave = std::sin(t * k_pi);
+      drive.lunge = 1.0F - (0.12F * t);
+      drive.jaw_open = 0.0F;
+      drive.crouch = 0.30F + (0.42F * smoothstep(t));
+      drive.rear = 1.0F - (0.88F * smoothstep(t));
+      drive.head_shake = std::sin(t * k_pi * 2.0F) * 0.75F;
+      drive.head_roll = -(0.45F + (0.42F * heave));
     } else if (phase < k_worry_end) {
 
-      float const t = (phase - k_contact) / (k_worry_end - k_contact);
-      float const thrash = std::sin(t * std::numbers::pi_v<float> * 5.0F);
-      drive.lunge = 1.0F - (0.24F * t);
+      float const t = (phase - k_wrench_end) / (k_worry_end - k_wrench_end);
+      float const thrash = std::sin(t * k_pi * 5.0F);
+      float const decay = 1.0F - (0.45F * t);
+      drive.lunge = 0.88F - (0.20F * t);
       drive.jaw_open = 0.0F;
-      drive.crouch = 0.25F + (0.30F * std::fabs(thrash));
-      drive.head_shake = thrash * (1.0F - (0.42F * t)) * 1.45F;
+      drive.crouch = 0.42F + (0.26F * std::fabs(thrash));
+      drive.head_shake = thrash * decay * 1.70F;
+      drive.head_roll = thrash * decay * 0.70F;
     } else {
 
-      float const t = (phase - k_worry_end) / (1.0F - k_worry_end);
-      drive.lunge = 0.76F * (1.0F - smoothstep(t));
+      float const t = smoothstep((phase - k_worry_end) / (1.0F - k_worry_end));
+      drive.lunge = 0.68F * (1.0F - t);
       drive.jaw_open = 0.0F;
-      drive.crouch = 0.42F * (1.0F - smoothstep(t));
+      drive.crouch = (0.42F * (1.0F - t)) + (0.55F * t);
+      drive.head_roll = 0.20F * (1.0F - t);
     }
     drive.stride_phase = 0.0F;
   }

--- a/render/wildlife/wolf_spec.cpp
+++ b/render/wildlife/wolf_spec.cpp
@@ -271,9 +271,71 @@ auto rotate_about_y(const QVector3D& point,
   return pivot + QVector3D((d.x() * c) + (d.z() * s), d.y(), (d.z() * c) - (d.x() * s));
 }
 
+auto head_chain(RigPose& pose) -> std::array<QVector3D*, 8> {
+  return {&pose.poll,
+          &pose.muzzle,
+          &pose.jaw_hinge,
+          &pose.jaw_tip,
+          &pose.ear_base_l,
+          &pose.ear_base_r,
+          &pose.ear_tip_l,
+          &pose.ear_tip_r};
+}
+
+auto rotate_about_z(const QVector3D& point,
+                    const QVector3D& pivot,
+                    float radians) -> QVector3D {
+  QVector3D const d = point - pivot;
+  float const c = std::cos(radians);
+  float const s = std::sin(radians);
+  return pivot + QVector3D((d.x() * c) - (d.y() * s), (d.x() * s) + (d.y() * c), d.z());
+}
+
+void apply_rear(RigPose& pose, const WolfDrive& drive) {
+  float const rear = std::clamp(drive.rear, 0.0F, 1.0F);
+  if (rear <= 0.0F) {
+    return;
+  }
+
+  QVector3D const lift(0.0F, 0.072F * rear, 0.020F * rear);
+  QVector3D const pivot = pose.body_rear;
+  float const pitch = -0.19F * rear;
+
+  auto raise = [&](QVector3D& point) {
+    point += lift;
+    point = rotate_about_x(point, pivot, pitch);
+  };
+
+  pose.root += lift * 0.45F;
+  pose.root = rotate_about_x(pose.root, pivot, pitch * 0.45F);
+  raise(pose.body_front);
+  raise(pose.withers);
+  for (auto* point : head_chain(pose)) {
+    raise(*point);
+  }
+
+  for (std::size_t i = 0; i < 2U; ++i) {
+
+    pose.legs[i].shoulder += lift * 0.95F;
+    pose.legs[i].knee += lift * 0.80F + QVector3D(0.0F, 0.0F, 0.052F * rear);
+    pose.legs[i].foot += lift * 0.62F + QVector3D(0.0F, 0.0F, 0.070F * rear);
+    pose.legs[i].toe += lift * 0.55F + QVector3D(0.0F, 0.0F, 0.078F * rear);
+  }
+  for (std::size_t i = 2U; i < k_leg_count; ++i) {
+
+    pose.legs[i].shoulder += QVector3D(0.0F, -0.022F * rear, 0.0F);
+    pose.legs[i].knee += QVector3D(0.0F, -0.016F * rear, -0.020F * rear);
+  }
+
+  pose.tail_base += lift * 0.35F;
+  pose.tail_mid += QVector3D(0.0F, 0.030F * rear, -0.024F * rear);
+  pose.tail_tip += QVector3D(0.0F, 0.058F * rear, -0.046F * rear);
+}
+
 void apply_lunge(RigPose& pose, const WolfDrive& drive) {
   float const lunge = std::clamp(drive.lunge, 0.0F, 1.0F);
-  if (lunge <= 0.0F && drive.jaw_open <= 0.0F && drive.head_shake == 0.0F) {
+  if (lunge <= 0.0F && drive.jaw_open <= 0.0F && drive.head_shake == 0.0F &&
+      drive.head_roll == 0.0F && drive.rear == 0.0F) {
     return;
   }
 
@@ -319,26 +381,25 @@ void apply_lunge(RigPose& pose, const WolfDrive& drive) {
   pose.ear_tip_l = rotate_about_x(pose.ear_tip_l, pivot, swing);
   pose.ear_tip_r = rotate_about_x(pose.ear_tip_r, pivot, swing);
 
-  pose.jaw_tip = rotate_about_x(pose.jaw_tip, pose.jaw_hinge, 0.50F * drive.jaw_open);
+  apply_rear(pose, drive);
+
+  pose.jaw_tip = rotate_about_x(pose.jaw_tip, pose.jaw_hinge, 1.05F * drive.jaw_open);
+
+  if (drive.head_roll != 0.0F) {
+
+    float const roll = 0.62F * drive.head_roll;
+    QVector3D const neck = pose.withers;
+    for (auto* point : head_chain(pose)) {
+      *point = rotate_about_z(*point, neck, roll);
+    }
+  }
 
   if (drive.head_shake != 0.0F) {
-
-    auto const head_chain = [&pose]() -> std::array<QVector3D*, 8> {
-      return {&pose.poll,
-              &pose.muzzle,
-              &pose.jaw_hinge,
-              &pose.jaw_tip,
-              &pose.ear_base_l,
-              &pose.ear_base_r,
-              &pose.ear_tip_l,
-              &pose.ear_tip_r};
-    };
-
     float const counter = -0.05F * drive.head_shake;
     QVector3D const spine_pivot = pose.body_rear;
     pose.body_front = rotate_about_y(pose.body_front, spine_pivot, counter);
     pose.withers = rotate_about_y(pose.withers, spine_pivot, counter);
-    for (auto* point : head_chain()) {
+    for (auto* point : head_chain(pose)) {
       *point = rotate_about_y(*point, spine_pivot, counter);
     }
     for (std::size_t i = 0; i < 2U; ++i) {
@@ -349,7 +410,7 @@ void apply_lunge(RigPose& pose, const WolfDrive& drive) {
 
     float const yaw = 0.80F * drive.head_shake;
     QVector3D const neck = pose.withers;
-    for (auto* point : head_chain()) {
+    for (auto* point : head_chain(pose)) {
       *point = rotate_about_y(*point, neck, yaw);
     }
   }
@@ -467,6 +528,52 @@ void apply_collapse(RigPose& pose, const WolfDrive& drive) {
   place(pose.tail_tip, (k_rest_body_y - k_lying_y) * tail_lag, 0.5F);
 }
 
+void apply_idle_motion(RigPose& pose, const WolfDrive& drive) {
+  if (drive.breath == 0.0F && drive.head_turn == 0.0F && drive.head_dip == 0.0F &&
+      drive.ear_swivel == 0.0F && drive.tail_sway == 0.0F &&
+      drive.weight_shift == 0.0F) {
+    return;
+  }
+
+  QVector3D const swell(0.0F, 0.013F * drive.breath, 0.0F);
+  float const shift = 0.019F * drive.weight_shift;
+
+  auto ride = [&](QVector3D& point, float swell_weight, float shift_weight) {
+    point += swell * swell_weight;
+    point.setX(point.x() + (shift * shift_weight));
+  };
+
+  ride(pose.root, 0.35F, 0.55F);
+  ride(pose.body_front, 1.0F, 0.70F);
+  ride(pose.body_rear, 0.62F, 1.0F);
+  ride(pose.withers, 0.90F, 0.70F);
+  for (std::size_t i = 0; i < k_leg_count; ++i) {
+    bool const hind = k_leg_plans[i].hind;
+    ride(pose.legs[i].shoulder, hind ? 0.45F : 0.85F, hind ? 1.0F : 0.65F);
+    ride(pose.legs[i].knee, hind ? 0.18F : 0.34F, hind ? 0.42F : 0.26F);
+  }
+
+  QVector3D const neck = pose.withers;
+  float const yaw = 0.34F * drive.head_turn;
+  float const pitch = 0.20F * drive.head_dip;
+  for (auto* point : head_chain(pose)) {
+    *point += swell * 0.85F;
+    point->setX(point->x() + (shift * 0.72F));
+    *point = rotate_about_y(*point, neck, yaw);
+    *point = rotate_about_x(*point, neck, pitch);
+  }
+
+  float const swivel = 0.62F * drive.ear_swivel;
+  pose.ear_tip_l = rotate_about_y(pose.ear_tip_l, pose.ear_base_l, swivel);
+  pose.ear_tip_r = rotate_about_y(pose.ear_tip_r, pose.ear_base_r, -swivel);
+
+  ride(pose.tail_base, 0.55F, 1.0F);
+  pose.tail_mid += swell * 0.4F;
+  pose.tail_tip += swell * 0.3F;
+  pose.tail_mid.setX(pose.tail_mid.x() + (0.038F * drive.tail_sway) + shift);
+  pose.tail_tip.setX(pose.tail_tip.x() + (0.082F * drive.tail_sway) + shift);
+}
+
 auto make_pose(const WolfDrive& drive) -> RigPose {
   RigPose pose;
   float const crouch = drive.crouch * 0.048F;
@@ -508,6 +615,7 @@ auto make_pose(const WolfDrive& drive) -> RigPose {
   pose.tail_mid += QVector3D(sway * 0.5F, (lift * 0.140F) + tail_bounce, 0.0F);
   pose.tail_tip += QVector3D(sway, (lift * 0.320F) + (tail_bounce * 1.8F), 0.0F);
 
+  apply_idle_motion(pose, drive);
   apply_lunge(pose, drive);
   apply_collapse(pose, drive);
   reattach_head(pose, head_attachment);

--- a/render/wildlife/wolf_spec.h
+++ b/render/wildlife/wolf_spec.h
@@ -40,7 +40,16 @@ struct WolfDrive {
   float jaw_open{0.0F};
 
   float head_shake{0.0F};
+  float head_roll{0.0F};
+  float rear{0.0F};
   float collapse{0.0F};
+
+  float breath{0.0F};
+  float head_turn{0.0F};
+  float head_dip{0.0F};
+  float ear_swivel{0.0F};
+  float tail_sway{0.0F};
+  float weight_shift{0.0F};
   WolfGait gait{WolfGait::Stand};
 };
 

--- a/tests/render/creature/humanoid_prepare_test.cpp
+++ b/tests/render/creature/humanoid_prepare_test.cpp
@@ -4126,6 +4126,93 @@ TEST(AnimationCoreLocomotionManifest, WalkCycleClosesOnItself) {
   EXPECT_NEAR(start.foot_pitch_l, wrap.foot_pitch_l, 0.05F);
 }
 
+namespace {
+
+auto stance_retreat_per_cycle(Animation::HumanoidLocomotionPoseInputs inputs,
+                              float early_phase,
+                              float late_phase) -> float {
+  inputs.cycle_phase = early_phase;
+  float const early = Animation::resolve_humanoid_locomotion_pose(inputs).foot_l.z;
+  inputs.cycle_phase = late_phase;
+  float const late = Animation::resolve_humanoid_locomotion_pose(inputs).foot_l.z;
+  return (early - late) / (late_phase - early_phase);
+}
+
+} // namespace
+
+TEST(AnimationCoreLocomotionManifest, WalkCadenceKeepsThePlantedFootStill) {
+  float const retreat = stance_retreat_per_cycle(walk_pose_inputs(), 0.20F, 0.40F);
+  ASSERT_GT(retreat, 0.0F);
+
+  for (float const speed : {1.6F, 2.0F, 2.35F, 2.8F}) {
+    float const cycle_time = Animation::humanoid_walk_cycle_time_for_speed(speed);
+    EXPECT_NEAR(retreat, speed * cycle_time, retreat * 0.05F)
+        << "walking at " << speed << " m/s slides the planted foot";
+  }
+}
+
+TEST(AnimationCoreLocomotionManifest, RunCadenceKeepsThePlantedFootStill) {
+  auto inputs = walk_pose_inputs();
+  inputs.state = Animation::HumanoidMotionState::Run;
+  inputs.run_blend = 1.0F;
+  inputs.stride_distance = 0.0F;
+  float const retreat = stance_retreat_per_cycle(inputs, 0.10F, 0.25F);
+  ASSERT_GT(retreat, 0.0F);
+
+  for (float const speed : {2.8F, 3.3F, 4.0F, 4.8F}) {
+    float const cycle_time = Animation::humanoid_run_cycle_time_for_speed(speed);
+    EXPECT_NEAR(retreat, speed * cycle_time, retreat * 0.05F)
+        << "running at " << speed << " m/s slides the planted foot";
+  }
+}
+
+TEST(AnimationCoreLocomotionManifest, ArmSwingStaysWithinTheArmsReach) {
+  auto inputs = walk_pose_inputs();
+  constexpr float k_arm_length = 0.55F;
+  inputs.arm_pendulum_length = k_arm_length;
+
+  for (int step = 0; step < 64; ++step) {
+    inputs.cycle_phase = static_cast<float>(step) / 64.0F;
+    auto const pose = Animation::resolve_humanoid_locomotion_pose(inputs);
+    for (auto const& hand : {pose.hand_l_delta, pose.hand_r_delta}) {
+      float const shoulder_to_hand_y = -k_arm_length + hand.y;
+      float const reach = std::sqrt((shoulder_to_hand_y * shoulder_to_hand_y) +
+                                    (hand.z * hand.z) + (hand.x * hand.x));
+      EXPECT_LE(reach, k_arm_length)
+          << "the swing straightens the elbow at phase " << inputs.cycle_phase;
+    }
+  }
+}
+
+TEST(AnimationCoreLocomotionManifest, PelvisLeansOverTheSupportingLeg) {
+  auto inputs = walk_pose_inputs();
+
+  inputs.cycle_phase = 0.25F;
+  auto const left_stance = Animation::resolve_humanoid_locomotion_pose(inputs);
+  inputs.cycle_phase = 0.75F;
+  auto const right_stance = Animation::resolve_humanoid_locomotion_pose(inputs);
+
+  EXPECT_LT(left_stance.pelvis_delta.x, -0.01F);
+  EXPECT_GT(right_stance.pelvis_delta.x, 0.01F);
+
+  EXPECT_LT(left_stance.shoulder_l_delta.x, 0.0F);
+  EXPECT_GT(std::abs(left_stance.pelvis_delta.x),
+            std::abs(left_stance.shoulder_l_delta.x));
+}
+
+TEST(AnimationCoreLocomotionManifest, PelvisCounterRotatesAgainstTheShoulders) {
+  auto inputs = walk_pose_inputs();
+
+  for (float const phase : {0.05F, 0.20F, 0.55F, 0.70F}) {
+    inputs.cycle_phase = phase;
+    auto const pose = Animation::resolve_humanoid_locomotion_pose(inputs);
+    float const hip_lead = pose.hip_l_delta.z - pose.hip_r_delta.z;
+    float const shoulder_lead = pose.shoulder_l_delta.z - pose.shoulder_r_delta.z;
+    EXPECT_LT(hip_lead * shoulder_lead, 0.0F)
+        << "hips and shoulders rotate together at phase " << phase;
+  }
+}
+
 TEST(AnimationCoreLocomotionManifest, GaitKeepsCyclingWhileTheStrideBlendsOut) {
   auto const walking =
       step_locomotion(walking_inputs(), 0.0F, 1.0F, 0.0F, 1.0F, 60, 1.0F / 60.0F);
@@ -9141,10 +9228,8 @@ TEST(HumanoidPrepare, TurnSignalIntroducesUpperBodyTwistDuringLocomotion) {
   Render::GL::HumanoidRendererBase::compute_locomotion_pose(
       777U, 0.25F, turning, variation, turning_pose);
 
-  float const neutral_twist =
-      std::abs(neutral_pose.shoulder_l.z() - neutral_pose.shoulder_r.z());
-  float const turning_twist =
-      std::abs(turning_pose.shoulder_l.z() - turning_pose.shoulder_r.z());
+  float const neutral_twist = neutral_pose.shoulder_l.z() - neutral_pose.shoulder_r.z();
+  float const turning_twist = turning_pose.shoulder_l.z() - turning_pose.shoulder_r.z();
   EXPECT_GT(turning_twist, neutral_twist + 0.01F);
   EXPECT_GT(turning_pose.pelvis_pos.x(), neutral_pose.pelvis_pos.x());
 }

--- a/tests/render/wildlife_action_pose_test.cpp
+++ b/tests/render/wildlife_action_pose_test.cpp
@@ -248,6 +248,80 @@ TEST(WildlifeActionPose, WolfWorriesWhatItHasHoldOf) {
       << "the shake has to go both ways or it is a lean, not a shake";
 }
 
+TEST(WildlifeActionPose, AStandingWolfStillBreathesAndLooksAround) {
+
+  WolfDrive rest;
+  rest.gait = WolfGait::Stand;
+  const auto still = Render::Wildlife::wolf_pose(rest);
+
+  WolfDrive alive = rest;
+  alive.breath = 1.0F;
+  alive.head_turn = 1.0F;
+  alive.tail_sway = 1.0F;
+  const auto moved = Render::Wildlife::wolf_pose(alive);
+
+  EXPECT_GT(moved.body_front.y() - still.body_front.y(), 0.004F)
+      << "the ribcage has to rise, otherwise a standing wolf is a statue";
+  EXPECT_GT(std::abs(moved.muzzle.x() - still.muzzle.x()), 0.05F);
+  EXPECT_GT(std::abs(moved.tail_tip.x() - still.tail_tip.x()), 0.02F);
+
+  WolfDrive const other_way = [&] {
+    WolfDrive d = rest;
+    d.head_turn = -1.0F;
+    return d;
+  }();
+  const auto turned_other = Render::Wildlife::wolf_pose(other_way);
+  EXPECT_LT((moved.muzzle.x() - still.muzzle.x()) *
+                (turned_other.muzzle.x() - still.muzzle.x()),
+            0.0F);
+}
+
+TEST(WildlifeActionPose, TheWolfGapesBeforeItCloses) {
+
+  WolfDrive shut;
+  shut.gait = WolfGait::Stand;
+  shut.lunge = 0.5F;
+  WolfDrive gaping = shut;
+  gaping.jaw_open = 1.0F;
+
+  const auto closed = Render::Wildlife::wolf_pose(shut);
+  const auto open = Render::Wildlife::wolf_pose(gaping);
+
+  float const closed_gap = (closed.jaw_tip - closed.muzzle).length();
+  float const open_gap = (open.jaw_tip - open.muzzle).length();
+  EXPECT_GT(open_gap, closed_gap * 2.0F)
+      << "a bite whose jaw barely parts reads as a nudge";
+
+  float const hinge = (open.jaw_tip - open.jaw_hinge).length();
+  float const rest_hinge = (closed.jaw_tip - closed.jaw_hinge).length();
+  EXPECT_NEAR(hinge, rest_hinge, rest_hinge * 0.08F)
+      << "the jaw must swing on its hinge, not stretch";
+}
+
+TEST(WildlifeActionPose, ASheepStartleThrowsItOffTheSpotAndBringsItBack) {
+
+  SheepDrive rest;
+  rest.gait = SheepGait::Stand;
+  const auto still = Render::Wildlife::sheep_pose(rest);
+
+  SheepDrive jolt = rest;
+  jolt.startle = 0.22F;
+  const auto thrown = Render::Wildlife::sheep_pose(jolt);
+
+  EXPECT_GT(std::abs(thrown.body_rear.x() - still.body_rear.x()), 0.05F)
+      << "the body has to shy sideways, not just nod";
+  EXPECT_GT(thrown.body_rear.y() - still.body_rear.y(), 0.02F)
+      << "the sheep should come off the ground as it bolts";
+  EXPECT_GT(thrown.poll.y() - still.poll.y(), 0.03F) << "the head should be thrown up";
+
+  SheepDrive settled = rest;
+  settled.startle = 1.0F;
+  const auto recovered = Render::Wildlife::sheep_pose(settled);
+  EXPECT_NEAR(recovered.body_rear.x(), still.body_rear.x(), 0.012F);
+  EXPECT_NEAR(recovered.body_rear.y(), still.body_rear.y(), 0.012F)
+      << "the clip has to end where the gait clips start or it will pop";
+}
+
 TEST(WildlifeActionState, BiteAndDeathProgressComeFromSimulationComponents) {
   Engine::Core::World world;
   auto* entity = world.create_entity();

--- a/tests/wildlife/wildlife_system_test.cpp
+++ b/tests/wildlife/wildlife_system_test.cpp
@@ -385,6 +385,75 @@ TEST_F(WildlifeSystemTest, WolfBiteDamageLandsAtTheAnimatedContactFrame) {
   EXPECT_EQ(wolf->bite_target_id, 0U);
 }
 
+TEST_F(WildlifeSystemTest, BittenAnimalsFlinchSoTheHitIsVisible) {
+  World world;
+  WildlifeSystem system;
+  WildlifeSettings settings = make_settings();
+  settings.wolves.enabled = true;
+  settings.wolves.group_count = 1;
+  settings.wolves.group_size_min = 1;
+  settings.wolves.group_size_max = 1;
+  settings.wolves.aggression = 1.0F;
+  settings.wolves.roam_radius = 12.0F;
+  settings.wolves.spawn_areas = {{0.0F, 0.0F, 1.5F}};
+  system.configure(settings, 1U);
+  system.update(&world, 0.1F);
+
+  bool flinched = false;
+  for (int step = 0; step < 600 && !flinched; ++step) {
+    system.update(&world, 0.05F);
+    for (const auto* animal : collect_species(world, Species::Sheep)) {
+      const auto* wildlife = animal->get_component<Engine::Core::WildlifeComponent>();
+      if (wildlife != nullptr && wildlife->flinch_timer > 0.0F) {
+        flinched = true;
+        break;
+      }
+    }
+  }
+
+  EXPECT_GT(system.stats().bites, 0U) << "the wolf never reached the herd";
+  EXPECT_TRUE(flinched) << "a bitten sheep never reacted to the hit";
+}
+
+TEST_F(WildlifeSystemTest, APackGangsUpOnOneAnimalInsteadOfSpreadingOut) {
+  World world;
+  WildlifeSystem system;
+  WildlifeSettings settings = make_settings();
+  settings.sheep.group_size_min = 6;
+  settings.sheep.group_size_max = 6;
+  settings.wolves.enabled = true;
+  settings.wolves.group_count = 1;
+  settings.wolves.group_size_min = 3;
+  settings.wolves.group_size_max = 3;
+  settings.wolves.aggression = 1.0F;
+  settings.wolves.roam_radius = 14.0F;
+  settings.wolves.spawn_areas = {{5.0F, 0.0F, 1.0F}};
+  system.configure(settings, 7U);
+  system.update(&world, 0.1F);
+
+  ASSERT_EQ(count_species(world, Species::Wolf), 3);
+
+  int most_shared = 0;
+  for (int step = 0; step < 120; ++step) {
+    system.update(&world, 0.1F);
+
+    std::vector<Engine::Core::EntityID> focus;
+    for (const auto* wolf : collect_species(world, Species::Wolf)) {
+      const auto* wildlife = wolf->get_component<Engine::Core::WildlifeComponent>();
+      if (wildlife != nullptr && wildlife->focus_id != 0) {
+        focus.push_back(wildlife->focus_id);
+      }
+    }
+    for (const auto id : focus) {
+      most_shared = std::max(
+          most_shared, static_cast<int>(std::count(focus.begin(), focus.end(), id)));
+    }
+  }
+
+  EXPECT_GE(most_shared, 2)
+      << "wolves each picked their own sheep, so a kill never looks like a pack";
+}
+
 TEST_F(WildlifeSystemTest, WolvesLeaveEscortedPeopleAlone) {
   World world;
   WildlifeSystem system;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,6 +12,7 @@ add_dependencies(arena_app bake_creature_assets)
 add_subdirectory(mesh_preview)
 add_subdirectory(building_preview)
 add_subdirectory(humanoid_preview)
+add_subdirectory(wildlife_preview)
 
 add_executable(battlefield_gameplay_verifier battlefield_capture_main.cpp)
 # render_gl currently calls back into map visibility owned by game_systems. Keep

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -238,6 +238,7 @@ inline constexpr char k_wildlife_herd_flees_troops_id[] = "wildlife_herd_flees_t
 inline constexpr char k_wildlife_wolf_hunt_id[] = "wildlife_wolf_hunt";
 inline constexpr char k_wildlife_wolf_pack_id[] = "wildlife_wolf_pack";
 inline constexpr char k_wildlife_wolf_ambush_id[] = "wildlife_wolf_ambush";
+inline constexpr char k_wildlife_pack_takedown_id[] = "wildlife_pack_takedown";
 inline constexpr char k_wildlife_bird_scatter_id[] = "wildlife_bird_scatter";
 inline constexpr char k_wildlife_bird_flyover_id[] = "wildlife_bird_flyover";
 inline constexpr char k_wildlife_mixed_pasture_id[] = "wildlife_mixed_pasture";

--- a/tools/arena/arena_wildlife_scenarios.cpp
+++ b/tools/arena/arena_wildlife_scenarios.cpp
@@ -244,6 +244,36 @@ auto build_wildlife_definitions() -> std::vector<ArenaScenarioDefinition> {
 
   {
     auto s = definition(
+        QString::fromLatin1(k_wildlife_pack_takedown_id),
+        QStringLiteral("Wildlife: Pack Takedown"),
+        QStringLiteral("Wolves spawn on top of a small flock and pull one down under "
+                       "a close camera: the bite, the sheep's flinch, the pack "
+                       "circling between bites and the kill all stay in frame."),
+        18.0F,
+        {17.0F, 40.0F, 22.0F});
+    s.wildlife = sheep_only(1, 4, 4.0F);
+    s.wildlife.seed = 4711U;
+    s.wildlife.sheep.spawn_areas = {{0.0F, 0.0F, 1.6F}};
+    s.wildlife.sheep.respawn = false;
+    s.wildlife.wolves.enabled = true;
+    s.wildlife.wolves.group_count = 1;
+    s.wildlife.wolves.group_size_min = 3;
+    s.wildlife.wolves.group_size_max = 3;
+    s.wildlife.wolves.aggression = 1.0F;
+    s.wildlife.wolves.roam_radius = 10.0F;
+    s.wildlife.wolves.respawn = false;
+    s.wildlife.wolves.spawn_areas = {{4.0F, 0.0F, 1.5F}};
+    s.groups = {observer_group({0.0F, 0.0F, -26.0F})};
+    s.expectations = {
+        expectation(Expect::WildlifeHuntObserved),
+        expectation(Expect::WildlifeFleeObserved),
+        expectation(Expect::WildlifeCasualtyObserved),
+    };
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
         QString::fromLatin1(k_wildlife_bird_scatter_id),
         QStringLiteral("Wildlife: Bird Scatter"),
         QStringLiteral("Flocks cruise and perch until a column marches underneath, "

--- a/tools/humanoid_preview/main.cpp
+++ b/tools/humanoid_preview/main.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
+#include <limits>
 #include <numbers>
 #include <string>
 #include <string_view>
@@ -196,6 +197,14 @@ void append_ground(std::vector<ColoredTriangle>& out) {
 
 struct FrameMetrics {
   float phase{0.0F};
+  float foot_l_z{0.0F};
+  float foot_r_z{0.0F};
+  float hand_l_z{0.0F};
+  float hand_r_z{0.0F};
+  float pelvis_y{0.0F};
+  float pelvis_x{0.0F};
+  float step_width{0.0F};
+  float shoulder_l_z{0.0F};
   float max_bone_stretch{0.0F};
   const char* worst_bone{"-"};
   float arm_reach_l{0.0F};
@@ -208,6 +217,15 @@ struct FrameMetrics {
 auto measure(std::span<const QMatrix4x4> palette, float phase) -> FrameMetrics {
   FrameMetrics metrics{};
   metrics.phase = phase;
+  metrics.foot_l_z = bone_origin(palette, Bone::FootL).z();
+  metrics.foot_r_z = bone_origin(palette, Bone::FootR).z();
+  metrics.hand_l_z = bone_origin(palette, Bone::HandL).z();
+  metrics.hand_r_z = bone_origin(palette, Bone::HandR).z();
+  metrics.pelvis_y = bone_origin(palette, Bone::Pelvis).y();
+  metrics.pelvis_x = bone_origin(palette, Bone::Pelvis).x();
+  metrics.shoulder_l_z = bone_origin(palette, Bone::ShoulderL).z();
+  metrics.step_width =
+      bone_origin(palette, Bone::FootR).x() - bone_origin(palette, Bone::FootL).x();
   for (auto const& rule : k_length_rules) {
     float const length =
         (bone_origin(palette, rule.to) - bone_origin(palette, rule.from)).length();
@@ -233,6 +251,79 @@ auto measure(std::span<const QMatrix4x4> palette, float phase) -> FrameMetrics {
     metrics.hand_r_axis = palette[hand_index].column(1).toVector3D();
   }
   return metrics;
+}
+
+struct StrideSummary {
+  float foot_travel{0.0F};
+  float planted_travel_per_cycle{0.0F};
+  float hand_swing{0.0F};
+  float pelvis_bob{0.0F};
+  float pelvis_sway{0.0F};
+  float step_width{0.0F};
+  float shoulder_twist{0.0F};
+  float foot_lift{0.0F};
+};
+
+auto summarize_stride(const BpatBlob& blob,
+                      const Render::Creature::Bpat::ClipView& clip) -> StrideSummary {
+  std::vector<FrameMetrics> frames;
+  std::vector<float> foot_l_y;
+  frames.reserve(clip.frame_count);
+  foot_l_y.reserve(clip.frame_count);
+  for (std::uint32_t f = 0; f < clip.frame_count; ++f) {
+    auto const palette = blob.frame_palette_view(clip.frame_offset + f);
+    frames.push_back(
+        measure(palette, static_cast<float>(f) / static_cast<float>(clip.frame_count)));
+    foot_l_y.push_back(bone_origin(palette, Bone::FootL).y());
+  }
+  if (frames.size() < 4U) {
+    return {};
+  }
+
+  auto range = [&](auto&& pick) {
+    float lo = std::numeric_limits<float>::max();
+    float hi = std::numeric_limits<float>::lowest();
+    for (auto const& m : frames) {
+      float const value = pick(m);
+      lo = std::min(lo, value);
+      hi = std::max(hi, value);
+    }
+    return hi - lo;
+  };
+
+  StrideSummary summary{};
+  summary.foot_travel = range([](const FrameMetrics& m) { return m.foot_l_z; });
+  summary.hand_swing = range([](const FrameMetrics& m) { return m.hand_l_z; });
+  summary.pelvis_bob = range([](const FrameMetrics& m) { return m.pelvis_y; });
+  summary.pelvis_sway = range([](const FrameMetrics& m) { return m.pelvis_x; });
+  for (auto const& m : frames) {
+    summary.step_width += m.step_width;
+  }
+  summary.step_width /= static_cast<float>(frames.size());
+  summary.shoulder_twist = range([](const FrameMetrics& m) { return m.shoulder_l_z; });
+
+  float const lowest = *std::min_element(foot_l_y.begin(), foot_l_y.end());
+  float const highest = *std::max_element(foot_l_y.begin(), foot_l_y.end());
+  summary.foot_lift = highest - lowest;
+
+  std::vector<float> slopes;
+  auto const count = static_cast<std::uint32_t>(frames.size());
+  float const d_phase = 1.0F / static_cast<float>(count);
+  for (std::uint32_t f = 0; f < count; ++f) {
+    std::uint32_t const next = (f + 1U) % count;
+    if (foot_l_y[f] > lowest + 0.015F || foot_l_y[next] > lowest + 0.015F) {
+      continue;
+    }
+    float const delta = frames[next].foot_l_z - frames[f].foot_l_z;
+    if (delta < 0.0F) {
+      slopes.push_back(-delta / d_phase);
+    }
+  }
+  if (!slopes.empty()) {
+    std::sort(slopes.begin(), slopes.end());
+    summary.planted_travel_per_cycle = slopes[slopes.size() / 2U];
+  }
+  return summary;
 }
 
 auto view_matrix(std::string_view view, int width, int height) -> QMatrix4x4 {
@@ -495,19 +586,22 @@ auto main(int argc, char** argv) -> int {
             << ")\n";
 
   if (report) {
-    std::cout
-        << "phase\tstretch\tworst\t\treach_l\treach_r\tfoot_y\tup_y\tblade_axis\n";
+    std::cout << "phase\tstretch\tworst\t\treach_l\treach_r\tfoot_y\tfoot_l_z\tfoot_r_"
+                 "z\tup_y\tblade_axis\n";
     float worst_stretch = 0.0F;
     for (auto const& m : metrics) {
       std::cout
           << QString::asprintf(
-                 "%.2f\t%.2f\t%-12s\t%.2f\t%.2f\t%+.3f\t%.2f\t(%+.2f,%+.2f,%+.2f)",
+                 "%.2f\t%.2f\t%-12s\t%.2f\t%.2f\t%+.3f\t%+.3f\t\t%+.3f\t\t%.2f\t(%+."
+                 "2f,%+.2f,%+.2f)",
                  static_cast<double>(m.phase),
                  static_cast<double>(m.max_bone_stretch),
                  m.worst_bone,
                  static_cast<double>(m.arm_reach_l),
                  static_cast<double>(m.arm_reach_r),
                  static_cast<double>(m.lowest_foot_y),
+                 static_cast<double>(m.foot_l_z),
+                 static_cast<double>(m.foot_r_z),
                  static_cast<double>(m.torso_up_y),
                  static_cast<double>(m.hand_r_axis.x()),
                  static_cast<double>(m.hand_r_axis.y()),
@@ -517,6 +611,29 @@ auto main(int argc, char** argv) -> int {
       worst_stretch = std::max(worst_stretch, m.max_bone_stretch);
     }
     std::cout << "worst bone stretch: " << worst_stretch << "x bind length\n";
+
+    auto const stride = summarize_stride(blob, clip);
+    std::cout << QString::asprintf(
+                     "stride: foot travel %.3f m, contact retreat %.3f m/cycle, "
+                     "foot lift %.3f m, hand swing %.3f m, pelvis bob %.3f m, "
+                     "pelvis sway %.3f m, shoulder twist %.3f m, step width %.3f m\n",
+                     static_cast<double>(stride.foot_travel),
+                     static_cast<double>(stride.planted_travel_per_cycle),
+                     static_cast<double>(stride.foot_lift),
+                     static_cast<double>(stride.hand_swing),
+                     static_cast<double>(stride.pelvis_bob),
+                     static_cast<double>(stride.pelvis_sway),
+                     static_cast<double>(stride.shoulder_twist),
+                     static_cast<double>(stride.step_width))
+                     .toStdString();
+    for (float const cycle_time : {0.70F, 0.85F, 1.00F}) {
+      std::cout << QString::asprintf(
+                       "  at cycle_time %.2fs this clip is skate-free at %.2f m/s\n",
+                       static_cast<double>(cycle_time),
+                       static_cast<double>(stride.planted_travel_per_cycle /
+                                           cycle_time))
+                       .toStdString();
+    }
   }
 
   return 0;

--- a/tools/wildlife_preview/CMakeLists.txt
+++ b/tools/wildlife_preview/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(wildlife_preview main.cpp)
+
+target_link_libraries(
+    wildlife_preview
+    PRIVATE
+        render_gl
+        engine_core
+        game_systems
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Gui
+)
+
+target_include_directories(wildlife_preview PRIVATE ${CMAKE_SOURCE_DIR})
+
+set_target_properties(
+    wildlife_preview
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)

--- a/tools/wildlife_preview/main.cpp
+++ b/tools/wildlife_preview/main.cpp
@@ -1,0 +1,296 @@
+#include <QGuiApplication>
+#include <QImage>
+#include <QMatrix4x4>
+#include <QPainter>
+#include <QVector3D>
+#include <QVector4D>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "render/creature/pipeline/creature_prepared_state.h"
+#include "render/creature/species_manifest.h"
+#include "render/rigged_mesh_bake.h"
+#include "render/snapshot_mesh_bake.h"
+#include "render/software/software_rasterizer.h"
+#include "render/wildlife/sheep_manifest.h"
+#include "render/wildlife/sheep_spec.h"
+#include "render/wildlife/wildlife_rig.h"
+#include "render/wildlife/wolf_manifest.h"
+#include "render/wildlife/wolf_spec.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+using Render::Creature::BakedRiggedMeshCpu;
+using Render::Creature::BakeInput;
+using Render::Software::ColoredTriangle;
+using Render::Software::RasterSettings;
+using Render::Software::SoftwareRasterizer;
+
+struct Bounds {
+  QVector3D min{1.0e9F, 1.0e9F, 1.0e9F};
+  QVector3D max{-1.0e9F, -1.0e9F, -1.0e9F};
+
+  void include(const QVector3D& point) {
+    min.setX(std::min(min.x(), point.x()));
+    min.setY(std::min(min.y(), point.y()));
+    min.setZ(std::min(min.z(), point.z()));
+    max.setX(std::max(max.x(), point.x()));
+    max.setY(std::max(max.y(), point.y()));
+    max.setZ(std::max(max.z(), point.z()));
+  }
+  [[nodiscard]] auto center() const -> QVector3D { return (min + max) * 0.5F; }
+  [[nodiscard]] auto span() const -> QVector3D { return max - min; }
+};
+
+auto wolf_role_colors() -> std::vector<QVector3D> {
+  QVector3D const base(0.42F, 0.37F, 0.32F);
+  return {base,
+          QVector3D(0.25F, 0.23F, 0.22F),
+          QVector3D(0.63F, 0.58F, 0.51F),
+          QVector3D(0.70F, 0.66F, 0.58F),
+          QVector3D(0.33F, 0.29F, 0.26F),
+          QVector3D(0.29F, 0.26F, 0.24F),
+          QVector3D(0.07F, 0.065F, 0.07F),
+          QVector3D(0.09F, 0.07F, 0.05F),
+          QVector3D(0.86F, 0.64F, 0.16F)};
+}
+
+auto sheep_role_colors() -> std::vector<QVector3D> {
+  QVector3D const wool(0.82F, 0.79F, 0.72F);
+  return {wool,
+          QVector3D(0.93F, 0.91F, 0.86F),
+          QVector3D(0.56F, 0.52F, 0.46F),
+          QVector3D(0.50F, 0.44F, 0.35F),
+          QVector3D(0.24F, 0.20F, 0.18F),
+          QVector3D(0.16F, 0.14F, 0.13F),
+          QVector3D(0.10F, 0.09F, 0.09F),
+          QVector3D(0.07F, 0.06F, 0.05F)};
+}
+
+struct ViewSpec {
+  std::string name;
+  QVector3D eye_dir;
+};
+
+auto make_view_projection(const Bounds& bounds,
+                          const QVector3D& eye_dir,
+                          int image_width,
+                          int image_height) -> QMatrix4x4 {
+  QVector3D const center = bounds.center();
+  QVector3D const span = bounds.span();
+  float const radius = std::max({span.x(), span.y(), span.z(), 1.0F});
+
+  QVector3D dir = eye_dir.normalized();
+  QMatrix4x4 view_mat;
+  view_mat.lookAt(center + (dir * radius * 6.0F), center, QVector3D(0.0F, 1.0F, 0.0F));
+
+  float const aspect =
+      static_cast<float>(image_width) / static_cast<float>(std::max(image_height, 1));
+  float ortho_h = radius * 0.78F;
+  float ortho_w = ortho_h * aspect;
+  float const needed_w = span.x() * 1.15F;
+  if (ortho_w < needed_w) {
+    ortho_w = needed_w;
+    ortho_h = ortho_w / std::max(aspect, 1.0e-6F);
+  }
+
+  QMatrix4x4 proj;
+  proj.ortho(-ortho_w * 0.5F,
+             ortho_w * 0.5F,
+             -ortho_h * 0.5F,
+             ortho_h * 0.5F,
+             0.1F,
+             radius * 20.0F);
+  return proj * view_mat;
+}
+
+auto skin(const BakedRiggedMeshCpu& baked,
+          std::span<const QMatrix4x4> bind,
+          std::span<const QMatrix4x4> frame) -> std::vector<QVector3D> {
+  std::vector<QMatrix4x4> delta(bind.size());
+  for (std::size_t i = 0; i < bind.size(); ++i) {
+    delta[i] = frame[i] * bind[i].inverted();
+  }
+  auto const skinned = Render::GL::bake_snapshot_vertices(
+      baked.vertices, std::span<const QMatrix4x4>(delta.data(), delta.size()));
+  std::vector<QVector3D> positions;
+  positions.reserve(skinned.size());
+  for (auto const& vertex : skinned) {
+    positions.emplace_back(vertex.position_bone_local[0],
+                           vertex.position_bone_local[1],
+                           vertex.position_bone_local[2]);
+  }
+  return positions;
+}
+
+void submit(const BakedRiggedMeshCpu& baked,
+            const std::vector<QVector3D>& positions,
+            std::span<const QVector3D> role_colors,
+            SoftwareRasterizer& rasterizer) {
+  for (std::size_t i = 0; i + 2 < baked.indices.size(); i += 3) {
+    std::uint32_t const ia = baked.indices[i];
+    std::uint32_t const ib = baked.indices[i + 1];
+    std::uint32_t const ic = baked.indices[i + 2];
+    if (ia >= positions.size() || ib >= positions.size() || ic >= positions.size()) {
+      continue;
+    }
+    std::uint8_t const role = baked.vertices[ia].color_role;
+    QVector3D const color = (role > 0U && role <= role_colors.size())
+                                ? role_colors[role - 1U]
+                                : QVector3D(0.8F, 0.8F, 0.8F);
+    rasterizer.submit(
+        ColoredTriangle{positions[ia], positions[ib], positions[ic], color, 1.0F});
+  }
+}
+
+auto compose(const std::vector<QImage>& tiles,
+             const std::vector<std::string>& labels,
+             int columns) -> QImage {
+  if (tiles.empty()) {
+    return {};
+  }
+  int const tile_w = tiles.front().width();
+  int const tile_h = tiles.front().height();
+  constexpr int k_label = 18;
+  int const rows = (static_cast<int>(tiles.size()) + columns - 1) / columns;
+  QImage sheet(tile_w * columns, (tile_h + k_label) * rows, QImage::Format_ARGB32);
+  sheet.fill(QColor(18, 20, 18));
+  QPainter painter(&sheet);
+  painter.setPen(QColor(220, 220, 210));
+  for (std::size_t i = 0; i < tiles.size(); ++i) {
+    int const col = static_cast<int>(i) % columns;
+    int const row = static_cast<int>(i) / columns;
+    int const x = col * tile_w;
+    int const y = row * (tile_h + k_label);
+    painter.drawImage(x, y, tiles[i]);
+    painter.drawText(
+        x + 4, y + tile_h + k_label - 5, QString::fromStdString(labels[i]));
+  }
+  painter.end();
+  return sheet;
+}
+
+auto render_clip(const Render::Creature::SpeciesManifest& manifest,
+                 std::span<const QVector3D> role_colors,
+                 std::size_t clip_index,
+                 int samples,
+                 const ViewSpec& view,
+                 const RasterSettings& settings,
+                 std::vector<QImage>& out_tiles,
+                 std::vector<std::string>& out_labels) -> bool {
+  auto const& spec = manifest.creature_spec();
+  auto const bind = manifest.bind_palette();
+  BakedRiggedMeshCpu const baked =
+      Render::Creature::bake_rigged_mesh_cpu({&spec.lod_full, bind});
+  if (baked.vertices.empty()) {
+    std::cerr << "bake produced no geometry\n";
+    return false;
+  }
+
+  auto const& desc = manifest.clips[clip_index];
+  std::uint32_t const frame_count = std::max<std::uint32_t>(desc.frame_count, 1U);
+
+  Bounds clip_bounds;
+  std::vector<std::vector<QVector3D>> frames;
+  frames.reserve(static_cast<std::size_t>(samples));
+  for (int sample = 0; sample < samples; ++sample) {
+    auto const frame_index = static_cast<std::uint32_t>(
+        (static_cast<float>(sample) / static_cast<float>(samples)) *
+        static_cast<float>(frame_count));
+    std::vector<QMatrix4x4> palette;
+    manifest.bake_clip_frame(
+        clip_index, std::min(frame_index, frame_count - 1U), palette, nullptr);
+    if (palette.size() < bind.size()) {
+      std::cerr << "clip frame produced a short palette\n";
+      return false;
+    }
+    auto positions = skin(baked, bind, palette);
+    for (auto const& position : positions) {
+      clip_bounds.include(position);
+    }
+    frames.push_back(std::move(positions));
+  }
+
+  QMatrix4x4 const view_proj =
+      make_view_projection(clip_bounds, view.eye_dir, settings.width, settings.height);
+  for (int sample = 0; sample < samples; ++sample) {
+    SoftwareRasterizer rasterizer(settings);
+    rasterizer.set_view_projection(view_proj);
+    submit(baked, frames[static_cast<std::size_t>(sample)], role_colors, rasterizer);
+    out_tiles.push_back(rasterizer.render());
+    out_labels.push_back(std::string(desc.name) + " " +
+                         std::to_string(sample * 100 / samples) + "%");
+  }
+  return true;
+}
+
+} // namespace
+
+auto main(int argc, char** argv) -> int {
+  QGuiApplication app(argc, argv);
+
+  std::string species = argc > 1 ? argv[1] : "wolf";
+  std::string out_dir = argc > 2 ? argv[2] : "wildlife_preview";
+  std::string wanted_clip = argc > 3 ? argv[3] : "";
+  int samples = argc > 4 ? std::atoi(argv[4]) : 8;
+  std::string view_name = argc > 5 ? argv[5] : "quarter";
+
+  if (species != "wolf" && species != "sheep") {
+    std::cerr << "usage: wildlife_preview <wolf|sheep> [out_dir] [clip] [samples] "
+                 "[side|quarter|front]\n";
+    return 1;
+  }
+
+  auto const& manifest = species == "wolf" ? Render::Wildlife::wolf_manifest()
+                                           : Render::Wildlife::sheep_manifest();
+  auto const colors = species == "wolf" ? wolf_role_colors() : sheep_role_colors();
+
+  ViewSpec view{"quarter", QVector3D(0.85F, 0.42F, 0.75F)};
+  if (view_name == "side") {
+    view = {"side", QVector3D(1.0F, 0.10F, 0.0F)};
+  } else if (view_name == "front") {
+    view = {"front", QVector3D(0.15F, 0.30F, 1.0F)};
+  }
+
+  RasterSettings settings;
+  settings.width = 300;
+  settings.height = 240;
+  settings.clear_color = QColor(46, 58, 40);
+
+  fs::create_directories(out_dir);
+
+  std::vector<QImage> tiles;
+  std::vector<std::string> labels;
+  for (std::size_t index = 0; index < manifest.clips.size(); ++index) {
+    std::string const name(manifest.clips[index].name);
+    if (!wanted_clip.empty() && name != wanted_clip) {
+      continue;
+    }
+    if (!render_clip(manifest, colors, index, samples, view, settings, tiles, labels)) {
+      return 1;
+    }
+  }
+  if (tiles.empty()) {
+    std::cerr << "no clip matched '" << wanted_clip << "'\n";
+    return 1;
+  }
+
+  QImage const sheet = compose(tiles, labels, samples);
+  fs::path const path =
+      fs::path(out_dir) /
+      (species + "_" + (wanted_clip.empty() ? std::string("all") : wanted_clip) + "_" +
+       view.name + ".png");
+  sheet.save(QString::fromStdString(path.string()));
+  std::cout << "wrote " << path << " (" << tiles.size() << " frames)\n";
+  return 0;
+}


### PR DESCRIPTION
Rework humanoid locomotion around authored stride distance so gait cadence, planted-foot travel, camera bob, and footstep timing stay synchronized across movement speeds. Expand the gait metrics and preview reporting to expose stride, contact retreat, lift, swing, sway, twist, and skate-free speed characteristics.

Add richer sheep and wolf clip specifications and manifests, including looping idle motion, tense and crouched holds, startle reactions, readable bite articulation, and updated locomotion/render state handling. Extend wildlife AI with aggression-aware pack joining, ring-slot orbiting between bites, health-driven flinches, stalled-movement recovery, and more robust flee routing.

Add the close-range pack takedown arena fixture, wildlife pose and system coverage, and the display-free wildlife preview tool wired into the tools build. Update the ambient-wildlife guide and changelog with the new behavior, authored clips, preview workflow, and gait diagnostics.