### PR TITLE
fix: stop a reel ever publishing a black first frame

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,3 +110,11 @@ jobs:
 
       - name: Validator integration tests
         run: bash tests/validator_integration_test.sh
+
+      # Frame zero of a published reel is the thumbnail every social platform
+      # picks up, and a black one has shipped three times now -- most recently
+      # because the advisory card faded its text up from an opaque black fill,
+      # which no reviewer sees without stepping the first sixteen frames. This
+      # needs no compiler, only the ffmpeg the job already installs.
+      - name: Promo first-frame tests
+        run: bash tests/promo_first_frame_test.sh

--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,12 @@ test-validator: build
 		exit 1; \
 	fi
 
+## Assert a published reel never opens on a black thumbnail frame. Needs ffmpeg, not a build.
+.PHONY: test-promo-first-frame
+test-promo-first-frame:
+	@echo "$(BOLD)$(BLUE)Running promo first-frame tests...$(RESET)"
+	@bash tests/promo_first_frame_test.sh
+
 # ---- Formatting (also strips comments via remove-comments.sh) ----
 .PHONY: format format-check format-changed format-check-changed \
 	format-staged format-doctor format-bootstrap clean-format-trash

--- a/docs/PROMO_CAPTURE.md
+++ b/docs/PROMO_CAPTURE.md
@@ -162,9 +162,48 @@ untouched. If a new translucent pass ever shows a bright outline in captures and
 not in the game, check the alpha channel of the poster PNG first — the fringe
 pixels will be the non-opaque ones, and it is not a shading bug.
 
-Note that the _finished cut_ opens on black by design — `promo-edit.py` applies
-an `OPENING_FADE` from black, so a dark first frame there is the edit, not the
-recorder.
+## Frame zero is the thumbnail
+
+Every social platform takes the first frame of an upload as the poster image, so
+a black frame zero is a black thumbnail. This has shipped three times, each time
+from a different layer, so the rule is enforced in three places rather than
+argued about:
+
+- **Nothing in the edit may fade up from black.** `OPENING_FADE` is 0, and a
+  card sitting at timeline zero passes `fade=0.0` to `drawtext` so its text is
+  at full opacity on the very first frame. This is the one that bit last: the
+  advisory card paints an opaque black box over the whole frame for its hold and
+  then faded its text in over the first quarter-second, which is sixteen pure
+  black frames at 60 fps. Nobody sees that in review — the card looks right the
+  moment you scrub anywhere into it.
+- **The check counts visible pixels, not the brightest one.** Peak luma alone
+  passes anything with a single hot sample in it, and film grain over a black
+  card supplies one; a mean would reject a legitimate title card, which is 99%
+  black on purpose. `FIRST_FRAME_MIN_VISIBLE` is the fraction of the frame at or
+  above `FIRST_FRAME_VISIBLE_LUMA`, which separates "an image" from "black with
+  something in it". The shipped advisory card measures about 0.95%.
+- **A refused cut is never left where it publishes.** `promo-edit.py` encodes to
+  `<name>.staging.mp4` and only renames it over `<name>.mp4` once every delivery
+  check has passed; a failure moves it to `<name>.rejected.mp4` and deletes any
+  earlier `<name>.mp4`. Reporting a non-zero exit status is not enough on its
+  own — a reel is cut at the end of a long pipeline, the message scrolls past,
+  and a plausible `.mp4` under the expected name is what gets uploaded.
+
+`tests/promo_first_frame_test.sh` runs the shipped trailer spec through the real
+script on stand-in footage and asserts all of it, including that a black opening
+is refused _and_ leaves nothing uploadable behind. It is in the PR gate, needs no
+compiler, and takes about 25 seconds.
+
+To measure a finished cut by hand:
+
+```sh
+ffmpeg -v info -i trailer.mp4 \
+  -vf "select='lt(n,20)',signalstats,metadata=print:key=lavfi.signalstats.YMAX" \
+  -fps_mode passthrough -f null - 2>&1 | grep YMAX
+```
+
+A run of `YMAX=16` frames at the head is a black opening — 16 is the limited-
+range floor, not a dim image.
 
 ## The commander duel reel
 

--- a/scripts/promo-edit.py
+++ b/scripts/promo-edit.py
@@ -49,8 +49,10 @@ the short is already published:
 
 * **Frame zero is never black.** Platforms use it as the thumbnail, so the cut
   opens hard rather than fading up from black; ``--opening-fade`` restores a
-  fade deliberately. The finished file is read back and the run fails if frame
-  zero is black anyway.
+  fade deliberately, and a card at timeline zero carries its text at full
+  opacity on its first frame. The finished file is read back and measured for
+  how much of it is bright enough to see, because a peak alone passes a black
+  frame with grain on it. See ``docs/PROMO_CAPTURE.md``.
 * **The cut does not flash.** The finished file is measured for mean-luminance
   jumps between frames and refused if it trips a miniature WCAG 2.3.1: any jump
   over ``FLASH_HARD_DELTA``, or more than ``FLASHES_PER_SECOND`` jumps over
@@ -66,7 +68,10 @@ the short is already published:
   ``docs/AUDIO_MASTERING.md``.
 
 Exit status is non-zero when the footage is missing or ffmpeg fails, so this
-can be chained straight after a capture run.
+can be chained straight after a capture run. A cut that fails a delivery check
+is never left at the output path -- it is quarantined as ``<name>.rejected.mp4``
+and any earlier publish is removed, so a failed run cannot leave an uploadable
+file behind for a later step to pick up.
 """
 
 from __future__ import annotations
@@ -87,6 +92,8 @@ CAPTION_FADE = 0.25
 END_CARD_SECONDS = 2.2
 OPENING_FADE = 0.0
 FIRST_FRAME_MIN_PEAK = 8
+FIRST_FRAME_VISIBLE_LUMA = 32
+FIRST_FRAME_MIN_VISIBLE = 0.001
 
 FLASH_DELTA = 25
 FLASH_HARD_DELTA = 60
@@ -250,8 +257,35 @@ def photosensitivity_offence(jumps: list[float], fps: float) -> str | None:
     return None
 
 
-def first_frame_peak(video: Path) -> int:
-    """Brightest sample in frame zero, 0-255, or -1 when it cannot be read."""
+class FirstFrame:
+    """What frame zero looks like to a thumbnail crawler.
+
+    ``peak`` alone cannot answer the question. Film grain over a black card puts
+    a handful of samples above any low threshold, and a title card is legible
+    while being 99% black, so a mean would reject it. What separates "an image"
+    from "black with something in it" is how much of the frame is bright enough
+    to see at all, which is what ``visible_fraction`` counts.
+    """
+
+    __slots__ = ("peak", "visible_fraction")
+
+    def __init__(self, peak: int, visible_fraction: float) -> None:
+        self.peak = peak
+        self.visible_fraction = visible_fraction
+
+    @property
+    def readable(self) -> bool:
+        return (
+            self.peak >= FIRST_FRAME_MIN_PEAK
+            and self.visible_fraction >= FIRST_FRAME_MIN_VISIBLE
+        )
+
+    def describe(self) -> str:
+        return f"peak luma {self.peak}, {self.visible_fraction * 100.0:.3f}% visible"
+
+
+def measure_first_frame(video: Path) -> FirstFrame | None:
+    """Read frame zero back off disk, or None when it cannot be decoded."""
     result = subprocess.run(
         [
             "ffmpeg",
@@ -272,8 +306,10 @@ def first_frame_peak(video: Path) -> int:
         capture_output=True,
     )
     if result.returncode != 0 or not result.stdout:
-        return -1
-    return max(array.array("B", result.stdout))
+        return None
+    samples = array.array("B", result.stdout)
+    visible = sum(1 for sample in samples if sample >= FIRST_FRAME_VISIBLE_LUMA)
+    return FirstFrame(max(samples), visible / len(samples))
 
 
 TRANSITIONS = {
@@ -321,6 +357,35 @@ inscriptional face is the fallback."""
 
 def fail(message: str) -> None:
     print(f"promo-edit: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def reject(staged: Path, output: Path, message: str) -> None:
+    """Refuse a finished encode without leaving it where it would be published.
+
+    The delivery checks can only run on a real encode, so by the time one fails
+    the whole file exists. Publishing it anyway and reporting a non-zero status
+    is not enough: a reel is cut at the end of a long capture pipeline, the
+    message scrolls away, and what is left on disk is a plausible-looking .mp4
+    under exactly the name the upload step expects. So the encode lands beside
+    the output and is only moved into place once every check has passed. A
+    rejected cut is kept for inspection under a name nobody will upload.
+    """
+    quarantine = output.with_suffix(f".rejected{output.suffix}")
+    if staged.is_file():
+        staged.replace(quarantine)
+        kept = f"the rejected cut is at {quarantine} for inspection"
+    else:
+        kept = "no encode survived to inspect"
+    removed = ""
+    if output.is_file():
+        output.unlink()
+        removed = f"\npromo-edit: removed the earlier {output.name}, which is stale"
+    print(
+        f"promo-edit: refusing to publish: {message}\n"
+        f"promo-edit: {kept}; {output.name} was not written{removed}",
+        file=sys.stderr,
+    )
     raise SystemExit(1)
 
 
@@ -389,11 +454,21 @@ def drawtext(
     start: float,
     end: float,
     color: str = "white",
+    fade: float = CAPTION_FADE,
 ) -> str:
-    """A centred, fading caption between two absolute timeline seconds."""
-    fade_in = f"min(1,(t-{start:.3f})/{CAPTION_FADE})"
+    """A centred, fading caption between two absolute timeline seconds.
+
+    ``fade`` of zero makes the text land at full opacity on its first frame,
+    which is what a card sitting at timeline zero needs: a fade-in there is a
+    black frame zero, and frame zero is the thumbnail.
+    """
     fade_out = f"min(1,({end:.3f}-t)/{CAPTION_FADE})"
-    alpha = f"if(between(t,{start:.3f},{end:.3f}),min({fade_in},{fade_out}),0)"
+    if fade <= 0.0:
+        visible = fade_out
+    else:
+        fade_in = f"min(1,(t-{start:.3f})/{fade:.3f})"
+        visible = f"min({fade_in},{fade_out})"
+    alpha = f"if(between(t,{start:.3f},{end:.3f}),{visible},0)"
     return (
         f"drawtext=fontfile='{font}':text='{escape_text(text)}'"
         f":fontcolor={color}:fontsize={size}:x=(w-text_w)/2:y={y_expr}"
@@ -653,6 +728,7 @@ def main() -> int:
     font = resolve_font(args.font)
     output = args.out or args.clips.with_suffix(".mp4")
     output.parent.mkdir(parents=True, exist_ok=True)
+    staged = output.with_suffix(f".staging{output.suffix}")
 
     default_kind, default_seconds = read_transition(
         spec.get("transition"), DEFAULT_TRANSITION, DEFAULT_TRANSITION_SECONDS
@@ -736,9 +812,10 @@ def main() -> int:
                             tracked(line.strip()), font, advisory_size, safe_width
                         ),
                         y_expr=f"h*0.5-{int(advisory_size * 0.6)}+{offset}",
-                        start=0.25,
+                        start=0.0,
                         end=hold,
                         color="white",
+                        fade=0.0,
                     )
                     + f"[advised{line_index}]"
                 )
@@ -967,7 +1044,7 @@ def main() -> int:
         str(manifest.get("fps", 60)),
         "-t",
         f"{total:.3f}",
-        str(output),
+        str(staged),
     ]
 
     blended = [join for join in joins[1:] if join.blended]
@@ -985,36 +1062,48 @@ def main() -> int:
     if workdir is not None:
         workdir.cleanup()
     if result.returncode != 0:
-        fail(f"ffmpeg failed with status {result.returncode}")
+        reject(staged, output, f"ffmpeg failed with status {result.returncode}")
 
-    peak = first_frame_peak(output)
-    if peak < 0:
-        print("promo-edit: warning: could not read the first frame back")
-    elif peak < FIRST_FRAME_MIN_PEAK:
-        fail(
-            f"the first frame of {output} is black (peak luma {peak}); social "
-            "platforms use it as the thumbnail. Check --opening-fade and the "
-            "first shot's framing."
+    first = measure_first_frame(staged)
+    if first is None:
+        reject(
+            staged,
+            output,
+            "the first frame could not be read back, so it cannot be shown to be "
+            "anything but black.",
+        )
+    elif not first.readable:
+        reject(
+            staged,
+            output,
+            f"frame zero is black ({first.describe()}); social platforms use it as "
+            "the thumbnail. An opening card must carry its text at full opacity on "
+            "its first frame rather than fading up, and a shot opening the cut must "
+            "already be lit. Check --opening-fade, the advisory card and the first "
+            "shot's framing.",
         )
 
     fps = float(manifest.get("fps", 60))
-    jumps = luma_jumps(output, fps)
+    jumps = luma_jumps(staged, fps)
     offence = photosensitivity_offence(jumps, fps)
     if not jumps:
         print("promo-edit: warning: could not measure the cut for flashing")
     elif offence is not None and not args.allow_flashes:
-        fail(
-            f"{output} flashes: {offence}. A full-frame flash is a seizure risk, so "
+        reject(
+            staged,
+            output,
+            f"the cut flashes: {offence}. A full-frame flash is a seizure risk, so "
             "this is refused by default. Replace `flash` joins with `dip` (through "
             "black) or `dissolve`, lengthen the join, or pass --allow-flashes if the "
-            "content genuinely needs it."
+            "content genuinely needs it.",
         )
     elif offence is not None:
         print(f"promo-edit: warning: --allow-flashes set; {offence}")
 
+    staged.replace(output)
     worst = max(jumps) if jumps else 0.0
     print(
-        f"promo-edit: wrote {output} (first frame peak luma {peak}, "
+        f"promo-edit: wrote {output} (frame zero {first.describe()}, "
         f"worst luminance jump {worst:.0f}/255)"
     )
     return 0

--- a/tests/promo_first_frame_test.sh
+++ b/tests/promo_first_frame_test.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Frame zero of a published reel is the social-media thumbnail. This asserts the
+# two properties that keep it from being black, against the real promo specs and
+# the real scripts/promo-edit.py.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROMO_EDIT="$REPO_ROOT/scripts/promo-edit.py"
+TRAILER_SPEC="$REPO_ROOT/tools/arena/promos/trailer.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+echo "Promo first-frame tests"
+echo "======================="
+echo ""
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo -e "${RED}✗ ffmpeg is required${NC}"
+  exit 1
+fi
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+CLIPS="$TEMP_DIR/clips"
+mkdir -p "$CLIPS"
+
+# Stand-in footage. The point of the test is the editorial layer the script
+# puts in front of the footage, so a flat mid-grey clip is enough and keeps a
+# 1080p encode down to a couple of seconds. It is deliberately not black.
+for index in 1 2; do
+  ffmpeg -hide_banner -loglevel error -y \
+    -f lavfi -i "color=c=0x6a6a6a:size=1920x1080:rate=60:duration=3" \
+    -c:v libx264 -preset ultrafast -crf 24 -pix_fmt yuv420p \
+    "$CLIPS/0${index}_shot.mp4"
+done
+
+python3 - "$CLIPS" <<'EOF'
+import json
+import sys
+from pathlib import Path
+
+clips = Path(sys.argv[1])
+(clips / "shots.json").write_text(
+    json.dumps(
+        {
+            "width": 1920,
+            "height": 1080,
+            "fps": 60,
+            "shots": [
+                {"name": "card_open", "clip": "01_shot.mp4", "clip_seconds": 3.0},
+                {"name": "valley_reveal", "clip": "02_shot.mp4", "clip_seconds": 3.0},
+            ],
+        }
+    )
+)
+EOF
+
+# The spec drives the opening card, so the test reads the shipped one rather
+# than a copy that could drift away from it. Music and sound effects are
+# dropped because this asserts on picture and their assets are derived.
+python3 - "$TRAILER_SPEC" "$TEMP_DIR/trailer.json" <<'EOF'
+import json
+import sys
+from pathlib import Path
+
+spec = json.loads(Path(sys.argv[1]).read_text())
+spec["shots"] = spec["shots"][:2]
+spec.pop("music", None)
+spec.pop("sfx", None)
+Path(sys.argv[2]).write_text(json.dumps(spec))
+EOF
+
+read_first_frame() {
+  ffmpeg -hide_banner -loglevel error -i "$1" -frames:v 1 \
+    -f rawvideo -pix_fmt gray - 2>/dev/null |
+    python3 -c "
+import sys
+data = sys.stdin.buffer.read()
+visible = sum(1 for sample in data if sample >= 32)
+print(f'{max(data)} {visible / len(data) * 100.0:.4f}')
+"
+}
+
+echo "Test 1: the shipped trailer spec opens on a readable frame..."
+if ! python3 "$PROMO_EDIT" --spec "$TEMP_DIR/trailer.json" --clips "$CLIPS" \
+  --out "$TEMP_DIR/trailer.mp4" --allow-flashes >"$TEMP_DIR/edit.log" 2>&1; then
+  echo -e "${RED}✗ Test 1 failed: promo-edit.py refused the shipped spec${NC}"
+  cat "$TEMP_DIR/edit.log"
+  exit 1
+fi
+if [ ! -f "$TEMP_DIR/trailer.mp4" ]; then
+  echo -e "${RED}✗ Test 1 failed: no output was published${NC}"
+  exit 1
+fi
+STATS=$(read_first_frame "$TEMP_DIR/trailer.mp4")
+PEAK=$(echo "$STATS" | cut -d' ' -f1)
+VISIBLE=$(echo "$STATS" | cut -d' ' -f2)
+if [ "$PEAK" -lt 8 ]; then
+  echo -e "${RED}✗ Test 1 failed: frame zero peak luma is $PEAK${NC}"
+  exit 1
+fi
+echo -e "${GREEN}✓ Test 1 passed: frame zero peak $PEAK, ${VISIBLE}% visible${NC}"
+echo ""
+
+# The card is what regressed before: it paints the frame black for its whole
+# hold, so its text has to be at full opacity on the very first frame. A
+# fade-in there is invisible in review and is a black thumbnail on upload.
+echo "Test 2: the opening card carries its text on frame zero..."
+if ! grep -q "advisory" "$TRAILER_SPEC"; then
+  echo -e "${RED}✗ Test 2 failed: the trailer spec no longer has an advisory${NC}"
+  exit 1
+fi
+CARD_VISIBLE=$(python3 -c "print(1 if float('$VISIBLE') >= 0.1 else 0)")
+if [ "$CARD_VISIBLE" -ne 1 ]; then
+  echo -e "${RED}✗ Test 2 failed: only ${VISIBLE}% of frame zero is above the"
+  echo -e "  visibility floor, so the card is fading up from black${NC}"
+  exit 1
+fi
+echo -e "${GREEN}✓ Test 2 passed: the card is legible on frame zero${NC}"
+echo ""
+
+# A check that only reports is not a guarantee. Publishing a black-opening cut
+# and returning non-zero still leaves an uploadable file under the name the
+# upload step expects, which is how a black frame reached social media before.
+echo "Test 3: a black opening is refused and not left where it publishes..."
+python3 - "$TEMP_DIR/trailer.json" "$TEMP_DIR/black.json" <<'EOF'
+import json
+import sys
+from pathlib import Path
+
+spec = json.loads(Path(sys.argv[1]).read_text())
+spec["advisory"] = ""
+spec["shots"][0].pop("act_title", None)
+Path(sys.argv[2]).write_text(json.dumps(spec))
+EOF
+ffmpeg -hide_banner -loglevel error -y \
+  -f lavfi -i "color=c=black:size=1920x1080:rate=60:duration=3" \
+  -c:v libx264 -preset ultrafast -crf 24 -pix_fmt yuv420p \
+  "$CLIPS/01_shot.mp4"
+rm -f "$TEMP_DIR/black.mp4" "$TEMP_DIR/black.rejected.mp4"
+if python3 "$PROMO_EDIT" --spec "$TEMP_DIR/black.json" --clips "$CLIPS" \
+  --out "$TEMP_DIR/black.mp4" --allow-flashes >"$TEMP_DIR/black.log" 2>&1; then
+  echo -e "${RED}✗ Test 3 failed: a black opening was published${NC}"
+  exit 1
+fi
+if [ -f "$TEMP_DIR/black.mp4" ]; then
+  echo -e "${RED}✗ Test 3 failed: the rejected cut was left at black.mp4,"
+  echo -e "  where an upload step would find it${NC}"
+  exit 1
+fi
+if [ ! -f "$TEMP_DIR/black.rejected.mp4" ]; then
+  echo -e "${RED}✗ Test 3 failed: the rejected cut was not kept for inspection${NC}"
+  exit 1
+fi
+if ! grep -q "frame zero is black" "$TEMP_DIR/black.log"; then
+  echo -e "${RED}✗ Test 3 failed: refused for the wrong reason${NC}"
+  cat "$TEMP_DIR/black.log"
+  exit 1
+fi
+echo -e "${GREEN}✓ Test 3 passed: refused, quarantined, nothing left to upload${NC}"
+echo ""
+
+# A stale reel under the published name is as dangerous as a black one: the
+# upload step cannot tell that the run which should have replaced it failed.
+echo "Test 4: a failed re-cut removes the previous publish..."
+printf 'stale' >"$TEMP_DIR/black.mp4"
+if python3 "$PROMO_EDIT" --spec "$TEMP_DIR/black.json" --clips "$CLIPS" \
+  --out "$TEMP_DIR/black.mp4" --allow-flashes >/dev/null 2>&1; then
+  echo -e "${RED}✗ Test 4 failed: a black opening was published${NC}"
+  exit 1
+fi
+if [ -f "$TEMP_DIR/black.mp4" ]; then
+  echo -e "${RED}✗ Test 4 failed: the stale reel survived a failed re-cut${NC}"
+  exit 1
+fi
+echo -e "${GREEN}✓ Test 4 passed: the stale reel was removed${NC}"
+echo ""
+
+echo "===================================="
+echo -e "${GREEN}All tests passed!${NC}"


### PR DESCRIPTION
The trailer opened on sixteen pure black frames, which is what every social platform took as its thumbnail. The cause is the advisory card, added after the two earlier attempts at this and untouched by both: it fills the frame with opaque black for its whole 3.2s hold but handed its text the standard caption fade, so the text was fully transparent until t=0.25. Measured on a reproduction, frames 0-15 come back at the limited-range floor and nothing else.

Give drawtext a fade parameter and open the advisory at full opacity on frame zero. A card sitting at timeline zero can never fade up, because there is nothing behind it to fade up from.

Count visible pixels instead of the brightest one. The existing guard asked only for a peak of 8, which any single sample satisfies -- film grain over a black card clears it, so the check could not have caught this even once the card was black. Frame zero must now have a tenth of a percent of its area at luma 32 or above. Real reels measure 95-98% and the advisory card 0.95%, so the bar sits an order of magnitude under the tightest legitimate case and no existing reel moves.

Stop leaving a refused cut where it publishes. The delivery checks can only run on a finished encode, and the old code wrote that encode straight to the output path, so a failed run still left a plausible .mp4 under exactly the name the upload step expects, with only a non-zero exit and a message that scrolls past at the end of an hour-long pipeline. That is how a checked black frame still reached an upload. Encode to <name>.staging.mp4, rename over <name>.mp4 only once every check passes, and on failure quarantine it as <name>.rejected.mp4 while deleting any earlier publish, which would otherwise be stale.

Add tests/promo_first_frame_test.sh to the PR gate. It runs the shipped trailer spec through the real script on stand-in footage and asserts frame zero is readable, that a black opening is refused, that the refusal leaves nothing uploadable, and that a failed re-cut removes the previous publish. Reverting the drawtext change fails it. It needs ffmpeg, which the job already installs, no compiler, and takes about 25 seconds.