### PR TITLE
test(ui): guard minimap clearance at maximum edge scroll

### DIFF
--- a/docs/CAMERA_CONTROLS.md
+++ b/docs/CAMERA_CONTROLS.md
@@ -38,6 +38,24 @@ Scaling the band by the interface scale is what keeps a 12 px band reachable on
 a 4K panel at 200%; without it the band stays 12 physical px while every other
 target doubles.
 
+### The minimap clearance
+
+The minimap is the one HUD control that is itself a camera move, so a band
+reaching under it would leave a minimap drag and edge scroll pushing the same
+camera at once. It does not, but only just. Clicking along the minimap's right
+edge in a running battle puts the last responsive pixel 25 logical px from the
+right of the surface — `hudZoneMargin` plus the panel's own padding — while the
+widest band the settings allow is `12 * 2.0 = 24`. Both sides scale with the
+interface, so the clearance stays proportional: measured at interface scale 1.0
+the minimap stops at 1255 and the band starts at 1256, and at 1.5 it stops at
+1243 and the band starts at 1244.
+
+One logical pixel of headroom is not a margin anyone chose. Widening the base
+band, raising `kMaxEdgeScrollSensitivity` or trimming the minimap's padding
+closes it, and then a minimap drag and edge scroll fight over the camera.
+`EdgeScrollTest.TheStrongestBandStaysClearOfTheMinimap` guards the C++ half;
+the QML half is a hand measurement, so re-measure it if you touch either.
+
 ## What suppresses edge scroll
 
 `mainWindow.edge_scroll_disabled` is **derived**, never assigned:
@@ -102,6 +120,10 @@ by hand when touching anything above. Every row should behave identically.
 ### Interaction checks (any one layout)
 
 - [ ] Right-drag pans; edge scroll does **not** fight it mid-drag.
+- [ ] With **edge scroll strength at maximum**, drag the camera around by the
+      minimap: the camera goes where the minimap says and does **not** also
+      creep sideways. See "The minimap clearance" above — this passes on a
+      single pixel.
 - [ ] Right-drag, then press `Esc` / open the menu mid-drag, then return to the
       battle: edge scroll still works. (This is the regression that used to
       latch it off permanently.)

--- a/tests/ui/edge_scroll_test.cpp
+++ b/tests/ui/edge_scroll_test.cpp
@@ -1,6 +1,8 @@
 #include <cmath>
 #include <gtest/gtest.h>
+#include <string>
 
+#include "app/core/user_settings.h"
 #include "ui/edge_scroll.h"
 
 namespace {
@@ -145,6 +147,37 @@ TEST(EdgeScrollTest, AHighResolutionSurfaceStillScrollsAtItsEdges) {
   EXPECT_LT(bottom.dz, 0.0);
   EXPECT_TRUE(
       Edge::vector_at(k_wide / 2.0, k_tall / 2.0, k_wide, k_tall, 1.0, 2.0).is_zero());
+}
+
+TEST(EdgeScrollTest, TheStrongestBandStaysClearOfTheMinimap) {
+  constexpr double k_minimap_hit_area_ends_px_from_right = 25.0;
+  constexpr double k_widest_band = 24.0;
+  const double strongest = App::Core::UserSettings::kMaxEdgeScrollSensitivity;
+
+  const auto why = [](double scale) {
+    return "at interface scale " + std::to_string(scale) +
+           ": the minimap is itself a camera move, so a band reaching under it "
+           "leaves a minimap drag and edge scroll pushing the same camera. Its "
+           "hit area ends 25 logical px from the right (hudZoneMargin plus the "
+           "panel's padding), measured by hand in a running battle, and the "
+           "widest band is 24 - one pixel of headroom. See the minimap "
+           "clearance in docs/CAMERA_CONTROLS.md and re-measure the QML side.";
+  };
+
+  EXPECT_DOUBLE_EQ(Edge::horizontal_zone(strongest, 1.0), k_widest_band);
+
+  for (const double scale : {1.0, 1.5, 2.0}) {
+    EXPECT_LT(Edge::horizontal_zone(strongest, scale),
+              k_minimap_hit_area_ends_px_from_right * scale)
+        << why(scale);
+
+    const double minimap_edge =
+        k_width - (k_minimap_hit_area_ends_px_from_right * scale);
+    EXPECT_TRUE(Edge::vector_at(
+                    minimap_edge, k_height / 2.0, k_width, k_height, strongest, scale)
+                    .is_zero())
+        << why(scale);
+  }
 }
 
 TEST(EdgeScrollTest, OppositeEdgesAreMirrorImages) {


### PR DESCRIPTION
Document the narrow clearance between the minimap hit area and the strongest edge-scroll band so future camera-control changes preserve their separation. Add a regression covering the maximum configured sensitivity at interface scales 1.0, 1.5, and 2.0, including the exact minimap boundary and zero-scroll behavior.