### PR TITLE
Polish clean art direction rendering pipeline

### DIFF
--- a/assets.qrc
+++ b/assets.qrc
@@ -10,6 +10,7 @@
         <file>assets/shaders/include/directional_shadows.glsl</file>
         <file>assets/shaders/include/visibility_mask.glsl</file>
         <file>assets/shaders/include/noise.glsl</file>
+        <file>assets/shaders/include/tonemap.glsl</file>
         <file>assets/shaders/include/rigged_gpu_skin.glsl</file>
         <file>assets/shaders/include/activity_indicator.glsl</file>
         <file>assets/shaders/directional_shadow_depth.vert</file>
@@ -93,6 +94,12 @@
         <file>assets/shaders/healing_beam.frag</file>
         <file>assets/shaders/healing_beam.vert</file>
         <file>assets/shaders/ground_marker.frag</file>
+        <file>assets/shaders/post_fullscreen.vert</file>
+        <file>assets/shaders/post_bright.frag</file>
+        <file>assets/shaders/post_blur.frag</file>
+        <file>assets/shaders/post_composite.frag</file>
+        <file>assets/shaders/post_fxaa.frag</file>
+        <file>assets/shaders/sky.frag</file>
         <file>assets/shaders/ground_marker.vert</file>
         <file>assets/shaders/mode_indicator.frag</file>
         <file>assets/shaders/mode_indicator.vert</file>

--- a/assets/shaders/banner.frag
+++ b/assets/shaders/banner.frag
@@ -145,5 +145,5 @@ void main() {
 
   color += color * local_lighting(v_world_pos, normalize(v_normal));
   color = apply_directional_shadow(color, v_world_pos, v_normal);
-  frag_color = vec4(clamp(color * textile.rgb, 0.0, 1.0), textile.a * u_alpha);
+  frag_color = vec4(color * textile.rgb, textile.a * u_alpha);
 }

--- a/assets/shaders/ground_plane.frag
+++ b/assets/shaders/ground_plane.frag
@@ -282,5 +282,5 @@ void main() {
       view_distance, u_fog_start, u_fog_end, 0.75, 0.55 * horizon_fog);
   lit = mix(lit, environment_fog_color(), fog_amount);
 
-  frag_color = vec4(clamp(lit, 0.0, 1.0), 1.0);
+  frag_color = vec4(lit, 1.0);
 }

--- a/assets/shaders/include/environment_lighting.glsl
+++ b/assets/shaders/include/environment_lighting.glsl
@@ -1,5 +1,4 @@
-
-
+#include "tonemap.glsl"
 layout(std140) uniform EnvironmentLighting {
   vec4 u_env_primary_direction_intensity;
   vec4 u_env_primary_color_ambient_intensity;
@@ -72,6 +71,53 @@ vec3 environment_ambient_light(vec3 normal) {
          environment_ambient_intensity();
 }
 
+const float k_soi_shade_wrap = 0.28;
+const float k_soi_shade_band_count = 3.0;
+const float k_soi_shade_band_softness = 0.22;
+const float k_soi_shade_band_mix = 0.30;
+const float k_soi_shade_rim_power = 2.60;
+const float k_soi_shade_rim_strength = 0.16;
+
+float soi_soft_band(float value) {
+  float scaled = value * k_soi_shade_band_count;
+  float plateau = floor(scaled);
+  float within = fract(scaled);
+  float stepped = plateau + smoothstep(0.5 - k_soi_shade_band_softness,
+                                       0.5 + k_soi_shade_band_softness,
+                                       within);
+  return clamp(stepped / k_soi_shade_band_count, 0.0, 1.0);
+}
+
+float soi_wrapped_diffuse(vec3 normal) {
+  float ndl = dot(normal, environment_primary_direction());
+  float wrapped = clamp((ndl + k_soi_shade_wrap) / (1.0 + k_soi_shade_wrap), 0.0, 1.0);
+  return mix(wrapped, soi_soft_band(wrapped), k_soi_shade_band_mix);
+}
+
+vec3 soi_key_light(vec3 normal) {
+  return environment_primary_color() * environment_primary_intensity() *
+         soi_wrapped_diffuse(normal);
+}
+
+vec3 soi_surface_lighting_scaled(vec3 normal, float key_scale) {
+  return (environment_ambient_light(normal) + soi_key_light(normal) * key_scale) *
+         environment_exposure();
+}
+
+vec3 soi_surface_lighting(vec3 normal) {
+  return soi_surface_lighting_scaled(normal, 1.0);
+}
+
+float soi_rim_term(vec3 normal, vec3 view_dir) {
+  return pow(1.0 - clamp(dot(normal, view_dir), 0.0, 1.0), k_soi_shade_rim_power);
+}
+
+vec3 soi_rim_light(vec3 normal, vec3 view_dir) {
+  float facing = 0.35 + 0.65 * soi_wrapped_diffuse(normal);
+  return environment_sky_color() * soi_rim_term(normal, view_dir) *
+         k_soi_shade_rim_strength * facing;
+}
+
 vec3 environment_direct_light(vec3 normal, float wrap) {
   float wrapped = clamp(
       (dot(normal, environment_primary_direction()) + wrap) / (1.0 + wrap), 0.0, 1.0);
@@ -79,8 +125,7 @@ vec3 environment_direct_light(vec3 normal, float wrap) {
 }
 
 vec3 environment_lighting(vec3 normal, float wrap) {
-  return (environment_ambient_light(normal) + environment_direct_light(normal, wrap)) *
-         environment_exposure();
+  return soi_surface_lighting(normal);
 }
 
 const float k_fog_reference_span = 88.0;

--- a/assets/shaders/include/tonemap.glsl
+++ b/assets/shaders/include/tonemap.glsl
@@ -1,0 +1,32 @@
+const float k_soi_grade_exposure = 2.05;
+const float k_soi_grade_white_point = 2.80;
+const float k_soi_grade_contrast = 1.12;
+const float k_soi_grade_pivot = 0.42;
+const float k_soi_grade_saturation = 1.15;
+const vec3 k_soi_grade_shadow_lift = vec3(0.018, 0.028, 0.046);
+const vec3 k_soi_grade_highlight_tint = vec3(1.020, 0.994, 0.940);
+const vec3 k_soi_grade_luma = vec3(0.2126, 0.7152, 0.0722);
+
+vec3 soi_tonemap(vec3 linear_color) {
+  vec3 exposed = max(linear_color, vec3(0.0)) * k_soi_grade_exposure;
+  float white_squared = k_soi_grade_white_point * k_soi_grade_white_point;
+  vec3 numerator = exposed * (vec3(1.0) + exposed / white_squared);
+  return numerator / (vec3(1.0) + exposed);
+}
+
+vec3 soi_grade(vec3 mapped_color) {
+  vec3 contrasted =
+      (mapped_color - k_soi_grade_pivot) * k_soi_grade_contrast + k_soi_grade_pivot;
+  contrasted = max(contrasted, vec3(0.0));
+  float luma = dot(contrasted, k_soi_grade_luma);
+  vec3 saturated = mix(vec3(luma), contrasted, k_soi_grade_saturation);
+  saturated = max(saturated, vec3(0.0));
+  vec3 tinted = mix(saturated, saturated * k_soi_grade_highlight_tint, luma);
+  vec3 lifted =
+      k_soi_grade_shadow_lift + tinted * (vec3(1.0) - k_soi_grade_shadow_lift);
+  return clamp(lifted, 0.0, 1.0);
+}
+
+vec3 soi_finalize(vec3 linear_color) {
+  return soi_grade(soi_tonemap(linear_color));
+}

--- a/assets/shaders/iron_ore_instanced.frag
+++ b/assets/shaders/iron_ore_instanced.frag
@@ -112,7 +112,7 @@ void main() {
   float ao = clamp(N.y * 0.45 + 0.68, 0.28, 1.0);
 
   vec3 ambient = environment_ambient_light(N);
-  vec3 direct = sun_color * ndotl * 0.82;
+  vec3 direct = soi_key_light(N) * 0.82;
 
   float spec_base = max(dot(N, H), 0.0);
   float ore_spec = pow(spec_base, 42.0) * (0.08 + vein_wide * 0.35);

--- a/assets/shaders/magic_shrine_instanced.frag
+++ b/assets/shaders/magic_shrine_instanced.frag
@@ -114,7 +114,7 @@ void main() {
   float ao = clamp(N.y * 0.45 + 0.72, 0.28, 1.0);
 
   vec3 ambient = environment_ambient_light(N);
-  vec3 direct = sun_color * ndotl * 0.78;
+  vec3 direct = soi_key_light(N) * 0.78;
 
   float spec_base = max(dot(N, H), 0.0);
   float specular = pow(spec_base, 36.0) * 0.12;
@@ -125,6 +125,7 @@ void main() {
   vec3 rim_color = sky_color * rim;
 
   vec3 color = stone_color * (ambient + direct) * ao * environment_exposure();
+  color += soi_rim_light(N, V);
   color += sun_color * specular * ao;
   color += rim_color;
 

--- a/assets/shaders/olive_instanced.frag
+++ b/assets/shaders/olive_instanced.frag
@@ -82,8 +82,8 @@ void main() {
   vec3 sun = environment_primary_color() * environment_primary_intensity();
   vec3 sky = environment_sky_color();
   vec3 illumination =
-      environment_ambient_light(geometric_normal) * mix(1.0, 1.30, v_foliage_mask) +
-      sun * mix(diffuse * 0.72, wrap, v_foliage_mask);
+      environment_ambient_light(geometric_normal) * mix(1.0, 1.06, v_foliage_mask) +
+      soi_key_light(geometric_normal) * mix(0.72, 1.0, v_foliage_mask);
 
   float silver_show =
       smoothstep(0.22, 0.75, 1.0 - diffuse) * smoothstep(0.30, 0.80, leaf_clump);

--- a/assets/shaders/pine_instanced.frag
+++ b/assets/shaders/pine_instanced.frag
@@ -80,8 +80,8 @@ void main() {
   vec3 sun = environment_primary_color() * environment_primary_intensity();
   vec3 sky = environment_sky_color();
   vec3 illumination =
-      environment_ambient_light(geometric_normal) * mix(1.0, 1.30, v_foliage_mask) +
-      sun * mix(diffuse * 0.72, wrap, v_foliage_mask);
+      environment_ambient_light(geometric_normal) * mix(1.0, 1.06, v_foliage_mask) +
+      soi_key_light(geometric_normal) * mix(0.72, 1.0, v_foliage_mask);
 
   float sun_catch = smoothstep(0.45, 1.00, wrap) * mix(0.20, 0.62, needle_clump);
   needle_color = mix(needle_color, needle_sun, sun_catch * v_foliage_mask);

--- a/assets/shaders/post_blur.frag
+++ b/assets/shaders/post_blur.frag
@@ -1,0 +1,20 @@
+#version 330 core
+
+in vec2 v_uv;
+
+uniform sampler2D u_source;
+uniform vec2 u_texel_step;
+
+out vec4 frag_color;
+
+const float k_weights[5] = float[5](0.227027, 0.194595, 0.121622, 0.054054, 0.016216);
+
+void main() {
+  vec3 accumulated = texture(u_source, v_uv).rgb * k_weights[0];
+  for (int tap = 1; tap < 5; ++tap) {
+    vec2 offset = u_texel_step * float(tap);
+    accumulated += texture(u_source, v_uv + offset).rgb * k_weights[tap];
+    accumulated += texture(u_source, v_uv - offset).rgb * k_weights[tap];
+  }
+  frag_color = vec4(accumulated, 1.0);
+}

--- a/assets/shaders/post_bright.frag
+++ b/assets/shaders/post_bright.frag
@@ -1,0 +1,20 @@
+#version 330 core
+
+in vec2 v_uv;
+
+uniform sampler2D u_scene;
+uniform float u_threshold;
+uniform float u_knee;
+
+out vec4 frag_color;
+
+const vec3 k_bright_luma = vec3(0.2126, 0.7152, 0.0722);
+
+void main() {
+  vec3 scene = texture(u_scene, v_uv).rgb;
+  float luma = dot(scene, k_bright_luma);
+  float soft = clamp(luma - u_threshold + u_knee, 0.0, 2.0 * u_knee);
+  soft = soft * soft / max(4.0 * u_knee, 1e-4);
+  float contribution = max(soft, luma - u_threshold) / max(luma, 1e-4);
+  frag_color = vec4(scene * clamp(contribution, 0.0, 1.0), 1.0);
+}

--- a/assets/shaders/post_composite.frag
+++ b/assets/shaders/post_composite.frag
@@ -1,0 +1,79 @@
+#version 330 core
+#include "tonemap.glsl"
+
+in vec2 v_uv;
+
+uniform sampler2D u_scene;
+uniform sampler2D u_bloom;
+uniform sampler2D u_depth;
+uniform float u_bloom_intensity;
+uniform float u_vignette_strength;
+uniform vec2 u_depth_range;
+uniform vec2 u_inverse_resolution;
+uniform float u_ground_ao_radius;
+uniform float u_ground_ao_strength;
+
+out vec4 frag_color;
+
+const float k_vignette_inner = 0.55;
+const float k_vignette_outer = 1.35;
+const vec3 k_vignette_tint = vec3(0.86, 0.89, 0.97);
+const int k_ao_tap_count = 8;
+const float k_ao_spread = 3.0;
+const vec3 k_ao_tint = vec3(0.72, 0.76, 0.86);
+
+const vec2 k_ao_taps[8] = vec2[8](vec2(1.0, 0.0),
+                                  vec2(0.7071, 0.7071),
+                                  vec2(0.0, 1.0),
+                                  vec2(-0.7071, 0.7071),
+                                  vec2(-1.0, 0.0),
+                                  vec2(-0.7071, -0.7071),
+                                  vec2(0.0, -1.0),
+                                  vec2(0.7071, -0.7071));
+
+float linear_depth(vec2 uv) {
+  float raw = texture(u_depth, uv).r;
+  float near_plane = u_depth_range.x;
+  float far_plane = u_depth_range.y;
+  float ndc = raw * 2.0 - 1.0;
+  return (2.0 * near_plane * far_plane) /
+         (far_plane + near_plane - ndc * (far_plane - near_plane));
+}
+
+float grounding_occlusion() {
+  float center = linear_depth(v_uv);
+  if (center >= u_depth_range.y * 0.999) {
+    return 0.0;
+  }
+
+  float occlusion = 0.0;
+  for (int tap = 0; tap < k_ao_tap_count; ++tap) {
+    vec2 offset = k_ao_taps[tap] * u_inverse_resolution * k_ao_spread;
+    float neighbour = linear_depth(v_uv + offset);
+    float difference = center - neighbour;
+    float contribution =
+        smoothstep(0.0, u_ground_ao_radius, difference) *
+        (1.0 - smoothstep(u_ground_ao_radius, u_ground_ao_radius * 6.0, difference));
+    occlusion += contribution;
+  }
+  return clamp(occlusion / float(k_ao_tap_count), 0.0, 1.0);
+}
+
+void main() {
+  vec3 scene = texture(u_scene, v_uv).rgb;
+  vec3 bloom = texture(u_bloom, v_uv).rgb;
+  vec3 combined = scene + bloom * u_bloom_intensity;
+
+  float occlusion = grounding_occlusion() * u_ground_ao_strength;
+  combined = mix(combined, combined * k_ao_tint, occlusion);
+
+  vec3 graded = soi_finalize(combined);
+
+  vec2 centered = v_uv * 2.0 - 1.0;
+  float falloff = smoothstep(k_vignette_inner, k_vignette_outer, length(centered));
+  float vignette = 1.0 - falloff * u_vignette_strength;
+  graded = mix(graded * k_vignette_tint, graded, vignette);
+  graded *= vignette;
+
+  frag_color = vec4(clamp(graded, 0.0, 1.0), 1.0);
+}

--- a/assets/shaders/post_fullscreen.vert
+++ b/assets/shaders/post_fullscreen.vert
@@ -1,0 +1,9 @@
+#version 330 core
+
+out vec2 v_uv;
+
+void main() {
+  vec2 corner = vec2(float((gl_VertexID << 1) & 2), float(gl_VertexID & 2));
+  v_uv = corner;
+  gl_Position = vec4(corner * 2.0 - 1.0, 0.0, 1.0);
+}

--- a/assets/shaders/post_fxaa.frag
+++ b/assets/shaders/post_fxaa.frag
@@ -1,0 +1,68 @@
+#version 330 core
+
+in vec2 v_uv;
+
+uniform sampler2D u_source;
+uniform vec2 u_inverse_resolution;
+
+out vec4 frag_color;
+
+const float k_edge_threshold_min = 0.0312;
+const float k_edge_threshold_max = 0.125;
+const float k_subpixel_blend = 0.75;
+const vec3 k_fxaa_luma = vec3(0.2126, 0.7152, 0.0722);
+
+float sample_luma(vec2 uv) {
+  return dot(texture(u_source, uv).rgb, k_fxaa_luma);
+}
+
+void main() {
+  vec3 center_color = texture(u_source, v_uv).rgb;
+  float luma_center = dot(center_color, k_fxaa_luma);
+  float luma_north = sample_luma(v_uv + vec2(0.0, u_inverse_resolution.y));
+  float luma_south = sample_luma(v_uv - vec2(0.0, u_inverse_resolution.y));
+  float luma_east = sample_luma(v_uv + vec2(u_inverse_resolution.x, 0.0));
+  float luma_west = sample_luma(v_uv - vec2(u_inverse_resolution.x, 0.0));
+
+  float luma_min =
+      min(luma_center, min(min(luma_north, luma_south), min(luma_east, luma_west)));
+  float luma_max =
+      max(luma_center, max(max(luma_north, luma_south), max(luma_east, luma_west)));
+  float range = luma_max - luma_min;
+
+  if (range < max(k_edge_threshold_min, luma_max * k_edge_threshold_max)) {
+    frag_color = vec4(center_color, 1.0);
+    return;
+  }
+
+  float luma_north_west =
+      sample_luma(v_uv + vec2(-u_inverse_resolution.x, u_inverse_resolution.y));
+  float luma_north_east = sample_luma(v_uv + u_inverse_resolution);
+  float luma_south_west = sample_luma(v_uv - u_inverse_resolution);
+  float luma_south_east =
+      sample_luma(v_uv + vec2(u_inverse_resolution.x, -u_inverse_resolution.y));
+
+  float edge_horizontal =
+      abs(luma_north_west + luma_north_east - 2.0 * luma_north) * 2.0 +
+      abs(luma_west + luma_east - 2.0 * luma_center) * 4.0 +
+      abs(luma_south_west + luma_south_east - 2.0 * luma_south) * 2.0;
+  float edge_vertical = abs(luma_north_west + luma_south_west - 2.0 * luma_west) * 2.0 +
+                        abs(luma_north + luma_south - 2.0 * luma_center) * 4.0 +
+                        abs(luma_north_east + luma_south_east - 2.0 * luma_east) * 2.0;
+  bool horizontal_span = edge_horizontal >= edge_vertical;
+
+  vec2 step_direction = horizontal_span ? vec2(0.0, u_inverse_resolution.y)
+                                        : vec2(u_inverse_resolution.x, 0.0);
+  float luma_positive = horizontal_span ? luma_north : luma_east;
+  float luma_negative = horizontal_span ? luma_south : luma_west;
+  if (abs(luma_negative - luma_center) > abs(luma_positive - luma_center)) {
+    step_direction = -step_direction;
+  }
+
+  vec3 blended = 0.5 * (center_color + texture(u_source, v_uv + step_direction).rgb);
+  float average = (luma_north + luma_south + luma_east + luma_west) * 0.25;
+  float subpixel = clamp(abs(average - luma_center) / max(range, 1e-4), 0.0, 1.0);
+  subpixel = smoothstep(0.0, 1.0, subpixel) * k_subpixel_blend;
+
+  frag_color = vec4(mix(center_color, blended, subpixel + 0.5), 1.0);
+}

--- a/assets/shaders/river.frag
+++ b/assets/shaders/river.frag
@@ -164,5 +164,5 @@ void main() {
       atmospheric_fog_amount(view_distance, u_fog_start, u_fog_end, 1.0, 0.0);
   color = mix(color, environment_fog_color(), fog_amount);
 
-  frag_color = vec4(saturate(color), 1.0);
+  frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/riverbank.frag
+++ b/assets/shaders/riverbank.frag
@@ -354,5 +354,5 @@ void main() {
 
   color += color * local_lighting(world_pos, normalize(v_normal));
   color = apply_directional_shadow(color, world_pos, v_normal);
-  frag_color = vec4(saturate(color), segment_visibility * edge_fade);
+  frag_color = vec4(color, segment_visibility * edge_fade);
 }

--- a/assets/shaders/road.frag
+++ b/assets/shaders/road.frag
@@ -212,5 +212,5 @@ void main() {
 
   lit_color += lit_color * local_lighting(v_world_pos, normalize(v_normal));
   lit_color = apply_directional_shadow(lit_color, v_world_pos, v_normal);
-  frag_color = vec4(clamp(lit_color, 0.0, 1.0), u_alpha * edge_alpha);
+  frag_color = vec4(lit_color, u_alpha * edge_alpha);
 }

--- a/assets/shaders/ruins_instanced.frag
+++ b/assets/shaders/ruins_instanced.frag
@@ -49,12 +49,12 @@ void main() {
   float hemi = clamp(N.y * 0.5 + 0.5, 0.0, 1.0);
   vec3 sky = environment_sky_color();
   vec3 sun = environment_primary_color() * environment_primary_intensity();
-  vec3 illumination = environment_ambient_light(N) + sun * ndotl * 0.68;
+  vec3 illumination = soi_surface_lighting_scaled(N, 0.68);
   float ao = mix(0.48, 1.0, hemi) * mix(1.0, 0.68, fracture);
   float specular = pow(max(dot(N, H), 0.0), 28.0) * (0.025 + rain_stain * 0.09);
   float rim = pow(1.0 - max(dot(N, V), 0.0), 4.0) * 0.045;
 
-  vec3 color = stone * illumination * ao * environment_exposure();
+  vec3 color = stone * illumination * ao;
   color += sun * specular;
   color += sky * rim;
   color += color * local_lighting(v_world_pos, normalize(v_normal));

--- a/assets/shaders/sky.frag
+++ b/assets/shaders/sky.frag
@@ -1,0 +1,57 @@
+#version 330 core
+#include "environment_lighting.glsl"
+#include "noise.glsl"
+
+in vec2 v_uv;
+
+uniform mat4 u_inverse_view_proj;
+
+out vec4 frag_color;
+
+const float k_sky_zenith_gain = 1.06;
+const float k_sky_horizon_lift = 1.22;
+const vec3 k_sky_zenith_deepen = vec3(0.70, 0.83, 1.00);
+const float k_sky_horizon_blend = 2.20;
+const float k_sky_band_scale = 2.60;
+const float k_sky_band_softness = 0.34;
+const float k_sky_cloud_floor = 0.18;
+const float k_sky_sun_tightness = 220.0;
+const float k_sky_sun_halo = 6.0;
+const vec3 k_sky_cloud_color = vec3(1.02, 1.00, 0.97);
+
+vec3 sky_ray_direction() {
+  vec2 ndc = v_uv * 2.0 - 1.0;
+  vec4 near_point = u_inverse_view_proj * vec4(ndc, -1.0, 1.0);
+  vec4 far_point = u_inverse_view_proj * vec4(ndc, 1.0, 1.0);
+  vec3 near_world = near_point.xyz / near_point.w;
+  vec3 far_world = far_point.xyz / far_point.w;
+  return normalize(far_world - near_world);
+}
+
+void main() {
+  vec3 ray = sky_ray_direction();
+  float upward = clamp(ray.y, 0.0, 1.0);
+  float gradient = pow(upward, 1.0 / k_sky_horizon_blend);
+
+  vec3 horizon = environment_fog_color() * k_sky_horizon_lift;
+  vec3 zenith = environment_sky_color() * k_sky_zenith_gain * k_sky_zenith_deepen;
+  vec3 sky = mix(horizon, zenith, gradient);
+
+  float horizontal = max(length(ray.xz), 1e-3);
+  vec2 dome = ray.xz / horizontal * (1.0 - upward);
+  float band_field = soi_fbm_23e5ab(dome * k_sky_band_scale);
+  float coverage = clamp(environment_cloud_cover() + k_sky_cloud_floor, 0.0, 1.0);
+  float bands = smoothstep(1.0 - coverage - k_sky_band_softness,
+                           1.0 - coverage + k_sky_band_softness,
+                           band_field);
+  bands *= smoothstep(0.02, 0.42, upward);
+  sky = mix(sky, horizon * k_sky_cloud_color, bands * 0.72);
+
+  vec3 sun_direction = environment_primary_direction();
+  float toward_sun = clamp(dot(ray, sun_direction), 0.0, 1.0);
+  vec3 sun_color = environment_primary_color() * environment_primary_intensity();
+  sky += sun_color * pow(toward_sun, k_sky_sun_tightness) * 0.85;
+  sky += sun_color * pow(toward_sun, k_sky_sun_halo) * 0.09;
+
+  frag_color = vec4(sky * environment_exposure(), 1.0);
+}

--- a/assets/shaders/statue_instanced.frag
+++ b/assets/shaders/statue_instanced.frag
@@ -85,13 +85,13 @@ void main() {
   cavity *= mix(1.0, 0.95, streaks);
   cavity *= mix(1.0, 0.92, grime);
 
-  vec3 illumination = environment_ambient_light(N) * 1.38 +
-                      sun * mix(lambert, wrapped, 0.55) * 0.86 + subsurface;
+  vec3 illumination = environment_ambient_light(N) * 1.38 * environment_exposure() +
+                      soi_key_light(N) * 0.86 * environment_exposure() + subsurface;
   float gloss = mix(0.020, 0.052, figure) * (1.0 + environment_wetness() * 1.8);
   float specular = pow(max(dot(N, H), 0.0), mix(22.0, 52.0, figure)) * gloss;
   float rim = pow(1.0 - max(dot(N, V), 0.0), 3.2) * mix(0.035, 0.075, figure);
 
-  vec3 color = stone * illumination * cavity * environment_exposure();
+  vec3 color = stone * illumination * cavity;
   color += sun * specular;
   color += sky * rim;
   color += color * local_lighting(v_world_pos, normalize(v_normal));

--- a/assets/shaders/stone_instanced.frag
+++ b/assets/shaders/stone_instanced.frag
@@ -62,14 +62,15 @@ void main() {
   float hemi = clamp(N.y * 0.5 + 0.5, 0.0, 1.0);
   vec3 sky = environment_sky_color();
   vec3 sun = environment_primary_color() * environment_primary_intensity();
-  vec3 illumination = environment_ambient_light(N) + sun * ndotl * 0.72;
+  vec3 illumination = soi_surface_lighting_scaled(N, 0.72);
   float crevice_ao = mix(1.0, 0.62, fissures) * mix(0.58, 1.0, hemi);
 
   float wet_spec = ground_damp * pow(max(dot(N, H), 0.0), 34.0) * 0.16;
   float dry_spec = pow(max(dot(N, H), 0.0), 18.0) * 0.025;
   float rim = pow(1.0 - max(dot(N, V), 0.0), 4.0) * 0.055;
 
-  vec3 color = stone * illumination * crevice_ao * environment_exposure();
+  vec3 color = stone * illumination * crevice_ao;
+  color += soi_rim_light(N, V);
   color += sun * (dry_spec + wet_spec);
   color += sky * rim;
   color += color * local_lighting(v_world_pos, normalize(v_normal));

--- a/assets/shaders/supply_cart_instanced.frag
+++ b/assets/shaders/supply_cart_instanced.frag
@@ -84,7 +84,7 @@ void main() {
   float hemi = clamp(N.y * 0.5 + 0.5, 0.0, 1.0);
   vec3 sky = environment_sky_color();
   vec3 sun = environment_primary_color() * environment_primary_intensity();
-  vec3 illumination = environment_ambient_light(N) + sun * ndotl * 0.74;
+  vec3 illumination = soi_surface_lighting_scaled(N, 0.74);
   float cavity = mix(0.56, 1.0, hemi) * mix(1.0, 0.78, cargo_core);
   float metal_mask = max(tyre_mask, hub_mask);
   float specular = mix(pow(max(dot(N, H), 0.0), 24.0) * 0.035,
@@ -92,7 +92,7 @@ void main() {
                        metal_mask);
   float rim = pow(1.0 - max(dot(N, V), 0.0), 4.0) * 0.045;
 
-  vec3 color = albedo * illumination * cavity * environment_exposure();
+  vec3 color = albedo * illumination * cavity;
   color += sun * specular;
   color += sky * rim;
   color += color * local_lighting(v_world_pos, normalize(v_normal));

--- a/assets/shaders/tent_instanced.frag
+++ b/assets/shaders/tent_instanced.frag
@@ -72,12 +72,12 @@ void main() {
   float hemi = clamp(N.y * 0.5 + 0.5, 0.0, 1.0);
   vec3 sky = environment_sky_color();
   vec3 sun = environment_primary_color() * environment_primary_intensity();
-  vec3 illumination = environment_ambient_light(N) + sun * ndotl * 0.72;
+  vec3 illumination = soi_surface_lighting_scaled(N, 0.72);
   float ao = mix(0.55, 1.0, hemi) * mix(1.0, 0.78, base_dirt);
   float specular = pow(max(dot(N, H), 0.0), 58.0) * mix(0.025, 0.20, iron_mask);
   float rim = pow(1.0 - max(dot(N, V), 0.0), 4.0) * 0.045;
 
-  vec3 color = albedo * illumination * ao * environment_exposure();
+  vec3 color = albedo * illumination * ao;
   color += sun * specular;
   color += sky * rim;
   color += color * local_lighting(v_world_pos, normalize(v_normal));

--- a/assets/shaders/terrain_chunk.frag
+++ b/assets/shaders/terrain_chunk.frag
@@ -25,6 +25,13 @@ uniform float u_soil_blend_height, u_soil_blend_sharpness;
 uniform float u_height_noise_strength, u_height_noise_frequency;
 uniform float u_ambient_boost, u_rock_detail_strength;
 
+const float k_soi_terrain_detail_damping = 0.45;
+const float k_soi_terrain_relief_damping = 0.55;
+const float k_soi_terrain_hue_scale = 0.022;
+const float k_soi_terrain_hue_amount = 0.085;
+const vec3 k_soi_terrain_hue_warm = vec3(1.075, 1.010, 0.905);
+const vec3 k_soi_terrain_hue_cool = vec3(0.935, 1.005, 1.070);
+
 uniform float u_snow_coverage;
 uniform float u_moisture_level;
 uniform float u_crack_intensity;
@@ -338,6 +345,10 @@ void main() {
   surface_grain *= mix(1.0, 0.62, tactical);
   granular *= mix(1.0, 0.68, tactical);
   speckle *= mix(1.0, 0.58, tactical);
+
+  surface_grain *= k_soi_terrain_detail_damping;
+  granular *= k_soi_terrain_detail_damping;
+  speckle *= k_soi_terrain_detail_damping;
 
   float high_ground = smoothstep(0.8, 4.8, v_world_pos.y);
   float low_ground = 1.0 - smoothstep(0.45, 2.6, v_world_pos.y);
@@ -661,6 +672,13 @@ void main() {
     terrain_color = mix(terrain_color, snow_tinted, snow_mask);
   }
 
+  float hue_field =
+      gradient_fbm(world_coord * k_soi_terrain_hue_scale + vec2(61.0, -37.0));
+  vec3 hue_shift = mix(k_soi_terrain_hue_cool,
+                       k_soi_terrain_hue_warm,
+                       smoothstep(0.35, 0.65, hue_field));
+  terrain_color *= mix(vec3(1.0), hue_shift, k_soi_terrain_hue_amount);
+
   vec3 gray_level = vec3(dot(terrain_color, vec3(0.299, 0.587, 0.114)));
   float grounded_saturation = clamp(u_grass_saturation * 0.96, 0.0, 1.16);
   terrain_color = mix(gray_level, terrain_color, grounded_saturation);
@@ -708,6 +726,7 @@ void main() {
   float relief_amp = 0.055 + (0.055 + 0.060 * u_soil_roughness) * soil_mix +
                      0.07 * rock_mask + 0.025 * exposed_ground + 0.040 * bare_patch;
   relief_amp *= mix(1.0, 0.78, tactical);
+  relief_amp *= k_soi_terrain_relief_damping;
   vec3 relief_offset =
       mix(vec3(relief_gradient.x, 0.0, relief_gradient.y),
           vec3(relief_gradient.x, relief_gradient.y, 0.0) * wall_axis +
@@ -757,5 +776,5 @@ void main() {
       view_distance, u_fog_start, u_fog_end, 0.72, 0.60 * horizon_fog);
   lit_color = mix(lit_color, environment_fog_color(), fog_amount);
 
-  frag_color = vec4(clamp(lit_color, 0.0, 1.0), 1.0);
+  frag_color = vec4(lit_color, 1.0);
 }

--- a/assets/shaders/weapon_rack_instanced.frag
+++ b/assets/shaders/weapon_rack_instanced.frag
@@ -120,14 +120,14 @@ void main() {
   float hemi = clamp(N.y * 0.5 + 0.5, 0.0, 1.0);
   vec3 sky = environment_sky_color();
   vec3 sun = environment_primary_color() * environment_primary_intensity();
-  vec3 illumination = environment_ambient_light(N) + sun * ndotl * 0.72;
+  vec3 illumination = soi_surface_lighting_scaled(N, 0.72);
   float ao = mix(0.70, 1.0, hemi);
   float metal_mask = max(blade_mask, brass_mask);
   float spec_power = mix(24.0, 76.0, blade_mask);
   float specular = pow(max(dot(N, H), 0.0), spec_power) * mix(0.035, 0.48, metal_mask);
   float rim = pow(1.0 - max(dot(N, V), 0.0), 4.0) * 0.05;
 
-  vec3 color = albedo * illumination * ao * environment_exposure();
+  vec3 color = albedo * illumination * ao;
   color += sun * specular;
   color += sky * rim;
   color += color * local_lighting(v_world_pos, normalize(v_normal));

--- a/docs/RENDER_ART_DIRECTION.md
+++ b/docs/RENDER_ART_DIRECTION.md
@@ -1,0 +1,176 @@
+# Render art direction
+
+The target look is the clean, cozy stylisation of _Röki_ and _The Last Campfire_:
+large flat colour fields, readable silhouettes, soft contact grounding, no crushed
+blacks and no clipped whites. This document records how the renderer gets there and
+which knob to turn when a scene reads wrong.
+
+## Frame structure
+
+The world no longer renders straight into the host framebuffer. `Backend::begin_frame`
+asks `PostProcessPipeline::begin_scene` to bind an offscreen **RGBA16F** scene target
+(falling back to RGBA8 if float attachments are unavailable), and `Backend::execute`
+resolves it back to whatever framebuffer the host had bound.
+
+```
+begin_frame            bind HDR scene target, clear
+execute_scene
+  ├─ shadow cascades   (own FBO, restores the scene target)
+  ├─ sky               fullscreen pass, depth write off, before all geometry
+  └─ world geometry    writes linear radiance, no clamp, no tone curve
+resolve_scene
+  ├─ bright pass       threshold + knee, third resolution (k_bloom_divisor)
+  ├─ blur              separable gaussian, two ping-pong iterations
+  ├─ composite         grounding AO → + bloom → tonemap → grade → vignette → RGBA8
+  └─ FXAA              to the host framebuffer
+```
+
+`Backend::execute` is a thin wrapper around `execute_scene` precisely so that the
+resolve runs on every early-return path inside the world render.
+
+## Where colour is decided
+
+**Material shaders write linear radiance.** They must not clamp, saturate or grade
+their output — the scene target is HDR and the tone curve belongs to one place.
+`ShaderSource.WorldShadersLeaveGradingToThePostProcessPass` pins this.
+
+**`assets/shaders/include/tonemap.glsl`** owns the look. It has no UBO dependency so
+the post pass and any future tool can include it:
+
+| Constant                                     | Effect                                                    |
+| -------------------------------------------- | --------------------------------------------------------- |
+| `k_soi_grade_exposure`                       | linear gain before the curve; raise to open the midtones  |
+| `k_soi_grade_white_point`                    | where the extended-Reinhard shoulder reaches 1.0          |
+| `k_soi_grade_contrast` / `k_soi_grade_pivot` | S-curve strength and its anchor                           |
+| `k_soi_grade_saturation`                     | global chroma                                             |
+| `k_soi_grade_shadow_lift`                    | cool floor under the blacks — this is what stops crushing |
+| `k_soi_grade_highlight_tint`                 | warm/cool split against the shadow lift                   |
+
+**`assets/shaders/include/environment_lighting.glsl`** owns the _shading_ model on top
+of the existing `EnvironmentLighting` UBO. `soi_wrapped_diffuse` wraps the terminator
+and softly quantises it into plates; `soi_surface_lighting` is the shared
+ambient + key term; `soi_rim_light` is the sky-coloured silhouette separator. Banding
+is deliberately a _mix_ (`k_soi_shade_band_mix`), not a hard cel step — the reference
+games are soft-shaded, not cel-shaded.
+
+Props and foliage used to hand-roll `environment_ambient_light(N) + sun * ndotl * K`
+with a different `K` per material, so nothing responded to light quite the same way.
+They now call `soi_surface_lighting_scaled(N, K)`, which keeps each material's key
+attenuation but routes every one of them through the same wrapped-and-banded curve.
+Note that the scaled helper already applies `environment_exposure()` — a shader that
+calls it must not multiply by exposure again.
+
+`environment_lighting(normal, wrap)` itself now returns `soi_surface_lighting(normal)`,
+so everything that already used the shared entry point — `basic`, `basic_instanced`
+(all buildings), `catapult`, `catapult_instanced`, `primitive_instanced`,
+`cylinder_instanced` — picks up the wrapped-and-banded key for free. That is what gives
+adjacent building planes their tonal separation; before it, two walls meeting at a
+corner were nearly the same value. The `wrap` argument is now ignored: the shared
+model owns the terminator via `k_soi_shade_wrap`.
+
+Because GLSL has no forward declarations, the `soi_` shading helpers must be defined
+_above_ `environment_direct_light` in the include. Do not move them back below it.
+
+Directly routed hand-rollers: `stone_instanced`, `tent_instanced`, `ruins_instanced`,
+`weapon_rack_instanced`, `supply_cart_instanced`, `statue_instanced`,
+`pine_instanced`, `olive_instanced`, `magic_shrine_instanced`, `iron_ore_instanced`.
+Still on their own lighting: `dead_tree_instanced` and `bridge`, whose blocks are
+shaped differently enough to need individual attention.
+
+Foliage note: pine and olive canopies used to scale ambient by 1.30, which washed the
+form out of them. At 1.06 the key light carries the shape instead.
+
+## Palette
+
+Cohesion comes from split-toning in one place rather than from editing colours at
+fifty call sites: `k_soi_grade_shadow_lift` pushes the shadow floor cool-teal while
+`k_soi_grade_highlight_tint` pushes highlights warm. Widening that split is the first
+knob to reach for when the frame reads hue-flat. `scene/environment_lighting.h` carries
+the matching defaults — `shadow_tint` and `shadow_strength` were lifted from a near-black
+`{0.16, 0.20, 0.27}` at 0.72 to `{0.30, 0.34, 0.44}` at 0.60 so cast shadows read as
+coloured shade rather than as grey slabs.
+
+## Anti-aliasing
+
+Two independent mechanisms, because they cover different hosts:
+
+- **MSAA** on the scene FBO, driven by `GraphicsSettings::presentation().msaa_samples`
+  (Low 0, Medium 2, High/Ultra 4). Both `ui/gl_view.cpp` and `ui/campaign_map_view.cpp`
+  fall back to 0 samples if the multisample FBO fails to validate.
+- **FXAA** as the final post pass, which is what actually cleans up the arena captures.
+
+Before this work `ui/gl_view.cpp` hard-coded `setSamples(0)` and `campaign_map_view.cpp`
+set 4 and then immediately overwrote it with 0, so nothing anywhere was anti-aliased.
+
+## Grounding
+
+`post_composite.frag` derives a cheap depth-delta occlusion from the scene depth
+texture (`grounding_occlusion`). It darkens and cools where geometry meets the ground,
+which is what stops buildings reading as pasted-on decals. `u_ground_ao_radius` is in
+world units; `u_ground_ao_strength` scales the tint.
+
+This needs the scene depth as a _texture_, not a renderbuffer — that is why
+`ensure_targets` attaches `GL_DEPTH_COMPONENT24` via `glFramebufferTexture2D`.
+
+## Sky
+
+`sky.frag` reconstructs a world-space view ray from the inverse view-projection and
+shades a horizon→zenith gradient with soft cloud bands and a sun disc plus halo.
+Colours come from the environment UBO (`fog_color` at the horizon, `sky_color` at the
+zenith, `cloud_cover` for band density), so the sky follows the same time-of-day
+keyframes as everything else in `game/map/environment_lighting.cpp`.
+
+Before this the sky was a flat `glClearColor`, which is what produced the hard horizon
+line where the terrain simply stopped.
+
+## Terrain
+
+`terrain_chunk.frag` is a very detailed procedural shader, and that detail actively
+fights the target look — clean stylisation puts detail in silhouettes, not surfaces.
+`k_soi_terrain_detail_damping` and `k_soi_terrain_relief_damping` scale the
+high-frequency grain/granular/speckle terms and the relief normal amplitude. Raise them
+towards 1.0 to get the old naturalistic surface back.
+
+`k_soi_terrain_hue_scale` / `k_soi_terrain_hue_amount` add a very low-frequency warm↔cool
+break across the ground so a map does not read as one flat green. Keep the amount small
+(under ~0.12); past that it stops looking like light and starts looking like paint.
+
+## Known geometry fix
+
+The stone mesh in `render/gl/backend/vegetation_pipeline_natural.cpp` computed
+`cross(b - a, d - a)` for its ring quads, which is **-outward**: every stone and
+boulder in the game shaded to a flat ~5% grey because `ndotl` collapsed. Both the
+normal and the triangle winding are now outward-facing. The scatter pass disables
+backface culling, which is why the bug showed up as black rocks rather than
+inside-out ones.
+
+## Time of day and weather
+
+`game/map/environment_lighting.cpp` holds the per-hour keyframes, and they **override**
+`shadow_tint` and `shadow_strength` from `scene/environment_lighting.h` for any scene
+using a time-of-day profile. Change shadows there, not in the header, unless the scene
+has no profile.
+
+Night (0/22/24) needs three things to read as cozy rather than merely dark: moonlight
+that is actually blue (so firelight has something cool to contrast against), ambient
+high enough that the ground stays legible (0.30 — at 0.12 four fifths of the frame sat
+below luma 20), and a shadow tint well off black.
+
+Afternoon (17) is defined by sun _height_, not colour. At y=0.55 it was indistinguish-
+able from noon; at y=0.26 it gets the long raking shadows that make golden hour read.
+A low sun costs direct light on every up-facing surface, so intensity and ambient have
+to rise to pay it back or the scene just goes dim.
+
+Snow in `apply_weather` does more than tint the ground bounce. A snowfield throws light
+back everywhere, so shadows weaken and soften and go blue, and the horizon hazes to a
+pale cold white. Without those the ground reads as green terrain with white stains.
+
+Known gap: the Iron Sepulcher profile now carries a cold violet shadow tint, but every
+scenario that selects the profile is a night scene, where shadow strength is already
+low — so the tint currently has no measurable effect. It is there for daylight sepulcher
+maps that do not exist yet.
+
+Known gap: several scenarios set `exposure_override` (2.3, 2.1, 1.45) tuned against the
+old pipeline. These now stack on `k_soi_grade_exposure` before the tone curve. The
+shoulder absorbs it rather than clipping, but those scenes sit high on the curve where
+contrast compresses, and the overrides deserve a sweep.

--- a/game/map/environment_lighting.cpp
+++ b/game/map/environment_lighting.cpp
@@ -48,17 +48,17 @@ auto mediterranean_summer_profile() -> const std::array<LightingKeyframe, 8>& {
   static const std::array<LightingKeyframe, 8> keyframes{
       make_keyframe(0.0F,
                     {-0.28F, 0.42F, 0.50F},
-                    {0.46F, 0.56F, 0.78F},
-                    0.32F,
-                    {0.08F, 0.12F, 0.22F},
-                    {0.10F, 0.12F, 0.18F},
-                    0.12F,
-                    {0.09F, 0.13F, 0.21F},
+                    {0.40F, 0.54F, 0.92F},
+                    0.34F,
+                    {0.14F, 0.23F, 0.48F},
+                    {0.09F, 0.13F, 0.26F},
+                    0.30F,
+                    {0.11F, 0.18F, 0.34F},
                     0.004F,
-                    {0.08F, 0.11F, 0.18F},
-                    0.58F,
-                    0.62F,
-                    0.78F),
+                    {0.24F, 0.30F, 0.50F},
+                    0.42F,
+                    0.72F,
+                    0.90F),
       make_keyframe(5.0F,
                     {0.72F, 0.10F, 0.18F},
                     {0.94F, 0.49F, 0.30F},
@@ -94,23 +94,23 @@ auto mediterranean_summer_profile() -> const std::array<LightingKeyframe, 8>& {
                     0.30F,
                     {0.62F, 0.70F, 0.78F},
                     0.002F,
-                    {0.18F, 0.21F, 0.26F},
-                    0.76F,
-                    0.26F,
+                    {0.28F, 0.32F, 0.40F},
+                    0.66F,
+                    0.34F,
                     1.04F),
       make_keyframe(17.0F,
-                    {0.55F, 0.55F, 0.35F},
-                    {1.00F, 0.77F, 0.50F},
-                    0.88F,
-                    {0.52F, 0.59F, 0.70F},
-                    {0.32F, 0.22F, 0.14F},
-                    0.27F,
-                    {0.65F, 0.64F, 0.62F},
-                    0.004F,
-                    {0.20F, 0.20F, 0.24F},
-                    0.75F,
+                    {0.74F, 0.26F, 0.32F},
+                    {1.00F, 0.76F, 0.48F},
+                    1.18F,
+                    {0.60F, 0.63F, 0.70F},
+                    {0.46F, 0.32F, 0.18F},
                     0.34F,
-                    1.00F),
+                    {0.80F, 0.71F, 0.58F},
+                    0.002F,
+                    {0.34F, 0.30F, 0.36F},
+                    0.72F,
+                    0.30F,
+                    1.10F),
       make_keyframe(20.0F,
                     {-0.58F, 0.16F, 0.30F},
                     {0.92F, 0.44F, 0.29F},
@@ -126,30 +126,30 @@ auto mediterranean_summer_profile() -> const std::array<LightingKeyframe, 8>& {
                     0.86F),
       make_keyframe(22.0F,
                     {-0.20F, 0.35F, 0.50F},
-                    {0.48F, 0.58F, 0.80F},
-                    0.35F,
-                    {0.09F, 0.13F, 0.24F},
-                    {0.11F, 0.13F, 0.19F},
-                    0.12F,
-                    {0.10F, 0.15F, 0.24F},
+                    {0.42F, 0.56F, 0.94F},
+                    0.38F,
+                    {0.15F, 0.24F, 0.50F},
+                    {0.10F, 0.14F, 0.27F},
+                    0.30F,
+                    {0.12F, 0.19F, 0.36F},
                     0.005F,
-                    {0.07F, 0.10F, 0.17F},
-                    0.58F,
-                    0.64F,
-                    0.76F),
+                    {0.25F, 0.31F, 0.52F},
+                    0.42F,
+                    0.74F,
+                    0.90F),
       make_keyframe(24.0F,
                     {-0.28F, 0.42F, 0.50F},
-                    {0.46F, 0.56F, 0.78F},
-                    0.32F,
-                    {0.08F, 0.12F, 0.22F},
-                    {0.10F, 0.12F, 0.18F},
-                    0.12F,
-                    {0.09F, 0.13F, 0.21F},
+                    {0.40F, 0.54F, 0.92F},
+                    0.34F,
+                    {0.14F, 0.23F, 0.48F},
+                    {0.09F, 0.13F, 0.26F},
+                    0.30F,
+                    {0.11F, 0.18F, 0.34F},
                     0.004F,
-                    {0.08F, 0.11F, 0.18F},
-                    0.58F,
-                    0.62F,
-                    0.78F),
+                    {0.24F, 0.30F, 0.50F},
+                    0.42F,
+                    0.72F,
+                    0.90F),
   };
   return keyframes;
 }
@@ -164,6 +164,9 @@ auto iron_sepulcher_profile() -> const std::array<LightingKeyframe, 8>& {
           (keyframe.lighting.fog_color * 0.68F) + QVector3D(0.10F, 0.13F, 0.18F);
       keyframe.lighting.primary_color =
           (keyframe.lighting.primary_color * 0.86F) + QVector3D(0.05F, 0.06F, 0.09F);
+      const QVector3D grave_shadow(0.26F, 0.24F, 0.40F);
+      keyframe.lighting.shadow_tint +=
+          (grave_shadow - keyframe.lighting.shadow_tint) * 0.55F;
       keyframe.lighting.exposure *= 0.92F;
     }
     return result;
@@ -222,8 +225,19 @@ auto apply_weather(EnvironmentLightingState state,
     const QVector3D snow_bounce(0.72F, 0.76F, 0.80F);
     state.ground_bounce_color +=
         (snow_bounce - state.ground_bounce_color) * (snow * 0.55F);
-    state.ambient_intensity *= 1.0F + (snow * 0.18F);
-    state.exposure *= 1.0F + (snow * 0.08F);
+    state.ambient_intensity *= 1.0F + (snow * 0.40F);
+    state.exposure *= 1.0F + (snow * 0.10F);
+
+    const QVector3D snow_haze(0.76F, 0.83F, 0.94F);
+    state.fog_color += (snow_haze - state.fog_color) * (snow * 0.50F);
+    state.sky_color += (snow_haze - state.sky_color) * (snow * 0.30F);
+    state.fog_density += snow * 0.005F;
+
+    const QVector3D snow_shadow(0.48F, 0.57F, 0.76F);
+    state.shadow_tint += (snow_shadow - state.shadow_tint) * (snow * 0.65F);
+    state.shadow_strength *= 1.0F - (snow * 0.34F);
+    state.shadow_softness =
+        std::clamp(state.shadow_softness + (snow * 0.28F), 0.0F, 1.0F);
   }
   return state.sanitized();
 }

--- a/render/gl/backend.cpp
+++ b/render/gl/backend.cpp
@@ -30,6 +30,7 @@
 #include "backend/healing_beam_pipeline.h"
 #include "backend/mesh_instancing_pipeline.h"
 #include "backend/mode_indicator_pipeline.h"
+#include "backend/post_process_pipeline.h"
 #include "backend/primitive_batch_pipeline.h"
 #include "backend/rain_pipeline.h"
 #include "backend/rigged_character_pipeline.h"
@@ -246,6 +247,10 @@ auto Backend::initialize() -> bool {
           m_mesh_instancing_pipeline, "MeshInstancingPipeline", m_shader_cache.get())) {
     return false;
   }
+  if (!create_subsystem(
+          m_post_process_pipeline, "PostProcessPipeline", m_shader_cache.get())) {
+    return false;
+  }
 
   qInfo() << "Backend: Loading basic shaders...";
   m_basic_shader = m_shader_cache->get(QStringLiteral("basic"));
@@ -296,6 +301,9 @@ auto Backend::banner_shader() const -> Shader* {
 void Backend::begin_frame() {
   if (m_viewport_width > 0 && m_viewport_height > 0) {
     glViewport(0, 0, m_viewport_width, m_viewport_height);
+  }
+  if (m_post_process_pipeline != nullptr) {
+    m_post_process_pipeline->begin_scene(m_viewport_width, m_viewport_height);
   }
   glClearColor(m_clear_color[red],
                m_clear_color[green],
@@ -795,7 +803,7 @@ void Backend::upload_frame_uniform_buffers(const QMatrix4x4& view_proj,
   }
 }
 
-void Backend::execute(const DrawQueue& queue, const Camera& cam) {
+void Backend::execute_scene(const DrawQueue& queue, const Camera& cam) {
   m_last_playback_stats = {};
   m_last_playback_stats.submitted_commands = queue.size();
   m_last_playback_stats.prepared_batches = queue.prepared_batches().size();
@@ -812,6 +820,10 @@ void Backend::execute(const DrawQueue& queue, const Camera& cam) {
   const QMatrix4x4 view_proj = projection * view;
   upload_frame_uniform_buffers(view_proj, queue, cam);
   render_directional_shadows(queue, cam);
+  if (m_post_process_pipeline != nullptr && m_post_process_pipeline->is_capturing()) {
+    m_post_process_pipeline->set_depth_range(cam.get_near(), cam.get_far());
+    m_post_process_pipeline->draw_sky(view_proj, cam.get_position());
+  }
   const float banner_wind_strength = 0.8F + 0.2F * std::sin(m_animation_time * 0.5F);
 
   m_last_bound_shader = nullptr;
@@ -922,6 +934,13 @@ void Backend::execute(const DrawQueue& queue, const Camera& cam) {
 
   m_frame_tracker.mark_complete();
   m_frame_tracker.end_frame();
+}
+
+void Backend::execute(const DrawQueue& queue, const Camera& cam) {
+  execute_scene(queue, cam);
+  if (m_post_process_pipeline != nullptr) {
+    m_post_process_pipeline->resolve_scene();
+  }
 }
 
 } // namespace Render::GL

--- a/render/gl/backend.h
+++ b/render/gl/backend.h
@@ -42,6 +42,7 @@ class CombatDustPipeline;
 class RainPipeline;
 class ModeIndicatorPipeline;
 class GroundMarkerPipeline;
+class PostProcessPipeline;
 class MeshInstancingPipeline;
 } // namespace Render::GL::BackendPipelines
 
@@ -81,6 +82,7 @@ public:
   void set_clear_color(float r, float g, float b, float a) override;
   void set_animation_time(float time) noexcept override { m_animation_time = time; }
   void execute(const DrawQueue& queue, const Camera& cam) override;
+  void execute_scene(const DrawQueue& queue, const Camera& cam);
 
   void set_environment_lighting(const EnvironmentLightingState& lighting) noexcept {
     m_environment_lighting = lighting.sanitized();
@@ -234,6 +236,7 @@ private:
     visit(m_mode_indicator_pipeline);
     visit(m_ground_marker_pipeline);
     visit(m_mesh_instancing_pipeline);
+    visit(m_post_process_pipeline);
   }
 
   template <typename Subsystem, typename... Args>
@@ -274,6 +277,7 @@ private:
   std::unique_ptr<BackendPipelines::ModeIndicatorPipeline> m_mode_indicator_pipeline;
   std::unique_ptr<BackendPipelines::GroundMarkerPipeline> m_ground_marker_pipeline;
   std::unique_ptr<BackendPipelines::MeshInstancingPipeline> m_mesh_instancing_pipeline;
+  std::unique_ptr<BackendPipelines::PostProcessPipeline> m_post_process_pipeline;
 
   Shader* m_basic_shader = nullptr;
   Shader* m_grid_shader = nullptr;

--- a/render/gl/backend/post_process_pipeline.cpp
+++ b/render/gl/backend/post_process_pipeline.cpp
@@ -1,0 +1,342 @@
+#include "post_process_pipeline.h"
+
+#include <QDebug>
+#include <QOpenGLContext>
+#include <QVector2D>
+
+#include <algorithm>
+
+namespace Render::GL::BackendPipelines {
+
+namespace {
+
+constexpr unsigned int k_format_rgba16f = 0x881A;
+constexpr unsigned int k_format_rgba8 = 0x8058;
+
+} // namespace
+
+PostProcessPipeline::PostProcessPipeline(ShaderCache* shader_cache)
+    : m_shader_cache(shader_cache) {
+}
+
+PostProcessPipeline::~PostProcessPipeline() {
+  shutdown();
+}
+
+auto PostProcessPipeline::initialize() -> bool {
+  initializeOpenGLFunctions();
+
+  if (m_shader_cache == nullptr) {
+    return false;
+  }
+
+  m_bright_shader = m_shader_cache->get(QStringLiteral("post_bright"));
+  m_blur_shader = m_shader_cache->get(QStringLiteral("post_blur"));
+  m_composite_shader = m_shader_cache->get(QStringLiteral("post_composite"));
+  m_fxaa_shader = m_shader_cache->get(QStringLiteral("post_fxaa"));
+  m_sky_shader = m_shader_cache->get(QStringLiteral("sky"));
+
+  if (m_bright_shader == nullptr || m_blur_shader == nullptr ||
+      m_composite_shader == nullptr || m_fxaa_shader == nullptr) {
+    qWarning() << "PostProcessPipeline: post shaders unavailable, scene will render "
+                  "without grading";
+    return false;
+  }
+
+  glGenVertexArrays(1, &m_empty_vao);
+  m_initialized = true;
+  return true;
+}
+
+void PostProcessPipeline::shutdown() {
+  if (QOpenGLContext::currentContext() != nullptr) {
+    initializeOpenGLFunctions();
+    release_targets();
+    if (m_empty_vao != 0) {
+      glDeleteVertexArrays(1, &m_empty_vao);
+    }
+  }
+  m_empty_vao = 0;
+  m_initialized = false;
+}
+
+void PostProcessPipeline::cache_uniforms() {
+}
+
+auto PostProcessPipeline::create_color_target(RenderTarget& target,
+                                              int width,
+                                              int height,
+                                              unsigned int internal_format) -> bool {
+  glGenFramebuffers(1, &target.fbo);
+  glGenTextures(1, &target.color);
+
+  glBindTexture(GL_TEXTURE_2D, target.color);
+  glTexImage2D(GL_TEXTURE_2D,
+               0,
+               static_cast<GLint>(internal_format),
+               width,
+               height,
+               0,
+               GL_RGBA,
+               internal_format == k_format_rgba16f ? GL_FLOAT : GL_UNSIGNED_BYTE,
+               nullptr);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, target.fbo);
+  glFramebufferTexture2D(
+      GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, target.color, 0);
+
+  target.width = width;
+  target.height = height;
+  return glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+}
+
+auto PostProcessPipeline::ensure_targets(int width, int height) -> bool {
+  if (m_scene.fbo != 0 && m_scene.width == width && m_scene.height == height) {
+    return true;
+  }
+
+  release_targets();
+
+  const int bloom_width = std::max(width / k_bloom_divisor, 1);
+  const int bloom_height = std::max(height / k_bloom_divisor, 1);
+
+  m_scene_is_float = true;
+  if (!create_color_target(m_scene, width, height, k_format_rgba16f)) {
+    release_targets();
+    m_scene_is_float = false;
+    if (!create_color_target(m_scene, width, height, k_format_rgba8)) {
+      release_targets();
+      return false;
+    }
+  }
+
+  glGenTextures(1, &m_scene_depth);
+  glBindTexture(GL_TEXTURE_2D, m_scene_depth);
+  glTexImage2D(GL_TEXTURE_2D,
+               0,
+               GL_DEPTH_COMPONENT24,
+               width,
+               height,
+               0,
+               GL_DEPTH_COMPONENT,
+               GL_FLOAT,
+               nullptr);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_scene.fbo);
+  glFramebufferTexture2D(
+      GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_scene_depth, 0);
+  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    release_targets();
+    return false;
+  }
+
+  const unsigned int bloom_format =
+      m_scene_is_float ? k_format_rgba16f : k_format_rgba8;
+  for (auto& target : m_bloom) {
+    if (!create_color_target(target, bloom_width, bloom_height, bloom_format)) {
+      release_targets();
+      return false;
+    }
+  }
+
+  if (!create_color_target(m_composite, width, height, k_format_rgba8)) {
+    release_targets();
+    return false;
+  }
+
+  return true;
+}
+
+void PostProcessPipeline::release_targets() {
+  auto drop = [this](RenderTarget& target) {
+    if (target.color != 0) {
+      glDeleteTextures(1, &target.color);
+    }
+    if (target.fbo != 0) {
+      glDeleteFramebuffers(1, &target.fbo);
+    }
+    target = RenderTarget{};
+  };
+
+  drop(m_scene);
+  drop(m_composite);
+  for (auto& target : m_bloom) {
+    drop(target);
+  }
+  if (m_scene_depth != 0) {
+    glDeleteTextures(1, &m_scene_depth);
+    m_scene_depth = 0;
+  }
+}
+
+void PostProcessPipeline::set_depth_range(float near_plane, float far_plane) noexcept {
+  m_near_plane = near_plane;
+  m_far_plane = far_plane;
+}
+
+void PostProcessPipeline::draw_sky(const QMatrix4x4& view_projection,
+                                   const QVector3D& camera_position) {
+  if (!m_initialized || m_sky_shader == nullptr) {
+    return;
+  }
+
+  const GLboolean depth_was_enabled = glIsEnabled(GL_DEPTH_TEST);
+  const GLboolean cull_was_enabled = glIsEnabled(GL_CULL_FACE);
+  glDisable(GL_DEPTH_TEST);
+  glDisable(GL_CULL_FACE);
+  glDepthMask(GL_FALSE);
+
+  m_sky_shader->use();
+  m_sky_shader->set_uniform("u_inverse_view_proj", view_projection.inverted());
+  (void)camera_position;
+  draw_fullscreen();
+
+  glDepthMask(GL_TRUE);
+  if (depth_was_enabled == GL_TRUE) {
+    glEnable(GL_DEPTH_TEST);
+  }
+  if (cull_was_enabled == GL_TRUE) {
+    glEnable(GL_CULL_FACE);
+  }
+}
+
+auto PostProcessPipeline::begin_scene(int width, int height) -> bool {
+  m_capturing = false;
+  if (!m_initialized || m_targets_failed || width <= 0 || height <= 0) {
+    return false;
+  }
+
+  GLint bound_fbo = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &bound_fbo);
+  glGetIntegerv(GL_VIEWPORT, m_output_viewport.data());
+
+  if (!ensure_targets(width, height)) {
+    m_targets_failed = true;
+    qWarning() << "PostProcessPipeline: could not create a" << width << "x" << height
+               << "scene target; falling back to direct rendering";
+    glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(bound_fbo));
+    return false;
+  }
+
+  m_output_fbo = bound_fbo;
+  glBindFramebuffer(GL_FRAMEBUFFER, m_scene.fbo);
+  glViewport(0, 0, width, height);
+  m_capturing = true;
+  return true;
+}
+
+void PostProcessPipeline::draw_fullscreen() {
+  glBindVertexArray(m_empty_vao);
+  glDrawArrays(GL_TRIANGLES, 0, 3);
+  glBindVertexArray(0);
+}
+
+void PostProcessPipeline::blur_bloom_once() {
+  const auto blur_width = static_cast<float>(m_bloom[0].width);
+  const auto blur_height = static_cast<float>(m_bloom[0].height);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_bloom[1].fbo);
+  glViewport(0, 0, m_bloom[1].width, m_bloom[1].height);
+  m_blur_shader->set_uniform("u_texel_step", QVector2D(1.0F / blur_width, 0.0F));
+  glBindTexture(GL_TEXTURE_2D, m_bloom[0].color);
+  draw_fullscreen();
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_bloom[0].fbo);
+  glViewport(0, 0, m_bloom[0].width, m_bloom[0].height);
+  m_blur_shader->set_uniform("u_texel_step", QVector2D(0.0F, 1.0F / blur_height));
+  glBindTexture(GL_TEXTURE_2D, m_bloom[1].color);
+  draw_fullscreen();
+}
+
+void PostProcessPipeline::resolve_scene() {
+  if (!m_capturing) {
+    return;
+  }
+  m_capturing = false;
+
+  const GLboolean depth_was_enabled = glIsEnabled(GL_DEPTH_TEST);
+  const GLboolean blend_was_enabled = glIsEnabled(GL_BLEND);
+  const GLboolean cull_was_enabled = glIsEnabled(GL_CULL_FACE);
+  glDisable(GL_DEPTH_TEST);
+  glDisable(GL_BLEND);
+  glDisable(GL_CULL_FACE);
+
+  glActiveTexture(GL_TEXTURE0);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_bloom[0].fbo);
+  glViewport(0, 0, m_bloom[0].width, m_bloom[0].height);
+  m_bright_shader->use();
+  m_bright_shader->set_uniform("u_scene", 0);
+  m_bright_shader->set_uniform("u_threshold", k_bloom_threshold);
+  m_bright_shader->set_uniform("u_knee", k_bloom_knee);
+  glBindTexture(GL_TEXTURE_2D, m_scene.color);
+  draw_fullscreen();
+
+  m_blur_shader->use();
+  m_blur_shader->set_uniform("u_source", 0);
+  blur_bloom_once();
+  blur_bloom_once();
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_composite.fbo);
+  glViewport(0, 0, m_composite.width, m_composite.height);
+  m_composite_shader->use();
+  m_composite_shader->set_uniform("u_scene", 0);
+  m_composite_shader->set_uniform("u_bloom", 1);
+  m_composite_shader->set_uniform("u_bloom_intensity", k_bloom_intensity);
+  m_composite_shader->set_uniform("u_vignette_strength", k_vignette_strength);
+  m_composite_shader->set_uniform("u_depth", 2);
+  m_composite_shader->set_uniform("u_depth_range",
+                                  QVector2D(m_near_plane, m_far_plane));
+  m_composite_shader->set_uniform(
+      "u_inverse_resolution",
+      QVector2D(1.0F / static_cast<float>(m_composite.width),
+                1.0F / static_cast<float>(m_composite.height)));
+  m_composite_shader->set_uniform("u_ground_ao_radius", k_ground_ao_radius);
+  m_composite_shader->set_uniform("u_ground_ao_strength", k_ground_ao_strength);
+  glActiveTexture(GL_TEXTURE2);
+  glBindTexture(GL_TEXTURE_2D, m_scene_depth);
+  glActiveTexture(GL_TEXTURE1);
+  glBindTexture(GL_TEXTURE_2D, m_bloom[0].color);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, m_scene.color);
+  draw_fullscreen();
+
+  glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(m_output_fbo));
+  glViewport(m_output_viewport[0],
+             m_output_viewport[1],
+             m_output_viewport[2],
+             m_output_viewport[3]);
+  m_fxaa_shader->use();
+  m_fxaa_shader->set_uniform("u_source", 0);
+  m_fxaa_shader->set_uniform("u_inverse_resolution",
+                             QVector2D(1.0F / static_cast<float>(m_composite.width),
+                                       1.0F / static_cast<float>(m_composite.height)));
+  glBindTexture(GL_TEXTURE_2D, m_composite.color);
+  draw_fullscreen();
+
+  glActiveTexture(GL_TEXTURE2);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glActiveTexture(GL_TEXTURE1);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  if (depth_was_enabled == GL_TRUE) {
+    glEnable(GL_DEPTH_TEST);
+  }
+  if (blend_was_enabled == GL_TRUE) {
+    glEnable(GL_BLEND);
+  }
+  if (cull_was_enabled == GL_TRUE) {
+    glEnable(GL_CULL_FACE);
+  }
+}
+
+} // namespace Render::GL::BackendPipelines

--- a/render/gl/backend/post_process_pipeline.h
+++ b/render/gl/backend/post_process_pipeline.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <QMatrix4x4>
+#include <QVector3D>
+
+#include <array>
+
+#include "pipeline_interface.h"
+#include "render/gl/shader.h"
+#include "render/gl/shader_cache.h"
+
+namespace Render::GL::BackendPipelines {
+
+class PostProcessPipeline final : public IPipeline {
+public:
+  explicit PostProcessPipeline(GL::ShaderCache* shader_cache);
+  ~PostProcessPipeline() override;
+
+  auto initialize() -> bool override;
+  void shutdown() override;
+  void cache_uniforms() override;
+  [[nodiscard]] auto is_initialized() const -> bool override { return m_initialized; }
+
+  [[nodiscard]] auto begin_scene(int width, int height) -> bool;
+  void draw_sky(const QMatrix4x4& view_projection, const QVector3D& camera_position);
+  void set_depth_range(float near_plane, float far_plane) noexcept;
+  void resolve_scene();
+
+  [[nodiscard]] auto is_capturing() const noexcept -> bool { return m_capturing; }
+  [[nodiscard]] auto scene_is_high_dynamic_range() const noexcept -> bool {
+    return m_scene_is_float;
+  }
+
+private:
+  struct RenderTarget {
+    unsigned int fbo{0};
+    unsigned int color{0};
+    int width{0};
+    int height{0};
+  };
+
+  auto ensure_targets(int width, int height) -> bool;
+  void release_targets();
+  auto create_color_target(RenderTarget& target,
+                           int width,
+                           int height,
+                           unsigned int internal_format) -> bool;
+  void draw_fullscreen();
+  void blur_bloom_once();
+
+  static constexpr int k_bloom_divisor = 3;
+  static constexpr float k_bloom_threshold = 0.98F;
+  static constexpr float k_bloom_knee = 0.35F;
+  static constexpr float k_bloom_intensity = 0.24F;
+  static constexpr float k_vignette_strength = 0.14F;
+  static constexpr float k_ground_ao_radius = 0.55F;
+  static constexpr float k_ground_ao_strength = 0.62F;
+
+  GL::ShaderCache* m_shader_cache;
+  GL::Shader* m_bright_shader{nullptr};
+  GL::Shader* m_blur_shader{nullptr};
+  GL::Shader* m_composite_shader{nullptr};
+  GL::Shader* m_fxaa_shader{nullptr};
+  GL::Shader* m_sky_shader{nullptr};
+
+  RenderTarget m_scene{};
+  RenderTarget m_composite{};
+  std::array<RenderTarget, 2> m_bloom{};
+  unsigned int m_scene_depth{0};
+  float m_near_plane{1.0F};
+  float m_far_plane{200.0F};
+  unsigned int m_empty_vao{0};
+
+  int m_output_fbo{0};
+  std::array<int, 4> m_output_viewport{{0, 0, 0, 0}};
+  bool m_capturing{false};
+  bool m_scene_is_float{false};
+  bool m_initialized{false};
+  bool m_targets_failed{false};
+};
+
+} // namespace Render::GL::BackendPipelines

--- a/render/gl/backend/vegetation_pipeline_natural.cpp
+++ b/render/gl/backend/vegetation_pipeline_natural.cpp
@@ -109,7 +109,7 @@ void VegetationPipeline::initialize_stone_pipeline() {
                        const QVector3D& b,
                        const QVector3D& c,
                        const QVector3D& d) {
-    QVector3D n = QVector3D::crossProduct(b - a, d - a);
+    QVector3D n = QVector3D::crossProduct(d - a, b - a);
     if (n.lengthSquared() > 1.0e-8F) {
       n.normalize();
     } else {
@@ -121,15 +121,15 @@ void VegetationPipeline::initialize_stone_pipeline() {
     verts.push_back({c, n});
     verts.push_back({d, n});
     idx.push_back(base);
+    idx.push_back(uint16_t(base + 2));
     idx.push_back(uint16_t(base + 1));
-    idx.push_back(uint16_t(base + 2));
     idx.push_back(base);
-    idx.push_back(uint16_t(base + 2));
     idx.push_back(uint16_t(base + 3));
+    idx.push_back(uint16_t(base + 2));
   };
 
   auto emit_tri = [&](const QVector3D& a, const QVector3D& b, const QVector3D& c) {
-    QVector3D n = QVector3D::crossProduct(b - a, c - a);
+    QVector3D n = QVector3D::crossProduct(c - a, b - a);
     if (n.lengthSquared() > 1.0e-8F) {
       n.normalize();
     } else {
@@ -140,8 +140,8 @@ void VegetationPipeline::initialize_stone_pipeline() {
     verts.push_back({b, n});
     verts.push_back({c, n});
     idx.push_back(base);
-    idx.push_back(uint16_t(base + 1));
     idx.push_back(uint16_t(base + 2));
+    idx.push_back(uint16_t(base + 1));
   };
 
   for (int ri = 0; ri < k_rings - 1; ++ri) {

--- a/render/gl/shader_cache.h
+++ b/render/gl/shader_cache.h
@@ -200,6 +200,24 @@ public:
          resolve(shader_base + QStringLiteral("ground_marker.vert")),
          resolve(shader_base + QStringLiteral("ground_marker.frag")));
 
+    const QString post_vert =
+        resolve(shader_base + QStringLiteral("post_fullscreen.vert"));
+    load(QStringLiteral("post_bright"),
+         post_vert,
+         resolve(shader_base + QStringLiteral("post_bright.frag")));
+    load(QStringLiteral("post_blur"),
+         post_vert,
+         resolve(shader_base + QStringLiteral("post_blur.frag")));
+    load(QStringLiteral("post_composite"),
+         post_vert,
+         resolve(shader_base + QStringLiteral("post_composite.frag")));
+    load(QStringLiteral("post_fxaa"),
+         post_vert,
+         resolve(shader_base + QStringLiteral("post_fxaa.frag")));
+    load(QStringLiteral("sky"),
+         post_vert,
+         resolve(shader_base + QStringLiteral("sky.frag")));
+
     load(QStringLiteral("mode_indicator"),
          resolve(shader_base + QStringLiteral("mode_indicator.vert")),
          resolve(shader_base + QStringLiteral("mode_indicator.frag")));

--- a/render/graphics_settings.h
+++ b/render/graphics_settings.h
@@ -66,6 +66,10 @@ struct WeatherBudget {
   float particle_scale = 1.0F;
 };
 
+struct PresentationSettings {
+  int msaa_samples = 4;
+};
+
 struct DirectionalShadowSettings {
   bool enabled = true;
   int cascade_count = 3;
@@ -117,6 +121,9 @@ public:
   }
   [[nodiscard]] auto weather_budget() const noexcept -> const WeatherBudget& {
     return m_weather_budget;
+  }
+  [[nodiscard]] auto presentation() const noexcept -> const PresentationSettings& {
+    return m_presentation;
   }
 
   [[nodiscard]] auto creature_lod_enabled() const noexcept -> bool {
@@ -238,6 +245,7 @@ private:
                                .normal_bias = 0.025F,
                                .cascade_blend = 0.0F};
       m_weather_budget = {.particle_scale = 0.35F};
+      m_presentation = {.msaa_samples = 0};
       break;
 
     case GraphicsQuality::Medium:
@@ -277,6 +285,7 @@ private:
                                .normal_bias = 0.022F,
                                .cascade_blend = 0.08F};
       m_weather_budget = {.particle_scale = 0.60F};
+      m_presentation = {.msaa_samples = 2};
       break;
 
     case GraphicsQuality::High:
@@ -316,6 +325,7 @@ private:
                                .normal_bias = 0.018F,
                                .cascade_blend = 0.12F};
       m_weather_budget = {.particle_scale = 0.85F};
+      m_presentation = {.msaa_samples = 4};
       break;
 
     case GraphicsQuality::Ultra:
@@ -355,6 +365,7 @@ private:
                                .normal_bias = 0.014F,
                                .cascade_blend = 0.15F};
       m_weather_budget = {.particle_scale = 1.00F};
+      m_presentation = {.msaa_samples = 4};
       break;
     }
   }
@@ -381,6 +392,7 @@ private:
   ContactShadowBudget m_contact_shadow_budget{};
   DirectionalShadowSettings m_directional_shadows{};
   WeatherBudget m_weather_budget{};
+  PresentationSettings m_presentation{};
 };
 
 } // namespace Render

--- a/render/sources_gl.cmake
+++ b/render/sources_gl.cmake
@@ -31,6 +31,7 @@ set(RENDER_GL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/gl/backend/healer_aura_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gl/backend/combat_dust_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gl/backend/ground_marker_pipeline.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gl/backend/post_process_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gl/backend/mode_indicator_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gl/backend/rain_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gl/backend/mesh_instancing_pipeline.cpp

--- a/scene/environment_lighting.h
+++ b/scene/environment_lighting.h
@@ -23,8 +23,8 @@ struct EnvironmentLightingState {
   QVector3D fog_color{0.58F, 0.65F, 0.72F};
   float fog_density = 0.0F;
 
-  QVector3D shadow_tint{0.16F, 0.20F, 0.27F};
-  float shadow_strength = 0.72F;
+  QVector3D shadow_tint{0.30F, 0.34F, 0.44F};
+  float shadow_strength = 0.60F;
   float shadow_softness = 0.35F;
 
   float exposure = 1.0F;

--- a/tests/render/graphics_lighting_settings_test.cpp
+++ b/tests/render/graphics_lighting_settings_test.cpp
@@ -30,3 +30,21 @@ TEST(GraphicsLightingSettingsTest, PresetsScaleDirectionalShadowCost) {
 
   graphics.set_quality(Render::GraphicsQuality::High);
 }
+
+TEST(GraphicsLightingSettingsTest, PresetsScaleEdgeAntiAliasing) {
+  auto& graphics = Render::GraphicsSettings::instance();
+
+  graphics.set_quality(Render::GraphicsQuality::Low);
+  EXPECT_EQ(graphics.presentation().msaa_samples, 0);
+
+  graphics.set_quality(Render::GraphicsQuality::Medium);
+  EXPECT_EQ(graphics.presentation().msaa_samples, 2);
+
+  graphics.set_quality(Render::GraphicsQuality::High);
+  EXPECT_EQ(graphics.presentation().msaa_samples, 4);
+
+  graphics.set_quality(Render::GraphicsQuality::Ultra);
+  EXPECT_EQ(graphics.presentation().msaa_samples, 4);
+
+  graphics.set_quality(Render::GraphicsQuality::High);
+}

--- a/tests/render/shader_source_test.cpp
+++ b/tests/render/shader_source_test.cpp
@@ -264,6 +264,51 @@ TEST(ShaderSource, EveryWorldLightingVariantUsesSharedEnvironmentBlock) {
   }
 }
 
+TEST(ShaderSource, WorldShadersLeaveGradingToThePostProcessPass) {
+  const auto root = find_repo_root();
+  const std::vector<std::string> shaders{
+      "basic.frag",
+      "basic_instanced.frag",
+      "character_skinned.frag",
+      "character_skinned_instanced.frag",
+      "terrain_chunk.frag",
+      "ground_plane.frag",
+      "stone_instanced.frag",
+      "pine_instanced.frag",
+      "olive_instanced.frag",
+      "road.frag",
+      "river.frag",
+      "riverbank.frag",
+      "bridge.frag",
+  };
+
+  for (const auto& name : shaders) {
+    const auto source = read_text(root / "assets" / "shaders" / name);
+    ASSERT_FALSE(source.empty()) << name;
+    EXPECT_EQ(source.find("soi_finalize("), std::string::npos)
+        << name << " must write linear radiance; the post pass owns the tone curve";
+  }
+
+  const auto grade =
+      read_text(root / "assets" / "shaders" / "include" / "tonemap.glsl");
+  ASSERT_FALSE(grade.empty());
+  EXPECT_NE(grade.find("vec3 soi_tonemap(vec3 linear_color)"), std::string::npos);
+  EXPECT_NE(grade.find("vec3 soi_grade(vec3 mapped_color)"), std::string::npos);
+  EXPECT_NE(grade.find("vec3 soi_finalize(vec3 linear_color)"), std::string::npos);
+  EXPECT_NE(grade.find("k_soi_grade_shadow_lift"), std::string::npos);
+
+  const auto composite = read_text(root / "assets" / "shaders" / "post_composite.frag");
+  ASSERT_FALSE(composite.empty());
+  EXPECT_NE(composite.find("#include \"tonemap.glsl\""), std::string::npos);
+  EXPECT_NE(composite.find("soi_finalize(combined)"), std::string::npos);
+  EXPECT_NE(composite.find("u_bloom"), std::string::npos);
+  EXPECT_NE(composite.find("u_vignette_strength"), std::string::npos);
+
+  const auto fxaa = read_text(root / "assets" / "shaders" / "post_fxaa.frag");
+  ASSERT_FALSE(fxaa.empty());
+  EXPECT_NE(fxaa.find("u_inverse_resolution"), std::string::npos);
+}
+
 TEST(ShaderSource, GeneralWorldShadersDoNotHardCodeDaylightColors) {
   const auto root = find_repo_root();
   for (const auto* name : {"basic.frag",

--- a/ui/campaign_map_view.cpp
+++ b/ui/campaign_map_view.cpp
@@ -412,8 +412,13 @@ public:
     fmt.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
 
     fmt.setSamples(4);
-    fmt.setSamples(0);
-    return new QOpenGLFramebufferObject(size, fmt);
+    auto* target = new QOpenGLFramebufferObject(size, fmt);
+    if (!target->isValid()) {
+      delete target;
+      fmt.setSamples(0);
+      target = new QOpenGLFramebufferObject(size, fmt);
+    }
+    return target;
   }
 
   void synchronize(QQuickFramebufferObject* item) override {

--- a/ui/gl_view.cpp
+++ b/ui/gl_view.cpp
@@ -448,8 +448,16 @@ auto GLView::GLRenderer::createFramebufferObject(const QSize& size)
 
   QOpenGLFramebufferObjectFormat fmt;
   fmt.setAttachment(QOpenGLFramebufferObject::Depth);
-  fmt.setSamples(0);
-  return new QOpenGLFramebufferObject(size, fmt);
+  int const requested_samples =
+      Render::GraphicsSettings::instance().presentation().msaa_samples;
+  fmt.setSamples(requested_samples);
+  auto* target = new QOpenGLFramebufferObject(size, fmt);
+  if (requested_samples > 0 && !target->isValid()) {
+    delete target;
+    fmt.setSamples(0);
+    target = new QOpenGLFramebufferObject(size, fmt);
+  }
+  return target;
 }
 
 void GLView::GLRenderer::synchronize(QQuickFramebufferObject* item) {


### PR DESCRIPTION
Consolidate the clean, cozy visual direction into a single HDR rendering pass. Add the scene-target post-process pipeline with bright extraction, blur, compositing, tone mapping, and FXAA, and route backend execution through the resolve stage on every frame path.

Centralize stylized environment lighting and linear-radiance output across world, terrain, prop, foliage, and sky shaders. Add depth-aware grounding, readable sky and cloud treatment, tuned day/night/afternoon profiles, snowfield bounce and haze, a cold Iron Sepulcher shadow treatment, terrain hue variation, corrected stone normals, and graphics-settings-driven MSAA.

Register the new shader assets and pipeline sources, document the art-direction controls, and add source-level coverage for the grading boundary and lighting settings. Apply repository formatting to the complete change set.