### PR TITLE
Fix dirty mode indicator silhouettes and shading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,7 +291,7 @@ than as something you compile yourself.
   shaders.
 - A CPU rasteriser fallback (`--force-software`) for machines without a 3.3
   driver. It is a diagnostic, not a supported way to play.
-- The "Iron and Ember" interface: activity medallions, Roman numerals, and a
+- The "Iron and Ember" interface: activity markers, Roman numerals, and a
   selection summary that regroups itself as a selection grows.
 
 ### Accessibility

--- a/assets/shaders/campaign_badge.frag
+++ b/assets/shaders/campaign_badge.frag
@@ -52,7 +52,7 @@ float sd_banner(vec2 p) {
   return max(rect, -v_cut);
 }
 
-float sd_medallion(vec2 p) {
+float sd_round_badge(vec2 p) {
 
   float r = 0.42;
   float d = length(p) - r;
@@ -98,7 +98,7 @@ float get_badge_sdf(vec2 p, int style) {
   if (style == 3)
     return sd_shield(p);
   if (style == 4)
-    return sd_medallion(p);
+    return sd_round_badge(p);
   return sd_circle(p, 0.4);
 }
 

--- a/assets/shaders/include/activity_indicator.glsl
+++ b/assets/shaders/include/activity_indicator.glsl
@@ -20,14 +20,13 @@ vec4 activity_indicator_shade(float layer,
   float breathe = 0.5 + 0.5 * sin(time * 2.0 + phase);
 
   if (layer < 0.5) {
-
-    float strength = mix(0.42, 0.05, clamp(radial, 0.0, 1.0));
+    float edge = smoothstep(0.0, 1.0, clamp(radial, 0.0, 1.0));
+    float strength = mix(0.24, 0.0, edge);
     return vec4(vec3(0.0), alpha * strength);
   }
 
   if (layer < 1.5) {
-
-    vec3 outline = mix(vec3(0.010), tint * 0.13, 0.45);
+    vec3 outline = mix(vec3(0.018), tint * 0.16, 0.32);
     return vec4(outline, clamp(alpha, 0.0, 1.0));
   }
 
@@ -38,28 +37,25 @@ vec4 activity_indicator_shade(float layer,
   float gloss;
   float rim = 0.0;
   if (layer < 2.5) {
-    vec3 lit = mix(tint, vec3(1.0), 0.20);
-
-    vec3 deep = mix(tint, vec3(0.0), 0.26);
+    vec3 lit = mix(tint, vec3(1.0), 0.14);
+    vec3 deep = mix(tint, vec3(0.0), 0.12);
     base = mix(deep, lit, smooth_sheen);
-    gloss = 0.70;
-
-    rim = pow(smooth_sheen, 7.0) * 0.30;
+    gloss = 0.42;
+    rim = pow(smooth_sheen, 7.0) * 0.12;
   } else if (layer < 3.5) {
-    base = mix(tint, vec3(1.0), 0.55);
-    gloss = 1.05;
+    base = mix(tint, vec3(1.0), 0.42);
+    gloss = 0.72;
   } else {
-
-    base = mix(tint, vec3(0.0), mix(0.72, 0.46, smooth_sheen));
-    gloss = 0.35;
+    base = mix(tint, vec3(0.0), mix(0.42, 0.28, smooth_sheen));
+    gloss = 0.22;
   }
 
-  float ambient = 0.42 + 0.14 * (normal.z * 0.5 + 0.5);
-  vec3 color = base * (ambient + 0.60 * lambert);
-  color += vec3(1.0) * specular * gloss * 0.42;
-  color += tint * fresnel * 0.30;
+  float ambient = 0.58 + 0.12 * (normal.z * 0.5 + 0.5);
+  vec3 color = base * (ambient + 0.38 * lambert);
+  color += vec3(1.0) * specular * gloss * 0.24;
+  color += tint * fresnel * 0.14;
   color += mix(tint, vec3(1.0), 0.7) * rim;
-  color *= 0.96 + 0.08 * breathe;
+  color *= 0.985 + 0.03 * breathe;
 
   return vec4(color, clamp(alpha, 0.0, 1.0));
 }

--- a/assets/shaders/mode_indicator.vert
+++ b/assets/shaders/mode_indicator.vert
@@ -19,7 +19,7 @@ void main() {
   v_radial = a_tex_coord.y;
   v_phase = 0.0;
 
-  float pulse = 1.0 + 0.015 * sin(u_time * 2.0);
+  float pulse = 1.0 + 0.006 * sin(u_time * 2.0);
   vec3 pos = vec3(a_position.xy * pulse, a_position.z);
   v_height = a_position.y * 2.0;
 

--- a/assets/shaders/mode_indicator_instanced.vert
+++ b/assets/shaders/mode_indicator_instanced.vert
@@ -42,7 +42,7 @@ void main() {
   v_instance_color = a_instance_color_alpha.rgb;
   v_instance_alpha = a_instance_color_alpha.a;
 
-  float pulse = 1.0 + 0.015 * sin(u_time * 2.0 + v_phase);
+  float pulse = 1.0 + 0.006 * sin(u_time * 2.0 + v_phase);
   vec3 pos = vec3(a_position.xy * pulse, a_position.z);
   v_height = a_position.y * 2.0;
 

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -130,9 +130,9 @@ order states — active, queued, unavailable, interrupted — never rely on colo
 alone:
 
 - **Shape.** A queued order carries a filled chevron in the corner of the
-  medallion, an interrupted one a pair of paused bars, an unavailable one a
+  marker, an interrupted one a pair of paused bars, an unavailable one a
   cross. An active order carries no corner mark at all.
-- **Weight.** Anything other than an active order also thickens the medallion
+- **Weight.** Anything other than an active order also thickens the marker
   border, so the difference survives a greyscale screenshot.
 - **Words.** Every marker exposes `Accessible.name` (the activity and its state)
   and `Accessible.description` (the same, plus the headcount when the marker

--- a/docs/RENDERING_ARCHITECTURE.md
+++ b/docs/RENDERING_ARCHITECTURE.md
@@ -902,23 +902,20 @@ text in the HUD. The simulation writes the result into
 which is why the renderer classifies nothing itself and touches no gameplay
 component to decide what to draw.
 
-Every one of them is the same medallion -- a soft drop shadow, a tinted halo, a
-dark contour, a near-neutral plaque, and a bevelled rim carrying the activity
-colour -- with a different icon stamped on its face. `add_medallion()` in
-`render/geom/mode_indicator.cpp` emits that frame first and the icon rides on top
-of it, which is what gives sixteen unrelated symbols one silhouette and one
-optical weight.
+Every one of them uses the same rendering treatment -- a soft drop shadow and a
+dark contour carrying the activity colour -- with a different icon. The shared
+glyph builder gives sixteen unrelated symbols one optical weight.
 
 The icons themselves are generated, not authored. `render/geom/icon_glyph.cpp`
 is a small vector builder -- bars, arcs, rings, convex polygons, arrow heads --
 and `mode_indicator.cpp` describes each icon as a handful of calls against it.
 `begin_glyph()`/`end_glyph()` records those flat shapes and turns them into a
-solid: it extracts the silhouette (the boundary edges of the recorded triangle
-soup), extrudes side walls along it, and lays a dark outline skirt outward from
-it. Everything an icon needs comes from its silhouette, so a new one is a few
-lines of 2D drawing and nothing else -- it does not even need to be drawn at the
-right size, because `fit_since()` scales whatever was emitted after the medallion
-down to a single radius that clears the rim.
+solid. It first unions overlapping bars, discs and polygons into one clean
+silhouette, then extrudes side walls and lays a narrow contour and offset shadow
+around only the exterior boundary. Internal primitive edges therefore never
+become dark seams. A new icon is still only a few lines of 2D drawing, and it
+does not need to be drawn at the right size because `fit_since()` scales the
+emitted geometry down to the shared footprint.
 
 Four properties are worth knowing before changing anything here:
 

--- a/render/equipment/weapons/shield_carthage.cpp
+++ b/render/equipment/weapons/shield_carthage.cpp
@@ -140,11 +140,12 @@ auto carthage_shield_archetype(float scale_multiplier) -> const RenderArchetype&
 
   QVector3D const emblem_plane =
       shield_center + QVector3D(0.0F, 0.0F, dome_depth * 0.92F);
-  QMatrix4x4 medallion;
-  medallion.translate(emblem_plane);
-  medallion.scale(shield_radius * 0.34F, shield_radius * 0.34F, shield_radius * 0.08F);
+  QMatrix4x4 emblem_disc;
+  emblem_disc.translate(emblem_plane);
+  emblem_disc.scale(
+      shield_radius * 0.34F, shield_radius * 0.34F, shield_radius * 0.08F);
   builder.add_palette_mesh(
-      get_unit_cylinder(), medallion, k_trim_slot, nullptr, 1.0F, 4);
+      get_unit_cylinder(), emblem_disc, k_trim_slot, nullptr, 1.0F, 4);
 
   QVector3D const emblem_body_top =
       emblem_plane + QVector3D(0.0F, shield_radius * 0.14F, 0.0F);

--- a/render/geom/icon_glyph.cpp
+++ b/render/geom/icon_glyph.cpp
@@ -1,9 +1,10 @@
 #include "icon_glyph.h"
 
+#include <QPainterPath>
+#include <QPointF>
+
 #include <algorithm>
 #include <cmath>
-#include <cstdint>
-#include <map>
 #include <utility>
 #include <vector>
 
@@ -112,16 +113,18 @@ void GlyphBuilder::end_glyph(const GlyphExtrusion& extrusion) {
   GlyphLayer const saved_layer = m_layer;
   auto const edges = collect_boundary_edges();
 
-  emit_silhouette(GlyphLayer::Shadow,
-                  extrusion.shadow_depth,
-                  extrusion.halo_grow,
-                  extrusion.shadow_offset,
-                  1.0F);
-  emit_silhouette(GlyphLayer::Shadow,
-                  extrusion.shadow_depth,
-                  extrusion.shadow_grow,
-                  extrusion.shadow_offset,
-                  0.0F);
+  auto shadow_edges = edges;
+  for (BoundaryEdge& edge : shadow_edges) {
+    edge.from += extrusion.shadow_offset;
+    edge.to += extrusion.shadow_offset;
+  }
+  emit_skirt(shadow_edges,
+             GlyphLayer::Shadow,
+             extrusion.shadow_depth,
+             0.0F,
+             extrusion.shadow_width,
+             0.0F,
+             1.0F);
 
   emit_skirt(edges,
              GlyphLayer::Outline,
@@ -145,57 +148,51 @@ void GlyphBuilder::end_glyph(const GlyphExtrusion& extrusion) {
 }
 
 auto GlyphBuilder::collect_boundary_edges() const -> std::vector<BoundaryEdge> {
-  constexpr float k_quantum = 4096.0F;
-  auto key_of = [](QVector2D point) -> std::int64_t {
-    auto const x = static_cast<std::int64_t>(std::lround(point.x() * k_quantum));
-    auto const y = static_cast<std::int64_t>(std::lround(point.y() * k_quantum));
-    return (x << 32) ^ (y & 0xFFFFFFFFLL);
-  };
-
-  struct Tally {
-    BoundaryEdge edge;
-    int uses = 0;
-  };
-
-  std::map<std::pair<std::int64_t, std::int64_t>, Tally> tallies;
-
+  QPainterPath silhouette;
+  silhouette.setFillRule(Qt::WindingFill);
   for (PendingTri const& tri : m_recorded) {
-    QVector2D a = tri.a;
-    QVector2D b = tri.b;
-    QVector2D c = tri.c;
-    float const area =
-        (b.x() - a.x()) * (c.y() - a.y()) - (c.x() - a.x()) * (b.y() - a.y());
-    if (std::abs(area) < 1.0e-9F) {
-      continue;
-    }
-    if (area < 0.0F) {
-      std::swap(b, c);
-    }
-
-    const QVector2D corners[3] = {a, b, c};
-    for (int i = 0; i < 3; ++i) {
-      QVector2D const from = corners[i];
-      QVector2D const to = corners[(i + 1) % 3];
-      std::int64_t const key_from = key_of(from);
-      std::int64_t const key_to = key_of(to);
-      std::int64_t const key_low = std::min(key_from, key_to);
-      std::int64_t const key_high = std::max(key_from, key_to);
-
-      auto [it, inserted] = tallies.try_emplace({key_low, key_high},
-                                                Tally{BoundaryEdge{from, to, {}}, 0});
-      if (inserted) {
-        QVector2D const along = to - from;
-        it->second.edge.outward = QVector2D(along.y(), -along.x()).normalized();
-      }
-      ++it->second.uses;
+    QPainterPath triangle;
+    triangle.moveTo(tri.a.x(), tri.a.y());
+    triangle.lineTo(tri.b.x(), tri.b.y());
+    triangle.lineTo(tri.c.x(), tri.c.y());
+    triangle.closeSubpath();
+    if (silhouette.isEmpty()) {
+      silhouette = triangle;
+    } else {
+      silhouette = silhouette.united(triangle);
     }
   }
 
+  constexpr float k_probe_distance = 0.001F;
   std::vector<BoundaryEdge> edges;
-  edges.reserve(tallies.size());
-  for (auto const& [key, tally] : tallies) {
-    if (tally.uses == 1) {
-      edges.push_back(tally.edge);
+  for (QPolygonF const& contour : silhouette.toSubpathPolygons()) {
+    if (contour.size() < 3) {
+      continue;
+    }
+    qsizetype count = contour.size();
+    if (contour.front() == contour.back()) {
+      --count;
+    }
+    for (qsizetype i = 0; i < count; ++i) {
+      QPointF const& from_point = contour[i];
+      QPointF const& to_point = contour[(i + 1) % count];
+      QVector2D const from(static_cast<float>(from_point.x()),
+                           static_cast<float>(from_point.y()));
+      QVector2D const to(static_cast<float>(to_point.x()),
+                         static_cast<float>(to_point.y()));
+      QVector2D const along = to - from;
+      if (along.lengthSquared() <= 1.0e-10F) {
+        continue;
+      }
+
+      QVector2D outward(along.y(), -along.x());
+      outward.normalize();
+      QVector2D const midpoint = (from + to) * 0.5F;
+      QVector2D const probe = midpoint + outward * k_probe_distance;
+      if (silhouette.contains(QPointF(probe.x(), probe.y()))) {
+        outward = -outward;
+      }
+      edges.push_back({from, to, outward});
     }
   }
   return edges;
@@ -214,39 +211,6 @@ void GlyphBuilder::emit_glyph_walls(const std::vector<BoundaryEdge>& edges,
     QVector3D const p3(edge.from.x(), edge.from.y(), face_depth);
     emit_positioned(p0, p1, p2, normal, normal, normal);
     emit_positioned(p0, p2, p3, normal, normal, normal);
-  }
-}
-
-void GlyphBuilder::emit_silhouette(
-    GlyphLayer layer, float depth, float grow, QVector2D offset, float shade) {
-  if (m_recorded.empty() || grow <= 0.0F) {
-    return;
-  }
-
-  QVector2D low(m_recorded.front().a);
-  QVector2D high(m_recorded.front().a);
-  auto extend = [&](QVector2D point) {
-    low.setX(std::min(low.x(), point.x()));
-    low.setY(std::min(low.y(), point.y()));
-    high.setX(std::max(high.x(), point.x()));
-    high.setY(std::max(high.y(), point.y()));
-  };
-  for (PendingTri const& tri : m_recorded) {
-    extend(tri.a);
-    extend(tri.b);
-    extend(tri.c);
-  }
-  QVector2D const center = (low + high) * 0.5F;
-
-  float const scale = 1.0F + grow;
-  auto place = [&](QVector2D point) {
-    return center + (point - center) * scale + offset;
-  };
-
-  for (PendingTri const& tri : m_recorded) {
-    for (QVector2D const point : {place(tri.a), place(tri.b), place(tri.c)}) {
-      push_skirt_vertex(layer, point, depth, shade);
-    }
   }
 }
 
@@ -273,7 +237,7 @@ void GlyphBuilder::emit_skirt(const std::vector<BoundaryEdge>& edges,
     return;
   }
 
-  constexpr int k_corner_segments = 12;
+  constexpr int k_corner_segments = 8;
 
   for (BoundaryEdge const& edge : edges) {
     QVector2D const inner_from = edge.from + edge.outward * inner_offset;

--- a/render/geom/icon_glyph.h
+++ b/render/geom/icon_glyph.h
@@ -51,8 +51,7 @@ public:
     float face_depth = 0.0F;
 
     float shadow_depth = 0.0F;
-    float shadow_grow = 0.0F;
-    float halo_grow = 0.0F;
+    float shadow_width = 0.0F;
     QVector2D shadow_offset{};
   };
 
@@ -106,8 +105,6 @@ private:
   };
 
   [[nodiscard]] auto collect_boundary_edges() const -> std::vector<BoundaryEdge>;
-  void emit_silhouette(
-      GlyphLayer layer, float depth, float grow, QVector2D offset, float shade);
   void emit_glyph_walls(const std::vector<BoundaryEdge>& edges,
                         float back_depth,
                         float face_depth);

--- a/render/geom/mode_indicator.cpp
+++ b/render/geom/mode_indicator.cpp
@@ -13,19 +13,18 @@ namespace {
 
 constexpr float k_pi = std::numbers::pi_v<float>;
 
-constexpr float k_glyph_fit_radius = 0.360F;
-constexpr float k_glyph_face_depth = 0.105F;
-constexpr float k_glyph_detail_depth = 0.118F;
+constexpr float k_glyph_fit_radius = 0.380F;
+constexpr float k_glyph_face_depth = 0.072F;
+constexpr float k_glyph_detail_depth = 0.086F;
 
 constexpr GlyphBuilder::GlyphExtrusion k_glyph_extrusion{
-    .outline_depth = 0.030F,
-    .outline_width = 0.034F,
-    .back_depth = 0.030F,
+    .outline_depth = 0.018F,
+    .outline_width = 0.026F,
+    .back_depth = 0.020F,
     .face_depth = k_glyph_face_depth,
-    .shadow_depth = -0.070F,
-    .shadow_grow = 0.046F,
-    .halo_grow = 0.112F,
-    .shadow_offset = {0.008F, -0.020F},
+    .shadow_depth = -0.022F,
+    .shadow_width = 0.046F,
+    .shadow_offset = {0.012F, -0.022F},
 };
 
 struct KindStyle {

--- a/tests/render/mode_indicator_test.cpp
+++ b/tests/render/mode_indicator_test.cpp
@@ -66,6 +66,40 @@ TEST(ModeIndicator, EveryNoteworthyActivityHasGlyphGeometry) {
   }
 }
 
+TEST(ModeIndicator, OverlappingPrimitivesProduceOnlyExteriorSideWalls) {
+  Render::Geom::GlyphBuilder builder;
+  builder.begin_glyph();
+  builder.bar({-0.40F, 0.0F}, {0.40F, 0.0F}, 0.16F);
+  builder.bar({0.0F, -0.40F}, {0.0F, 0.40F}, 0.16F);
+  builder.end_glyph({.back_depth = 0.01F, .face_depth = 0.05F});
+
+  auto inside_cross = [](float x, float y) {
+    constexpr float half_width = 0.08F;
+    constexpr float half_length = 0.40F;
+    return (std::abs(x) < half_length && std::abs(y) < half_width) ||
+           (std::abs(x) < half_width && std::abs(y) < half_length);
+  };
+
+  auto const& vertices = builder.vertices();
+  auto const& indices = builder.indices();
+  constexpr float probe = 0.012F;
+  for (std::size_t i = 0; i + 2U < indices.size(); i += 3U) {
+    auto const& a = vertices[indices[i]];
+    if (static_cast<int>(a.tex_coord[0]) != static_cast<int>(GlyphLayer::GlyphSide)) {
+      continue;
+    }
+    auto const& b = vertices[indices[i + 1U]];
+    auto const& c = vertices[indices[i + 2U]];
+    float const x = (a.position[0] + b.position[0] + c.position[0]) / 3.0F;
+    float const y = (a.position[1] + b.position[1] + c.position[1]) / 3.0F;
+    bool const touches_exterior =
+        !inside_cross(x + probe, y) || !inside_cross(x - probe, y) ||
+        !inside_cross(x, y + probe) || !inside_cross(x, y - probe);
+    EXPECT_TRUE(touches_exterior)
+        << "side wall remained inside the merged glyph at " << x << ", " << y;
+  }
+}
+
 TEST(ModeIndicator, ItemsShareOneNormalisedFootprint) {
   for (IndicatorKind const kind : all_kinds()) {
     auto const builder = Render::Geom::build_indicator_glyph(kind);

--- a/ui/campaign_map_render_utils.h
+++ b/ui/campaign_map_render_utils.h
@@ -464,7 +464,7 @@ enum class BadgeStyle {
   Seal,
   Banner,
   Shield,
-  Medallion
+  Round
 };
 
 struct MissionBadgeConfig {
@@ -529,9 +529,9 @@ inline auto generate_banner_badge(const QVector2D& center,
   return verts;
 }
 
-inline auto generate_medallion_badge(const QVector2D& center,
-                                     float size,
-                                     int segments = 24) -> std::vector<QVector2D> {
+inline auto generate_round_badge(const QVector2D& center,
+                                 float size,
+                                 int segments = 24) -> std::vector<QVector2D> {
   std::vector<QVector2D> verts;
   verts.reserve(static_cast<size_t>(segments + 1));
 

--- a/ui/qml/design/controls/IronActivityIcon.qml
+++ b/ui/qml/design/controls/IronActivityIcon.qml
@@ -52,7 +52,7 @@ Item {
         spacing: Design.Metrics.space8
 
         Item {
-            id: medallion
+            id: indicatorFrame
 
             width: root.glyphSize + Design.Metrics.space8
             height: width


### PR DESCRIPTION
Collapse overlapping glyph primitives into a single unioned silhouette so contour and extrusion geometry follow only the exterior boundary. Replace per-triangle translucent shadow replay with a narrow exterior skirt, removing accumulated alpha and internal walls that made indicators read as dirty blobs. Tune depth, outline, shadow, lighting, specular, rim, and pulse parameters for a flatter and cleaner visual hierarchy. Add regression coverage for overlapping primitives, update rendering documentation, and remove stale terminology from related UI, shader, and accessibility references.