### PR TITLE
feat(ui): centralize scalable typography tokens

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -72,6 +72,12 @@ jobs:
           git ls-files -z '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp' '*.py' '*.sh' \
             | xargs -0 -r python scripts/check-quality-markers.py
 
+      # A hard-coded font size ignores the interface scale a player sets, which
+      # is invisible in review and only shows up as "the text is too small" from
+      # a tester on a screen nobody on the team runs.
+      - name: QML typography
+        run: python scripts/check-typography.py
+
       # There used to be a scripts/validate_shader_config.py here, excluded
       # because it "reports 24 pre-existing content issues on main". Those 24
       # were not real: it expected a per-nation, per-unit .vert/.frag pair and a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,12 @@ repos:
         types_or: [c, c++, python, shell]
         exclude: ^(third_party/|scripts/check-quality-markers\.py$)
 
+      - id: soi-typography
+        name: font sizes come from Design.Typography
+        entry: python3 scripts/check-typography.py
+        language: system
+        files: ^ui/qml/.*\.qml$
+
       # always_run, because the failure this catches is a deleted asset whose
       # .qrc entry stayed behind - and pre-commit never passes deleted files to
       # a hook, so a `files: \.qrc$` filter would miss exactly that commit.

--- a/Makefile
+++ b/Makefile
@@ -610,6 +610,8 @@ quality:
 	@echo "$(BOLD)$(BLUE)Checking quality markers...$(RESET)"
 	@git ls-files -z '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp' '*.py' '*.sh' \
 		| xargs -0 -r $(PYTHON) scripts/check-quality-markers.py
+	@echo "$(BOLD)$(BLUE)Checking QML typography...$(RESET)"
+	@$(PYTHON) scripts/check-typography.py
 	@$(PYTHON) scripts/validate_qrc_resources.py
 	@echo "$(GREEN)✓ Quality checks passed$(RESET)"
 

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -93,9 +93,22 @@ the UI:
 
 `UiPreferences.uiScale` runs from 75% to 200%. Both metric systems follow it:
 the design-system tokens (`Design.Metrics`, `Design.Typography`) and the older
-`Theme` spacing and font sizes, which are no longer constant. The settings panel
-itself is sized in scaled pixels and takes up to 90% of the window, so the
-screen where the scale is changed stays reachable at every step.
+`Theme` spacing, which is no longer constant. The settings panel itself is sized
+in scaled pixels and takes up to 90% of the window, so the screen where the scale
+is changed stays reachable at every step.
+
+Every font size in the product comes from `Design.Typography`, so the slider
+moves the campaign, the menus and the in-match HUD together. It used to move only
+some of them: the gameplay panels carried their own point sizes, which ignored
+the setting entirely and rendered small enough that testers reported them as
+unreadable. `scripts/check-typography.py` fails the build on a font size that is
+not a token, and `tests/ui/qml/tst_gameplay_typography.qml` measures the real
+production panel at 75%, 100% and 200% to prove the slider reaches it.
+
+The bottom of the type ladder carries a floor of 12px
+(`Design.Typography.minimumSize`), so costs, counters and objective text stay
+readable at the smallest interface scale rather than shrinking with it — the same
+guarantee `Design.Metrics.minTouchTarget` gives pointer targets.
 
 ### Team identity without hue
 

--- a/docs/UI_DESIGN_SYSTEM.md
+++ b/docs/UI_DESIGN_SYSTEM.md
@@ -10,14 +10,15 @@ and how to build a screen on top of it.
 1. The aesthetic the tokens encode
 2. How the module is packaged and imported
 3. The token singletons and who owns which value
-4. Accessibility: one preference, every surface
-5. Faction identity as a skin, never a layout
-6. The single notification queue
-7. Iconography, and why emoji are banned
-8. Reviewing a screen with a screenshot
-9. The component gallery
-10. How the system is tested
-11. How the Qt Widgets tools stay in the same product
+4. The type ladder and its legibility floor
+5. Accessibility: one preference, every surface
+6. Faction identity as a skin, never a layout
+7. The single notification queue
+8. Iconography, and why emoji are banned
+9. Reviewing a screen with a screenshot
+10. The component gallery
+11. How the system is tested
+12. How the Qt Widgets tools stay in the same product
 
 ## The aesthetic: "Iron and Ember"
 
@@ -76,6 +77,47 @@ QML product cannot drift apart: `Theme.qml` reads `StandardOfIron.Theme` and lay
 accessibility variants on top of it.
 
 Screens should reference tokens, never literals. `Metrics.space12`, not `12`.
+
+## Type
+
+One ladder, in pixels, for every screen in the product:
+
+| Rung         | px at scale 1.0 | Used for                                     |
+| ------------ | --------------- | -------------------------------------------- |
+| `caption`    | 13              | Costs, counters, queue indices, hotkey chips |
+| `label`      | 15              | Field labels, button text, list rows         |
+| `body`       | 16              | Running prose, tooltips, descriptions        |
+| `bodyLarge`  | 19              | Emphasised body, panel intros                |
+| `subheading` | 21              | Section headings inside a panel              |
+| `heading`    | 24              | Panel titles                                 |
+| `title`      | 32              | Screen titles                                |
+| `hero`       | 40              | Menu and outcome display text                |
+| `glyphSmall` | 28              | Icon glyphs standing in for missing art      |
+| `glyph`      | 44              | Unit card glyphs                             |
+| `glyphLarge` | 56              | Large recruit card glyphs                    |
+
+Rules, in order of how often they are broken:
+
+- **Always `font.pixelSize`, never `font.pointSize`.** Points resolve against the screen's
+  reported DPI, so a point-sized label and a pixel-sized token drift apart on the same
+  panel. The ladder used to exist twice — pixels here, points on `Theme` — and the point
+  copy rendered a third larger, which is how the gameplay HUD ended up smaller than the
+  menus around it. `Theme` no longer carries font sizes.
+- **`caption` through `heading` carry a legibility floor** (`Typography.minimumSize`, 12px).
+  A player who drops the interface scale to 0.75 still gets readable costs and counters;
+  the bottom rungs converge on the floor rather than shrinking past it, the same way
+  `Metrics.minTouchTarget` refuses to go under 32px.
+- **For a size that is genuinely computed** — a damage number that ramps with severity, a
+  menu title that halves on a narrow window — use `Typography.scaled(px)` (floored) or
+  `Typography.display(px)` (unfloored). Both follow the interface scale. A bare number does
+  not, and `scripts/check-typography.py` rejects it.
+- **A `Control` is not the thing that draws its label.** `Button.font` is inherited default
+  state; the `contentItem: Text` under it is what renders, and its own `font.pixelSize`
+  survives. Set the size there, and measure there — a test that reads `button.font` is
+  reading a value no player ever sees.
+- **If the text scales, the box around it has to scale too.** A label on the ladder inside a
+  `height: 16` pill is legible at 1.0 and spills at 2.0. Size those containers from the
+  content (`implicitHeight + padding`) or from `A11y.scaled()`.
 
 ## Accessibility
 
@@ -318,7 +360,11 @@ the component belongs in the library first.
 `tests/ui/qml/` holds QtQuickTest cases that run against the real shipped module:
 
 - `tst_design_tokens.qml` — scale monotonicity, UI scale propagation and clamping, touch
-  target floor, reduced motion, high contrast, colour-vision repainting
+  target floor, the type legibility floor, reduced motion, high contrast, colour-vision
+  repainting
+- `tst_gameplay_typography.qml` — walks the real production panel at the minimum, default
+  and maximum interface scale: nothing renders under the legibility floor, every label
+  grows when the scale doubles, and no label outgrows the box drawn around it
 - `tst_component_library.qml` — every published type instantiates; accessible names;
   focus-ring behaviour; scale response
 - `tst_notifications.qml` — priority ordering, FIFO within a band, channel collapsing and

--- a/scripts/check-typography.py
+++ b/scripts/check-typography.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Reject hard-coded font sizes in QML.
+
+Gameplay text has to follow the interface scale a player sets in Settings, and
+it has to stay above a legibility floor at the smallest scale. Neither happens
+when a screen writes ``font.pixelSize: 9``: the literal is frozen at whatever
+the author's monitor made look right. Every font size therefore has to come
+from ``Design.Typography`` -- a named rung, or ``Typography.scaled()`` /
+``Typography.display()`` for the few sizes that are genuinely computed.
+
+Point sizes are rejected outright. Qt resolves them against the screen's
+reported DPI, so the same declaration renders at a different size than the
+pixel-based design tokens do, and the two ladders drift apart.
+
+Used by the pre-commit hook and by ``make quality``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+DECLARATION = re.compile(r"\bfont\.(pixelSize|pointSize)\s*:\s*(.+?)\s*(?://.*)?$")
+
+
+BARE_NUMBER = re.compile(r"(?<![\w.])\d+(?![\w.])")
+
+TOKEN_SOURCE = re.compile(r"\bTypography\.\w+")
+
+GUIDANCE = (
+    "\nFont sizes come from Design.Typography, never from a literal.\n"
+    "  font.pixelSize: Design.Typography.body        -- a named rung\n"
+    "  font.pixelSize: Design.Typography.scaled(15)  -- computed, with the "
+    "legibility floor\n"
+    "  font.pixelSize: Design.Typography.display(54) -- computed display text, "
+    "no floor\n"
+    "The rungs live in ui/qml/design/Typography.qml; add one there rather than "
+    "reaching for a literal.\n"
+)
+
+
+def check(path: Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [f"{path}: cannot read: {exc}"]
+
+    problems: list[str] = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        match = DECLARATION.search(line)
+        if match is None:
+            continue
+
+        prop, expression = match.groups()
+        where = f"{path}:{number}"
+
+        if prop == "pointSize":
+            problems.append(
+                f"{where}: font.pointSize is DPI-dependent; use font.pixelSize "
+                f"with a Design.Typography rung: {expression}"
+            )
+            continue
+
+        if TOKEN_SOURCE.search(expression):
+            continue
+
+        if BARE_NUMBER.search(expression):
+            problems.append(f"{where}: hard-coded font size: {expression}")
+
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    paths = [Path(arg) for arg in argv] or sorted(Path("ui/qml").rglob("*.qml"))
+
+    problems: list[str] = []
+    for path in paths:
+        if path.suffix != ".qml" or not path.is_file():
+            continue
+        problems.extend(check(path))
+
+    for problem in problems:
+        print(problem, file=sys.stderr)
+
+    if problems:
+        print(GUIDANCE, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/ui/qml/tst_design_tokens.qml
+++ b/tests/ui/qml/tst_design_tokens.qml
@@ -39,9 +39,32 @@ TestCase {
     function test_type_scale_is_monotonic() {
         verify(Typography.caption < Typography.label);
         verify(Typography.label < Typography.body);
-        verify(Typography.body < Typography.heading);
+        verify(Typography.body < Typography.bodyLarge);
+        verify(Typography.bodyLarge < Typography.subheading);
+        verify(Typography.subheading < Typography.heading);
         verify(Typography.heading < Typography.title);
         verify(Typography.title < Typography.hero);
+    }
+
+    function test_glyph_scale_is_monotonic() {
+        verify(Typography.glyphSmall < Typography.glyph);
+        verify(Typography.glyph < Typography.glyphLarge);
+    }
+
+    function test_gameplay_type_never_falls_below_the_legibility_floor() {
+        Core.UiPreferences.uiScale = Core.UiPreferences.minUiScale;
+        verify(Typography.minimumSize >= 12, "the floor itself is under 12px");
+        verify(Typography.caption >= Typography.minimumSize, "caption fell under the floor");
+        verify(Typography.label >= Typography.minimumSize, "label fell under the floor");
+        verify(Typography.body >= Typography.minimumSize, "body fell under the floor");
+        compare(Typography.scaled(4), Typography.minimumSize);
+    }
+
+    function test_display_sizes_follow_the_scale_without_the_floor() {
+        Core.UiPreferences.uiScale = 1.0;
+        compare(Typography.display(54), 54);
+        Core.UiPreferences.uiScale = 2.0;
+        compare(Typography.display(54), 108);
     }
 
     function test_ui_scale_resizes_spacing_and_type() {

--- a/tests/ui/qml/tst_gameplay_typography.qml
+++ b/tests/ui/qml/tst_gameplay_typography.qml
@@ -1,0 +1,194 @@
+import QtQuick 2.15
+import QtTest 1.15
+import StandardOfIron 1.0 as Core
+import StandardOfIron.Design 1.0
+
+TestCase {
+    id: testCase
+
+    name: "GameplayTypography"
+    when: windowShown
+    width: 1280
+    height: 720
+    visible: true
+
+    function init() {
+        Core.UiPreferences.reset_to_defaults();
+    }
+
+    function cleanupTestCase() {
+        Core.UiPreferences.reset_to_defaults();
+    }
+
+    QtObject {
+        id: stubEngine
+
+        function has_selected_type(type) {
+            return type === "barracks";
+        }
+
+        function get_selected_production_state() {
+            return {
+                "has_barracks": true,
+                "produced_count": 3,
+                "max_units": 500,
+                "queue_size": 2,
+                "in_progress": true,
+                "production_queue": ["archer", "swordsman"],
+                "product_type": "archer",
+                "villager_cost": 1,
+                "manpower_available": 120,
+                "build_time": 10,
+                "time_remaining": 4.5,
+                "nation_id": "roman_republic",
+                "has_home": true
+            };
+        }
+
+        function get_unit_production_info(unitType, nationId) {
+            return {
+                "cost": 50,
+                "population_cost": 50,
+                "resource_costs": {
+                    "food": 120,
+                    "wood": 40
+                },
+                "build_time": 10
+            };
+        }
+
+        function selected_player_state() {
+            return {
+                "food": 500,
+                "wood": 500,
+                "stone": 500,
+                "iron": 500,
+                "gold": 500
+            };
+        }
+    }
+
+    property var panelComponent: null
+
+    function panel_component() {
+        if (panelComponent === null) {
+            panelComponent = Qt.createComponent(Qt.resolvedUrl("../../../ui/qml/ProductionPanel.qml"));
+            compare(panelComponent.status, Component.Ready, "ProductionPanel did not compile: " + panelComponent.errorString());
+        }
+        return panelComponent;
+    }
+
+    function makePanel() {
+        var host = hostComponent.createObject(testCase, {
+                "width": 320,
+                "height": 720
+            });
+        verify(host !== null, "panel host was not created");
+        var panel = panel_component().createObject(host, {
+                "width": 320,
+                "game_instance": stubEngine
+            });
+        verify(panel !== null, "ProductionPanel was not created");
+        host.panel = panel;
+        wait(1);
+        return host;
+    }
+
+    Component {
+        id: hostComponent
+
+        Item {
+            property var panel: null
+        }
+    }
+
+    function collectVisibleText(item, out) {
+        for (var i = 0; i < item.children.length; ++i) {
+            var child = item.children[i];
+            if (child === null || child.visible === false) {
+                continue;
+            }
+            if (child.contentHeight !== undefined && child.text !== undefined && String(child.text).length > 0) {
+                out.push(child);
+            }
+            collectVisibleText(child, out);
+        }
+    }
+
+    function panelText() {
+        var host = makePanel();
+        var found = [];
+        collectVisibleText(host.panel, found);
+        verify(found.length > 0, "the production panel rendered no text to measure");
+        return {
+            "host": host,
+            "items": found
+        };
+    }
+
+    function test_no_gameplay_text_falls_below_the_legibility_floor_data() {
+        return [{
+                "tag": "min",
+                "scale": Core.UiPreferences.minUiScale
+            }, {
+                "tag": "default",
+                "scale": 1.0
+            }, {
+                "tag": "max",
+                "scale": Core.UiPreferences.maxUiScale
+            }];
+    }
+
+    function test_no_gameplay_text_falls_below_the_legibility_floor(data) {
+        Core.UiPreferences.uiScale = data.scale;
+        var probe = panelText();
+        for (var i = 0; i < probe.items.length; ++i) {
+            var item = probe.items[i];
+            verify(item.font.pixelSize >= Typography.minimumSize, "\"" + String(item.text).substring(0, 24) + "\" renders at " + item.font.pixelSize + "px at scale " + data.tag + ", under the " + Typography.minimumSize + "px floor");
+        }
+        probe.host.destroy();
+    }
+
+    function test_every_label_follows_the_interface_scale() {
+        Core.UiPreferences.uiScale = 1.0;
+        var small = panelText();
+        var baseline = [];
+        for (var i = 0; i < small.items.length; ++i) {
+            baseline.push({
+                    "text": String(small.items[i].text),
+                    "px": small.items[i].font.pixelSize
+                });
+        }
+        small.host.destroy();
+        Core.UiPreferences.uiScale = 2.0;
+        var large = panelText();
+        compare(large.items.length, baseline.length, "the panel changed shape between scales");
+        for (var j = 0; j < large.items.length; ++j) {
+            var grew = large.items[j].font.pixelSize > baseline[j].px;
+            verify(grew, "\"" + baseline[j].text.substring(0, 24) + "\" stayed at " + baseline[j].px + "px when the interface scale doubled");
+        }
+        large.host.destroy();
+    }
+
+    function test_labels_stay_inside_the_box_drawn_around_them_data() {
+        return test_no_gameplay_text_falls_below_the_legibility_floor_data();
+    }
+
+    function test_labels_stay_inside_the_box_drawn_around_them(data) {
+        Core.UiPreferences.uiScale = data.scale;
+        var probe = panelText();
+        var tolerance = 1.0;
+        for (var i = 0; i < probe.items.length; ++i) {
+            var item = probe.items[i];
+            var box = item.parent;
+            if (box === null || box.width <= 0 || box.height <= 0) {
+                continue;
+            }
+            if (item.elide !== Text.ElideNone || item.wrapMode !== Text.NoWrap) {
+                continue;
+            }
+            verify(item.contentHeight <= box.height + tolerance, "\"" + String(item.text).substring(0, 24) + "\" is " + item.contentHeight + "px tall inside a " + box.height + "px box at scale " + data.tag);
+        }
+        probe.host.destroy();
+    }
+}

--- a/ui/qml/CampaignMenu.qml
+++ b/ui/qml/CampaignMenu.qml
@@ -82,7 +82,7 @@ Item {
                 Label {
                     text: qsTr("Campaign Missions")
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeHero
+                    font.pixelSize: Design.Typography.hero
                     font.bold: true
                     Layout.fillWidth: true
                 }
@@ -151,7 +151,7 @@ Item {
                                     Label {
                                         text: modelData.title || ""
                                         color: Theme.textMain
-                                        font.pointSize: Theme.fontSizeTitle
+                                        font.pixelSize: Design.Typography.heading
                                         font.bold: true
                                         Layout.fillWidth: true
                                     }
@@ -169,7 +169,7 @@ Item {
                                             anchors.centerIn: parent
                                             text: qsTr("✓ Completed")
                                             color: Theme.successText
-                                            font.pointSize: Theme.fontSizeSmall
+                                            font.pixelSize: Design.Typography.body
                                             font.bold: true
                                         }
                                     }
@@ -187,7 +187,7 @@ Item {
                                             anchors.centerIn: parent
                                             text: Design.Icons.locked + " " + qsTr("Locked")
                                             color: Theme.textDim
-                                            font.pointSize: Theme.fontSizeSmall
+                                            font.pixelSize: Design.Typography.body
                                         }
                                     }
                                 }
@@ -199,13 +199,13 @@ Item {
                                     maximumLineCount: 2
                                     elide: Text.ElideRight
                                     Layout.fillWidth: true
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                 }
                             }
 
                             Text {
                                 text: Design.Icons.chevronForward
-                                font.pointSize: Theme.fontSizeHero
+                                font.pixelSize: Design.Typography.hero
                                 color: Theme.textHint
                             }
                         }
@@ -229,7 +229,7 @@ Item {
                 visible: root.campaigns.length === 0
                 text: qsTr("No campaign missions available")
                 color: Theme.textDim
-                font.pointSize: Theme.fontSizeMedium
+                font.pixelSize: Design.Typography.bodyLarge
                 horizontalAlignment: Text.AlignHCenter
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -393,7 +393,7 @@ Item {
                 Label {
                     text: missionDetailPanel.campaign_data ? (missionDetailPanel.campaign_data.title || "") : ""
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeHero
+                    font.pixelSize: Design.Typography.hero
                     font.bold: true
                     Layout.fillWidth: true
                 }
@@ -403,7 +403,7 @@ Item {
                     color: Theme.textSubLite
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
-                    font.pointSize: Theme.fontSizeMedium
+                    font.pixelSize: Design.Typography.bodyLarge
                 }
 
                 Rectangle {
@@ -453,7 +453,7 @@ Item {
                             anchors.centerIn: parent
                             text: qsTr("Loading map…")
                             color: Theme.textDim
-                            font.pointSize: Theme.fontSizeMedium
+                            font.pixelSize: Design.Typography.bodyLarge
                         }
                     }
 
@@ -630,7 +630,7 @@ Item {
                             visible: false
                             text: modelData.display_name || modelData.name
                             color: (campaignMapLoader.item && campaignMapLoader.item.hover_province_id === modelData.id) ? Theme.accent : Theme.textMain
-                            font.pointSize: Theme.fontSizeSmall
+                            font.pixelSize: Design.Typography.body
                             font.bold: true
                             style: Text.Outline
                             styleColor: "#101010"
@@ -674,7 +674,7 @@ Item {
                                 Text {
                                     text: city_data.display_name || city_data.name
                                     color: "#111111"
-                                    font.pointSize: Theme.fontSizeTiny
+                                    font.pixelSize: Design.Typography.label
                                     font.bold: true
                                     style: Text.Outline
                                     styleColor: "#f2e6c8"
@@ -709,7 +709,7 @@ Item {
                                 style: Text.Outline
                                 styleColor: "#000000"
                                 font.bold: true
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                             }
 
                             Label {
@@ -717,7 +717,7 @@ Item {
                                 color: "#ffffff"
                                 style: Text.Outline
                                 styleColor: "#000000"
-                                font.pointSize: Theme.fontSizeTiny
+                                font.pixelSize: Design.Typography.label
                             }
                         }
                     }
@@ -730,7 +730,7 @@ Item {
                     Label {
                         text: qsTr("Legend")
                         color: Theme.textMain
-                        font.pointSize: Theme.fontSizeSmall
+                        font.pixelSize: Design.Typography.body
                         font.bold: true
                     }
 
@@ -752,7 +752,7 @@ Item {
                             Label {
                                 text: modelData.name
                                 color: Theme.textSubLite
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                             }
                         }
                     }
@@ -767,7 +767,7 @@ Item {
                 Label {
                     text: qsTr("Select a Mission")
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeTitle
+                    font.pixelSize: Design.Typography.heading
                     font.bold: true
                     Layout.fillWidth: true
                 }
@@ -821,7 +821,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.ordinal(modelData.order_index)
                                     color: Theme.accent
-                                    font.pointSize: Theme.fontSizeTitle
+                                    font.pixelSize: Design.Typography.heading
                                     font.bold: true
                                     Layout.preferredWidth: 40
                                 }
@@ -833,7 +833,7 @@ Item {
                                     Label {
                                         text: titleize(modelData.mission_id || "")
                                         color: Theme.textMain
-                                        font.pointSize: Theme.fontSizeLarge
+                                        font.pixelSize: Design.Typography.subheading
                                         font.bold: true
                                         Layout.fillWidth: true
                                     }
@@ -845,13 +845,13 @@ Item {
                                         maximumLineCount: 2
                                         elide: Text.ElideRight
                                         Layout.fillWidth: true
-                                        font.pointSize: Theme.fontSizeSmall
+                                        font.pixelSize: Design.Typography.body
                                     }
                                 }
 
                                 Text {
                                     text: Design.Icons.chevronForward
-                                    font.pointSize: Theme.fontSizeTitle
+                                    font.pixelSize: Design.Typography.heading
                                     color: Theme.textHint
                                 }
                             }

--- a/ui/qml/CampaignScreen.qml
+++ b/ui/qml/CampaignScreen.qml
@@ -185,7 +185,7 @@ Item {
                     Label {
                         text: current_campaign ? current_campaign.title : qsTr("Campaign")
                         color: Theme.textMain
-                        font.pointSize: Theme.fontSizeHero
+                        font.pixelSize: Design.Typography.hero
                         font.bold: true
                         font.family: "serif"
                         Layout.fillWidth: true
@@ -194,7 +194,7 @@ Item {
                     Label {
                         text: qsTr("Campaign Chronicle • ") + (current_campaign ? current_campaign.description : "")
                         color: Theme.textSubLite
-                        font.pointSize: Theme.fontSizeMedium
+                        font.pixelSize: Design.Typography.bodyLarge
                         font.family: "serif"
                         wrapMode: Text.WordWrap
                         Layout.fillWidth: true
@@ -241,7 +241,7 @@ Item {
                         Label {
                             text: qsTr("Campaign Chronicle")
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeTitle
+                            font.pixelSize: Design.Typography.heading
                             font.bold: true
                             font.family: "serif"
                         }
@@ -269,7 +269,7 @@ Item {
                                     Label {
                                         text: qsTr("Campaign Progress:")
                                         color: Theme.textMain
-                                        font.pointSize: Theme.fontSizeSmall
+                                        font.pixelSize: Design.Typography.body
                                         font.bold: true
                                         font.family: "serif"
                                     }
@@ -326,7 +326,7 @@ Item {
 
                                         text: Design.Numerals.ratio(completed_count, total_count)
                                         color: Theme.textMain
-                                        font.pointSize: Theme.fontSizeSmall
+                                        font.pixelSize: Design.Typography.body
                                         font.bold: true
                                     }
                                 }
@@ -384,7 +384,7 @@ Item {
                                 anchors.centerIn: parent
                                 text: root.theater_heading
                                 color: "#f0dfbc"
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                                 font.bold: true
                                 font.family: "serif"
                             }

--- a/ui/qml/CombatDamageNumbers.qml
+++ b/ui/qml/CombatDamageNumbers.qml
@@ -51,7 +51,7 @@ Item {
                     "killingBlow": killingBlow,
                     "incoming": incoming
                 })
-            property real fontSize: (focused ? 17 : 14) + (killingBlow ? 4 : 0) + severity * 3
+            property real fontSize: Design.Typography.display((focused ? 17 : 14) + (killingBlow ? 4 : 0) + severity * 3)
 
             width: label.implicitWidth + 14
             height: label.implicitHeight + 6
@@ -131,7 +131,7 @@ Item {
                     anchors.verticalCenter: parent.verticalCenter
                     text: "×" + tick.hits
                     color: tick.accent
-                    font.pixelSize: Math.max(10, tick.fontSize - 5)
+                    font.pixelSize: Math.max(Design.Typography.minimumSize, tick.fontSize - 5)
                     font.bold: true
                 }
             }

--- a/ui/qml/ControlsBindingList.qml
+++ b/ui/qml/ControlsBindingList.qml
@@ -125,7 +125,7 @@ Item {
                 Layout.fillWidth: true
                 text: root.capturing_action !== "" ? qsTr("Press a key or click a mouse button. Backspace clears it, Esc cancels.") : qsTr("Select a command to rebind it.")
                 color: root.capturing_action !== "" ? Theme.accent : Theme.textSub
-                font.pointSize: Theme.fontSizeSmall
+                font.pixelSize: Design.Typography.body
                 wrapMode: Text.WordWrap
             }
 
@@ -161,7 +161,7 @@ Item {
                     Layout.fillWidth: true
                     text: qsTr("%1 is already used by %2.").arg(InputBindings.describe(root.pending_shortcut)).arg(root.conflict_summary(root.pending_conflicts))
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeMedium
+                    font.pixelSize: Design.Typography.bodyLarge
                     wrapMode: Text.WordWrap
                 }
 
@@ -185,7 +185,7 @@ Item {
                     Layout.fillWidth: true
                     text: qsTr("Taking it leaves the other command unbound.")
                     color: Theme.textSub
-                    font.pointSize: Theme.fontSizeSmall
+                    font.pixelSize: Design.Typography.body
                     wrapMode: Text.WordWrap
                 }
             }
@@ -212,7 +212,7 @@ Item {
                     visible: bindingRow.starts_category
                     text: modelData.category
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeMedium
+                    font.pixelSize: Design.Typography.bodyLarge
                     font.bold: true
                 }
 
@@ -228,7 +228,7 @@ Item {
                             Layout.fillWidth: true
                             text: modelData.name
                             color: Theme.textSub
-                            font.pointSize: Theme.fontSizeMedium
+                            font.pixelSize: Design.Typography.bodyLarge
                             wrapMode: Text.WordWrap
                         }
 
@@ -237,7 +237,7 @@ Item {
                             visible: modelData.description !== "" || modelData.conflicts.length > 0
                             text: modelData.conflicts.length > 0 ? qsTr("Conflicts with %1").arg(root.conflict_summary(modelData.conflicts)) : modelData.description
                             color: modelData.conflicts.length > 0 ? Theme.warning : Theme.textSub
-                            font.pointSize: Theme.fontSizeSmall
+                            font.pixelSize: Design.Typography.body
                             opacity: modelData.conflicts.length > 0 ? 1.0 : 0.7
                             wrapMode: Text.WordWrap
                         }

--- a/ui/qml/GameView.qml
+++ b/ui/qml/GameView.qml
@@ -1074,7 +1074,7 @@ Item {
             anchors.centerIn: parent
             color: Theme.textMain
             text: qsTr("%1/%2 walls  •  %3 wood").arg(game.placement.construction_preview_valid_segment_count).arg(game.placement.construction_preview_segment_count).arg(game.placement.construction_preview_total_cost)
-            font.pixelSize: 14
+            font.pixelSize: Design.Typography.label
         }
     }
 
@@ -1170,14 +1170,14 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 color: orderFeedbackBanner.accepted ? Theme.successText : Theme.dangerBr
                 text: orderFeedbackBanner.glyph_for(orderFeedbackBanner.kind, orderFeedbackBanner.accepted)
-                font.pixelSize: 14
+                font.pixelSize: Design.Typography.label
             }
 
             Text {
                 anchors.verticalCenter: parent.verticalCenter
                 color: orderFeedbackBanner.accepted ? Theme.textMain : Theme.warningText
                 text: orderFeedbackBanner.message
-                font.pixelSize: 13
+                font.pixelSize: Design.Typography.caption
             }
         }
     }
@@ -1264,14 +1264,14 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 color: attackTargetHint.attackable ? Theme.dangerBr : Theme.textDim
                 text: attackTargetHint.attackable ? "⚔" : "⊘"
-                font.pixelSize: 14
+                font.pixelSize: Design.Typography.label
             }
 
             Text {
                 anchors.verticalCenter: parent.verticalCenter
                 color: attackTargetHint.attackable ? Theme.textMain : Theme.textDim
                 text: attackTargetHint.hint_text()
-                font.pixelSize: 13
+                font.pixelSize: Design.Typography.caption
             }
 
             Text {
@@ -1279,7 +1279,7 @@ Item {
                 visible: attackTargetHint.range_text().length > 0
                 color: attackTargetHint.in_range ? Theme.successText : Theme.warningText
                 text: attackTargetHint.range_glyph() + " " + attackTargetHint.range_text()
-                font.pixelSize: 12
+                font.pixelSize: Design.Typography.caption
             }
         }
     }

--- a/ui/qml/HUDBottomCommander.qml
+++ b/ui/qml/HUDBottomCommander.qml
@@ -230,14 +230,14 @@ RowLayout {
                     Text {
                         text: qsTr("COMMANDER")
                         color: hs.bronze
-                        font.pointSize: 9
+                        font.pixelSize: Design.Typography.caption
                         font.bold: true
                     }
 
                     Text {
                         text: bottomRoot.status_value("name", qsTr("Commander"))
                         color: Theme.textMain
-                        font.pointSize: 12
+                        font.pixelSize: Design.Typography.body
                         font.bold: true
                         elide: Text.ElideRight
                     }
@@ -245,7 +245,7 @@ RowLayout {
                     Text {
                         text: bottomRoot.status_value("nation", "") !== "" ? bottomRoot.status_value("nation", "") : qsTr("Frontline command")
                         color: Theme.textSubLite
-                        font.pointSize: 9
+                        font.pixelSize: Design.Typography.caption
                         elide: Text.ElideRight
                     }
                 }
@@ -282,7 +282,7 @@ RowLayout {
                             anchors.verticalCenter: parent.verticalCenter
                             text: bottomRoot.status_value("aura_active", false) ? qsTr("Aura active") : (bottomRoot.status_value("aura_ready", false) ? qsTr("Aura ready") : qsTr("Aura cooling"))
                             color: Theme.textMain
-                            font.pointSize: 7
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                         }
                     }
@@ -305,7 +305,7 @@ RowLayout {
                         Text {
                             text: qsTr("HP %1/%2").arg(bottomRoot.status_value("health", 0)).arg(bottomRoot.status_value("max_health", 0))
                             color: Theme.textMain
-                            font.pointSize: 8
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                         }
 
@@ -334,7 +334,7 @@ RowLayout {
                         Text {
                             text: bottomRoot.status_value("can_run", false) ? qsTr("STM %1%").arg(Math.round(Number(bottomRoot.status_value("stamina_ratio", 1)) * 100)) : qsTr("Stable")
                             color: Theme.textMain
-                            font.pointSize: 8
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                         }
 
@@ -359,7 +359,7 @@ RowLayout {
                 Text {
                     text: qsTr("Posture")
                     color: Theme.textMain
-                    font.pointSize: 8
+                    font.pixelSize: Design.Typography.caption
                 }
 
                 Rectangle {
@@ -384,7 +384,7 @@ RowLayout {
                 visible: !bottomRoot.fpv_mode
                 text: qsTr("State: %1").arg(bottomRoot.stance_label())
                 color: Theme.textSubLite
-                font.pointSize: 8
+                font.pixelSize: Design.Typography.caption
                 wrapMode: Text.WordWrap
                 maximumLineCount: 1
                 elide: Text.ElideRight
@@ -394,7 +394,7 @@ RowLayout {
                 visible: !bottomRoot.fpv_mode
                 text: bottomRoot.status_value("perfect_guard_active", false) ? qsTr("Perfect guard live") : (bottomRoot.status_value("finisher_ready", false) ? qsTr("Finisher primed") : (bottomRoot.fpv_mode ? qsTr("Aura %1").arg(bottomRoot.status_value("aura_active", false) ? qsTr("empowers nearby troops") : qsTr("is recovering")) : qsTr("Camera: %1").arg(bottomRoot.status_value("camera_mode", qsTr("Chase")))))
                 color: Theme.textSubLite
-                font.pointSize: 9
+                font.pixelSize: Design.Typography.caption
                 wrapMode: Text.WordWrap
             }
         }
@@ -417,7 +417,7 @@ RowLayout {
             Text {
                 text: bottomRoot.fpv_mode ? qsTr("ORDERS") : qsTr("ABILITIES")
                 color: hs.bronze
-                font.pointSize: 9
+                font.pixelSize: Design.Typography.caption
                 font.bold: true
             }
 
@@ -440,7 +440,7 @@ RowLayout {
                         Text {
                             text: qsTr("Rally")
                             color: Theme.textMain
-                            font.pointSize: bottomRoot.fpv_mode ? 9 : 11
+                            font.pixelSize: bottomRoot.fpv_mode ? Design.Typography.caption : Design.Typography.label
                             font.bold: true
                         }
 
@@ -460,7 +460,7 @@ RowLayout {
                                 anchors.centerIn: parent
                                 text: bottomRoot.rally_label()
                                 color: Theme.textMain
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
                         }
@@ -488,7 +488,7 @@ RowLayout {
                         text: bottomRoot.rally_description()
                         color: Theme.textSubLite
                         wrapMode: Text.WordWrap
-                        font.pointSize: 9
+                        font.pixelSize: Design.Typography.caption
                     }
 
                     GridLayout {
@@ -533,7 +533,7 @@ RowLayout {
                             contentItem: Text {
                                 text: parent.text
                                 color: rallyButton.allowed ? Theme.textMain : Theme.textDim
-                                font.pointSize: bottomRoot.fpv_mode ? 9 : 10
+                                font.pixelSize: bottomRoot.fpv_mode ? Design.Typography.caption : Design.Typography.label
                                 font.bold: true
                                 horizontalAlignment: Text.AlignHCenter
                                 verticalAlignment: Text.AlignVCenter
@@ -572,7 +572,7 @@ RowLayout {
                             contentItem: Text {
                                 text: parent.text
                                 color: auraButton.allowed || bottomRoot.status_value("aura_active", false) ? Theme.textMain : Theme.textDim
-                                font.pointSize: bottomRoot.fpv_mode ? 9 : 10
+                                font.pixelSize: bottomRoot.fpv_mode ? Design.Typography.caption : Design.Typography.label
                                 font.bold: true
                                 horizontalAlignment: Text.AlignHCenter
                                 verticalAlignment: Text.AlignVCenter
@@ -587,7 +587,7 @@ RowLayout {
                         Text {
                             text: qsTr("Combo")
                             color: hs.bronze
-                            font.pointSize: 9
+                            font.pixelSize: Design.Typography.caption
                         }
 
                         Repeater {
@@ -655,7 +655,7 @@ RowLayout {
                             Text {
                                 text: qsTr("%1 [%2]").arg(modelData["title"]).arg(modelData["key"])
                                 color: bottomRoot.status_value(modelData["readyKey"], true) ? hs.bronze : hs.bronzeDeep
-                                font.pointSize: 9
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -680,7 +680,7 @@ RowLayout {
                                 text: modelData["description"]
                                 color: Theme.textSubLite
                                 wrapMode: Text.WordWrap
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                             }
                         }
                     }
@@ -707,7 +707,7 @@ RowLayout {
             Text {
                 text: qsTr("COMBAT CONTROLS")
                 color: hs.bronze
-                font.pointSize: 9
+                font.pixelSize: Design.Typography.caption
                 font.bold: true
             }
 
@@ -723,7 +723,7 @@ RowLayout {
                     delegate: Text {
                         text: modelData
                         color: Theme.textMain
-                        font.pointSize: bottomRoot.fpv_mode ? 7 : 8
+                        font.pixelSize: bottomRoot.fpv_mode ? Design.Typography.caption : Design.Typography.label
                         elide: Text.ElideRight
                     }
                 }
@@ -737,7 +737,7 @@ RowLayout {
                 Layout.fillWidth: true
                 text: !bottomRoot.status_value("alive", false) ? qsTr("Commander unavailable") : (bottomRoot.status_value("rally_in_progress", false) ? qsTr("Rally autopilot engaged until the flag is planted") : (bottomRoot.fpv_mode ? qsTr("Combat HUD synced for close-quarters command") : qsTr("First-person command engaged")))
                 color: Theme.textSubLite
-                font.pointSize: bottomRoot.fpv_mode ? 7 : 8
+                font.pixelSize: bottomRoot.fpv_mode ? Design.Typography.caption : Design.Typography.label
                 wrapMode: Text.WordWrap
                 maximumLineCount: 1
                 elide: Text.ElideRight

--- a/ui/qml/LoadGamePanel.qml
+++ b/ui/qml/LoadGamePanel.qml
@@ -130,7 +130,7 @@ Item {
                 Label {
                     text: qsTr("Load Game")
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeHero
+                    font.pixelSize: Design.Typography.hero
                     font.bold: true
                     Layout.fillWidth: true
                 }
@@ -288,7 +288,7 @@ Item {
                                             anchors.centerIn: parent
                                             text: qsTr("No Preview")
                                             color: Theme.textHint
-                                            font.pointSize: Theme.fontSizeTiny
+                                            font.pixelSize: Design.Typography.label
                                         }
                                     }
                                 }
@@ -301,7 +301,7 @@ Item {
                                     Label {
                                         text: model.title
                                         color: Theme.textMain
-                                        font.pointSize: Theme.fontSizeLarge
+                                        font.pixelSize: Design.Typography.subheading
                                         font.bold: true
                                         Layout.fillWidth: true
                                         elide: Label.ElideRight
@@ -310,7 +310,7 @@ Item {
                                     Label {
                                         text: qsTr("%1 · %2").arg(model.map_name).arg(root.describe_mode(model.mode, model.kind))
                                         color: Theme.textSub
-                                        font.pointSize: Theme.fontSizeMedium
+                                        font.pixelSize: Design.Typography.bodyLarge
                                         Layout.fillWidth: true
                                         elide: Label.ElideRight
                                     }
@@ -322,7 +322,7 @@ Item {
                                         Label {
                                             text: qsTr("Saved %1").arg(Qt.formatDateTime(new Date(model.timestamp), "MMM d, yyyy · h:mm AP"))
                                             color: Theme.textHint
-                                            font.pointSize: Theme.fontSizeSmall
+                                            font.pixelSize: Design.Typography.body
                                             Layout.fillWidth: true
                                             elide: Label.ElideRight
                                         }
@@ -330,7 +330,7 @@ Item {
                                         Label {
                                             text: model.playTime !== "" ? qsTr("Played %1").arg(model.playTime) : ""
                                             color: Theme.textHint
-                                            font.pointSize: Theme.fontSizeSmall
+                                            font.pixelSize: Design.Typography.body
                                             visible: model.playTime !== ""
                                         }
                                     }
@@ -339,7 +339,7 @@ Item {
                                 Label {
                                     text: model.slot_name
                                     color: Theme.textDim
-                                    font.pointSize: Theme.fontSizeLarge
+                                    font.pixelSize: Design.Typography.subheading
                                     Layout.fillWidth: true
                                     horizontalAlignment: Text.AlignHCenter
                                     visible: model.isEmpty
@@ -403,7 +403,7 @@ Item {
                 Label {
                     text: root.status_message
                     color: Theme.textHint
-                    font.pointSize: Theme.fontSizeSmall
+                    font.pixelSize: Design.Typography.body
                     Layout.fillWidth: true
                     elide: Label.ElideRight
                 }
@@ -466,7 +466,7 @@ Item {
                 text: qsTr("Are you sure you want to delete the save:\n\"%1\"?\n\nThis action cannot be undone.").arg(confirmDeleteDialog.slot_name)
                 color: Theme.textMain
                 wrapMode: Text.WordWrap
-                font.pointSize: Theme.fontSizeMedium
+                font.pixelSize: Design.Typography.bodyLarge
             }
         }
     }
@@ -492,7 +492,7 @@ Item {
                 Label {
                     text: root.verify_result_title
                     color: root.verify_result_success ? Theme.success : Theme.danger
-                    font.pointSize: Theme.fontSizeHero
+                    font.pixelSize: Design.Typography.hero
                     font.bold: true
                     Layout.fillWidth: true
                 }
@@ -500,7 +500,7 @@ Item {
                 Label {
                     text: root.verify_result_message
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeMedium
+                    font.pixelSize: Design.Typography.bodyLarge
                     Layout.fillWidth: true
                     wrapMode: Text.WordWrap
                 }
@@ -530,7 +530,7 @@ Item {
                 Label {
                     text: qsTr("Save files found in the exports folder:")
                     color: Theme.textSub
-                    font.pointSize: Theme.fontSizeSmall
+                    font.pixelSize: Design.Typography.body
                     Layout.fillWidth: true
                     wrapMode: Text.WordWrap
                 }
@@ -564,7 +564,7 @@ Item {
                         Label {
                             text: model.name
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeSmall
+                            font.pixelSize: Design.Typography.body
                             Layout.fillWidth: true
                             elide: Label.ElideMiddle
                         }
@@ -585,7 +585,7 @@ Item {
                 Label {
                     text: importModel.count === 0 ? qsTr("No importable save files were found.") : ""
                     color: Theme.textHint
-                    font.pointSize: Theme.fontSizeSmall
+                    font.pixelSize: Design.Typography.body
                     visible: importModel.count === 0
                     Layout.fillWidth: true
                     wrapMode: Text.WordWrap

--- a/ui/qml/LoadScreen.qml
+++ b/ui/qml/LoadScreen.qml
@@ -144,7 +144,7 @@ Rectangle {
             text: qsTr("Loading...")
             color: Theme.textMain
             font.family: "serif"
-            font.pixelSize: 40
+            font.pixelSize: Design.Typography.hero
             font.bold: true
             font.letterSpacing: 4
             style: Text.Outline
@@ -268,7 +268,7 @@ Rectangle {
                 anchors.centerIn: parent
                 text: Design.Numerals.percent(Math.floor(load_screen.display_progress * 100))
                 color: Theme.textMain
-                font.pixelSize: 14
+                font.pixelSize: Design.Typography.label
                 font.bold: true
                 font.letterSpacing: 1.2
                 style: Text.Outline
@@ -280,7 +280,7 @@ Rectangle {
             anchors.horizontalCenter: parent.horizontalCenter
             text: load_screen.stage_text
             color: Theme.textSubLite
-            font.pixelSize: 14
+            font.pixelSize: Design.Typography.label
             font.letterSpacing: 0.6
         }
     }

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -232,7 +232,7 @@ ApplicationWindow {
                 Text {
                     text: qsTr("PAUSED")
                     color: Theme.textMain
-                    font.pixelSize: 36
+                    font.pixelSize: Design.Typography.hero
                     font.bold: true
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
@@ -240,7 +240,7 @@ ApplicationWindow {
                 Text {
                     text: qsTr("Press Space to resume")
                     color: Theme.textSubLite
-                    font.pixelSize: 14
+                    font.pixelSize: Design.Typography.label
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
             }

--- a/ui/qml/MainMenu.qml
+++ b/ui/qml/MainMenu.qml
@@ -379,7 +379,7 @@ Item {
                             anchors.verticalCenter: parent.verticalCenter
                             text: qsTr("SPQR")
                             color: Theme.accentBright
-                            font.pixelSize: root.narrow ? 11 : 12
+                            font.pixelSize: root.narrow ? Design.Typography.caption : Design.Typography.label
                             font.bold: true
                             font.letterSpacing: 3.2
                         }
@@ -396,7 +396,7 @@ Item {
                             anchors.verticalCenter: parent.verticalCenter
                             text: qsTr("QART-HADAST")
                             color: Theme.accentBright
-                            font.pixelSize: root.narrow ? 11 : 12
+                            font.pixelSize: root.narrow ? Design.Typography.caption : Design.Typography.label
                             font.bold: true
                             font.letterSpacing: 3.2
                         }
@@ -425,7 +425,7 @@ Item {
                             text: qsTr("STANDARD OF IRON")
                             color: "#00060403"
                             font.family: "serif"
-                            font.pixelSize: root.narrow ? 36 : 54
+                            font.pixelSize: Design.Typography.display(root.narrow ? 36 : 54)
                             font.bold: true
                             font.letterSpacing: root.narrow ? 1.2 : 2.4
                             elide: Text.ElideRight
@@ -442,7 +442,7 @@ Item {
                             text: qsTr("STANDARD OF IRON")
                             color: Theme.textMain
                             font.family: "serif"
-                            font.pixelSize: root.narrow ? 36 : 54
+                            font.pixelSize: Design.Typography.display(root.narrow ? 36 : 54)
                             font.bold: true
                             font.letterSpacing: root.narrow ? 1.2 : 2.4
                             elide: Text.ElideRight
@@ -487,7 +487,7 @@ Item {
                         width: parent.width
                         text: qsTr("Rome and Carthage at the edge of empire")
                         color: Theme.textSubLite
-                        font.pixelSize: root.narrow ? 13 : 15
+                        font.pixelSize: root.narrow ? Design.Typography.caption : Design.Typography.label
                         font.letterSpacing: 0.8
                         elide: Text.ElideRight
                         maximumLineCount: 1
@@ -654,7 +654,7 @@ Item {
                                     text: Design.Numerals.ordinal(commandItem.index)
                                     color: commandItem.selected ? Theme.accentBright : Theme.textDim
                                     font.family: "serif"
-                                    font.pixelSize: root.narrow ? 11 : 13
+                                    font.pixelSize: root.narrow ? Design.Typography.caption : Design.Typography.label
                                     font.bold: true
                                     font.letterSpacing: 0.5
                                 }
@@ -670,7 +670,7 @@ Item {
                                     text: qsTr(commandItem.title)
                                     color: commandItem.selected ? Theme.textMain : Theme.textBright
                                     font.family: "serif"
-                                    font.pixelSize: root.narrow ? 18 : 21
+                                    font.pixelSize: root.narrow ? Design.Typography.bodyLarge : Design.Typography.subheading
                                     font.bold: true
                                     font.letterSpacing: commandItem.selected ? 0.9 : 0.3
                                     elide: Text.ElideRight
@@ -687,7 +687,7 @@ Item {
                                     Layout.fillWidth: true
                                     text: qsTr(commandItem.subtitle)
                                     color: commandItem.selected ? Theme.accentBright : Theme.textDim
-                                    font.pixelSize: root.narrow ? 11 : 13
+                                    font.pixelSize: root.narrow ? Design.Typography.caption : Design.Typography.label
                                     elide: Text.ElideRight
                                     maximumLineCount: 1
                                 }
@@ -709,7 +709,7 @@ Item {
                                     anchors.centerIn: parent
                                     text: qsTr(commandItem.detail).toUpperCase()
                                     color: commandItem.selected ? Theme.accentBright : Theme.textDim
-                                    font.pixelSize: 9
+                                    font.pixelSize: Design.Typography.caption
                                     font.bold: true
                                     font.letterSpacing: 1.4
                                 }
@@ -850,7 +850,7 @@ Item {
                                 anchors.centerIn: parent
                                 text: modelData === "navigate" ? "↑ ↓" : (modelData === "confirm" ? qsTr("Enter") : qsTr("Esc"))
                                 color: Theme.textSubLite
-                                font.pixelSize: 9
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                                 font.letterSpacing: 1
                             }
@@ -860,7 +860,7 @@ Item {
                             anchors.verticalCenter: parent.verticalCenter
                             text: modelData === "navigate" ? qsTr("Navigate") : (modelData === "confirm" ? qsTr("Confirm") : qsTr("Resume battle"))
                             color: Theme.textDim
-                            font.pixelSize: 11
+                            font.pixelSize: Design.Typography.caption
                             font.letterSpacing: 0.6
                         }
                     }
@@ -1038,7 +1038,7 @@ Item {
                     text: qsTr("SECOND PUNIC WAR")
                     color: Theme.textMain
                     font.family: "serif"
-                    font.pixelSize: 19
+                    font.pixelSize: Design.Typography.bodyLarge
                     font.bold: true
                     font.letterSpacing: 3
                     horizontalAlignment: Text.AlignHCenter
@@ -1051,7 +1051,7 @@ Item {
                     Layout.topMargin: 5
                     text: qsTr("Legions, fleets, elephants, and contested supply lines")
                     color: Theme.textDim
-                    font.pixelSize: 12
+                    font.pixelSize: Design.Typography.caption
                     font.letterSpacing: 0.4
                     horizontalAlignment: Text.AlignHCenter
                     wrapMode: Text.WordWrap
@@ -1138,7 +1138,7 @@ Item {
                                         text: plaque.carthaginian ? qsTr("Hannibal Barca") : qsTr("Scipio Africanus")
                                         color: Theme.textBright
                                         font.family: "serif"
-                                        font.pixelSize: 13
+                                        font.pixelSize: Design.Typography.caption
                                         font.bold: true
                                         elide: Text.ElideRight
                                         maximumLineCount: 1
@@ -1155,7 +1155,7 @@ Item {
                                         width: parent.width
                                         text: plaque.carthaginian ? qsTr("CARTHAGE") : qsTr("ROME")
                                         color: Theme.textDim
-                                        font.pixelSize: 10
+                                        font.pixelSize: Design.Typography.caption
                                         font.letterSpacing: 1.6
                                         elide: Text.ElideRight
                                         maximumLineCount: 1
@@ -1202,7 +1202,7 @@ Item {
         anchors.bottomMargin: 8
         text: "v" + Qt.application.version
         color: Theme.textDim
-        font.pixelSize: 10
+        font.pixelSize: Design.Typography.caption
         font.letterSpacing: 0.8
         opacity: 0.8
         z: 12

--- a/ui/qml/MapListPanel.qml
+++ b/ui/qml/MapListPanel.qml
@@ -24,7 +24,7 @@ Item {
 
         text: qsTr("Maps")
         color: colors.textMain
-        font.pixelSize: 18
+        font.pixelSize: Design.Typography.bodyLarge
         font.bold: true
 
         anchors {
@@ -39,7 +39,7 @@ Item {
 
         text: "(" + Design.Numerals.roman(list.count || 0) + ")"
         color: colors.textSubLite
-        font.pixelSize: 12
+        font.pixelSize: Design.Typography.caption
 
         anchors {
             left: title.right
@@ -91,7 +91,7 @@ Item {
                 Text {
                     text: qsTr("No maps available")
                     color: colors.textSub
-                    font.pixelSize: 14
+                    font.pixelSize: Design.Typography.label
                     anchors.centerIn: parent
                 }
             }
@@ -178,7 +178,7 @@ Item {
                         Text {
                             text: (typeof name !== "undefined") ? String(name) : ""
                             color: (index === list.currentIndex) ? "white" : "#dff0ff"
-                            font.pixelSize: (index === list.currentIndex) ? 15 : 14
+                            font.pixelSize: (index === list.currentIndex) ? Design.Typography.body : Design.Typography.label
                             font.bold: (index === list.currentIndex)
                             elide: Text.ElideRight
                             width: parent.width
@@ -187,7 +187,7 @@ Item {
                         Text {
                             text: (typeof description !== "undefined") ? String(description) : ""
                             color: (index === list.currentIndex) ? "#d0e8ff" : colors.textSub
-                            font.pixelSize: 11
+                            font.pixelSize: Design.Typography.caption
                             elide: Text.ElideRight
                             width: parent.width
                         }

--- a/ui/qml/MapPreview.qml
+++ b/ui/qml/MapPreview.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import StandardOfIron 1.0
+import StandardOfIron.Design 1.0 as Design
 
 Rectangle {
     id: root
@@ -55,7 +56,7 @@ Rectangle {
 
         text: qsTr("Map Preview")
         color: Theme.textMain
-        font.pixelSize: 16
+        font.pixelSize: Design.Typography.body
         font.bold: true
 
         anchors {
@@ -112,7 +113,7 @@ Rectangle {
 
                 text: qsTr("Player bases shown as colored circles")
                 color: Theme.textSubLite
-                font.pixelSize: 12
+                font.pixelSize: Design.Typography.caption
                 font.italic: true
                 wrapMode: Text.WordWrap
                 horizontalAlignment: Text.AlignLeft
@@ -127,7 +128,7 @@ Rectangle {
             anchors.centerIn: parent
             text: qsTr("Select a map\nto see preview")
             color: Theme.textHint
-            font.pixelSize: 13
+            font.pixelSize: Design.Typography.caption
             horizontalAlignment: Text.AlignHCenter
             visible: !loading && preview_image.status !== Image.Ready && map_path === ""
         }
@@ -136,7 +137,7 @@ Rectangle {
             anchors.centerIn: parent
             text: qsTr("No preview available")
             color: Theme.textHint
-            font.pixelSize: 13
+            font.pixelSize: Design.Typography.caption
             horizontalAlignment: Text.AlignHCenter
             visible: !loading && preview_image.status !== Image.Ready && map_path !== ""
         }
@@ -150,7 +151,7 @@ Rectangle {
             Text {
                 anchors.centerIn: parent
                 text: "⟳"
-                font.pixelSize: 36
+                font.pixelSize: Design.Typography.hero
                 color: Theme.accent
 
                 RotationAnimator on rotation  {

--- a/ui/qml/MapSelect.qml
+++ b/ui/qml/MapSelect.qml
@@ -509,7 +509,7 @@ Item {
 
                     text: qsTr("Maps")
                     color: Theme.textMain
-                    font.pixelSize: 20
+                    font.pixelSize: Design.Typography.subheading
                     font.bold: true
                     Layout.fillWidth: true
                 }
@@ -628,7 +628,7 @@ Item {
                                         Text {
                                             anchors.centerIn: parent
                                             text: Design.Icons.terrainPlains
-                                            font.pixelSize: Theme.fontSizeTitle
+                                            font.pixelSize: Design.Typography.heading
                                             color: Theme.textDim
                                         }
                                     }
@@ -650,7 +650,7 @@ Item {
 
                                         text: (typeof name !== "undefined") ? String(name) : (typeof modelData === "string" ? modelData : (modelData && modelData.name ? String(modelData.name) : ""))
                                         color: (index === list.currentIndex) ? Theme.textMain : Theme.textBright
-                                        font.pixelSize: (index === list.currentIndex) ? 17 : 15
+                                        font.pixelSize: (index === list.currentIndex) ? Design.Typography.body : Design.Typography.label
                                         font.bold: (index === list.currentIndex)
                                         elide: Text.ElideRight
 
@@ -670,7 +670,7 @@ Item {
                                     Text {
                                         text: (typeof description !== "undefined") ? String(description) : (modelData && modelData.description ? String(modelData.description) : "")
                                         color: (index === list.currentIndex) ? Theme.accentBright : Theme.textSub
-                                        font.pixelSize: 12
+                                        font.pixelSize: Design.Typography.caption
                                         elide: Text.ElideRight
 
                                         anchors {
@@ -682,7 +682,7 @@ Item {
 
                                     Text {
                                         text: Design.Icons.chevronForward
-                                        font.pointSize: 18
+                                        font.pixelSize: Design.Typography.heading
                                         color: (index === list.currentIndex) ? Theme.textMain : Theme.textHint
 
                                         anchors {
@@ -717,7 +717,7 @@ Item {
                     Text {
                         text: qsTr("No maps available")
                         color: Theme.textSub
-                        font.pixelSize: 14
+                        font.pixelSize: Design.Typography.label
                         anchors.centerIn: parent
                     }
                 }
@@ -733,7 +733,7 @@ Item {
 
                         Text {
                             text: "⟳"
-                            font.pixelSize: 24
+                            font.pixelSize: Design.Typography.heading
                             color: Theme.accent
                             anchors.horizontalCenter: parent.horizontalCenter
 
@@ -749,7 +749,7 @@ Item {
                         Text {
                             text: qsTr("Loading maps...")
                             color: Theme.textSub
-                            font.pixelSize: 12
+                            font.pixelSize: Design.Typography.caption
                             anchors.horizontalCenter: parent.horizontalCenter
                         }
                     }
@@ -776,7 +776,7 @@ Item {
 
                 text: selected_map_data ? qsTr("► %1").arg(field(selected_map_data, "name")) : qsTr("Select a map to continue")
                 color: selected_map_data ? Theme.accent : Theme.textHint
-                font.pixelSize: 13
+                font.pixelSize: Design.Typography.caption
                 font.italic: !selected_map_data
                 elide: Text.ElideRight
 
@@ -806,7 +806,7 @@ Item {
 
                     Text {
                         text: "⟳"
-                        font.pixelSize: 40
+                        font.pixelSize: Design.Typography.hero
                         color: Theme.accent
                         anchors.horizontalCenter: parent.horizontalCenter
 
@@ -822,7 +822,7 @@ Item {
                     Text {
                         text: qsTr("Loading maps...")
                         color: Theme.textSub
-                        font.pixelSize: 14
+                        font.pixelSize: Design.Typography.label
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
                 }
@@ -921,7 +921,7 @@ Item {
                     Text {
                         text: qsTr("Loading map details...")
                         color: Theme.textHint
-                        font.pixelSize: 12
+                        font.pixelSize: Design.Typography.caption
                         font.italic: true
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
@@ -938,7 +938,7 @@ Item {
                 }
                 visible: selected_map_data !== null
                 color: Theme.textMain
-                font.pixelSize: 24
+                font.pixelSize: Design.Typography.heading
                 font.bold: true
                 elide: Text.ElideRight
 
@@ -956,7 +956,7 @@ Item {
                 text: field(selected_map_data, "description")
                 visible: selected_map_data !== null
                 color: Theme.textSubLite
-                font.pixelSize: 13
+                font.pixelSize: Design.Typography.caption
                 wrapMode: Text.WordWrap
                 maximumLineCount: 3
                 elide: Text.ElideRight
@@ -1001,7 +1001,7 @@ Item {
                         Text {
                             text: qsTr("Players")
                             color: Theme.textMain
-                            font.pixelSize: 17
+                            font.pixelSize: Design.Typography.body
                             font.bold: true
                         }
 
@@ -1016,7 +1016,7 @@ Item {
                                 anchors.centerIn: parent
                                 text: Design.Numerals.roman(players_model.count)
                                 color: Theme.textMain
-                                font.pixelSize: 13
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
                         }
@@ -1024,7 +1024,7 @@ Item {
                         Text {
                             text: qsTr("• Click color/team to cycle")
                             color: Theme.textSubLite
-                            font.pixelSize: 11
+                            font.pixelSize: Design.Typography.caption
                             font.italic: true
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -1032,7 +1032,7 @@ Item {
                         Text {
                             text: qsTr("• Click nation tag to change")
                             color: Theme.textSubLite
-                            font.pixelSize: 11
+                            font.pixelSize: Design.Typography.caption
                             font.italic: true
                             anchors.verticalCenter: parent.verticalCenter
                         }
@@ -1099,7 +1099,7 @@ Item {
                                         anchors.centerIn: parent
                                         text: model.isEnabled ? "✓" : ""
                                         color: Theme.accent
-                                        font.pixelSize: 18
+                                        font.pixelSize: Design.Typography.bodyLarge
                                         font.bold: true
                                     }
 
@@ -1142,7 +1142,7 @@ Item {
                                     anchors.verticalCenter: parent.verticalCenter
                                     text: model.playerName || ""
                                     color: model.isEnabled ? (model.isHuman ? Theme.accentBright : Theme.textBright) : Theme.textDim
-                                    font.pixelSize: model.isHuman ? 15 : 14
+                                    font.pixelSize: model.isHuman ? Design.Typography.body : Design.Typography.label
                                     font.bold: true
                                     opacity: model.isEnabled ? 1 : 0.5
                                 }
@@ -1178,7 +1178,7 @@ Item {
                                             anchors.centerIn: parent
                                             text: model.colorName || qsTr("Color")
                                             color: model.colorHex || Theme.textMain
-                                            font.pixelSize: 13
+                                            font.pixelSize: Design.Typography.caption
                                             font.bold: true
                                         }
 
@@ -1244,7 +1244,7 @@ Item {
                                             visible: parent.emblem_source === ""
                                             text: model.nationName || qsTr("Nation")
                                             color: Theme.textMain
-                                            font.pixelSize: 11
+                                            font.pixelSize: Design.Typography.caption
                                             font.bold: true
                                         }
 
@@ -1298,7 +1298,7 @@ Item {
                                                 anchors.horizontalCenter: parent.horizontalCenter
                                                 text: qsTr("Commander")
                                                 color: Theme.textSubLite
-                                                font.pixelSize: 10
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
 
@@ -1307,7 +1307,7 @@ Item {
                                                 width: parent.parent.width - Theme.spacingSmall * 2
                                                 text: model.commanderName || qsTr("Commander")
                                                 color: Theme.textMain
-                                                font.pixelSize: 12
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                                 horizontalAlignment: Text.AlignHCenter
                                                 wrapMode: Text.WordWrap
@@ -1365,7 +1365,7 @@ Item {
                                                 anchors.horizontalCenter: parent.horizontalCenter
                                                 text: model.teamIcon || "⚪"
                                                 color: Theme.textMain
-                                                font.pixelSize: 20
+                                                font.pixelSize: Design.Typography.subheading
                                                 font.bold: true
                                             }
 
@@ -1373,7 +1373,7 @@ Item {
                                                 anchors.horizontalCenter: parent.horizontalCenter
                                                 text: qsTr("Team %1").arg(Design.Numerals.roman(model.team_id || 0))
                                                 color: Theme.textBright
-                                                font.pixelSize: 10
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -1425,7 +1425,7 @@ Item {
                                             anchors.centerIn: parent
                                             text: "✕"
                                             color: Theme.textMain
-                                            font.pixelSize: 16
+                                            font.pixelSize: Design.Typography.body
                                             font.bold: true
                                         }
 
@@ -1513,7 +1513,7 @@ Item {
 
                         contentItem: Text {
                             text: parent.text
-                            font.pixelSize: 13
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                             color: addCpuButton.allowed ? Theme.textMain : Theme.textDim
                             horizontalAlignment: Text.AlignHCenter
@@ -1584,14 +1584,14 @@ Item {
                                         return player_ids_for_map(selected_map_data).length;
                                     })()))
                         color: Theme.textMain
-                        font.pixelSize: 14
+                        font.pixelSize: Design.Typography.label
                         font.bold: true
                     }
 
                     Text {
                         text: qsTr("Select your player ID:")
                         color: Theme.textSubLite
-                        font.pixelSize: 12
+                        font.pixelSize: Design.Typography.caption
                     }
 
                     Flow {
@@ -1630,7 +1630,7 @@ Item {
                                             return Theme.textSub;
                                         return (game.selected_player_id === pid) ? Theme.textMain : Theme.textSub;
                                     }
-                                    font.pixelSize: 12
+                                    font.pixelSize: Design.Typography.caption
                                     font.bold: {
                                         var pid = modelData;
                                         if (typeof game === 'undefined')
@@ -1670,7 +1670,7 @@ Item {
                             return qsTr("CPU will control: ID %1").arg(others.join(qsTr(", ID ")));
                         }
                         color: Theme.textSubLite
-                        font.pixelSize: 11
+                        font.pixelSize: Design.Typography.caption
                         wrapMode: Text.WordWrap
                         width: parent.width
                     }
@@ -1710,7 +1710,7 @@ Item {
                 text: validation_error
                 visible: validation_error !== ""
                 color: Theme.removeColor
-                font.pixelSize: 13
+                font.pixelSize: Design.Typography.caption
                 font.bold: true
                 wrapMode: Text.WordWrap
                 horizontalAlignment: Text.AlignHCenter
@@ -1753,7 +1753,7 @@ Item {
 
                 contentItem: Text {
                     text: parent.text
-                    font.pixelSize: backHover.containsMouse ? 14 : 13
+                    font.pixelSize: backHover.containsMouse ? Design.Typography.label : Design.Typography.caption
                     font.bold: backHover.containsMouse
                     color: Theme.textBright
                     horizontalAlignment: Text.AlignHCenter
@@ -1839,7 +1839,7 @@ Item {
 
                 contentItem: Text {
                     text: parent.text
-                    font.pixelSize: playButton.allowed ? (playHover.containsMouse ? 15 : 14) : 14
+                    font.pixelSize: (playButton.allowed && playHover.containsMouse) ? Design.Typography.body : Design.Typography.label
                     font.bold: true
                     color: playButton.allowed ? Theme.textMain : Theme.textDim
                     horizontalAlignment: Text.AlignHCenter

--- a/ui/qml/MediterraneanMapPanel.qml
+++ b/ui/qml/MediterraneanMapPanel.qml
@@ -717,7 +717,7 @@ Rectangle {
                 anchors.centerIn: parent
                 text: qsTr("Loading map…")
                 color: "#c8b89a"
-                font.pointSize: Theme.fontSizeMedium
+                font.pixelSize: Design.Typography.bodyLarge
             }
         }
 
@@ -782,7 +782,7 @@ Rectangle {
                     anchors.centerIn: parent
                     text: qsTr("Tilt -")
                     color: "#f2dfba"
-                    font.pointSize: Theme.fontSizeTiny
+                    font.pixelSize: Design.Typography.label
                     font.bold: true
                 }
 
@@ -816,7 +816,7 @@ Rectangle {
                     anchors.centerIn: parent
                     text: qsTr("Tilt +")
                     color: "#f2dfba"
-                    font.pointSize: Theme.fontSizeTiny
+                    font.pixelSize: Design.Typography.label
                     font.bold: true
                 }
 
@@ -850,7 +850,7 @@ Rectangle {
                     anchors.centerIn: parent
                     text: qsTr("Reset view")
                     color: "#f2dfba"
-                    font.pointSize: Theme.fontSizeTiny
+                    font.pixelSize: Design.Typography.label
                     font.bold: true
                 }
 
@@ -1029,7 +1029,7 @@ Rectangle {
                         anchors.centerIn: parent
                         text: "⚔"
                         color: "#ffffff"
-                        font.pointSize: Theme.fontSizeSmall
+                        font.pixelSize: Design.Typography.body
                         font.bold: true
                     }
 
@@ -1184,13 +1184,13 @@ Rectangle {
                     text: root.hover_province_name
                     color: "#2d241c"
                     font.bold: true
-                    font.pointSize: Theme.fontSizeSmall
+                    font.pixelSize: Design.Typography.body
                 }
 
                 Label {
                     text: qsTr("Control: ") + root.hover_province_owner
                     color: "#4a3f32"
-                    font.pointSize: Theme.fontSizeTiny
+                    font.pixelSize: Design.Typography.label
                 }
             }
         }
@@ -1218,7 +1218,7 @@ Rectangle {
                 Label {
                     text: qsTr("Legend")
                     color: Design.Theme.textSecondary
-                    font.pointSize: Theme.fontSizeSmall
+                    font.pixelSize: Design.Typography.body
                     font.bold: true
                 }
 
@@ -1250,7 +1250,7 @@ Rectangle {
                         Label {
                             text: modelData.name
                             color: "#4a3f32"
-                            font.pointSize: Theme.fontSizeTiny
+                            font.pixelSize: Design.Typography.label
                         }
                     }
                 }
@@ -1301,7 +1301,7 @@ Rectangle {
                 anchors.centerIn: parent
                 text: Design.Icons.capture + " " + root.active_region_name
                 color: "#2d241c"
-                font.pointSize: Theme.fontSizeSmall
+                font.pixelSize: Design.Typography.body
                 font.bold: true
             }
         }

--- a/ui/qml/MissionDetailPanel.qml
+++ b/ui/qml/MissionDetailPanel.qml
@@ -219,7 +219,7 @@ Rectangle {
                             return mission_data && mission_data.mission_id ? titleize(mission_data.mission_id) : "";
                         }
                         color: Theme.textMain
-                        font.pointSize: Theme.fontSizeTitle
+                        font.pixelSize: Design.Typography.heading
                         font.bold: true
                         font.family: "serif"
                         Layout.fillWidth: true
@@ -245,7 +245,7 @@ Rectangle {
                                 anchors.centerIn: parent
                                 text: command_glyph
                                 color: "#f2dfba"
-                                font.pointSize: Theme.fontSizeTiny
+                                font.pixelSize: Design.Typography.label
                                 font.bold: true
                             }
                         }
@@ -276,7 +276,7 @@ Rectangle {
                                             return "";
                                         return Design.Icons.terrain(mission_definition.terrain_type);
                                     }
-                                    font.pointSize: Theme.fontSizeSmall
+                                    font.pixelSize: Design.Typography.body
                                 }
 
                                 Label {
@@ -286,7 +286,7 @@ Rectangle {
                                         return terrain_label(mission_definition.terrain_type);
                                     }
                                     color: "#ffffff"
-                                    font.pointSize: Theme.fontSizeTiny
+                                    font.pixelSize: Design.Typography.label
                                     font.bold: true
                                 }
                             }
@@ -299,7 +299,7 @@ Rectangle {
                         color: Theme.textSubLite
                         wrapMode: Text.WordWrap
                         Layout.fillWidth: true
-                        font.pointSize: Theme.fontSizeMedium
+                        font.pixelSize: Design.Typography.bodyLarge
                         font.family: "serif"
                     }
 
@@ -321,7 +321,7 @@ Rectangle {
 
                             Label {
                                 text: Design.Icons.briefing
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                                 Layout.alignment: Qt.AlignTop
                             }
 
@@ -332,7 +332,7 @@ Rectangle {
                                 color: Theme.textSubLite
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
-                                font.pointSize: Theme.fontSizeTiny
+                                font.pixelSize: Design.Typography.label
                                 font.italic: true
                                 font.family: "serif"
                             }
@@ -351,7 +351,7 @@ Rectangle {
                                 return qsTr("Campaign Objectives:");
                             }
                             color: Theme.textDim
-                            font.pointSize: Theme.fontSizeSmall
+                            font.pixelSize: Design.Typography.body
                             font.bold: true
                         }
 
@@ -365,7 +365,7 @@ Rectangle {
                             delegate: Label {
                                 text: "• " + (modelData.description || qsTr("Complete mission objective"))
                                 color: Theme.textSubLite
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
                             }
@@ -375,7 +375,7 @@ Rectangle {
                             visible: !!(mission_definition && mission_definition.optional_objectives && mission_definition.optional_objectives.length > 0)
                             text: qsTr("Optional:")
                             color: Theme.textDim
-                            font.pointSize: Theme.fontSizeTiny
+                            font.pixelSize: Design.Typography.label
                             font.bold: true
                         }
 
@@ -389,7 +389,7 @@ Rectangle {
                             delegate: Label {
                                 text: "• " + (modelData.description || qsTr("Complete optional objective"))
                                 color: Theme.textSubLite
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
                             }
@@ -399,7 +399,7 @@ Rectangle {
                             visible: !!(mission_definition && mission_definition.defeat_conditions && mission_definition.defeat_conditions.length > 0)
                             text: qsTr("Failure:")
                             color: Theme.textDim
-                            font.pointSize: Theme.fontSizeTiny
+                            font.pixelSize: Design.Typography.label
                             font.bold: true
                         }
 
@@ -413,7 +413,7 @@ Rectangle {
                             delegate: Label {
                                 text: "• " + (modelData.description || qsTr("Avoid mission failure"))
                                 color: Theme.textSubLite
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
                             }
@@ -423,7 +423,7 @@ Rectangle {
                             visible: !mission_definition || objectives_empty()
                             text: qsTr("• Complete the mission successfully")
                             color: Theme.textSubLite
-                            font.pointSize: Theme.fontSizeSmall
+                            font.pixelSize: Design.Typography.body
                         }
                     }
 
@@ -435,7 +435,7 @@ Rectangle {
                         Label {
                             text: qsTr("Army Composition:")
                             color: Theme.textDim
-                            font.pointSize: Theme.fontSizeSmall
+                            font.pixelSize: Design.Typography.body
                             font.bold: true
                         }
 
@@ -478,7 +478,7 @@ Rectangle {
                                         anchors.centerIn: parent
                                         text: Design.Numerals.roman(modelData.count) + "x " + titleize(modelData.type)
                                         color: Theme.infoText
-                                        font.pointSize: Theme.fontSizeTiny
+                                        font.pixelSize: Design.Typography.label
                                     }
                                 }
                             }
@@ -492,7 +492,7 @@ Rectangle {
                         Label {
                             text: qsTr("Historical Ledger:")
                             color: Theme.textDim
-                            font.pointSize: Theme.fontSizeSmall
+                            font.pixelSize: Design.Typography.body
                             font.bold: true
                         }
 
@@ -523,7 +523,7 @@ Rectangle {
                                         anchors.centerIn: parent
                                         text: modelData.text
                                         color: Theme.textSubLite
-                                        font.pointSize: Theme.fontSizeTiny
+                                        font.pixelSize: Design.Typography.label
                                     }
                                 }
                             }
@@ -578,7 +578,7 @@ Rectangle {
                                 Label {
                                     text: commander_title
                                     color: Theme.textMain
-                                    font.pointSize: Theme.fontSizeSmall
+                                    font.pixelSize: Design.Typography.body
                                     font.bold: true
                                     font.family: "serif"
                                     Layout.fillWidth: true
@@ -588,7 +588,7 @@ Rectangle {
                                 Label {
                                     text: root.player_commander && root.player_commander.display_name ? root.player_commander.display_name : root.command_banner_text
                                     color: Theme.textMain
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     font.bold: true
                                     Layout.fillWidth: true
                                     wrapMode: Text.WordWrap
@@ -597,7 +597,7 @@ Rectangle {
                                 Label {
                                     text: root.player_commander && root.player_commander.battlefield_role ? root.player_commander.battlefield_role : root.commander_title
                                     color: Theme.textDim
-                                    font.pointSize: Theme.fontSizeTiny
+                                    font.pixelSize: Design.Typography.label
                                     Layout.fillWidth: true
                                     wrapMode: Text.WordWrap
                                 }
@@ -607,7 +607,7 @@ Rectangle {
                                     text: root.player_commander && root.player_commander.bonus_summary ? root.player_commander.bonus_summary : ""
                                     color: Theme.textSubLite
                                     wrapMode: Text.WordWrap
-                                    font.pointSize: Theme.fontSizeTiny
+                                    font.pixelSize: Design.Typography.label
                                     Layout.fillWidth: true
                                 }
 
@@ -615,7 +615,7 @@ Rectangle {
                                     text: root.reward_summary
                                     color: Theme.textSubLite
                                     wrapMode: Text.WordWrap
-                                    font.pointSize: Theme.fontSizeTiny
+                                    font.pixelSize: Design.Typography.label
                                     Layout.fillWidth: true
                                 }
 
@@ -623,7 +623,7 @@ Rectangle {
                                     visible: root.opposing_forces.length > 0
                                     text: qsTr("Opposition Command")
                                     color: Theme.textDim
-                                    font.pointSize: Theme.fontSizeSmall
+                                    font.pixelSize: Design.Typography.body
                                     font.bold: true
                                     Layout.fillWidth: true
                                 }
@@ -654,7 +654,7 @@ Rectangle {
                                                 Label {
                                                     text: root.command_glyph_for_setup(modelData)
                                                     color: "#c29555"
-                                                    font.pointSize: Theme.fontSizeSmall
+                                                    font.pixelSize: Design.Typography.body
                                                     font.bold: true
                                                 }
 
@@ -662,7 +662,7 @@ Rectangle {
                                                     Layout.fillWidth: true
                                                     text: modelData.commander && modelData.commander.display_name ? modelData.commander.display_name : qsTr("Field Command Pending")
                                                     color: Theme.textMain
-                                                    font.pointSize: Theme.fontSizeSmall
+                                                    font.pixelSize: Design.Typography.body
                                                     font.bold: true
                                                     wrapMode: Text.WordWrap
                                                 }
@@ -672,7 +672,7 @@ Rectangle {
                                                 Layout.fillWidth: true
                                                 text: root.setup_summary(modelData)
                                                 color: Theme.textDim
-                                                font.pointSize: Theme.fontSizeTiny
+                                                font.pixelSize: Design.Typography.label
                                                 wrapMode: Text.WordWrap
                                                 visible: text.length > 0
                                             }
@@ -681,7 +681,7 @@ Rectangle {
                                                 Layout.fillWidth: true
                                                 text: modelData.commander && modelData.commander.battlefield_role ? modelData.commander.battlefield_role : root.command_banner_for_setup(modelData)
                                                 color: Theme.textSubLite
-                                                font.pointSize: Theme.fontSizeTiny
+                                                font.pixelSize: Design.Typography.label
                                                 wrapMode: Text.WordWrap
                                             }
 
@@ -689,7 +689,7 @@ Rectangle {
                                                 Layout.fillWidth: true
                                                 text: modelData.commander && modelData.commander.bonus_summary ? modelData.commander.bonus_summary : qsTr("No named commander assigned to this force.")
                                                 color: Theme.textSubLite
-                                                font.pointSize: Theme.fontSizeTiny
+                                                font.pixelSize: Design.Typography.label
                                                 wrapMode: Text.WordWrap
                                             }
                                         }
@@ -718,7 +718,7 @@ Rectangle {
                     text: mission_data && !mission_data.unlocked ? qsTr("Orders sealed until prior victories are secured.") : (mission_data && mission_data.completed ? qsTr("Victory recorded. You may replay this engagement at will.") : qsTr("Orders issued. Deploy when ready."))
                     color: Theme.textSubLite
                     wrapMode: Text.WordWrap
-                    font.pointSize: Theme.fontSizeTiny
+                    font.pixelSize: Design.Typography.label
                     verticalAlignment: Text.AlignVCenter
                 }
             }
@@ -742,7 +742,7 @@ Rectangle {
 
                     Label {
                         text: Design.Icons.objective
-                        font.pointSize: Theme.fontSizeMedium
+                        font.pixelSize: Design.Typography.bodyLarge
                         Layout.alignment: Qt.AlignTop
                     }
 
@@ -751,7 +751,7 @@ Rectangle {
                         color: Theme.textSubLite
                         wrapMode: Text.WordWrap
                         Layout.fillWidth: true
-                        font.pointSize: Theme.fontSizeTiny
+                        font.pixelSize: Design.Typography.label
                     }
                 }
             }
@@ -776,7 +776,7 @@ Rectangle {
                 visible: !!(mission_data && !mission_data.unlocked)
                 text: Design.Icons.locked + " " + qsTr("Locked")
                 color: Theme.textDim
-                font.pointSize: Theme.fontSizeSmall
+                font.pixelSize: Design.Typography.body
                 horizontalAlignment: Text.AlignHCenter
                 Layout.alignment: Qt.AlignHCenter
             }
@@ -785,7 +785,7 @@ Rectangle {
                 visible: !!(mission_data && mission_data.completed)
                 text: qsTr("✓ Completed")
                 color: Theme.successText
-                font.pointSize: Theme.fontSizeSmall
+                font.pixelSize: Design.Typography.body
                 font.bold: true
                 horizontalAlignment: Text.AlignHCenter
                 Layout.alignment: Qt.AlignHCenter

--- a/ui/qml/MissionListItem.qml
+++ b/ui/qml/MissionListItem.qml
@@ -97,7 +97,7 @@ Rectangle {
                 anchors.centerIn: parent
                 text: mission_data ? Design.Numerals.ordinal(mission_data.order_index) : "?"
                 color: "#f5e7c5"
-                font.pointSize: Theme.fontSizeMedium
+                font.pixelSize: Design.Typography.bodyLarge
                 font.bold: true
             }
         }
@@ -115,7 +115,7 @@ Rectangle {
                 Label {
                     text: mission_glyph_prefix + root.mission_title
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeMedium
+                    font.pixelSize: Design.Typography.bodyLarge
                     font.bold: true
                     font.family: "serif"
                     Layout.fillWidth: true
@@ -139,7 +139,7 @@ Rectangle {
                         anchors.centerIn: parent
                         text: qsTr("✓ Archived")
                         color: Theme.successText
-                        font.pointSize: Theme.fontSizeTiny
+                        font.pixelSize: Design.Typography.label
                         font.bold: true
                     }
                 }
@@ -159,7 +159,7 @@ Rectangle {
                         anchors.centerIn: parent
                         text: Design.Icons.locked + " " + qsTr("Sealed")
                         color: Theme.textDim
-                        font.pointSize: Theme.fontSizeTiny
+                        font.pixelSize: Design.Typography.label
                     }
                 }
 
@@ -178,7 +178,7 @@ Rectangle {
                         anchors.centerIn: parent
                         text: qsTr("Open Order")
                         color: Theme.infoText
-                        font.pointSize: Theme.fontSizeTiny
+                        font.pixelSize: Design.Typography.label
                         font.bold: true
                     }
                 }
@@ -193,7 +193,7 @@ Rectangle {
                 maximumLineCount: 2
                 elide: Text.ElideRight
                 Layout.fillWidth: true
-                font.pointSize: Theme.fontSizeSmall
+                font.pixelSize: Design.Typography.body
                 font.family: "serif"
             }
 
@@ -204,7 +204,7 @@ Rectangle {
                 Label {
                     text: qsTr("Difficulty:")
                     color: Theme.textDim
-                    font.pointSize: Theme.fontSizeTiny
+                    font.pixelSize: Design.Typography.label
                 }
 
                 Repeater {
@@ -223,7 +223,7 @@ Rectangle {
 
                         text: index < filled ? "★" : "☆"
                         color: index < filled ? Theme.warningText : Theme.textDim
-                        font.pointSize: Theme.fontSizeTiny
+                        font.pixelSize: Design.Typography.label
                     }
                 }
             }
@@ -233,7 +233,7 @@ Rectangle {
             id: advanceArrow
 
             text: "➤"
-            font.pointSize: Theme.fontSizeTitle
+            font.pixelSize: Design.Typography.heading
             color: "#c29555"
             Layout.alignment: Qt.AlignVCenter
 

--- a/ui/qml/PlayerConfigPanel.qml
+++ b/ui/qml/PlayerConfigPanel.qml
@@ -64,7 +64,7 @@ Item {
 
         text: root.map_title
         color: colors.textMain
-        font.pixelSize: 20
+        font.pixelSize: Design.Typography.subheading
         font.bold: true
         elide: Text.ElideRight
 
@@ -92,7 +92,7 @@ Item {
 
             text: qsTr("Players (%1)").arg(Design.Numerals.roman(players_model ? players_model.count : 0))
             color: colors.textMain
-            font.pixelSize: 16
+            font.pixelSize: Design.Typography.body
             font.bold: true
         }
 
@@ -101,7 +101,7 @@ Item {
 
             text: qsTr("Click color/team to cycle")
             color: colors.textSubLite
-            font.pixelSize: 11
+            font.pixelSize: Design.Typography.caption
             font.italic: true
 
             anchors {
@@ -148,7 +148,7 @@ Item {
                         anchors.centerIn: parent
                         text: qsTr("Select a map to configure players")
                         color: colors.textSub
-                        font.pixelSize: 13
+                        font.pixelSize: Design.Typography.caption
                     }
                 }
 
@@ -202,7 +202,7 @@ Item {
 
             contentItem: Text {
                 text: addCPUBtn.text
-                font.pixelSize: 12
+                font.pixelSize: Design.Typography.caption
                 font.bold: true
                 color: addCPUBtn.allowed ? colors.addColor : colors.textSub
                 horizontalAlignment: Text.AlignHCenter
@@ -237,7 +237,7 @@ Item {
                 return available === 1 ? qsTr("%1 slot available").arg(Design.Numerals.roman(available)) : qsTr("%1 slots available").arg(Design.Numerals.roman(available));
             }
             color: colors.textSubLite
-            font.pixelSize: 11
+            font.pixelSize: Design.Typography.caption
 
             anchors {
                 left: addCPUBtn.right
@@ -279,7 +279,7 @@ Item {
             visible: !previewImage.visible
             text: qsTr("(map preview)")
             color: colors.hint
-            font.pixelSize: 14
+            font.pixelSize: Design.Typography.label
         }
     }
 }

--- a/ui/qml/PlayerListItem.qml
+++ b/ui/qml/PlayerListItem.qml
@@ -36,7 +36,7 @@ Rectangle {
                 anchors.centerIn: parent
                 text: player_data.playerName || ""
                 color: player_data.isHuman ? colors.addColor : colors.textMain
-                font.pixelSize: 14
+                font.pixelSize: Design.Typography.label
                 font.bold: player_data.isHuman || false
             }
         }
@@ -53,7 +53,7 @@ Rectangle {
                 anchors.centerIn: parent
                 text: player_data.colorName || qsTr("Color")
                 color: "white"
-                font.pixelSize: 11
+                font.pixelSize: Design.Typography.caption
                 font.bold: true
                 style: Text.Outline
                 styleColor: "black"
@@ -103,14 +103,14 @@ Rectangle {
                         return team_icons[(player_data.team_id - 1) % team_icons.length];
                     }
                     color: colors.textMain
-                    font.pixelSize: 18
+                    font.pixelSize: Design.Typography.bodyLarge
                 }
 
                 Text {
                     anchors.horizontalCenter: parent.horizontalCenter
                     text: "T" + Design.Numerals.roman(player_data.team_id || 1)
                     color: colors.textSubLite
-                    font.pixelSize: 9
+                    font.pixelSize: Design.Typography.caption
                 }
             }
 
@@ -152,7 +152,7 @@ Rectangle {
 
                 text: player_data.factionName || "Standard of Iron"
                 color: colors.textSub
-                font.pixelSize: 11
+                font.pixelSize: Design.Typography.caption
                 elide: Text.ElideRight
                 width: parent.width - 8
                 horizontalAlignment: Text.AlignHCenter
@@ -184,7 +184,7 @@ Rectangle {
                 anchors.centerIn: parent
                 text: "✕"
                 color: "white"
-                font.pixelSize: 16
+                font.pixelSize: Design.Typography.body
                 font.bold: true
             }
 

--- a/ui/qml/ProductionPanel.qml
+++ b/ui/qml/ProductionPanel.qml
@@ -338,7 +338,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("PRODUCTION QUEUE")
                         color: hs.bronze
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                         font.bold: true
                     }
 
@@ -364,8 +364,8 @@ Rectangle {
                                     return "archer";
                                 }
 
-                                width: 36
-                                height: 36
+                                width: Design.A11y.scaled(36)
+                                height: Design.A11y.scaled(36)
                                 radius: 6
                                 color: is_producing ? "#7F9A5F" : (is_occupied ? "#2F251D" : "#120D09")
                                 border.color: is_producing ? "#8FA46B" : (is_occupied ? "#6F8E8C" : "#3B2F24")
@@ -375,8 +375,8 @@ Rectangle {
                                     id: queueIconImage
 
                                     anchors.centerIn: parent
-                                    width: 28
-                                    height: 28
+                                    width: Design.A11y.scaled(28)
+                                    height: Design.A11y.scaled(28)
                                     fillMode: Image.PreserveAspectFit
                                     smooth: true
                                     source: parent.is_occupied ? productionPanel.unit_icon_source(parent.queue_unit_type, productionContent.prod.nation_id) : ""
@@ -387,7 +387,7 @@ Rectangle {
                                     anchors.centerIn: parent
                                     text: parent.is_occupied ? productionPanel.unit_icon_emoji(parent.queue_unit_type) : "·"
                                     color: parent.is_producing ? "#F4E7C8" : (parent.is_occupied ? "#D4B57C" : "#6B5231")
-                                    font.pointSize: parent.is_occupied ? 16 : 20
+                                    font.pixelSize: parent.is_occupied ? Design.Typography.subheading : Design.Typography.heading
                                     font.bold: parent.is_producing
                                     visible: !queueIconImage.visible
                                 }
@@ -398,7 +398,7 @@ Rectangle {
                                     anchors.margins: 2
                                     text: (index + 1).toString()
                                     color: parent.is_occupied ? "#8D7146" : "#3B2F24"
-                                    font.pointSize: 7
+                                    font.pixelSize: Design.Typography.caption
                                     font.bold: true
                                 }
 
@@ -428,13 +428,13 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: queue_total + " / 5"
                         color: queue_total >= 5 ? "#C0403B" : "#D4B57C"
-                        font.pointSize: 9
+                        font.pixelSize: Design.Typography.caption
                         font.bold: queue_total >= 5
                     }
 
                     Rectangle {
                         width: parent.width - 20
-                        height: 20
+                        height: Math.max(Design.A11y.scaled(20), Design.Typography.label + 6)
                         anchors.horizontalCenter: parent.horizontalCenter
                         radius: 10
                         color: "#120D09"
@@ -478,7 +478,7 @@ Rectangle {
                             anchors.centerIn: parent
                             text: productionContent.prod.in_progress ? qsTr("%1s").arg(Math.max(0, productionContent.prod.time_remaining).toFixed(1)) : qsTr("Idle")
                             color: "#F4E7C8"
-                            font.pointSize: 9
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                             style: Text.Outline
                             styleColor: "#120D09"
@@ -489,7 +489,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("Available Population: %1 / %2").arg(productionContent.prod.manpower_available || 0).arg(productionContent.prod.max_units || 0)
                         color: (productionContent.prod.manpower_available <= 0) ? "#C0403B" : "#D4B57C"
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                     }
                 }
             }
@@ -519,7 +519,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("RECRUIT UNITS")
                         color: hs.bronze
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                         font.bold: true
                     }
 
@@ -563,7 +563,7 @@ Rectangle {
                                 visible: !archerRecruitIcon.visible
                                 text: productionPanel.unit_icon_emoji("archer")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -579,7 +579,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: archerCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: archerCostRow.implicitHeight + 6
                                         radius: 8
                                         color: archerCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: archerCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -592,8 +592,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -602,7 +602,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: archerCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -693,7 +693,7 @@ Rectangle {
                                 visible: !swordsmanRecruitIcon.visible
                                 text: productionPanel.unit_icon_emoji("swordsman")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -709,7 +709,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: swordsmanCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: swordsmanCostRow.implicitHeight + 6
                                         radius: 8
                                         color: swordsmanCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: swordsmanCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -722,8 +722,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -732,7 +732,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: swordsmanCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -823,7 +823,7 @@ Rectangle {
                                 visible: !spearmanRecruitIcon.visible
                                 text: productionPanel.unit_icon_emoji("spearman")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -839,7 +839,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: spearmanCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: spearmanCostRow.implicitHeight + 6
                                         radius: 8
                                         color: spearmanCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: spearmanCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -852,8 +852,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -862,7 +862,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: spearmanCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -953,7 +953,7 @@ Rectangle {
                                 visible: !horseKnightIcon.visible
                                 text: productionPanel.unit_icon_emoji("horse_swordsman")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -969,7 +969,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: horseKnightCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: horseKnightCostRow.implicitHeight + 6
                                         radius: 8
                                         color: horseKnightCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: horseKnightCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -982,8 +982,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -992,7 +992,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: horseKnightCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -1083,7 +1083,7 @@ Rectangle {
                                 visible: !horseArcherIcon.visible
                                 text: productionPanel.unit_icon_emoji("horse_archer")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -1099,7 +1099,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: horseArcherCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: horseArcherCostRow.implicitHeight + 6
                                         radius: 8
                                         color: horseArcherCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: horseArcherCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -1112,8 +1112,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -1122,7 +1122,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: horseArcherCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -1213,7 +1213,7 @@ Rectangle {
                                 visible: !horseSpearmanIcon.visible
                                 text: productionPanel.unit_icon_emoji("horse_spearman")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -1229,7 +1229,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: horseSpearmanCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: horseSpearmanCostRow.implicitHeight + 6
                                         radius: 8
                                         color: horseSpearmanCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: horseSpearmanCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -1242,8 +1242,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -1252,7 +1252,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: horseSpearmanCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -1343,7 +1343,7 @@ Rectangle {
                                 visible: !healerRecruitIcon.visible
                                 text: productionPanel.unit_icon_emoji("healer")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -1359,7 +1359,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: healerCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: healerCostRow.implicitHeight + 6
                                         radius: 8
                                         color: healerCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: healerCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -1372,8 +1372,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -1382,7 +1382,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: healerCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -1473,7 +1473,7 @@ Rectangle {
                                 visible: !builderRecruitIcon.visible
                                 text: productionPanel.unit_icon_emoji("builder")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -1489,7 +1489,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: builderRecruitCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: builderRecruitCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderRecruitCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderRecruitCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -1502,8 +1502,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -1512,7 +1512,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderRecruitCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -1604,7 +1604,7 @@ Rectangle {
                                 visible: !elephantRecruitIcon.visible
                                 text: productionPanel.unit_icon_emoji("elephant")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 42
+                                font.pixelSize: Design.Typography.glyphLarge
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -1620,7 +1620,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: elephantCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: elephantCostRow.implicitHeight + 6
                                         radius: 8
                                         color: elephantCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: elephantCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -1633,8 +1633,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -1643,7 +1643,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: elephantCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -1729,7 +1729,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("HOME RECRUITMENT")
                         color: hs.bronze
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                         font.bold: true
                     }
 
@@ -1742,7 +1742,7 @@ Rectangle {
                             return qsTr("Available civilians: %1 / %2").arg(ready).arg(homeProductionContent.prod.max_units || 0);
                         }
                         color: Theme.textSubLite
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                     }
 
                     Rectangle {
@@ -1783,7 +1783,7 @@ Rectangle {
                             visible: !civilianRecruitIcon.visible
                             text: productionPanel.unit_icon_emoji("civilian")
                             color: parent.is_enabled ? Theme.textMain : Theme.textHint
-                            font.pointSize: 36
+                            font.pixelSize: Design.Typography.glyph
                             opacity: parent.is_enabled ? 0.9 : 0.4
                         }
 
@@ -1799,7 +1799,7 @@ Rectangle {
 
                                 delegate: Rectangle {
                                     width: civilianCostRow.implicitWidth + 8
-                                    height: 16
+                                    height: civilianCostRow.implicitHeight + 6
                                     radius: 8
                                     color: civilianCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                     border.color: civilianCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -1812,8 +1812,8 @@ Rectangle {
                                         spacing: 3
 
                                         Image {
-                                            width: 9
-                                            height: 9
+                                            width: Design.A11y.scaled(9)
+                                            height: Design.A11y.scaled(9)
                                             fillMode: Image.PreserveAspectFit
                                             smooth: true
                                             source: productionPanel.cost_icon_source(modelData.key)
@@ -1822,7 +1822,7 @@ Rectangle {
                                         Text {
                                             text: modelData.amount
                                             color: civilianCard.is_enabled ? Theme.textMain : Theme.textDim
-                                            font.pointSize: 7
+                                            font.pixelSize: Design.Typography.caption
                                             font.bold: true
                                         }
                                     }
@@ -1894,7 +1894,7 @@ Rectangle {
 
                         anchors.horizontalCenter: parent.horizontalCenter
                         width: parent.parent.width - 20
-                        height: 32
+                        height: Design.A11y.scaled(32)
                         text: rallyContent.placing_barracks_rally ? Design.Icons.rally + " " + qsTr("Click Map to Set Rally") : Design.Icons.rally + " " + qsTr("Set Rally Point")
                         focusPolicy: Qt.NoFocus
                         onClicked: {
@@ -1918,7 +1918,7 @@ Rectangle {
 
                         contentItem: Text {
                             text: parent.text
-                            font.pointSize: 9
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                             color: rallyButton.allowed ? "#F4E7C8" : "#6B5231"
                             horizontalAlignment: Text.AlignHCenter
@@ -1930,7 +1930,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: rallyContent.placing_barracks_rally ? qsTr("Right-click to cancel") : ""
                         color: "#8D7146"
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                         font.italic: true
                     }
                 }
@@ -1990,7 +1990,7 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                             text: builderHeaderIcon.visible ? qsTr("BUILDER CONSTRUCTION") : Design.Icons.build + " " + qsTr("BUILDER CONSTRUCTION")
                             color: hs.bronze
-                            font.pointSize: 9
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                         }
                     }
@@ -1999,12 +1999,12 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("Build siege weapons, structures, and gather wood, stone, and iron")
                         color: "#8D7146"
-                        font.pointSize: 7
+                        font.pixelSize: Design.Typography.caption
                     }
 
                     Rectangle {
                         width: parent.width - 20
-                        height: 20
+                        height: Math.max(Design.A11y.scaled(20), Design.Typography.label + 6)
                         anchors.horizontalCenter: parent.horizontalCenter
                         radius: 10
                         color: "#120D09"
@@ -2048,7 +2048,7 @@ Rectangle {
                             anchors.centerIn: parent
                             text: builderProductionContent.builder_prod.in_progress ? qsTr("%1s").arg(Math.max(0, builderProductionContent.builder_prod.time_remaining).toFixed(1)) : qsTr("Idle")
                             color: "#F4E7C8"
-                            font.pointSize: 9
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                             style: Text.Outline
                             styleColor: "#120D09"
@@ -2079,7 +2079,7 @@ Rectangle {
                             return (is_collection_task ? qsTr("Task: %1") : qsTr("Building: %1")).arg(label);
                         }
                         color: builderProductionContent.builder_prod.in_progress ? "#7F9A5F" : "#8D7146"
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                         font.bold: builderProductionContent.builder_prod.in_progress
                         visible: true
                     }
@@ -2124,7 +2124,7 @@ Rectangle {
                                 visible: !builderCatapultIcon.visible
                                 text: productionPanel.unit_icon_emoji("catapult")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 36
+                                font.pixelSize: Design.Typography.glyph
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -2134,7 +2134,7 @@ Rectangle {
                                 anchors.bottomMargin: 24
                                 text: qsTr("Catapult")
                                 color: parent.is_enabled ? "#D4B57C" : "#6B5231"
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -2150,7 +2150,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: catapultCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: catapultCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderCatapultCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderCatapultCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -2163,8 +2163,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -2173,7 +2173,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderCatapultCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -2264,7 +2264,7 @@ Rectangle {
                                 visible: !builderBallistaIcon.visible
                                 text: productionPanel.unit_icon_emoji("ballista")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 36
+                                font.pixelSize: Design.Typography.glyph
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -2274,7 +2274,7 @@ Rectangle {
                                 anchors.bottomMargin: 24
                                 text: qsTr("Ballista")
                                 color: parent.is_enabled ? "#D4B57C" : "#6B5231"
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -2290,7 +2290,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: ballistaCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: ballistaCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderBallistaCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderBallistaCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -2303,8 +2303,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -2313,7 +2313,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderBallistaCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -2404,7 +2404,7 @@ Rectangle {
                                 visible: !builderDefenseTowerIcon.visible
                                 text: Design.Icons.unitGlyph("defense_tower")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 36
+                                font.pixelSize: Design.Typography.glyph
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -2414,7 +2414,7 @@ Rectangle {
                                 anchors.bottomMargin: 24
                                 text: qsTr("Defense Tower")
                                 color: parent.is_enabled ? "#D4B57C" : "#6B5231"
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -2430,7 +2430,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: defenseTowerCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: defenseTowerCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderDefenseTowerCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderDefenseTowerCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -2443,8 +2443,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -2453,7 +2453,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderDefenseTowerCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -2544,7 +2544,7 @@ Rectangle {
                                 visible: !builderHomeIcon.visible
                                 text: Design.Icons.unitGlyph("home")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 36
+                                font.pixelSize: Design.Typography.glyph
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -2554,7 +2554,7 @@ Rectangle {
                                 anchors.bottomMargin: 24
                                 text: qsTr("Home")
                                 color: parent.is_enabled ? "#D4B57C" : "#6B5231"
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -2570,7 +2570,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: homeCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: homeCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderHomeCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderHomeCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -2583,8 +2583,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -2593,7 +2593,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderHomeCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -2684,7 +2684,7 @@ Rectangle {
                                 visible: !builderWallSegmentIcon.visible
                                 text: Design.Icons.collect
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 34
+                                font.pixelSize: Design.Typography.glyph
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -2694,7 +2694,7 @@ Rectangle {
                                 anchors.bottomMargin: 24
                                 text: qsTr("Wall Segment")
                                 color: parent.is_enabled ? "#D4B57C" : "#6B5231"
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -2710,7 +2710,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: wallSegmentCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: wallSegmentCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderWallSegmentCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderWallSegmentCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -2723,8 +2723,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -2733,7 +2733,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderWallSegmentCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -2824,7 +2824,7 @@ Rectangle {
                                 visible: !builderWallGateIcon.visible
                                 text: Design.Icons.gate
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 34
+                                font.pixelSize: Design.Typography.glyph
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -2834,7 +2834,7 @@ Rectangle {
                                 anchors.bottomMargin: 24
                                 text: qsTr("Wall Gate")
                                 color: parent.is_enabled ? "#D4B57C" : "#6B5231"
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -2850,7 +2850,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: wallGateCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: wallGateCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderWallGateCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderWallGateCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -2863,8 +2863,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -2873,7 +2873,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderWallGateCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -2964,7 +2964,7 @@ Rectangle {
                                 visible: builderMarketplaceIcon.status !== Image.Ready
                                 text: Design.Icons.unitGlyph("marketplace")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 34
+                                font.pixelSize: Design.Typography.glyph
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -2974,7 +2974,7 @@ Rectangle {
                                 anchors.bottomMargin: 24
                                 text: qsTr("Marketplace")
                                 color: parent.is_enabled ? "#D4B57C" : "#6B5231"
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -2990,7 +2990,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: marketplaceCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: marketplaceCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderMarketplaceCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderMarketplaceCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -3003,8 +3003,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -3013,7 +3013,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderMarketplaceCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -3104,7 +3104,7 @@ Rectangle {
                                 visible: builderTempleIcon.status !== Image.Ready
                                 text: Design.Icons.unitGlyph("temple")
                                 color: parent.is_enabled ? "#F4E7C8" : "#6B5231"
-                                font.pointSize: 34
+                                font.pixelSize: Design.Typography.glyph
                                 opacity: parent.is_enabled ? 0.9 : 0.4
                             }
 
@@ -3114,7 +3114,7 @@ Rectangle {
                                 anchors.bottomMargin: 24
                                 text: qsTr("Temple")
                                 color: parent.is_enabled ? "#D4B57C" : "#6B5231"
-                                font.pointSize: 8
+                                font.pixelSize: Design.Typography.caption
                                 font.bold: true
                             }
 
@@ -3130,7 +3130,7 @@ Rectangle {
 
                                     delegate: Rectangle {
                                         width: templeCostRow.implicitWidth + 8
-                                        height: 16
+                                        height: templeCostRow.implicitHeight + 6
                                         radius: 8
                                         color: builderTempleCard.is_enabled ? "#cc2a1d12" : "#991f150d"
                                         border.color: builderTempleCard.is_enabled ? hs.bronze : "#8C6A3E"
@@ -3143,8 +3143,8 @@ Rectangle {
                                             spacing: 3
 
                                             Image {
-                                                width: 9
-                                                height: 9
+                                                width: Design.A11y.scaled(9)
+                                                height: Design.A11y.scaled(9)
                                                 fillMode: Image.PreserveAspectFit
                                                 smooth: true
                                                 source: productionPanel.cost_icon_source(modelData.key)
@@ -3153,7 +3153,7 @@ Rectangle {
                                             Text {
                                                 text: modelData.amount
                                                 color: builderTempleCard.is_enabled ? Theme.textMain : Theme.textDim
-                                                font.pointSize: 7
+                                                font.pixelSize: Design.Typography.caption
                                                 font.bold: true
                                             }
                                         }
@@ -3254,7 +3254,7 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                             text: marketplaceHeaderIcon.visible ? qsTr("MARKETPLACE") : Design.Icons.unitGlyph("marketplace") + " " + qsTr("MARKETPLACE")
                             color: hs.bronze
-                            font.pointSize: 9
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                         }
                     }
@@ -3263,7 +3263,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: marketplaceContent.market_state.has_marketplace ? qsTr("Trade resources for gold at fixed exchange rates") : qsTr("Select your marketplace to trade")
                         color: "#8D7146"
-                        font.pointSize: 7
+                        font.pixelSize: Design.Typography.caption
                     }
 
                     Text {
@@ -3271,7 +3271,7 @@ Rectangle {
                         visible: marketplaceContent.market_state.has_marketplace
                         text: qsTr("Gold: %1    Trade size: %2").arg(productionPanel.resource_amount(productionPanel.current_resources(), "gold")).arg(Math.max(0, marketplaceContent.market_state.trade_quantity || 0))
                         color: "#F4E7C8"
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                         font.bold: true
                     }
 
@@ -3280,7 +3280,7 @@ Rectangle {
                         visible: !marketplaceContent.market_state.has_marketplace
                         text: qsTr("Trading is available only for your own marketplace.")
                         color: "#8D7146"
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                         wrapMode: Text.WordWrap
                         horizontalAlignment: Text.AlignHCenter
                         width: parent.width - 24
@@ -3327,14 +3327,14 @@ Rectangle {
                                         Text {
                                             text: modelData.label
                                             color: "#F4E7C8"
-                                            font.pointSize: 8
+                                            font.pixelSize: Design.Typography.caption
                                             font.bold: true
                                         }
 
                                         Text {
                                             text: qsTr("You have %1").arg(productionPanel.resource_amount(productionPanel.current_resources(), resource_key))
                                             color: "#8D7146"
-                                            font.pointSize: 7
+                                            font.pixelSize: Design.Typography.caption
                                         }
                                     }
 
@@ -3421,7 +3421,7 @@ Rectangle {
                             anchors.verticalCenter: parent.verticalCenter
                             text: templeHeaderIcon.visible ? qsTr("TEMPLE") : Design.Icons.unitGlyph("temple") + " " + qsTr("TEMPLE")
                             color: hs.bronze
-                            font.pointSize: 9
+                            font.pixelSize: Design.Typography.caption
                             font.bold: true
                         }
                     }
@@ -3430,7 +3430,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("The sanctuary of your nation, raised in its own architectural style")
                         color: "#8D7146"
-                        font.pointSize: 7
+                        font.pixelSize: Design.Typography.caption
                         wrapMode: Text.WordWrap
                         horizontalAlignment: Text.AlignHCenter
                         width: parent.width
@@ -3440,7 +3440,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("Watches over a wide stretch of ground and holds a settlement together")
                         color: "#F4E7C8"
-                        font.pointSize: 8
+                        font.pixelSize: Design.Typography.caption
                         wrapMode: Text.WordWrap
                         horizontalAlignment: Text.AlignHCenter
                         width: parent.width
@@ -3467,14 +3467,14 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: Design.Icons.unitGlyph("defense_tower")
                         color: "#3B2F24"
-                        font.pointSize: 32
+                        font.pixelSize: Design.Typography.glyph
                     }
 
                     Text {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("No Barracks Selected")
                         color: "#8D7146"
-                        font.pointSize: 11
+                        font.pixelSize: Design.Typography.label
                         font.bold: true
                     }
 
@@ -3482,7 +3482,7 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("Select a barracks to recruit units")
                         color: Theme.textSubLite
-                        font.pointSize: 9
+                        font.pixelSize: Design.Typography.caption
                     }
                 }
             }

--- a/ui/qml/RpgDamageNumbers.qml
+++ b/ui/qml/RpgDamageNumbers.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import StandardOfIron.Design 1.0 as Design
 
 Item {
     id: root
@@ -205,7 +206,7 @@ Item {
                     text: burst.dmg.toString()
                     color: "#000000"
                     opacity: 0.82
-                    font.pixelSize: burst.killingBlow ? 42 : (burst.severity >= 0.72 ? 36 : 30)
+                    font.pixelSize: Design.Typography.display(burst.killingBlow ? 42 : (burst.severity >= 0.72 ? 36 : 30))
                     font.bold: true
                     style: Text.Outline
                     styleColor: "#66000000"
@@ -216,7 +217,7 @@ Item {
                     anchors.centerIn: parent
                     text: burst.dmg.toString()
                     color: burst.killingBlow ? "#fff3bf" : (burst.severity >= 0.72 ? "#ffebe3" : (burst.severity >= 0.46 ? "#fff0c6" : "#ffffff"))
-                    font.pixelSize: burst.killingBlow ? 42 : (burst.severity >= 0.72 ? 36 : 30)
+                    font.pixelSize: Design.Typography.display(burst.killingBlow ? 42 : (burst.severity >= 0.72 ? 36 : 30))
                     font.bold: true
                     font.letterSpacing: burst.severity >= 0.72 ? 0.6 : 0.2
                     style: Text.Outline

--- a/ui/qml/RpgFpvOverlay.qml
+++ b/ui/qml/RpgFpvOverlay.qml
@@ -11,9 +11,14 @@ Item {
     property var status: ({})
     property var engine: null
 
-    readonly property real uiScale: Math.max(0.75, Math.min(2.0, height / 1080))
+    readonly property real resolutionScale: Math.max(0.75, Math.min(2.0, height / 1080))
+    readonly property real uiScale: Math.max(0.75, Math.min(4.0, root.resolutionScale * Design.A11y.uiScale))
     function scaled(value) {
         return Math.round(value * root.uiScale);
+    }
+
+    function fontSize(rung) {
+        return Math.max(Design.Typography.minimumSize, Math.round(rung * root.resolutionScale));
     }
 
     property real pulsePhase
@@ -747,7 +752,7 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 text: focusPlate.targetName
                 color: "#f2ece0"
-                font.pixelSize: root.scaled(13)
+                font.pixelSize: root.fontSize(Design.Typography.label)
                 font.bold: true
                 style: Text.Outline
                 styleColor: "#cc000000"
@@ -856,7 +861,7 @@ Item {
                     anchors.centerIn: parent
                     text: qsTr("HP %1/%2").arg(Number(root.status_value("health", 0))).arg(Number(root.status_value("max_health", 100)))
                     color: "#ffffff"
-                    font.pixelSize: root.scaled(12)
+                    font.pixelSize: root.fontSize(Design.Typography.label)
                     font.bold: true
                     style: Text.Outline
                     styleColor: "#88000000"
@@ -918,7 +923,7 @@ Item {
                     anchors.centerIn: parent
                     text: qsTr("STM %1%").arg(Number(root.status_value("stamina_ratio", 1) * 100).toFixed(0))
                     color: "#cff7ffff"
-                    font.pixelSize: root.scaled(12)
+                    font.pixelSize: root.fontSize(Design.Typography.label)
                     font.bold: true
                     style: Text.Outline
                     styleColor: "#66000000"
@@ -951,7 +956,7 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             text: comboIndicator.finisherReady ? qsTr("FINISHER") : qsTr("COMBO")
             color: comboIndicator.finisherReady ? "#ffdd00" : "#99ffffff"
-            font.pixelSize: root.scaled(9)
+            font.pixelSize: root.fontSize(Design.Typography.caption)
             font.bold: true
             font.letterSpacing: 1.2
             style: Text.Outline
@@ -1035,7 +1040,7 @@ Item {
             anchors.centerIn: parent
             text: qsTr("POSTURE")
             color: "#99ffffff"
-            font.pixelSize: root.scaled(8)
+            font.pixelSize: root.fontSize(Design.Typography.caption)
             font.bold: true
             font.letterSpacing: 1.0
         }
@@ -1058,7 +1063,7 @@ Item {
             anchors.centerIn: parent
             text: qsTr("GUARD BROKEN")
             color: "#ff4444"
-            font.pixelSize: root.scaled(22)
+            font.pixelSize: root.fontSize(Design.Typography.subheading)
             font.bold: true
             font.letterSpacing: 2.0
             style: Text.Outline
@@ -1083,7 +1088,7 @@ Item {
             anchors.centerIn: parent
             text: qsTr("\u26A1 PUNISH \u26A1")
             color: "#ffcc00"
-            font.pixelSize: root.scaled(18)
+            font.pixelSize: root.fontSize(Design.Typography.bodyLarge)
             font.bold: true
             style: Text.Outline
             styleColor: "#88000000"
@@ -1110,7 +1115,7 @@ Item {
             anchors.centerIn: parent
             text: root.bowStance ? qsTr("BOW  ·  X") : qsTr("BLADE  ·  X")
             color: root.bowStance ? "#f0dcae" : "#d6e2ea"
-            font.pixelSize: root.scaled(10)
+            font.pixelSize: root.fontSize(Design.Typography.caption)
             font.bold: true
             font.letterSpacing: 1.0
         }
@@ -1200,7 +1205,7 @@ Item {
                         anchors.centerIn: parent
                         text: modelData.key
                         color: "#1a120b"
-                        font.pixelSize: root.scaled(10)
+                        font.pixelSize: root.fontSize(Design.Typography.caption)
                         font.bold: true
                     }
                 }
@@ -1217,7 +1222,7 @@ Item {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: modelData.name
                         color: abilityLabels.ready ? "#eeffeeee" : "#88aaaaaa"
-                        font.pixelSize: root.scaled(11)
+                        font.pixelSize: root.fontSize(Design.Typography.label)
                         font.bold: true
                         font.letterSpacing: 0.8
                     }
@@ -1226,7 +1231,7 @@ Item {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: abilityLabels.ready ? qsTr("READY") : Math.ceil(Number(root.status_value(modelData.cdKey, 0.0))).toString()
                         color: abilityLabels.ready ? "#d2ffe7cb" : "#d2f5c88f"
-                        font.pixelSize: root.scaled(9)
+                        font.pixelSize: root.fontSize(Design.Typography.caption)
                         font.bold: true
                         font.letterSpacing: 0.7
                     }

--- a/ui/qml/SaveGamePanel.qml
+++ b/ui/qml/SaveGamePanel.qml
@@ -69,7 +69,7 @@ Item {
                 Label {
                     text: qsTr("Save Game")
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeHero
+                    font.pixelSize: Design.Typography.hero
                     font.bold: true
                     Layout.fillWidth: true
                 }
@@ -94,7 +94,7 @@ Item {
                 Label {
                     text: qsTr("Save Name:")
                     color: Theme.textSub
-                    font.pointSize: Theme.fontSizeMedium
+                    font.pixelSize: Design.Typography.bodyLarge
                 }
 
                 TextField {
@@ -103,7 +103,7 @@ Item {
                     Layout.fillWidth: true
                     placeholderText: qsTr("Enter save name...")
                     text: "Save_" + Qt.formatDateTime(new Date(), "yyyy-MM-dd_HH-mm")
-                    font.pointSize: Theme.fontSizeMedium
+                    font.pixelSize: Design.Typography.bodyLarge
                     color: Theme.textMain
 
                     background: Rectangle {
@@ -132,7 +132,7 @@ Item {
             Label {
                 text: qsTr("Existing Saves")
                 color: Theme.textSub
-                font.pointSize: Theme.fontSizeMedium
+                font.pixelSize: Design.Typography.bodyLarge
             }
 
             Rectangle {
@@ -228,7 +228,7 @@ Item {
                                         visible: !thumbnailImage.visible
                                         text: qsTr("No Preview")
                                         color: Theme.textHint
-                                        font.pointSize: Theme.fontSizeTiny
+                                        font.pixelSize: Design.Typography.label
                                     }
                                 }
 
@@ -239,7 +239,7 @@ Item {
                                     Label {
                                         text: model.title
                                         color: Theme.textMain
-                                        font.pointSize: Theme.fontSizeLarge
+                                        font.pixelSize: Design.Typography.subheading
                                         font.bold: true
                                         Layout.fillWidth: true
                                         elide: Label.ElideRight
@@ -248,7 +248,7 @@ Item {
                                     Label {
                                         text: qsTr("Slot: %1").arg(model.slot_name)
                                         color: Theme.textSub
-                                        font.pointSize: Theme.fontSizeSmall
+                                        font.pixelSize: Design.Typography.body
                                         Layout.fillWidth: true
                                         elide: Label.ElideRight
                                     }
@@ -256,7 +256,7 @@ Item {
                                     Label {
                                         text: model.uncompressed_size > 0 ? qsTr("%1 - %2 (%3 KB on disk)").arg(model.map_name).arg(model.mode === "campaign" ? qsTr("Campaign") : qsTr("Skirmish")).arg(Design.Numerals.roman(Math.max(1, Math.round(model.stored_size / 1024)))) : model.map_name
                                         color: Theme.textSub
-                                        font.pointSize: Theme.fontSizeSmall
+                                        font.pixelSize: Design.Typography.body
                                         Layout.fillWidth: true
                                         elide: Label.ElideRight
                                     }
@@ -264,7 +264,7 @@ Item {
                                     Label {
                                         text: qsTr("Last saved: %1").arg(Qt.formatDateTime(new Date(model.timestamp), "yyyy-MM-dd hh:mm:ss"))
                                         color: Theme.textHint
-                                        font.pointSize: Theme.fontSizeSmall
+                                        font.pixelSize: Design.Typography.body
                                         Layout.fillWidth: true
                                         elide: Label.ElideRight
                                     }
@@ -332,7 +332,7 @@ Item {
                     color: Theme.textMain
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
-                    font.pointSize: Theme.fontSizeMedium
+                    font.pixelSize: Design.Typography.bodyLarge
                 }
             }
         }

--- a/ui/qml/SaveProgressOverlay.qml
+++ b/ui/qml/SaveProgressOverlay.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 import StandardOfIron 1.0
+import StandardOfIron.Design 1.0 as Design
 
 Item {
     id: root
@@ -59,7 +60,7 @@ Item {
             Label {
                 text: root.show_error ? qsTr("Save failed") : qsTr("Saving \"%1\"").arg(typeof game !== 'undefined' ? game.save_progress_slot : "")
                 color: Theme.textMain
-                font.pointSize: Theme.fontSizeMedium
+                font.pixelSize: Design.Typography.bodyLarge
                 font.bold: true
                 Layout.fillWidth: true
                 elide: Label.ElideRight
@@ -68,7 +69,7 @@ Item {
             Label {
                 text: root.show_error ? root.last_error : (typeof game !== 'undefined' ? game.save_progress_stage : "")
                 color: root.show_error ? Theme.dangerBr : Theme.textSub
-                font.pointSize: Theme.fontSizeSmall
+                font.pixelSize: Design.Typography.body
                 wrapMode: Text.WordWrap
                 Layout.fillWidth: true
             }

--- a/ui/qml/SettingsPanel.qml
+++ b/ui/qml/SettingsPanel.qml
@@ -102,7 +102,7 @@ Item {
                 Label {
                     text: qsTr("Settings")
                     color: Theme.textMain
-                    font.pointSize: Theme.fontSizeHero
+                    font.pixelSize: Design.Typography.hero
                     font.bold: true
                     Layout.fillWidth: true
                 }
@@ -138,7 +138,7 @@ Item {
                         Label {
                             text: qsTr("Audio Settings")
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeLarge
+                            font.pixelSize: Design.Typography.subheading
                             font.bold: true
                         }
 
@@ -158,7 +158,7 @@ Item {
                             Label {
                                 text: qsTr("Master Volume:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -181,7 +181,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.percent(master_volume_slider.value)
                                     color: Theme.textSub
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.minimumWidth: 88
                                 }
                             }
@@ -189,7 +189,7 @@ Item {
                             Label {
                                 text: qsTr("Music Volume:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -212,7 +212,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.percent(music_volume_slider.value)
                                     color: Theme.textSub
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.minimumWidth: 88
                                 }
                             }
@@ -220,7 +220,7 @@ Item {
                             Label {
                                 text: qsTr("SFX Volume:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -243,7 +243,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.percent(sfx_volume_slider.value)
                                     color: Theme.textSub
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.minimumWidth: 88
                                 }
                             }
@@ -251,7 +251,7 @@ Item {
                             Label {
                                 text: qsTr("Voice Volume:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -274,7 +274,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.percent(voice_volume_slider.value)
                                     color: Theme.textSub
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.minimumWidth: 88
                                 }
                             }
@@ -282,7 +282,7 @@ Item {
                             Label {
                                 text: qsTr("Ambience Volume:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -305,7 +305,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.percent(ambience_volume_slider.value)
                                     color: Theme.textSub
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.minimumWidth: 88
                                 }
                             }
@@ -325,7 +325,7 @@ Item {
                         Label {
                             text: qsTr("Graphics Settings")
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeLarge
+                            font.pixelSize: Design.Typography.subheading
                             font.bold: true
                         }
 
@@ -345,7 +345,7 @@ Item {
                             Label {
                                 text: qsTr("Graphics Quality:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             StyledComboBox {
@@ -363,7 +363,7 @@ Item {
                             Label {
                                 text: typeof graphics_settings !== 'undefined' ? graphics_settings.get_quality_description() : ""
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 opacity: 0.7
                                 wrapMode: Text.WordWrap
                                 Layout.columnSpan: 2
@@ -385,7 +385,7 @@ Item {
                         Label {
                             text: qsTr("Controls")
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeLarge
+                            font.pixelSize: Design.Typography.subheading
                             font.bold: true
                         }
 
@@ -413,7 +413,7 @@ Item {
                             Label {
                                 text: qsTr("Edge scroll strength:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                                 enabled: UiPreferences.edgeScrollEnabled
                             }
 
@@ -437,7 +437,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.percent(edge_scroll_slider.value * 100)
                                     color: Theme.textMain
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.preferredWidth: 96
                                     horizontalAlignment: Text.AlignRight
                                 }
@@ -448,7 +448,7 @@ Item {
                                 Layout.fillWidth: true
                                 text: qsTr("Sets both how far in from the edge the band reaches and how fast the camera moves inside it. At this setting the band is %1 px along the sides and %2 px along the top and bottom, measured at your interface scale.").arg(Math.round(EdgeScroll.horizontalZone(edge_scroll_slider.value, UiPreferences.uiScale))).arg(Math.round(EdgeScroll.verticalZone(edge_scroll_slider.value, UiPreferences.uiScale)))
                                 color: Theme.textDim
-                                font.pointSize: Theme.fontSizeTiny
+                                font.pixelSize: Design.Typography.label
                                 wrapMode: Text.WordWrap
                                 enabled: UiPreferences.edgeScrollEnabled
                             }
@@ -472,7 +472,7 @@ Item {
                         Label {
                             text: qsTr("Autosave")
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeLarge
+                            font.pixelSize: Design.Typography.subheading
                             font.bold: true
                         }
 
@@ -492,7 +492,7 @@ Item {
                             Label {
                                 text: qsTr("Autosaves to keep:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -517,7 +517,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.roman(autosave_slot_slider.value)
                                     color: Theme.textMain
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.preferredWidth: 56
                                     horizontalAlignment: Text.AlignRight
                                 }
@@ -526,7 +526,7 @@ Item {
                             Label {
                                 text: qsTr("Autosave every:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -551,7 +551,7 @@ Item {
                                 Label {
                                     text: autosave_interval_slider.value <= 0 ? qsTr("Off") : qsTr("%1 min").arg(Design.Numerals.roman(autosave_interval_slider.value))
                                     color: Theme.textMain
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.preferredWidth: 104
                                     horizontalAlignment: Text.AlignRight
                                 }
@@ -560,7 +560,7 @@ Item {
                             Label {
                                 text: qsTr("Older autosaves beyond this count are deleted automatically.")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 opacity: 0.7
                                 wrapMode: Text.WordWrap
                                 Layout.columnSpan: 2
@@ -582,7 +582,7 @@ Item {
                         Label {
                             text: qsTr("Accessibility")
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeLarge
+                            font.pixelSize: Design.Typography.subheading
                             font.bold: true
                         }
 
@@ -602,7 +602,7 @@ Item {
                             Label {
                                 text: qsTr("Interface Scale:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -624,7 +624,7 @@ Item {
                                 Label {
                                     text: Design.Numerals.percent(ui_scale_slider.value * 100)
                                     color: Theme.textMain
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.preferredWidth: 96
                                     horizontalAlignment: Text.AlignRight
                                 }
@@ -633,7 +633,7 @@ Item {
                             Label {
                                 text: qsTr("Colour Vision:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             StyledComboBox {
@@ -695,7 +695,7 @@ Item {
                             Label {
                                 text: qsTr("Screen effects:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -717,7 +717,7 @@ Item {
                                 Label {
                                     text: screen_effect_slider.value <= 0 ? qsTr("Off") : Design.Numerals.percent(screen_effect_slider.value * 100)
                                     color: Theme.textMain
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.preferredWidth: 96
                                     horizontalAlignment: Text.AlignRight
                                 }
@@ -726,7 +726,7 @@ Item {
                             Label {
                                 text: qsTr("Camera motion:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             RowLayout {
@@ -748,7 +748,7 @@ Item {
                                 Label {
                                     text: camera_motion_slider.value <= 0 ? qsTr("Off") : Design.Numerals.percent(camera_motion_slider.value * 100)
                                     color: Theme.textMain
-                                    font.pointSize: Theme.fontSizeMedium
+                                    font.pixelSize: Design.Typography.bodyLarge
                                     Layout.preferredWidth: 96
                                     horizontalAlignment: Text.AlignRight
                                 }
@@ -757,7 +757,7 @@ Item {
                             Label {
                                 text: qsTr("Reduces head bob and sway while leading the commander. It never limits camera movement you ask for.")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 opacity: 0.7
                                 wrapMode: Text.WordWrap
                                 Layout.columnSpan: 2
@@ -767,7 +767,7 @@ Item {
                             Label {
                                 text: qsTr("These settings apply to the campaign, skirmish and editor tools alike.")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 opacity: 0.7
                                 wrapMode: Text.WordWrap
                                 Layout.columnSpan: 2
@@ -789,7 +789,7 @@ Item {
                         Label {
                             text: qsTr("Language")
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeLarge
+                            font.pixelSize: Design.Typography.subheading
                             font.bold: true
                         }
 
@@ -809,7 +809,7 @@ Item {
                             Label {
                                 text: qsTr("Select Language:")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                             }
 
                             StyledComboBox {
@@ -840,7 +840,7 @@ Item {
                             Label {
                                 text: qsTr("Language changes apply immediately")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 opacity: 0.7
                                 Layout.columnSpan: 2
                             }
@@ -860,7 +860,7 @@ Item {
                         Label {
                             text: qsTr("About")
                             color: Theme.textMain
-                            font.pointSize: Theme.fontSizeLarge
+                            font.pixelSize: Design.Typography.subheading
                             font.bold: true
                         }
 
@@ -878,14 +878,14 @@ Item {
                             Label {
                                 text: qsTr("Standard of Iron - RTS Game")
                                 color: Theme.textMain
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                                 font.bold: true
                             }
 
                             Label {
                                 text: qsTr("Version %1").arg(Qt.application.version)
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                             }
 
                             Rectangle {
@@ -900,14 +900,14 @@ Item {
                             Label {
                                 text: qsTr("Third-Party Software")
                                 color: Theme.textMain
-                                font.pointSize: Theme.fontSizeMedium
+                                font.pixelSize: Design.Typography.bodyLarge
                                 font.bold: true
                             }
 
                             Label {
                                 text: qsTr("This game uses the Qt framework, licensed under the GNU Lesser General Public License v3 (LGPL v3).")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
                             }
@@ -915,7 +915,7 @@ Item {
                             Label {
                                 text: qsTr("Qt is dynamically linked, allowing you to replace Qt libraries with your own versions.")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
                             }
@@ -923,7 +923,7 @@ Item {
                             Label {
                                 text: "<a href='https://www.gnu.org/licenses/lgpl-3.0.html'>" + qsTr("LGPL v3 License") + "</a> | <a href='https://www.qt.io'>" + qsTr("Qt Website") + "</a>"
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 textFormat: Text.RichText
                                 onLinkActivated: function (link) {
                                     Qt.openUrlExternally(link);
@@ -939,7 +939,7 @@ Item {
                             Label {
                                 text: qsTr("Music generated with Meta's AudioCraft, whose models are licensed CC BY-NC 4.0. This game is distributed free of charge, which that licence permits; it may not be sold.")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
                             }
@@ -947,7 +947,7 @@ Item {
                             Label {
                                 text: qsTr("Voice lines recorded by Adam Djellouli.")
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 wrapMode: Text.WordWrap
                                 Layout.fillWidth: true
                             }
@@ -955,7 +955,7 @@ Item {
                             Label {
                                 text: "<a href='https://creativecommons.org/licenses/by-nc/4.0/'>" + qsTr("CC BY-NC 4.0 License") + "</a> | <a href='https://github.com/facebookresearch/audiocraft'>" + qsTr("AudioCraft") + "</a>"
                                 color: Theme.textSub
-                                font.pointSize: Theme.fontSizeSmall
+                                font.pixelSize: Design.Typography.body
                                 textFormat: Text.RichText
                                 onLinkActivated: function (link) {
                                     Qt.openUrlExternally(link);

--- a/ui/qml/design/Typography.qml
+++ b/ui/qml/design/Typography.qml
@@ -2,15 +2,33 @@ pragma Singleton
 import QtQuick 2.15
 
 QtObject {
+    id: root
+
     readonly property string family: "Noto Sans"
     readonly property string displayFamily: "Noto Serif"
 
-    readonly property int caption: A11y.scaledFont(11)
-    readonly property int label: A11y.scaledFont(13)
-    readonly property int body: A11y.scaledFont(14)
-    readonly property int heading: A11y.scaledFont(20)
-    readonly property int title: A11y.scaledFont(28)
-    readonly property int hero: A11y.scaledFont(40)
+    readonly property int minimumSize: 12
+
+    function scaled(px) {
+        return Math.max(root.minimumSize, A11y.scaledFont(px));
+    }
+
+    function display(px) {
+        return A11y.scaledFont(px);
+    }
+
+    readonly property int caption: scaled(13)
+    readonly property int label: scaled(15)
+    readonly property int body: scaled(16)
+    readonly property int bodyLarge: scaled(19)
+    readonly property int subheading: scaled(21)
+    readonly property int heading: scaled(24)
+    readonly property int title: display(32)
+    readonly property int hero: display(40)
+
+    readonly property int glyphSmall: display(28)
+    readonly property int glyph: display(44)
+    readonly property int glyphLarge: display(56)
 
     readonly property int regular: Font.Normal
     readonly property int medium: Font.DemiBold

--- a/ui/theme.h
+++ b/ui/theme.h
@@ -90,13 +90,6 @@ class Theme : public QObject {
   Q_PROPERTY(int animNormal READ animNormal CONSTANT)
   Q_PROPERTY(int animSlow READ animSlow CONSTANT)
 
-  Q_PROPERTY(int fontSizeTiny READ fontSizeTiny NOTIFY metrics_changed)
-  Q_PROPERTY(int fontSizeSmall READ fontSizeSmall NOTIFY metrics_changed)
-  Q_PROPERTY(int fontSizeMedium READ fontSizeMedium NOTIFY metrics_changed)
-  Q_PROPERTY(int fontSizeLarge READ fontSizeLarge NOTIFY metrics_changed)
-  Q_PROPERTY(int fontSizeTitle READ fontSizeTitle NOTIFY metrics_changed)
-  Q_PROPERTY(int fontSizeHero READ fontSizeHero NOTIFY metrics_changed)
-
   Q_PROPERTY(QVariantList playerColors READ playerColors NOTIFY player_colors_changed)
   Q_PROPERTY(QVariantList teamIcons READ teamIcons CONSTANT)
   Q_PROPERTY(QVariantList factions READ factions CONSTANT)
@@ -189,13 +182,6 @@ public:
   [[nodiscard]] static auto animFast() -> int { return 120; }
   [[nodiscard]] static auto animNormal() -> int { return 160; }
   [[nodiscard]] static auto animSlow() -> int { return 200; }
-
-  [[nodiscard]] static auto fontSizeTiny() -> int { return scaled(11); }
-  [[nodiscard]] static auto fontSizeSmall() -> int { return scaled(12); }
-  [[nodiscard]] static auto fontSizeMedium() -> int { return scaled(14); }
-  [[nodiscard]] static auto fontSizeLarge() -> int { return scaled(16); }
-  [[nodiscard]] static auto fontSizeTitle() -> int { return scaled(18); }
-  [[nodiscard]] static auto fontSizeHero() -> int { return scaled(28); }
 
   [[nodiscard]] static auto playerColors() -> QVariantList;
   [[nodiscard]] static auto teamIcons() -> QVariantList;


### PR DESCRIPTION
Move the QML interface onto one pixel-based typography ladder owned by Design.Typography. Replace legacy Theme point-size properties and gameplay font declarations with named tokens so menus, panels, counters, overlays, and settings respond consistently to the user's interface scale.

Add a 12px legibility floor for ordinary text, retain unfloored display and glyph helpers for intentionally large content, and remove the obsolete C++ Theme font properties. Enforce the policy with the typography checker in pre-commit, quality automation, and CI, while expanding token coverage and production-panel coverage across the supported interface scale range.

Update the accessibility and UI design-system documentation with the type ladder, scaling rules, container guidance, and review expectations so future screens continue to use the shared tokens.