### PR TITLE
feat(ui): add data-backed command order tooltips

### DIFF
--- a/app/mission/tutorial_director.cpp
+++ b/app/mission/tutorial_director.cpp
@@ -635,18 +635,21 @@ auto TutorialDirector::step_body(TutorialStepId id) -> QString {
               "in front, archers behind, and the commander close so his aura "
               "reaches them. Break the raid to continue.");
   case TutorialStepId::Stances:
-    return tr("Soldiers can be told how to behave. Guard: hold a spot and chase "
-              "anything that comes near, then return. Hold: stand your ground and "
-              "do not pursue - best for archers on a hill or a wall line. Patrol: "
-              "walk between two points and engage whatever crosses the route. Give "
-              "one of these orders to your soldiers.");
+    return tr("Soldiers can be told how to behave, and the three orders are not "
+              "the same. Guard: click a spot; they meet anything that comes near "
+              "it, then walk back to it. Hold: they never take a step, but they "
+              "reach further, hit harder and brace against a charge - archers and "
+              "spearmen only. Patrol: click two waypoints and they march the beat "
+              "between them, fighting whatever crosses it. Hover any of the three "
+              "to read the full rules, then give one of them to your soldiers.");
   case TutorialStepId::Commander:
     return tr("Your commander carries the standard. Troops near him fight with "
               "higher morale, and while he is selected two commands appear: Aura "
-              "briefly empowers every soldier around him, and Rally plants a flag "
-              "that the army marches to. If he dies, your lines break and the "
-              "mission is lost - keep him behind the spears. Trigger the Aura "
-              "now.");
+              "empowers every soldier in a ring around him for a stretch and then "
+              "recharges - the button prints the radius, how long it lasts and how "
+              "long until it returns - and Rally plants a flag that the army "
+              "marches to. If he dies, your lines break and the mission is lost - "
+              "keep him behind the spears. Trigger the Aura now.");
   case TutorialStepId::Camera:
     return tr("Move the view with the arrow keys or WASD, or push the mouse to the "
               "screen edge. Scroll to zoom, Q and E rotate, and the reset button in "

--- a/app/orders/rts_action_model.cpp
+++ b/app/orders/rts_action_model.cpp
@@ -2,15 +2,18 @@
 
 #include <QString>
 
+#include <cmath>
 #include <string>
 
 #include "game/core/component.h"
 #include "game/core/entity.h"
 #include "game/core/world.h"
 #include "game/systems/builder_product_types.h"
+#include "game/systems/combat_system/combat_types.h"
 #include "game/systems/owner_registry.h"
 #include "game/systems/selection_system.h"
 #include "game/units/spawn_type.h"
+#include "game/util/asset_text.h"
 
 namespace {
 
@@ -43,6 +46,8 @@ struct ActionStatus {
   bool mixed = false;
   bool placing = false;
   bool passive = false;
+
+  QVariantMap detail;
 };
 
 constexpr ActionId k_all_actions[] = {ActionId::Attack,
@@ -273,20 +278,114 @@ auto unit_is_active_for_action(const Engine::Core::Entity& entity,
   return false;
 }
 
+auto percent_bonus(float multiplier) -> int {
+  return static_cast<int>(std::lround((multiplier - 1.0F) * 100.0F));
+}
+
+auto guard_detail(const Engine::Core::Entity* sample) -> QVariantMap {
+  const auto* guard = sample != nullptr
+                          ? sample->get_component<Engine::Core::GuardModeComponent>()
+                          : nullptr;
+  QVariantMap detail;
+  detail[QStringLiteral("radius")] =
+      guard != nullptr ? guard->guard_radius
+                       : Engine::Core::Defaults::k_guard_default_radius;
+  detail[QStringLiteral("returnThreshold")] =
+      Engine::Core::Defaults::k_guard_return_threshold;
+  return detail;
+}
+
+auto hold_detail() -> QVariantMap {
+  namespace Constants = Game::Systems::Combat::Constants;
+  static_assert(Constants::k_damage_multiplier_archer_hold ==
+                    Constants::k_damage_multiplier_spearman_hold,
+                "the hold tooltip quotes one damage bonus for both eligible types");
+
+  QVariantMap detail;
+  detail[QStringLiteral("archerRangeBonusPercent")] =
+      percent_bonus(Constants::k_range_multiplier_hold);
+  detail[QStringLiteral("spearmanRangeBonusPercent")] =
+      percent_bonus(Constants::k_range_multiplier_spearman_hold);
+  detail[QStringLiteral("damageBonusPercent")] =
+      percent_bonus(Constants::k_damage_multiplier_archer_hold);
+  detail[QStringLiteral("healthBonusPercent")] =
+      percent_bonus(Constants::k_health_multiplier_hold);
+  return detail;
+}
+
+auto patrol_detail(const App::Core::ActionContext& context) -> QVariantMap {
+  int stage = 0;
+  if (context.has_patrol_first_waypoint) {
+    stage = 2;
+  } else if (context.cursor_mode == CursorMode::Patrol) {
+    stage = 1;
+  }
+
+  QVariantMap detail;
+  detail[QStringLiteral("waypointStage")] = stage;
+  return detail;
+}
+
+auto aura_detail(const Engine::Core::Entity* sample) -> QVariantMap {
+  const auto* commander =
+      sample != nullptr ? sample->get_component<Engine::Core::CommanderComponent>()
+                        : nullptr;
+  QVariantMap detail;
+  if (commander == nullptr) {
+    return detail;
+  }
+
+  detail[QStringLiteral("radius")] = commander->aura_radius;
+  detail[QStringLiteral("duration")] = commander->aura_ability_duration;
+  detail[QStringLiteral("remaining")] = commander->aura_ability_remaining;
+  detail[QStringLiteral("cooldown")] = commander->aura_ability_cooldown;
+  detail[QStringLiteral("cooldownRemaining")] =
+      commander->aura_ability_cooldown_remaining;
+  detail[QStringLiteral("wounded")] = commander->wounded;
+  if (!commander->bonus_summary.empty()) {
+    detail[QStringLiteral("summary")] = Game::Util::tr_asset(
+        Game::Util::k_commanders_context, commander->bonus_summary);
+  }
+  return detail;
+}
+
+auto action_detail(const App::Core::ActionContext& context,
+                   ActionId action,
+                   const Engine::Core::Entity* sample) -> QVariantMap {
+  switch (action) {
+  case ActionId::Guard:
+    return guard_detail(sample);
+  case ActionId::Hold:
+    return hold_detail();
+  case ActionId::Patrol:
+    return patrol_detail(context);
+  case ActionId::Aura:
+    return aura_detail(sample);
+  default:
+    break;
+  }
+  return {};
+}
+
 auto get_status(const App::Core::ActionContext& context,
                 ActionId action) -> ActionStatus {
   ActionStatus status;
   const auto* selected = selected_units(context.world);
   if (selected == nullptr) {
+    status.detail = action_detail(context, action, nullptr);
     return status;
   }
 
+  const Engine::Core::Entity* first_eligible = nullptr;
   for (const auto entity_id : *selected) {
     auto* entity = context.world->get_entity(entity_id);
     if ((entity == nullptr) || !unit_is_eligible_for_action(*entity, action)) {
       continue;
     }
 
+    if (first_eligible == nullptr) {
+      first_eligible = entity;
+    }
     ++status.eligible_count;
     status.active_count += unit_is_active_for_action(*entity, action) ? 1 : 0;
     if (action == ActionId::Aura) {
@@ -295,6 +394,8 @@ auto get_status(const App::Core::ActionContext& context,
           commander != nullptr && commander->can_activate_aura_ability() ? 1 : 0;
     }
   }
+
+  status.detail = action_detail(context, action, first_eligible);
 
   switch (action) {
   case ActionId::Stop:
@@ -362,6 +463,7 @@ auto to_variant_map(const ActionStatus& status) -> QVariantMap {
 
   result[QStringLiteral("activeCount")] = status.active_count;
   result[QStringLiteral("readyCount")] = status.ready_count;
+  result[QStringLiteral("detail")] = status.detail;
   return result;
 }
 

--- a/design_resources.qrc
+++ b/design_resources.qrc
@@ -25,6 +25,7 @@
         <file alias="controls/IronIconButton.qml">ui/qml/design/controls/IronIconButton.qml</file>
         <file alias="controls/IronTabBar.qml">ui/qml/design/controls/IronTabBar.qml</file>
         <file alias="controls/IronTooltip.qml">ui/qml/design/controls/IronTooltip.qml</file>
+        <file alias="controls/IronCommandTooltip.qml">ui/qml/design/controls/IronCommandTooltip.qml</file>
         <file alias="controls/IronDialog.qml">ui/qml/design/controls/IronDialog.qml</file>
         <file alias="controls/IronDropdown.qml">ui/qml/design/controls/IronDropdown.qml</file>
         <file alias="controls/IronSlider.qml">ui/qml/design/controls/IronSlider.qml</file>

--- a/docs/UI_DESIGN_SYSTEM.md
+++ b/docs/UI_DESIGN_SYSTEM.md
@@ -147,6 +147,26 @@ Reduced motion collapses durations to zero rather than removing bindings, so sta
 lands in the right place. Notification dwell times are deliberately _not_ affected — that
 is reading time, not motion.
 
+A third rule applies to anything that explains itself:
+
+- **An explanation a mouse can reach, a keyboard can reach.** `IronCommandButton` takes
+  `Qt.TabFocus` and opens its `IronCommandTooltip` on `hovered || showFocusRing`, so hover,
+  Tab and controller navigation all surface the same panel. An order that cannot be given
+  keeps its tooltip: the refusal is printed under the rules rather than instead of them.
+
+## Explaining an order
+
+`IronCommandTooltip` is the panel behind every button in the order grid. It is not a
+one-line hint: it carries the order's name and hotkey, a sentence of summary, a list of
+term/text rules — scope, how to give it, how to cancel it, which troops may obey — a live
+`status` line, and a `warning` line when the selection cannot take the order.
+
+The numbers in those rules are not written by hand. `App::Core::get_action_states()` puts a
+`detail` map on each action (guard radius, hold's range and damage bonuses, the patrol
+waypoint the next click sets, the selected commander's aura radius, duration and cooldown),
+and `HUDBottom` formats that map into the rules. A balance change moves the tooltip with
+it; there is no second copy of the truth to forget.
+
 ## Faction identity
 
 `FactionTheme` maps a nation id (`roman_republic`, `carthage`, `iron_sepulcher`) to an

--- a/tests/core/rts_action_model_test.cpp
+++ b/tests/core/rts_action_model_test.cpp
@@ -210,4 +210,123 @@ TEST(RtsActionModel, AnAutoGatheringBuilderShowsTheOrderAsActive) {
             QStringLiteral("mixed"));
 }
 
+TEST(RtsActionModel, GuardQuotesTheRingItActuallyFightsIn) {
+  Engine::Core::World world;
+  world.add_system(std::make_unique<Game::Systems::SelectionSystem>());
+  auto* selection = world.get_system<Game::Systems::SelectionSystem>();
+  ASSERT_NE(selection, nullptr);
+
+  auto* unit = add_selected_unit(world, *selection, Game::Units::SpawnType::Spearman);
+
+  App::Core::ActionContext context;
+  context.world = &world;
+
+  auto detail = App::Core::get_action_states(context)[QStringLiteral("guard")]
+                    .toMap()[QStringLiteral("detail")]
+                    .toMap();
+  EXPECT_FLOAT_EQ(detail[QStringLiteral("radius")].toFloat(),
+                  Engine::Core::Defaults::k_guard_default_radius);
+
+  auto* guard = unit->add_component<Engine::Core::GuardModeComponent>();
+  guard->guard_radius = 4.5F;
+  detail = App::Core::get_action_states(context)[QStringLiteral("guard")]
+               .toMap()[QStringLiteral("detail")]
+               .toMap();
+  EXPECT_FLOAT_EQ(detail[QStringLiteral("radius")].toFloat(), 4.5F);
+}
+
+TEST(RtsActionModel, HoldQuotesTheBonusesThatMakeItWorthPressing) {
+  Engine::Core::World world;
+  world.add_system(std::make_unique<Game::Systems::SelectionSystem>());
+  auto* selection = world.get_system<Game::Systems::SelectionSystem>();
+  ASSERT_NE(selection, nullptr);
+
+  add_selected_unit(world, *selection, Game::Units::SpawnType::Archer);
+
+  App::Core::ActionContext context;
+  context.world = &world;
+
+  const auto detail = App::Core::get_action_states(context)[QStringLiteral("hold")]
+                          .toMap()[QStringLiteral("detail")]
+                          .toMap();
+  EXPECT_EQ(detail[QStringLiteral("archerRangeBonusPercent")].toInt(), 50);
+  EXPECT_EQ(detail[QStringLiteral("spearmanRangeBonusPercent")].toInt(), 100);
+  EXPECT_EQ(detail[QStringLiteral("damageBonusPercent")].toInt(), 50);
+  EXPECT_EQ(detail[QStringLiteral("healthBonusPercent")].toInt(), 20);
+}
+
+TEST(RtsActionModel, PatrolSaysWhichWaypointComesNext) {
+  Engine::Core::World world;
+  world.add_system(std::make_unique<Game::Systems::SelectionSystem>());
+  auto* selection = world.get_system<Game::Systems::SelectionSystem>();
+  ASSERT_NE(selection, nullptr);
+
+  add_selected_unit(world, *selection, Game::Units::SpawnType::Archer);
+
+  const auto stage = [](const App::Core::ActionContext& context) {
+    return App::Core::get_action_states(context)[QStringLiteral("patrol")]
+        .toMap()[QStringLiteral("detail")]
+        .toMap()[QStringLiteral("waypointStage")]
+        .toInt();
+  };
+
+  App::Core::ActionContext context;
+  context.world = &world;
+  EXPECT_EQ(stage(context), 0);
+
+  context.cursor_mode = CursorMode::Patrol;
+  EXPECT_EQ(stage(context), 1);
+
+  context.has_patrol_first_waypoint = true;
+  EXPECT_EQ(stage(context), 2);
+}
+
+TEST(RtsActionModel, AuraQuotesTheSelectedCommandersOwnNumbers) {
+  Engine::Core::World world;
+  world.add_system(std::make_unique<Game::Systems::SelectionSystem>());
+  auto* selection = world.get_system<Game::Systems::SelectionSystem>();
+  ASSERT_NE(selection, nullptr);
+
+  auto* entity =
+      add_selected_unit(world, *selection, Game::Units::SpawnType::RomanVeteranConsul);
+  auto* commander = entity->add_component<Engine::Core::CommanderComponent>();
+  ASSERT_NE(commander, nullptr);
+  commander->aura_radius = 13.0F;
+  commander->aura_ability_duration = 12.0F;
+  commander->aura_ability_cooldown = 45.0F;
+  commander->aura_ability_cooldown_remaining = 9.0F;
+  commander->bonus_summary = "Nearby spearmen regenerate health.";
+
+  App::Core::ActionContext context;
+  context.world = &world;
+
+  const auto detail = App::Core::get_action_states(context)[QStringLiteral("aura")]
+                          .toMap()[QStringLiteral("detail")]
+                          .toMap();
+  EXPECT_FLOAT_EQ(detail[QStringLiteral("radius")].toFloat(), 13.0F);
+  EXPECT_FLOAT_EQ(detail[QStringLiteral("duration")].toFloat(), 12.0F);
+  EXPECT_FLOAT_EQ(detail[QStringLiteral("cooldown")].toFloat(), 45.0F);
+  EXPECT_FLOAT_EQ(detail[QStringLiteral("cooldownRemaining")].toFloat(), 9.0F);
+  EXPECT_EQ(detail[QStringLiteral("summary")].toString(),
+            QStringLiteral("Nearby spearmen regenerate health."));
+}
+
+TEST(RtsActionModel, AnEmptySelectionStillCarriesTheStaticOrderFacts) {
+  Engine::Core::World world;
+  world.add_system(std::make_unique<Game::Systems::SelectionSystem>());
+
+  App::Core::ActionContext context;
+  context.world = &world;
+
+  const auto states = App::Core::get_action_states(context);
+  EXPECT_FALSE(states[QStringLiteral("guard")]
+                   .toMap()[QStringLiteral("detail")]
+                   .toMap()
+                   .isEmpty());
+  EXPECT_TRUE(states[QStringLiteral("aura")]
+                  .toMap()[QStringLiteral("detail")]
+                  .toMap()
+                  .isEmpty());
+}
+
 } // namespace

--- a/tests/ui/qml/tst_command_button.qml
+++ b/tests/ui/qml/tst_command_button.qml
@@ -117,6 +117,93 @@ TestCase {
         button.destroy();
     }
 
+    function test_an_order_explains_its_rules_beyond_the_one_line_hint() {
+        var button = makeButton({
+                "actionId": "guard",
+                "label": "Guard",
+                "hint": "Anchor troops to a spot.",
+                "details": [{
+                        "term": "Reach",
+                        "text": "They fight anything within 10 m of that spot."
+                    }, {
+                        "term": "Release",
+                        "text": "Press Guard again."
+                    }]
+            });
+        compare(button.details.length, 2);
+        compare(button.details[0].term, "Reach");
+        button.destroy();
+    }
+
+    function test_the_order_grid_is_reachable_without_a_mouse() {
+        var button = makeButton({
+                "actionId": "patrol",
+                "label": "Patrol"
+            });
+        compare(button.focusPolicy, Qt.TabFocus);
+        button.destroy();
+    }
+
+    function test_keyboard_focus_opens_the_same_tooltip_hovering_would() {
+        var button = makeButton({
+                "actionId": "patrol",
+                "label": "Patrol",
+                "hotkey": "P",
+                "hint": "March a beat between two points.",
+                "details": [{
+                        "term": "Give it",
+                        "text": "Click the first waypoint, then the second."
+                    }],
+                "statusText": "Click waypoint 1",
+                "width": 200,
+                "height": 48
+            });
+        verify(!button.tooltip.visible);
+        button.forceActiveFocus(Qt.TabFocusReason);
+        tryVerify(function () {
+                return button.tooltip.visible;
+            }, 4000);
+        compare(button.tooltip.title, "Patrol");
+        compare(button.tooltip.hotkey, "P");
+        compare(button.tooltip.summary, "March a beat between two points.");
+        compare(button.tooltip.details.length, 1);
+        compare(button.tooltip.status, "Click waypoint 1");
+        button.focus = false;
+        tryVerify(function () {
+                return !button.tooltip.visible;
+            }, 4000);
+        button.destroy();
+    }
+
+    function test_an_order_the_selection_cannot_take_says_so_in_the_tooltip() {
+        var button = makeButton({
+                "actionId": "hold",
+                "label": "Hold",
+                "blocked": true,
+                "hint": "Stand fast.",
+                "disabledReason": "Hold is only available to archers and spearmen"
+            });
+        button.forceActiveFocus(Qt.TabFocusReason);
+        tryVerify(function () {
+                return button.tooltip.visible;
+            }, 4000);
+        compare(button.tooltip.warning, "Hold is only available to archers and spearmen");
+        compare(button.tooltip.summary, "Stand fast.");
+        button.destroy();
+    }
+
+    function test_live_order_state_reads_on_the_button_face() {
+        var button = makeButton({
+                "actionId": "aura",
+                "label": "Aura",
+                "statusText": "Ready in 43s",
+                "cooldown": 0.7
+            });
+        compare(button.statusText, "Ready in 43s");
+        compare(button.cooldown, 0.7);
+        button.destroy();
+    }
+
     function test_the_active_state_is_exposed_to_assistive_tech() {
         var button = makeButton({
                 "actionId": "hold",

--- a/tests/ui/qml/tst_command_tooltip.qml
+++ b/tests/ui/qml/tst_command_tooltip.qml
@@ -1,0 +1,112 @@
+import QtQuick 2.15
+import QtTest 1.15
+import StandardOfIron 1.0 as Core
+import StandardOfIron.Design 1.0
+
+TestCase {
+    id: testCase
+
+    name: "CommandTooltip"
+    when: windowShown
+    width: 400
+    height: 200
+    visible: true
+
+    function init() {
+        Core.UiPreferences.reset_to_defaults();
+    }
+
+    function cleanupTestCase() {
+        Core.UiPreferences.reset_to_defaults();
+    }
+
+    function makeTooltip(props) {
+        return tooltipComponent.createObject(testCase, props || {});
+    }
+
+    function test_a_bare_title_is_not_worth_showing() {
+        var tip = makeTooltip({
+                "title": "Guard"
+            });
+        verify(!tip.hasBody);
+        tip.destroy();
+    }
+
+    function test_a_summary_alone_is_worth_showing() {
+        var tip = makeTooltip({
+                "title": "Hold",
+                "summary": "Troops dig in where they stand."
+            });
+        verify(tip.hasBody);
+        tip.destroy();
+    }
+
+    function test_rules_alone_are_worth_showing() {
+        var tip = makeTooltip({
+                "title": "Patrol",
+                "details": [{
+                        "term": "Give it",
+                        "text": "Click the first waypoint, then the second."
+                    }]
+            });
+        verify(tip.hasBody);
+        compare(tip.detail_term(tip.details[0]), "Give it");
+        compare(tip.detail_text(tip.details[0]), "Click the first waypoint, then the second.");
+        tip.destroy();
+    }
+
+    function test_a_live_status_is_worth_showing_on_its_own() {
+        var tip = makeTooltip({
+                "title": "Aura",
+                "status": "Ready in 43s"
+            });
+        verify(tip.hasBody);
+        tip.destroy();
+    }
+
+    function test_a_refusal_is_worth_showing_on_its_own() {
+        var tip = makeTooltip({
+                "title": "Hold",
+                "warning": "Hold is only available to archers and spearmen"
+            });
+        verify(tip.hasBody);
+        tip.destroy();
+    }
+
+    function test_the_rules_grow_with_the_interface_scale() {
+        var props = {
+            "title": "Guard",
+            "summary": "Anchor troops to a spot they will hold.",
+            "details": [{
+                    "term": "Reach",
+                    "text": "They fight what comes within 10 m of that spot, and drop a target that leaves it."
+                }]
+        };
+        var small = makeTooltip(props);
+        var narrow = small.implicitWidth;
+        var flat = small.implicitHeight;
+        small.destroy();
+        Core.UiPreferences.uiScale = 1.75;
+        var large = makeTooltip(props);
+        verify(large.implicitWidth > narrow);
+        verify(large.implicitHeight > flat);
+        large.destroy();
+    }
+
+    function test_a_missing_rule_does_not_break_the_layout() {
+        var tip = makeTooltip({
+                "title": "Guard",
+                "details": [{}, null]
+            });
+        compare(tip.detail_term(tip.details[0]), "");
+        compare(tip.detail_text(tip.details[1]), "");
+        tip.destroy();
+    }
+
+    Component {
+        id: tooltipComponent
+
+        IronCommandTooltip {
+        }
+    }
+}

--- a/tests/ui/qml/tst_component_library.qml
+++ b/tests/ui/qml/tst_component_library.qml
@@ -37,6 +37,9 @@ TestCase {
                 "tag": "IronTooltip",
                 "qml": "IronTooltip {}"
             }, {
+                "tag": "IronCommandTooltip",
+                "qml": "IronCommandTooltip { title: \"Guard\" }"
+            }, {
                 "tag": "IronDialog",
                 "qml": "IronDialog {}"
             }, {

--- a/tests/ui/qml/tst_order_tooltips.qml
+++ b/tests/ui/qml/tst_order_tooltips.qml
@@ -1,0 +1,141 @@
+import QtQuick 2.15
+import QtTest 1.15
+import StandardOfIron.Design 1.0
+import "../../../ui/qml"
+
+TestCase {
+    id: testCase
+
+    name: "OrderTooltips"
+    when: windowShown
+    width: 1200
+    height: 400
+    visible: true
+
+    property var panel: null
+
+    function init() {
+        panel = hudComponent.createObject(testCase, {});
+        verify(panel !== null);
+    }
+
+    function cleanup() {
+        if (panel) {
+            panel.destroy();
+            panel = null;
+        }
+    }
+
+    function entry_for(id) {
+        var commands = panel.commands;
+        for (var i = 0; i < commands.length; ++i) {
+            if (commands[i].id === id)
+                return commands[i];
+        }
+        return null;
+    }
+
+    function state_with(detail, extra) {
+        var state = {
+            "enabled": true,
+            "active": false,
+            "mixed": false,
+            "placing": false,
+            "passive": false,
+            "eligibleCount": 1,
+            "activeCount": 0,
+            "readyCount": 1,
+            "detail": detail
+        };
+        for (var key in extra || {})
+            state[key] = extra[key];
+        return state;
+    }
+
+    function text_of(details, term) {
+        for (var i = 0; i < details.length; ++i) {
+            if (details[i].term === term)
+                return details[i].text;
+        }
+        return "";
+    }
+
+    function test_guard_quotes_the_ring_the_simulation_uses() {
+        var details = panel.command_details(entry_for("guard"), state_with({
+                    "radius": 7
+                }));
+        verify(text_of(details, "Reach").indexOf("7 m") >= 0);
+        verify(text_of(details, "Release") !== "");
+        verify(text_of(details, "Troops") !== "");
+        verify(text_of(details, "vs Hold").indexOf("Hold") >= 0);
+    }
+
+    function test_hold_states_what_digging_in_is_worth() {
+        var details = panel.command_details(entry_for("hold"), state_with({
+                    "archerRangeBonusPercent": 50,
+                    "spearmanRangeBonusPercent": 100,
+                    "damageBonusPercent": 50,
+                    "healthBonusPercent": 20
+                }));
+        var dugIn = text_of(details, "Dug in");
+        verify(dugIn.indexOf("50%") >= 0);
+        verify(dugIn.indexOf("100%") >= 0);
+        verify(dugIn.indexOf("20%") >= 0);
+        verify(text_of(details, "Troops").indexOf("spearmen") >= 0);
+        verify(text_of(details, "vs Guard").indexOf("Guard") >= 0);
+    }
+
+    function test_patrol_walks_the_player_through_the_two_clicks() {
+        var entry = entry_for("patrol");
+        verify(text_of(panel.command_details(entry, state_with({})), "Give it").indexOf("first waypoint") >= 0);
+        compare(panel.command_status(entry, state_with({
+                        "waypointStage": 1
+                    })), "Click waypoint 1");
+        compare(panel.command_status(entry, state_with({
+                        "waypointStage": 2
+                    })), "Click waypoint 2");
+        compare(panel.command_status(entry, state_with({}, {
+                        "active": true
+                    })), "On patrol");
+    }
+
+    function test_the_aura_prints_its_own_numbers_and_its_timer() {
+        var entry = entry_for("aura");
+        var detail = {
+            "radius": 13,
+            "duration": 12,
+            "remaining": 0,
+            "cooldown": 40,
+            "cooldownRemaining": 10,
+            "summary": "Nearby spearmen regenerate health."
+        };
+        var details = panel.command_details(entry, state_with(detail));
+        compare(text_of(details, "Effect"), "Nearby spearmen regenerate health.");
+        verify(text_of(details, "Reach").indexOf("13 m") >= 0);
+        compare(text_of(details, "Lasts"), "12s");
+        verify(text_of(details, "Recharge").indexOf("40s") >= 0);
+        compare(panel.command_status(entry, state_with(detail)), "Ready in 10s");
+        compare(panel.command_cooldown(entry, state_with(detail)), 0.25);
+        detail.remaining = 5;
+        detail.cooldownRemaining = 0;
+        compare(panel.command_status(entry, state_with(detail, {
+                        "active": true
+                    })), "Active 5s");
+        compare(panel.command_cooldown(entry, state_with(detail)), 0);
+    }
+
+    function test_an_order_without_live_facts_still_explains_itself() {
+        var details = panel.command_details(entry_for("stop"), state_with({}));
+        verify(details.length > 0);
+        verify(text_of(details, "Keeps").indexOf("Guard") >= 0);
+    }
+
+    Component {
+        id: hudComponent
+
+        HUDBottom {
+            width: 1200
+            height: 300
+        }
+    }
+}

--- a/ui/qml/HUDBottom.qml
+++ b/ui/qml/HUDBottom.qml
@@ -49,8 +49,84 @@ RowLayout {
             "passive": false,
             "eligibleCount": 0,
             "activeCount": 0,
-            "readyCount": 0
+            "readyCount": 0,
+            "detail": ({})
         };
+    }
+
+    function detail_of(state) {
+        return state && state.detail ? state.detail : ({});
+    }
+
+    function measure(value) {
+        return qsTr("%1 m").arg(Math.round(value));
+    }
+
+    function seconds(value) {
+        return qsTr("%1s").arg(Math.max(0, Math.ceil(value)));
+    }
+
+    function fact(term, text) {
+        return {
+            "term": term,
+            "text": text
+        };
+    }
+
+    function command_details(entry, state) {
+        var d = bottomRoot.detail_of(state);
+        switch (entry.id) {
+        case "guard":
+            return [bottomRoot.fact(qsTr("Give it"), qsTr("Press Guard, then click the ground to hold. Right-click cancels.")), bottomRoot.fact(qsTr("Reach"), qsTr("They fight what comes within %1 of that spot, and drop a target that leaves it.").arg(bottomRoot.measure(d.radius !== undefined ? d.radius : 10))), bottomRoot.fact(qsTr("After"), qsTr("They walk back to the spot when the fight ends.")), bottomRoot.fact(qsTr("Release"), qsTr("Press Guard again, or order a move or attack. Stop does not lift it.")), bottomRoot.fact(qsTr("Troops"), qsTr("Any soldier, and the commander.")), bottomRoot.fact(qsTr("vs Hold"), qsTr("Guards step out to meet the enemy; Hold never moves."))];
+        case "hold":
+            return [bottomRoot.fact(qsTr("Give it"), qsTr("Press Hold. There is nothing to click.")), bottomRoot.fact(qsTr("Stance"), qsTr("They kneel, strike whatever reaches them, and never pursue.")), bottomRoot.fact(qsTr("Dug in"), qsTr("Archers reach %1% further and spearmen %2%; both hit %3% harder, take %4% more punishment, and braced spears break a charge.").arg(d.archerRangeBonusPercent !== undefined ? d.archerRangeBonusPercent : 50).arg(d.spearmanRangeBonusPercent !== undefined ? d.spearmanRangeBonusPercent : 100).arg(d.damageBonusPercent !== undefined ? d.damageBonusPercent : 50).arg(d.healthBonusPercent !== undefined ? d.healthBonusPercent : 20)), bottomRoot.fact(qsTr("Release"), qsTr("Press Hold again, or order a move, attack or Stop. Standing up takes a moment.")), bottomRoot.fact(qsTr("Troops"), qsTr("Archers and spearmen only.")), bottomRoot.fact(qsTr("vs Guard"), qsTr("Guard would chase; Hold trades that for reach and staying power."))];
+        case "patrol":
+            return [bottomRoot.fact(qsTr("Give it"), qsTr("Press Patrol, left-click the first waypoint, then left-click the second. Right-click cancels.")), bottomRoot.fact(qsTr("Route"), qsTr("They march between the two points for good, attacking whatever crosses the line.")), bottomRoot.fact(qsTr("Release"), qsTr("Any other order, or Stop, clears the route.")), bottomRoot.fact(qsTr("Troops"), qsTr("Every soldier and the commander."))];
+        case "aura":
+            return [bottomRoot.fact(qsTr("Effect"), d.summary !== undefined && d.summary !== "" ? d.summary : qsTr("Nearby troops fight with steadier morale and the commander's own bonus.")), bottomRoot.fact(qsTr("Reach"), qsTr("%1 around the commander, and it moves with him.").arg(bottomRoot.measure(d.radius !== undefined ? d.radius : 12))), bottomRoot.fact(qsTr("Lasts"), bottomRoot.seconds(d.duration !== undefined ? d.duration : 15)), bottomRoot.fact(qsTr("Recharge"), qsTr("%1 once it fades. A wounded commander cannot call it.").arg(bottomRoot.seconds(d.cooldown !== undefined ? d.cooldown : 60))), bottomRoot.fact(qsTr("Troops"), qsTr("Your own living troops inside the ring; a glow marks each one."))];
+        }
+        return entry.details || [];
+    }
+
+    function command_status(entry, state) {
+        var d = bottomRoot.detail_of(state);
+        if (entry.id === "patrol") {
+            if (d.waypointStage === 1)
+                return qsTr("Click waypoint 1");
+            if (d.waypointStage === 2)
+                return qsTr("Click waypoint 2");
+            if (state.active)
+                return qsTr("On patrol");
+            return "";
+        }
+        if (entry.id === "aura") {
+            if (state.active)
+                return qsTr("Active %1").arg(bottomRoot.seconds(d.remaining !== undefined ? d.remaining : 0));
+            if (d.cooldownRemaining !== undefined && d.cooldownRemaining > 0)
+                return qsTr("Ready in %1").arg(bottomRoot.seconds(d.cooldownRemaining));
+            if (state.enabled)
+                return qsTr("Ready");
+            return "";
+        }
+        if (entry.id === "guard" && state.active)
+            return qsTr("Holding a spot");
+        if (entry.id === "hold" && state.active)
+            return qsTr("Dug in");
+        return "";
+    }
+
+    function command_cooldown(entry, state) {
+        if (entry.id !== "aura")
+            return 0;
+        var d = bottomRoot.detail_of(state);
+        if (!d.cooldown || d.cooldown <= 0 || !d.cooldownRemaining)
+            return 0;
+        return Math.max(0, Math.min(1, d.cooldownRemaining / d.cooldown));
+    }
+
+    function aura_is_ticking() {
+        var d = bottomRoot.detail_of(bottomRoot.action_state("aura"));
+        return (d.remaining !== undefined && d.remaining > 0) || (d.cooldownRemaining !== undefined && d.cooldownRemaining > 0);
     }
 
     function unavailable_reason(entry, state) {
@@ -66,10 +142,21 @@ RowLayout {
             return qsTr("No troops selected");
         if (current_command_mode === "normal")
             return qsTr("Orders ready");
+        if (current_command_mode === "patrol") {
+            var stage = bottomRoot.detail_of(bottomRoot.action_state("patrol")).waypointStage;
+            if (stage === 2)
+                return qsTr("Patrol: click the second waypoint");
+            if (stage === 1)
+                return qsTr("Patrol: click the first waypoint");
+            return qsTr("On patrol");
+        }
+        if (current_command_mode === "guard") {
+            if (bottomRoot.action_state("guard").placing)
+                return qsTr("Guard: click the spot to hold");
+            return qsTr("Guarding a spot");
+        }
         var labels = ({
                 "attack": qsTr("Attack order"),
-                "guard": qsTr("Guard order"),
-                "patrol": qsTr("Patrol order"),
                 "heal": qsTr("Medic order"),
                 "build": qsTr("Engineer order"),
                 "repair": qsTr("Repair order"),
@@ -97,7 +184,17 @@ RowLayout {
             "binding": "rts.order_attack",
             "needsTroops": true,
             "mode": "attack",
-            "hint": qsTr("Attack enemy units or buildings. Only eligible selected troops receive the order."),
+            "hint": qsTr("Send the selected troops at one enemy unit or building."),
+            "details": [{
+                    "term": qsTr("Give it"),
+                    "text": qsTr("Press Attack, then left-click the target. Right-click cancels. A right-click on an enemy does the same thing.")
+                }, {
+                    "term": qsTr("Scope"),
+                    "text": qsTr("They chase the target until it dies or you order otherwise.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Every fighting unit; healers and builders sit it out.")
+                }],
             "unavailable": qsTr("Attack is not available for the current selection")
         }, {
             "id": "guard",
@@ -105,7 +202,7 @@ RowLayout {
             "binding": "rts.order_guard",
             "needsTroops": true,
             "mode": "guard",
-            "hint": qsTr("Guard a position. Only guard-capable troops receive the order."),
+            "hint": qsTr("Anchor troops to a spot. They step out to meet what comes near, then walk back."),
             "unavailable": qsTr("Guard is not available for the current selection")
         }, {
             "id": "patrol",
@@ -113,14 +210,20 @@ RowLayout {
             "binding": "rts.order_patrol",
             "needsTroops": true,
             "mode": "patrol",
-            "hint": qsTr("Patrol between waypoints."),
+            "hint": qsTr("March a beat between two points and fight whatever crosses it."),
             "unavailable": qsTr("Patrol is not available for the current selection")
         }, {
             "id": "heal",
             "label": qsTr("Medic"),
             "needsTroops": true,
-            "alwaysDisabled": true,
-            "hint": qsTr("Healers tend nearby allies on their own."),
+            "hint": qsTr("Healers tend the wounded around them on their own."),
+            "details": [{
+                    "term": qsTr("Passive"),
+                    "text": qsTr("There is nothing to press: a healer mends nearby allies whenever they are hurt.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Healers only. Keep them behind the line and they will work.")
+                }],
             "passiveReason": qsTr("Healers automatically heal nearby allies. This is passive, not a manual order."),
             "unavailable": qsTr("Select healer units")
         }, {
@@ -129,7 +232,14 @@ RowLayout {
             "binding": "rts.order_stop",
             "needsTroops": true,
             "ignoreActionState": true,
-            "hint": qsTr("Stop all actions immediately."),
+            "hint": qsTr("Drop everything the selected troops are doing and stand still."),
+            "details": [{
+                    "term": qsTr("Clears"),
+                    "text": qsTr("Movement, the current target, Patrol, Hold, formation and gathering orders.")
+                }, {
+                    "term": qsTr("Keeps"),
+                    "text": qsTr("Guard: press Guard again to release troops from their anchor.")
+                }],
             "unavailable": qsTr("Select troops first"),
             "invoke": function () {
                 if (bottomRoot.game_ready() && game.orders.stop)
@@ -140,8 +250,8 @@ RowLayout {
             "label": qsTr("Hold"),
             "binding": "rts.order_hold",
             "needsTroops": true,
-            "hint": qsTr("Hold position and defend."),
-            "unavailable": qsTr("Hold is not available for the current selection"),
+            "hint": qsTr("Stand fast. Troops dig in where they are, hit harder and further, and never pursue."),
+            "unavailable": qsTr("Hold is only available to archers and spearmen"),
             "invoke": function () {
                 if (bottomRoot.game_ready() && game.orders.hold)
                     game.orders.hold();
@@ -151,7 +261,14 @@ RowLayout {
             "label": qsTr("Build"),
             "needsTroops": true,
             "mode": "build",
-            "hint": qsTr("Open builder orders and place structures."),
+            "hint": qsTr("Open the builder's structure list and place one."),
+            "details": [{
+                    "term": qsTr("Give it"),
+                    "text": qsTr("Pick a structure, move the outline onto flat clear ground, scroll to rotate, left-click to confirm. Right-click cancels.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Builders only.")
+                }],
             "unavailable": qsTr("Build is only available to builders"),
             "invoke": function () {
                 if (!bottomRoot.game_ready())
@@ -172,7 +289,17 @@ RowLayout {
             "label": qsTr("Collect"),
             "needsTroops": true,
             "activeFromPlacing": true,
-            "hint": qsTr("Click a tree, boulder or ore deposit. Right-click to cancel."),
+            "hint": qsTr("Send a builder to fell a tree, break a boulder or work an ore seam."),
+            "details": [{
+                    "term": qsTr("Give it"),
+                    "text": qsTr("Press Collect, then left-click the node. Right-click cancels.")
+                }, {
+                    "term": qsTr("Scope"),
+                    "text": qsTr("The load only counts once it is dropped at the yard beside a barracks.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Builders only.")
+                }],
             "unavailable": qsTr("Collect is only available to builders"),
             "invoke": function () {
                 if (!bottomRoot.game_ready())
@@ -190,7 +317,14 @@ RowLayout {
             "id": "auto_gather",
             "label": qsTr("Auto Gather"),
             "needsTroops": true,
-            "hint": qsTr("Builders keep finding and collecting the nearest resource on their own. Any new order cancels it."),
+            "hint": qsTr("Builders keep finding and working the nearest resource on their own."),
+            "details": [{
+                    "term": qsTr("Scope"),
+                    "text": qsTr("Runs until you stop it; any new order cancels it.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Builders only.")
+                }],
             "unavailable": qsTr("Auto Gather is only available to builders"),
             "invoke": function () {
                 if (bottomRoot.game_ready() && game.activity) {
@@ -203,7 +337,14 @@ RowLayout {
             "label": qsTr("Repair"),
             "needsTroops": true,
             "activeFromPlacing": true,
-            "hint": qsTr("Click a damaged building of yours. Right-click to cancel."),
+            "hint": qsTr("Send a builder to mend one of your damaged buildings."),
+            "details": [{
+                    "term": qsTr("Give it"),
+                    "text": qsTr("Press Repair, then left-click the damaged building. Right-click cancels.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Builders only.")
+                }],
             "unavailable": qsTr("Repair is only available to builders"),
             "invoke": function () {
                 if (bottomRoot.game_ready() && game.activity)
@@ -214,13 +355,30 @@ RowLayout {
             "label": qsTr("Deliver"),
             "needsTroops": true,
             "mode": "deliver",
-            "hint": qsTr("Click a friendly barracks. Only selected civilians receive the order."),
+            "hint": qsTr("Send civilians to a barracks to refill the population it recruits from."),
+            "details": [{
+                    "term": qsTr("Give it"),
+                    "text": qsTr("Press Deliver, then left-click a friendly barracks. Right-click cancels.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Civilians only; other selected units ignore it.")
+                }],
             "unavailable": qsTr("Deliver is only available to civilians")
         }, {
             "id": "rally",
             "label": qsTr("Rally"),
             "binding": "rts.commander_rally",
-            "hint": qsTr("The commander plants a rally flag; troops march to it once placed."),
+            "hint": qsTr("The commander plants a flag and the army marches to it."),
+            "details": [{
+                    "term": qsTr("Give it"),
+                    "text": qsTr("Press Rally, then left-click where the flag should stand. He walks there and plants it.")
+                }, {
+                    "term": qsTr("Scope"),
+                    "text": qsTr("Troops near the flag march in; it also steadies wavering men.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Needs your commander selected.")
+                }],
             "unavailable": qsTr("Select a commander to use rally"),
             "invoke": function () {
                 if (bottomRoot.game_ready() && game.commander.start_flag_rally)
@@ -230,6 +388,13 @@ RowLayout {
             "id": "gate",
             "label": qsTr("Gate"),
             "hint": qsTr("Cycle the selected gates: automatic, held open, held shut."),
+            "details": [{
+                    "term": qsTr("Scope"),
+                    "text": qsTr("Automatic gates open for your own troops and shut behind them.")
+                }, {
+                    "term": qsTr("Troops"),
+                    "text": qsTr("Select one of your own gates.")
+                }],
             "unavailable": qsTr("Select one of your gates to control it"),
             "invoke": function () {
                 if (bottomRoot.game_ready() && game.orders.gate) {
@@ -240,7 +405,7 @@ RowLayout {
         }, {
             "id": "aura",
             "label": qsTr("Aura"),
-            "hint": qsTr("Temporarily empower nearby troops. A glow marks every affected soldier."),
+            "hint": qsTr("The commander empowers the troops around him for a while, then must recharge."),
             "unavailable": qsTr("Select a ready commander to activate the aura"),
             "invoke": function () {
                 if (bottomRoot.game_ready() && game.commander.trigger_aura) {
@@ -290,6 +455,13 @@ RowLayout {
         }
 
         target: bottomRoot.game_ready() ? game : null
+    }
+
+    Timer {
+        interval: 500
+        repeat: true
+        running: bottomRoot.aura_is_ticking()
+        onTriggered: bottomRoot.update_action_states()
     }
 
     Connections {
@@ -438,9 +610,11 @@ RowLayout {
                     label: modelData.label
                     hotkey: bottomRoot.hotkey_for(modelData)
                     hint: modelData.hint || ""
+                    details: bottomRoot.command_details(modelData, state)
+                    statusText: bottomRoot.command_status(modelData, state)
+                    cooldown: bottomRoot.command_cooldown(modelData, state)
                     disabledReason: bottomRoot.unavailable_reason(modelData, state)
 
-                    enabled: !modelData.alwaysDisabled
                     blocked: (modelData.needsTroops && !bottomRoot.has_movable_units) || (!modelData.ignoreActionState && !state.enabled)
                     active: modelData.activeFromPlacing ? state.placing : (modelData.mode ? (bottomRoot.current_command_mode === modelData.mode && bottomRoot.has_movable_units) : state.active)
                     mixed: state.mixed

--- a/ui/qml/HelpPanel.qml
+++ b/ui/qml/HelpPanel.qml
@@ -25,8 +25,14 @@ Item {
             "heading": qsTr("Giving orders"),
             "body": qsTr("Right-click the ground to move, right-click an enemy to attack. The command grid offers Attack, Guard, Patrol, Hold, Stop and the builder and commander orders. A marker shows where troops are going and the banner above the grid confirms each order - or explains why it was refused.")
         }, {
-            "heading": qsTr("Stances"),
-            "body": qsTr("Guard holds a spot, chases what comes near and returns. Hold stands the ground without pursuing - for archers and spearmen. Patrol walks between two points and engages what crosses the route. Stop cancels everything.")
+            "heading": qsTr("Guard - hold a spot"),
+            "body": qsTr("Press Guard, then left-click the ground the troops should hold. They fight anything that comes within about 10 m of that spot, let go of anything that runs past it, and walk back once the fight is over. Press Guard again, or give a move or attack order, to release them; Stop alone will not lift it. Any soldier can guard.")
+        }, {
+            "heading": qsTr("Hold - stand fast"),
+            "body": qsTr("Press Hold and the troops kneel where they stand. They never take a step, but they reach further, hit harder and take more punishment than they would on the move, and braced spears gut a cavalry charge. That is the trade: pursuit for staying power. Press Hold again, or give a move, attack or Stop order, to stand them up. Only archers and spearmen can hold.")
+        }, {
+            "heading": qsTr("Patrol - walk a beat"),
+            "body": qsTr("Press Patrol, left-click the first waypoint, then left-click the second. The troops march between the two points for good and attack whatever crosses the line - useful for watching a flank while you look elsewhere. Right-click cancels while you are setting it; any other order, or Stop, clears the route.")
         }, {
             "heading": qsTr("Winning and losing"),
             "body": qsTr("Each mission states its own victory and defeat conditions in the Objectives screen (Escape, then Objectives). In every battle your commander must survive: a nation dies with the man who leads it, and a lone commander is already lost.")
@@ -70,7 +76,7 @@ Item {
             "body": qsTr("Your commander carries the standard. Troops close to him fight with higher morale, and morale decides who breaks first. Keep him behind the spears: if he falls the mission is lost.")
         }, {
             "heading": qsTr("Aura and Rally"),
-            "body": qsTr("With the commander selected, Aura briefly empowers every soldier around him and then recharges. Rally plants a flag that your army marches to - useful for pulling a scattered force back into a line.")
+            "body": qsTr("With the commander selected, Aura empowers his troops for a stretch and then has to recharge - each commander brings his own bonus, radius and timings, and the button prints them along with the time left. A glow marks every soldier inside the ring, the ring travels with him, and a wounded commander cannot call it. Rally plants a flag that your army marches to - useful for pulling a scattered force back into a line.")
         }, {
             "heading": qsTr("Taking direct control"),
             "body": qsTr("Where the mission allows it, you can step into the commander's boots and lead from the field. The controls for that mode are listed under Controls.")

--- a/ui/qml/design/ComponentGallery.qml
+++ b/ui/qml/design/ComponentGallery.qml
@@ -148,6 +148,15 @@ ScrollView {
                                 label: qsTr("Guard")
                                 hotkey: "G"
                                 active: true
+                                hint: qsTr("Anchor troops to a spot. They step out to meet what comes near, then walk back.")
+                                statusText: qsTr("Holding a spot")
+                                details: [{
+                                        "term": qsTr("Reach"),
+                                        "text": qsTr("They fight what comes within 10 m of that spot, and drop a target that leaves it.")
+                                    }, {
+                                        "term": qsTr("Release"),
+                                        "text": qsTr("Press Guard again, or order a move or attack.")
+                                    }]
                             }
                             Design.IronCommandButton {
                                 actionId: "patrol"

--- a/ui/qml/design/controls/IronCommandButton.qml
+++ b/ui/qml/design/controls/IronCommandButton.qml
@@ -26,11 +26,17 @@ AbstractButton {
     property string disabledReason: ""
     property string hint: ""
 
+    property var details: []
+
+    property string statusText: ""
+
     property bool blocked: false
     readonly property bool interactive: enabled && !blocked
 
     property bool compact: width > 0 && width < minimumLabelledWidth
-    readonly property real minimumLabelledWidth: Design.Metrics.iconMedium + labelMetrics.width + hotkeyLabel.width + Design.Metrics.space24
+
+    readonly property real minimumLabelledWidth: Design.Metrics.iconMedium + labelMetrics.width + hotkeyWidth + Design.Metrics.space24
+    readonly property real hotkeyWidth: control.hotkey !== "" ? hotkeyMetrics.width + Design.Metrics.space8 : 0
 
     TextMetrics {
         id: labelMetrics
@@ -41,18 +47,31 @@ AbstractButton {
         text: control.label
     }
 
+    TextMetrics {
+        id: hotkeyMetrics
+
+        font.family: "monospace"
+        font.pixelSize: Design.Typography.caption
+        text: control.hotkey
+    }
+
     readonly property bool highlighted: active || placing
     readonly property bool showFocusRing: visualFocus || (Design.A11y.alwaysShowFocus && activeFocus)
     readonly property color stateColor: !interactive ? Design.Theme.textDisabled : placing ? Design.Theme.warning : active ? Design.Theme.accent : mixed ? Design.Theme.textSecondary : Design.Theme.borderStrong
 
     readonly property string tooltipText: control.interactive ? control.hint : control.disabledReason
 
+    readonly property alias tooltip: commandTooltip
+
+    readonly property bool hasTooltipBody: control.hint !== "" || control.statusText !== "" || (!control.interactive && control.disabledReason !== "") || (control.details && control.details.length > 0)
+
     readonly property string coverageText: (eligibleCount > 0 && activeCount > 0 && activeCount < eligibleCount) ? qsTr("%1 of %2").arg(activeCount).arg(eligibleCount) : ""
 
     implicitHeight: Math.max(Design.Metrics.commandButtonSize, Design.Metrics.minTouchTarget)
     implicitWidth: compact ? Design.Metrics.commandButtonSize + Design.Metrics.space24 : Design.Metrics.commandButtonSize * 3
     hoverEnabled: true
-    focusPolicy: Qt.NoFocus
+
+    focusPolicy: Qt.TabFocus
 
     Accessible.role: Accessible.Button
     Accessible.name: control.label
@@ -60,9 +79,22 @@ AbstractButton {
     Accessible.checkable: true
     Accessible.checked: control.active
 
-    ToolTip.text: control.compact && control.interactive && control.hint === "" ? control.label : control.tooltipText
-    ToolTip.visible: control.hovered && ToolTip.text.length > 0
-    ToolTip.delay: Design.Metrics.tooltipDelay
+    Keys.onReturnPressed: control.clicked()
+    Keys.onEnterPressed: control.clicked()
+
+    Design.IronCommandTooltip {
+        id: commandTooltip
+
+        parent: control
+        visible: (control.hovered || control.showFocusRing) && control.hasTooltipBody
+        title: control.label
+        hotkey: control.hotkey
+        summary: control.hint
+
+        details: visible ? control.details : []
+        status: control.interactive ? control.statusText : ""
+        warning: control.interactive ? "" : control.disabledReason
+    }
 
     Connections {
         function onClicked() {
@@ -118,7 +150,7 @@ AbstractButton {
     }
 
     contentItem: Item {
-        implicitWidth: control.compact ? Design.Metrics.iconMedium + hotkeyLabel.width + Design.Metrics.space16 : Design.Metrics.iconMedium + textColumn.implicitWidth + Design.Metrics.space24
+        implicitWidth: control.compact ? Design.Metrics.iconMedium + control.hotkeyWidth + Design.Metrics.space16 : Design.Metrics.iconMedium + textColumn.implicitWidth + Design.Metrics.space24
 
         Item {
             id: iconSlot
@@ -187,7 +219,7 @@ AbstractButton {
             Text {
                 width: parent.width
                 visible: text !== ""
-                text: control.placing ? qsTr("Pick a target") : control.coverageText
+                text: control.statusText !== "" ? control.statusText : (control.placing ? qsTr("Pick a target") : control.coverageText)
                 color: Design.Theme.textSecondary
                 font.family: Design.Typography.family
                 font.pixelSize: Design.Typography.caption

--- a/ui/qml/design/controls/IronCommandTooltip.qml
+++ b/ui/qml/design/controls/IronCommandTooltip.qml
@@ -1,0 +1,158 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import ".." as Design
+
+ToolTip {
+    id: control
+
+    property string title: ""
+    property string hotkey: ""
+
+    property string summary: ""
+
+    property var details: []
+
+    property string status: ""
+    property string warning: ""
+
+    readonly property bool hasBody: summary !== "" || status !== "" || warning !== "" || (details && details.length > 0)
+
+    function detail_term(entry) {
+        return entry && entry.term !== undefined ? entry.term : "";
+    }
+
+    function detail_text(entry) {
+        return entry && entry.text !== undefined ? entry.text : "";
+    }
+
+    y: -control.height - Design.Metrics.space4
+    x: {
+        if (!control.parent)
+            return 0;
+        var centered = Math.round((control.parent.width - control.implicitWidth) / 2);
+        var host = control.Overlay.overlay;
+        if (!host || host.width <= 0)
+            return centered;
+        var left = control.parent.mapToItem(host, centered, 0).x;
+        var limit = host.width - control.implicitWidth - Design.Metrics.space8;
+        var clamped = Math.max(Design.Metrics.space8, Math.min(left, limit));
+        return centered + (clamped - left);
+    }
+
+    delay: Design.Metrics.tooltipDelay
+    timeout: -1
+    padding: Design.Metrics.space8
+    implicitWidth: Design.Metrics.tooltipWidth
+
+    implicitHeight: body.implicitHeight + control.topPadding + control.bottomPadding
+
+    background: Rectangle {
+        color: Design.Theme.panelLeather
+        radius: Design.Metrics.radiusSmall
+        border.color: Design.Theme.borderStrong
+        border.width: Design.Metrics.borderThin
+    }
+
+    contentItem: Column {
+        id: body
+
+        spacing: Design.Metrics.space4
+        width: control.implicitWidth - control.leftPadding - control.rightPadding
+
+        Item {
+            width: parent.width
+            height: Math.max(titleText.implicitHeight, hotkeyChip.height)
+
+            Text {
+                id: titleText
+
+                anchors.left: parent.left
+                anchors.right: hotkeyChip.visible ? hotkeyChip.left : parent.right
+                anchors.rightMargin: hotkeyChip.visible ? Design.Metrics.space8 : 0
+                anchors.verticalCenter: parent.verticalCenter
+                visible: control.title !== ""
+                text: control.title
+                color: Design.Theme.textPrimary
+                font.family: Design.Typography.family
+                font.pixelSize: Design.Typography.label
+                font.weight: Design.Typography.bold
+                elide: Text.ElideRight
+            }
+
+            Design.IronHotkeyLabel {
+                id: hotkeyChip
+
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                visible: control.hotkey !== ""
+                text: control.hotkey
+            }
+        }
+
+        Text {
+            width: parent.width
+            visible: control.summary !== ""
+            text: control.summary
+            color: Design.Theme.textPrimary
+            font.family: Design.Typography.family
+            font.pixelSize: Design.Typography.caption
+            wrapMode: Text.WordWrap
+        }
+
+        Repeater {
+            model: control.details
+
+            delegate: Row {
+                id: detailRow
+
+                required property var modelData
+
+                readonly property int termWidth: Math.round(width * 0.3)
+
+                width: body.width
+                spacing: Design.Metrics.space8
+
+                Text {
+                    width: detailRow.termWidth
+                    text: control.detail_term(detailRow.modelData)
+                    color: Design.Theme.textSecondary
+                    font.family: Design.Typography.family
+                    font.pixelSize: Design.Typography.caption
+                    font.weight: Design.Typography.medium
+                    wrapMode: Text.WordWrap
+                }
+
+                Text {
+                    width: detailRow.width - detailRow.termWidth - detailRow.spacing
+                    text: control.detail_text(detailRow.modelData)
+                    color: Design.Theme.textPrimary
+                    font.family: Design.Typography.family
+                    font.pixelSize: Design.Typography.caption
+                    wrapMode: Text.WordWrap
+                }
+            }
+        }
+
+        Text {
+            width: parent.width
+            visible: control.status !== ""
+            text: control.status
+            color: Design.Theme.accent
+            font.family: Design.Typography.family
+            font.pixelSize: Design.Typography.caption
+            font.weight: Design.Typography.medium
+            wrapMode: Text.WordWrap
+        }
+
+        Text {
+            width: parent.width
+            visible: control.warning !== ""
+            text: control.warning
+            color: Design.Theme.warning
+            font.family: Design.Typography.family
+            font.pixelSize: Design.Typography.caption
+            font.weight: Design.Typography.medium
+            wrapMode: Text.WordWrap
+        }
+    }
+}

--- a/ui/qml/design/qmldir
+++ b/ui/qml/design/qmldir
@@ -21,6 +21,7 @@ IronButton 1.0 controls/IronButton.qml
 IronIconButton 1.0 controls/IronIconButton.qml
 IronTabBar 1.0 controls/IronTabBar.qml
 IronTooltip 1.0 controls/IronTooltip.qml
+IronCommandTooltip 1.0 controls/IronCommandTooltip.qml
 IronDialog 1.0 controls/IronDialog.qml
 IronDropdown 1.0 controls/IronDropdown.qml
 IronSlider 1.0 controls/IronSlider.qml


### PR DESCRIPTION
Give every tactical order a shared explanation that is reachable by mouse hover, keyboard focus, and controller navigation. The tooltip presents the command name, hotkey, summary, live status, refusal reason, and rule rows without hiding the explanation when an order is unavailable.

Expose the simulation facts needed by those explanations through the action-state model, including Guard radius, Hold bonuses, Patrol waypoint progress, and commander Aura timing and range. Keep the UI text tied to the same constants and component state that execute the orders.

Add the reusable IronCommandTooltip control, wire it into IronCommandButton and HUDBottom, register the new QML/resource entries, and expand the tutorial, help panel, design gallery, and design-system documentation so the behavior is discoverable and accessible.

Add focused C++ and QML coverage for live order details, tooltip layout and fallback behavior, keyboard-facing command controls, and the order-specific rule text.