### PR TITLE
movement: formations face their travel intent, soldiers hold contact yaw

### DIFF
--- a/docs/COMBAT_SYSTEM.md
+++ b/docs/COMBAT_SYSTEM.md
@@ -307,6 +307,35 @@ Combat::deal_damage()
 
 when the attack connects.
 
+### Soldiers do not whip when an engagement drops
+
+`publish_formation_presentation` turns each engaged soldier toward its
+opponent's slot at 300 degrees per second. Engagement pairs are re-derived every
+tick, so in a dense press a soldier's pair can vanish for a few ticks and come
+back; the first version turned him straight back to the rank's facing the tick
+the pair dropped and out again when it returned — measured at ~6,400
+turn-and-return whips over one `massed_battle_1000` run, ±70 degrees in 0.2 s.
+An unassigned soldier now holds his last contact yaw for
+`k_contact_yaw_hold_seconds` (0.6 s) and only then turns back at
+`k_disengage_turn_degrees` (120 deg/s); `FormationSoldierPresentation::
+unassigned_seconds` carries the timer between ticks. Position already eased
+(`k_max_reposition_speed`), yaw was the only value that snapped.
+
+The formation's own facing has a related rule in `MovementSystem`
+(`heading_reference`): a formation with a movement target faces its
+**intended travel direction** — the current waypoint — not its instantaneous
+velocity, and without a target velocity steers it only above
+`k_formation_heading_min_speed` (0.4 m/s, or a quarter of the unit's speed).
+The first cut of the massed reel showed formations jammed behind their own
+front line pivoting on every shove local avoidance gave them: they were
+stopped, lurching at 0-1 m/s, and their yaw tracked whatever direction the
+last push had. The moonwalk guard (`heading_translation_scale`) measures the
+body's facing against the same reference, so a formation facing its waypoint
+still slides freely when the crowd pushes it sideways, while a body that has
+been ordered about-face still turns before it walks. Measured with
+`arena_app --animation-diagnostics` on `massed_battle_1000`: soldier
+turn-and-return whips over the run went from ~6,400 to ~1,850.
+
 ## Deterministic Visual Variation
 
 Combat visuals may appear random, but their variation should remain deterministic.

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -1971,6 +1971,7 @@ struct FormationSoldierPresentation {
   float combat_phase_bias{0.0F};
   float combat_speed_scale{1.0F};
   bool damage_carrier{false};
+  float unassigned_seconds{0.0F};
 
   auto operator==(const FormationSoldierPresentation&) const -> bool = default;
 };

--- a/game/systems/combat_system/formation_contact_processor.cpp
+++ b/game/systems/combat_system/formation_contact_processor.cpp
@@ -24,6 +24,8 @@ using FrontMap = std::unordered_map<Engine::Core::EntityID,
 constexpr float k_target_switch_hysteresis = 0.35F;
 
 constexpr float k_max_reposition_speed = 1.8F;
+constexpr float k_contact_yaw_hold_seconds = 0.6F;
+constexpr float k_disengage_turn_degrees = 120.0F;
 
 struct PairEvaluation {
   std::uint64_t signature{0};
@@ -708,6 +710,22 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
         }
       } else {
         directive.action = Engine::Core::FormationSoldierAction::FollowUnit;
+      }
+
+      bool const assigned = assignment.front != nullptr && assignment.pair != nullptr;
+      if (!assigned && previous != nullptr && directive.alive) {
+        directive.unassigned_seconds =
+            std::min(previous->unassigned_seconds + std::max(0.0F, delta_time),
+                     k_contact_yaw_hold_seconds + 1.0F);
+        if (directive.unassigned_seconds < k_contact_yaw_hold_seconds) {
+          directive.local_yaw = previous->local_yaw;
+        } else {
+          float const yaw_delta =
+              std::remainder(directive.local_yaw - previous->local_yaw, 360.0F);
+          float const max_turn = k_disengage_turn_degrees * std::max(0.0F, delta_time);
+          directive.local_yaw =
+              previous->local_yaw + std::clamp(yaw_delta, -max_turn, max_turn);
+        }
       }
 
       if (previous != nullptr && directive.alive) {

--- a/game/systems/movement_system.cpp
+++ b/game/systems/movement_system.cpp
@@ -39,6 +39,9 @@ constexpr float k_duel_footwork_period_seconds = 9.0F;
 constexpr float k_duel_footwork_turn_degrees_per_second = 360.0F;
 constexpr float k_duel_min_reach_sq = 0.04F;
 constexpr float desired_yaw_turn_speed_degrees = 720.0F;
+constexpr float k_formation_heading_min_speed = 0.4F;
+constexpr float k_formation_heading_speed_fraction = 0.25F;
+constexpr float k_formation_intent_min_distance = 1.0F;
 constexpr float full_translation_heading_error_degrees = 20.0F;
 constexpr float stopped_translation_heading_error_degrees = 100.0F;
 
@@ -56,13 +59,45 @@ auto formation_turn_speed_degrees(const Engine::Core::Entity& entity,
   return std::clamp(derived, 30.0F, single_body_turn_speed);
 }
 
-auto heading_translation_scale(float yaw_degrees, float vx, float vz) -> float {
-  if (vx * vx + vz * vz <= 1.0e-5F) {
+struct HeadingReference {
+  bool valid{false};
+  float yaw{0.0F};
+};
+
+auto heading_reference(const Engine::Core::Entity& entity,
+                       const Engine::Core::TransformComponent& transform,
+                       const Engine::Core::MovementComponent& movement,
+                       const Engine::Core::UnitComponent* unit) -> HeadingReference {
+  bool const formation =
+      unit != nullptr && FormationCombat::has_formation_slots(entity);
+  if (formation && movement.get_has_target()) {
+    float const intent_x = movement.get_target_x() - transform.position.x;
+    float const intent_z = movement.get_target_y() - transform.position.z;
+    if (intent_x * intent_x + intent_z * intent_z >
+        k_formation_intent_min_distance * k_formation_intent_min_distance) {
+      return {true,
+              std::atan2(intent_x, intent_z) * 180.0F / std::numbers::pi_v<float>};
+    }
+  }
+  float const vx = movement.get_vx();
+  float const vz = movement.get_vz();
+  float const speed2 = vx * vx + vz * vz;
+  float const min_speed =
+      formation ? std::max(k_formation_heading_min_speed,
+                           unit->speed * k_formation_heading_speed_fraction)
+                : 0.0F;
+  if (speed2 <= std::max(1.0e-5F, min_speed * min_speed)) {
+    return {};
+  }
+  return {true, std::atan2(vx, vz) * 180.0F / std::numbers::pi_v<float>};
+}
+
+auto heading_translation_scale(float yaw_degrees, HeadingReference reference) -> float {
+  if (!reference.valid) {
     return 1.0F;
   }
-  float const velocity_yaw = std::atan2(vx, vz) * 180.0F / std::numbers::pi_v<float>;
   float const error =
-      std::fabs(std::fmod((velocity_yaw - yaw_degrees + 540.0F), 360.0F) - 180.0F);
+      std::fabs(std::fmod((reference.yaw - yaw_degrees + 540.0F), 360.0F) - 180.0F);
   return 1.0F - std::clamp((error - full_translation_heading_error_degrees) /
                                (stopped_translation_heading_error_degrees -
                                 full_translation_heading_error_degrees),
@@ -207,8 +242,6 @@ void finalize_orientation(Engine::Core::Entity* entity,
     return;
   }
 
-  float const speed2 =
-      movement->get_vx() * movement->get_vx() + movement->get_vz() * movement->get_vz();
   auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
   float const turn_speed =
       (unit != nullptr ? formation_turn_speed_degrees(
@@ -218,9 +251,9 @@ void finalize_orientation(Engine::Core::Entity* entity,
 
   bool const shell_holds_its_face =
       DefensiveUnitLayoutService::holds_position(*entity) && transform->has_desired_yaw;
-  if (speed2 > 1e-5F && !shell_holds_its_face) {
-    float const target_yaw = std::atan2(movement->get_vx(), movement->get_vz()) *
-                             180.0F / std::numbers::pi_v<float>;
+  auto const reference = heading_reference(*entity, *transform, *movement, unit);
+  if (reference.valid && !shell_holds_its_face) {
+    float const target_yaw = reference.yaw;
     float const current = transform->rotation.y;
     float const diff = std::fmod((target_yaw - current + 540.0F), 360.0F) - 180.0F;
     float const step =
@@ -707,7 +740,9 @@ void MovementSystem::move_unit(Engine::Core::Entity* entity,
   float const old_z = transform->position.z;
   float const translation_scale =
       current_position_allowed
-          ? heading_translation_scale(transform->rotation.y, movement->vx, movement->vz)
+          ? heading_translation_scale(
+                transform->rotation.y,
+                heading_reference(*entity, *transform, *movement, unit))
           : 1.0F;
 
   float const translated_vx = movement->vx * translation_scale;


### PR DESCRIPTION
Two sources of the whip visible when the massed lines meet:

- A formation jammed behind its own front line lurched at 0-1 m/s under local avoidance and its yaw tracked whatever direction the last shove had, so the whole body pivoted on jitter. heading_reference now points a formation with a movement target at its current waypoint, and without one only lets velocity steer above 0.4 m/s / a quarter of unit speed; the moonwalk guard measures facing against the same reference so shoved formations still slide.
- An engaged soldier turned 300 deg/s toward his opponent and straight back the tick the pair dropped. Unassigned soldiers now hold their contact yaw for 0.6 s and then turn back at 120 deg/s (FormationSoldierPresentation:: unassigned_seconds).

Soldier turn-and-return whips over a massed_battle_1000 run: ~6,400 -> ~1,850, measured with arena_app --animation-diagnostics.