### PR TITLE
feat(tutorial, portrait): spotlight tutorial steps and paint a comman…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -809,8 +809,10 @@ if(QT_VERSION_MAJOR EQUAL 6)
             ui/qml/SaveProgressOverlay.qml
             ui/qml/ObjectivesPanel.qml
             ui/qml/CommanderMessagePanel.qml
+            ui/qml/CommanderFaceOverlay.qml
             ui/qml/HelpPanel.qml
             ui/qml/TutorialOverlay.qml
+            ui/qml/TutorialFocusOverlay.qml
             ui/qml/SettingsPanel.qml
             ui/qml/ControlsBindingList.qml
             ui/qml/HUDVictory.qml

--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -43,6 +43,7 @@
 #include <qvectornd.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <map>
 #include <memory>
@@ -50,6 +51,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <thread>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -553,6 +555,46 @@ void GameEngine::finish_replay_verification_if_done() {
     QCoreApplication::exit(0);
   }
   m_replay_verify_exit = false;
+}
+
+namespace {
+
+constexpr auto k_render_frame_wait_budget = std::chrono::milliseconds(2000);
+constexpr auto k_render_frame_wait_poll = std::chrono::microseconds(250);
+
+} // namespace
+
+GameEngine::WorldFreeze::WorldFreeze(GameEngine& engine)
+    : m_engine(engine) {
+  m_engine.m_world_freeze_depth.fetch_add(1);
+
+  const auto deadline = std::chrono::steady_clock::now() + k_render_frame_wait_budget;
+  while (m_engine.m_render_frame_active.load()) {
+    if (std::chrono::steady_clock::now() >= deadline) {
+      qWarning() << "GameEngine: the render thread did not finish its frame within"
+                 << static_cast<int>(k_render_frame_wait_budget.count())
+                 << "ms; rebuilding the world anyway";
+      break;
+    }
+    std::this_thread::sleep_for(k_render_frame_wait_poll);
+  }
+}
+
+GameEngine::WorldFreeze::~WorldFreeze() {
+  m_engine.m_world_freeze_depth.fetch_sub(1);
+}
+
+auto GameEngine::try_begin_render_frame() -> bool {
+  m_render_frame_active.store(true);
+  if (m_world_freeze_depth.load() > 0) {
+    m_render_frame_active.store(false);
+    return false;
+  }
+  return true;
+}
+
+void GameEngine::end_render_frame() {
+  m_render_frame_active.store(false);
 }
 
 void GameEngine::update(float dt) {
@@ -1165,6 +1207,8 @@ void GameEngine::start_skirmish_internal(const QString& map_path,
                                          const QVariantList& player_configs,
                                          bool set_skirmish_context) {
 
+  auto world_freeze = std::make_shared<WorldFreeze>(*this);
+
   clear_error();
   reset_preload_interaction_state();
   reset_mission_runtime_state();
@@ -1211,7 +1255,7 @@ void GameEngine::start_skirmish_internal(const QString& map_path,
   } else {
     AudioResourceLoader::load_audio_resources(AudioLoadPolicy::Mission);
   }
-  QTimer::singleShot(50, this, [this, map_path, player_configs]() {
+  QTimer::singleShot(50, this, [this, map_path, player_configs, world_freeze]() {
     if (!m_world || !m_renderer || (m_camera == nullptr) || !m_skirmish_runtime) {
       set_error(tr("Cannot start skirmish: renderer not initialized"));
       m_runtime.loading = false;
@@ -1930,6 +1974,8 @@ void GameEngine::load_game_from_slot(const QString& slot_name) {
     return;
   }
 
+  const WorldFreeze world_freeze(*this);
+
   if (m_commander_view_model->active()) {
     m_commander_view_model->exit_mode();
   }
@@ -2603,6 +2649,7 @@ void GameEngine::update_tutorial(float real_dt) {
   }
   const float elapsed = m_tutorial_observe_accumulator;
   m_tutorial_observe_accumulator = 0.0F;
+  const QVariantMap wave_status = m_mission_waves.status();
   m_tutorial_director->advance(
       App::Mission::observe_tutorial_frame(
           {.world = m_world,
@@ -2612,9 +2659,40 @@ void GameEngine::update_tutorial(float real_dt) {
            .enemy_troops_defeated = m_enemy_troops_defeated,
            .mission_running = m_runtime.initialized && !is_loading(),
            .placement = m_placement_view_model.get(),
-           .wave_status = m_mission_waves.status()}),
+           .wave_status = wave_status}),
       elapsed);
   m_tutorial_notes.reset();
+  publish_tutorial_focus_points(wave_status);
+}
+
+void GameEngine::publish_tutorial_focus_points(const QVariantMap& wave_status) {
+  if (!m_tutorial_director) {
+    return;
+  }
+  QVariantList points = App::Mission::resolve_tutorial_focus_points(
+      {.world = m_world,
+       .local_owner_id = m_runtime.local_owner_id,
+       .target = m_tutorial_director->focus_target_id(),
+       .wave_alerts = wave_status.value(QStringLiteral("alerts")).toList()});
+
+  if (!points.isEmpty() && m_minimap_manager && m_minimap_manager->has_minimap()) {
+    const float world_width = m_minimap_manager->get_world_width();
+    const float world_height = m_minimap_manager->get_world_height();
+    for (auto& value : points) {
+      QVariantMap point = value.toMap();
+      const auto [nx, ny] =
+          Game::Map::Minimap::world_to_pixel(point.value("world_x").toFloat(),
+                                             point.value("world_z").toFloat(),
+                                             world_width,
+                                             world_height,
+                                             1.0F,
+                                             1.0F);
+      point["nx"] = std::clamp(nx, 0.0F, 1.0F);
+      point["ny"] = std::clamp(ny, 0.0F, 1.0F);
+      value = point;
+    }
+  }
+  m_tutorial_director->set_focus_points(points);
 }
 
 auto GameEngine::activity_view_model() const -> QObject* {

--- a/app/core/game_engine.h
+++ b/app/core/game_engine.h
@@ -298,6 +298,23 @@ public:
   void render(int pixel_width, int pixel_height);
   void set_input_viewport_size(qreal width, qreal height);
 
+  [[nodiscard]] auto try_begin_render_frame() -> bool;
+  void end_render_frame();
+
+  class WorldFreeze {
+  public:
+    explicit WorldFreeze(GameEngine& engine);
+    ~WorldFreeze();
+
+    WorldFreeze(const WorldFreeze&) = delete;
+    auto operator=(const WorldFreeze&) -> WorldFreeze& = delete;
+    WorldFreeze(WorldFreeze&&) = delete;
+    auto operator=(WorldFreeze&&) -> WorldFreeze& = delete;
+
+  private:
+    GameEngine& m_engine;
+  };
+
 private:
   struct RuntimeState {
     bool initialized = false;
@@ -383,6 +400,7 @@ private:
   void restore_mission_stages(const QJsonObject& stage_state);
   void restore_mission_waves(const QJsonObject& wave_state);
   void update_tutorial(float real_dt);
+  void publish_tutorial_focus_points(const QVariantMap& wave_status);
   void activate_tutorial_if_configured();
   void update_loading_overlay();
   void update_cursor_position();
@@ -496,6 +514,9 @@ private:
   std::uint64_t m_last_world_props_revision = 0;
   bool m_loading_overlay_active = false;
   std::atomic_bool m_loading_overlay_wait_for_first_frame{false};
+
+  std::atomic<int> m_world_freeze_depth{0};
+  std::atomic<bool> m_render_frame_active{false};
   int m_loading_overlay_frames_remaining = 0;
   qint64 m_loading_overlay_last_frame_ms = 0;
   qint64 m_loading_overlay_min_duration_ms = 0;

--- a/app/core/user_settings.h
+++ b/app/core/user_settings.h
@@ -38,6 +38,7 @@ inline constexpr char kUiDamageNumbersKey[] = "ui/damage_numbers";
 inline constexpr char kUiScreenEffectsKey[] = "ui/screen_effect_intensity";
 inline constexpr char kUiEconomyCoachKey[] = "ui/economy_coach";
 inline constexpr char kUiCameraLegendSeenKey[] = "ui/camera_legend_seen";
+inline constexpr char kUiTutorialCompletedKey[] = "ui/tutorial_completed";
 inline constexpr char kInputBindingsGroup[] = "input/bindings";
 
 inline constexpr int kDefaultAutosaveSlotCount = 3;
@@ -385,6 +386,14 @@ inline auto load_ui_camera_legend_seen() -> bool {
 
 inline void save_ui_camera_legend_seen(bool seen) {
   Detail::save_bool(kUiCameraLegendSeenKey, seen);
+}
+
+inline auto load_ui_tutorial_completed() -> bool {
+  return Detail::load_bool(kUiTutorialCompletedKey, false);
+}
+
+inline void save_ui_tutorial_completed(bool completed) {
+  Detail::save_bool(kUiTutorialCompletedKey, completed);
 }
 
 inline auto load_ui_economy_coach() -> bool {

--- a/app/mission/tutorial_observation.cpp
+++ b/app/mission/tutorial_observation.cpp
@@ -1,11 +1,19 @@
 #include "app/mission/tutorial_observation.h"
 
 #include <QLatin1String>
+#include <QVector3D>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
 
 #include "app/viewmodels/placement_view_model.h"
 #include "game/core/component.h"
 #include "game/core/entity.h"
 #include "game/core/world.h"
+#include "game/map/map_definition.h"
+#include "game/map/terrain_service.h"
 #include "game/systems/owner_registry.h"
 #include "game/systems/player_resource_registry.h"
 #include "game/systems/selection_system.h"
@@ -128,6 +136,246 @@ auto observe_tutorial_frame(const TutorialObservationInputs& inputs)
   o.wave_pending = waves.value(QStringLiteral("active")).toBool() &&
                    waves.value(QStringLiteral("seconds_until_next")).toDouble() >= 0.0;
   return o;
+}
+
+namespace {
+
+constexpr int k_max_focus_points = 6;
+constexpr float k_scout_search_radius = 38.0F;
+
+struct FocusCandidate {
+  QVector3D position;
+  float distance_sq = 0.0F;
+};
+
+auto to_point(const QVector3D& position) -> QVariantMap {
+  QVariantMap point;
+  point[QStringLiteral("world_x")] = position.x();
+  point[QStringLiteral("world_z")] = position.z();
+  return point;
+}
+
+void keep_nearest(std::vector<FocusCandidate>& candidates, std::size_t limit) {
+  if (candidates.size() <= limit) {
+    return;
+  }
+  std::partial_sort(candidates.begin(),
+                    candidates.begin() + static_cast<std::ptrdiff_t>(limit),
+                    candidates.end(),
+                    [](const FocusCandidate& lhs, const FocusCandidate& rhs) {
+                      return lhs.distance_sq < rhs.distance_sq;
+                    });
+  candidates.resize(limit);
+}
+
+auto nearest_props(const QVector3D& anchor,
+                   bool (*matches)(Game::Map::WorldProp::Type),
+                   int limit) -> std::vector<QVector3D> {
+  std::vector<FocusCandidate> candidates;
+  for (const auto& prop : Game::Map::TerrainService::instance().world_props()) {
+    if (!matches(prop.type)) {
+      continue;
+    }
+    const float dx = prop.x - anchor.x();
+    const float dz = prop.z - anchor.z();
+    candidates.push_back({QVector3D(prop.x, 0.0F, prop.z), dx * dx + dz * dz});
+  }
+  keep_nearest(candidates, static_cast<std::size_t>(std::max(0, limit)));
+  std::sort(candidates.begin(),
+            candidates.end(),
+            [](const FocusCandidate& lhs, const FocusCandidate& rhs) {
+              return lhs.distance_sq < rhs.distance_sq;
+            });
+  std::vector<QVector3D> positions;
+  positions.reserve(candidates.size());
+  for (const auto& candidate : candidates) {
+    positions.push_back(candidate.position);
+  }
+  return positions;
+}
+
+auto is_tree(Game::Map::WorldProp::Type type) -> bool {
+  return Game::Map::is_tree_world_prop_type(type);
+}
+
+auto is_boulder(Game::Map::WorldProp::Type type) -> bool {
+  return Game::Map::is_boulder_world_prop_type(type);
+}
+
+auto is_iron_ore(Game::Map::WorldProp::Type type) -> bool {
+  return Game::Map::is_iron_ore_world_prop_type(type);
+}
+
+struct OwnedUnits {
+  std::vector<QVector3D> troops;
+  std::vector<QVector3D> builders;
+  std::vector<QVector3D> barracks;
+  std::vector<QVector3D> commander;
+  std::vector<QVector3D> enemy_troops;
+  std::vector<QVector3D> enemy_camp;
+  QVector3D anchor;
+  bool has_anchor = false;
+};
+
+auto collect_units(Engine::Core::World* world, int owner) -> OwnedUnits {
+  OwnedUnits units;
+  const auto& owners = Game::Systems::OwnerRegistry::instance();
+  world->for_each_entity([&](const Engine::Core::Entity& entity) {
+    const auto* unit = entity.get_component<Engine::Core::UnitComponent>();
+    const auto* transform = entity.get_component<Engine::Core::TransformComponent>();
+    if (unit == nullptr || transform == nullptr || unit->health <= 0) {
+      return;
+    }
+    const QVector3D position(
+        transform->position.x, transform->position.y, transform->position.z);
+    const bool commander =
+        entity.get_component<Engine::Core::CommanderComponent>() != nullptr;
+
+    if (unit->owner_id != owner) {
+      if (!owners.are_enemies(owner, unit->owner_id)) {
+        return;
+      }
+      if (commander || unit->spawn_type == Game::Units::SpawnType::Barracks) {
+        units.enemy_camp.push_back(position);
+        return;
+      }
+      if (Game::Units::is_troop_spawn(unit->spawn_type) &&
+          unit->spawn_type != Game::Units::SpawnType::Builder &&
+          unit->spawn_type != Game::Units::SpawnType::Civilian) {
+        units.enemy_troops.push_back(position);
+      }
+      return;
+    }
+
+    if (unit->spawn_type == Game::Units::SpawnType::Barracks) {
+      units.barracks.push_back(position);
+      if (!units.has_anchor) {
+        units.anchor = position;
+        units.has_anchor = true;
+      }
+      return;
+    }
+    if (commander) {
+      units.commander.push_back(position);
+      return;
+    }
+    if (unit->spawn_type == Game::Units::SpawnType::Builder) {
+      units.builders.push_back(position);
+      return;
+    }
+    if (Game::Units::is_building_spawn(unit->spawn_type) ||
+        unit->spawn_type == Game::Units::SpawnType::Civilian) {
+      return;
+    }
+    if (Game::Units::is_troop_spawn(unit->spawn_type)) {
+      units.troops.push_back(position);
+    }
+  });
+
+  if (!units.has_anchor) {
+    if (!units.commander.empty()) {
+      units.anchor = units.commander.front();
+      units.has_anchor = true;
+    } else if (!units.troops.empty()) {
+      units.anchor = units.troops.front();
+      units.has_anchor = true;
+    } else if (!units.builders.empty()) {
+      units.anchor = units.builders.front();
+      units.has_anchor = true;
+    }
+  }
+  return units;
+}
+
+auto to_points(const std::vector<QVector3D>& positions, int limit) -> QVariantList {
+  QVariantList list;
+  const int count = std::min(static_cast<int>(positions.size()), limit);
+  for (int i = 0; i < count; ++i) {
+    list.append(to_point(positions[static_cast<std::size_t>(i)]));
+  }
+  return list;
+}
+
+} // namespace
+
+auto resolve_tutorial_focus_points(const TutorialFocusInputs& inputs) -> QVariantList {
+  using Game::Mission::TutorialFocusTarget;
+  if (inputs.target == TutorialFocusTarget::None) {
+    return {};
+  }
+  if (inputs.target == TutorialFocusTarget::WaveEntry) {
+    QVariantList points;
+    for (const auto& value : inputs.wave_alerts) {
+      const QVariantMap alert = value.toMap();
+      if (!alert.contains(QStringLiteral("x"))) {
+        continue;
+      }
+      points.append(to_point(QVector3D(alert.value(QStringLiteral("x")).toFloat(),
+                                       0.0F,
+                                       alert.value(QStringLiteral("z")).toFloat())));
+      if (points.size() >= k_max_focus_points) {
+        break;
+      }
+    }
+    return points;
+  }
+
+  if (inputs.world == nullptr) {
+    return {};
+  }
+  const OwnedUnits units = collect_units(inputs.world, inputs.local_owner_id);
+
+  switch (inputs.target) {
+  case TutorialFocusTarget::OwnTroops:
+    return to_points(units.troops, k_max_focus_points);
+
+  case TutorialFocusTarget::Builders:
+    return to_points(units.builders, 3);
+
+  case TutorialFocusTarget::Barracks:
+    return to_points(units.barracks, 2);
+
+  case TutorialFocusTarget::Commander:
+    return to_points(units.commander, 1);
+
+  case TutorialFocusTarget::EnemyCamp:
+    return to_points(units.enemy_camp, 3);
+
+  case TutorialFocusTarget::EnemyScouts: {
+    if (!units.has_anchor) {
+      return to_points(units.enemy_troops, 3);
+    }
+    std::vector<QVector3D> near_scouts;
+    for (const auto& position : units.enemy_troops) {
+      const float dx = position.x() - units.anchor.x();
+      const float dz = position.z() - units.anchor.z();
+      if (dx * dx + dz * dz <= k_scout_search_radius * k_scout_search_radius) {
+        near_scouts.push_back(position);
+      }
+    }
+    return to_points(near_scouts.empty() ? units.enemy_troops : near_scouts, 3);
+  }
+
+  case TutorialFocusTarget::Timber:
+    if (!units.has_anchor) {
+      return {};
+    }
+    return to_points(nearest_props(units.anchor, &is_tree, 3), 3);
+
+  case TutorialFocusTarget::StoneAndIron: {
+    if (!units.has_anchor) {
+      return {};
+    }
+    QVariantList points = to_points(nearest_props(units.anchor, &is_boulder, 2), 2);
+    points.append(to_points(nearest_props(units.anchor, &is_iron_ore, 2), 2));
+    return points;
+  }
+
+  case TutorialFocusTarget::None:
+  case TutorialFocusTarget::WaveEntry:
+    break;
+  }
+  return {};
 }
 
 } // namespace App::Mission

--- a/app/mission/tutorial_observation.h
+++ b/app/mission/tutorial_observation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+#include <QVariantList>
 #include <QVariantMap>
 
 #include "game/mission/tutorial_director.h"
@@ -42,7 +43,18 @@ struct TutorialObservationInputs {
   QVariantMap wave_status;
 };
 
+struct TutorialFocusInputs {
+
+  Engine::Core::World* world = nullptr;
+  int local_owner_id = 1;
+  Game::Mission::TutorialFocusTarget target = Game::Mission::TutorialFocusTarget::None;
+  QVariantList wave_alerts;
+};
+
 [[nodiscard]] auto observe_tutorial_frame(const TutorialObservationInputs& inputs)
     -> Game::Mission::TutorialObservation;
+
+[[nodiscard]] auto
+resolve_tutorial_focus_points(const TutorialFocusInputs& inputs) -> QVariantList;
 
 } // namespace App::Mission

--- a/app/viewmodels/camera_view_model.cpp
+++ b/app/viewmodels/camera_view_model.cpp
@@ -1,9 +1,12 @@
 #include "app/viewmodels/camera_view_model.h"
 
+#include <QVector3D>
+
 #include "app/core/client_context.h"
 #include "app/input/input_command_handler.h"
 #include "app/input/rts_camera_controller.h"
 #include "app/utils/engine_view_helpers.h"
+#include "scene/camera.h"
 
 namespace App::ViewModels {
 
@@ -73,6 +76,19 @@ void CameraViewModel::reset() {
   }
   camera->reset(m_context.local_owner_id, *m_context.level);
   emit distance_changed();
+}
+
+void CameraViewModel::look_at_world(float x, float z) {
+  m_host.ensure_initialized();
+  auto* camera = m_context.active_camera;
+  if (camera == nullptr) {
+    return;
+  }
+  const QVector3D target(x, 0.0F, z);
+  const QVector3D offset = camera->get_position() - camera->get_target();
+  camera->look_at(target + offset, target, camera->get_up_vector());
+  set_following_selection(false);
+  emit moved();
 }
 
 void CameraViewModel::follow_selection(bool enable) {

--- a/app/viewmodels/camera_view_model.h
+++ b/app/viewmodels/camera_view_model.h
@@ -29,6 +29,7 @@ public:
   Q_INVOKABLE void orbit(float yaw_deg, float pitch_deg);
   Q_INVOKABLE void tilt(int direction, bool shift);
   Q_INVOKABLE void reset();
+  Q_INVOKABLE void look_at_world(float x, float z);
   Q_INVOKABLE void follow_selection(bool enable);
   Q_INVOKABLE void set_follow_lerp(float alpha);
 

--- a/assets/shaders/combat_dust.frag
+++ b/assets/shaders/combat_dust.frag
@@ -7,6 +7,7 @@ in vec2 v_texcoord;
 in vec3 v_local_pos;
 in float v_intensity;
 in float v_alpha;
+in float v_lick;
 
 out vec4 frag_color;
 
@@ -119,14 +120,24 @@ void main() {
         (unit_flame ? (0.96 + 0.06 * radius_factor) : (1.02 + 0.10 * radius_factor));
 
     float edge_soften =
-        inv_smoothstep(unit_flame ? 0.06 : 0.15, unit_flame ? 0.50 : 1.15, axis_radius);
+        inv_smoothstep(unit_flame ? 0.03 : 0.15, unit_flame ? 0.42 : 1.15, axis_radius);
     float height_fade =
         1.0 -
-        smoothstep(unit_flame ? 0.76 : 0.76, unit_flame ? 0.99 : 1.04, flame_height);
+        smoothstep(unit_flame ? 0.58 : 0.72, unit_flame ? 0.97 : 1.04, flame_height);
 
     float tongues = smoothstep(0.18, 0.72, body_noise * 0.55 + curl_noise * 0.45);
-    float flame_alpha = v_alpha * edge_soften * height_fade * mix(0.35, 1.0, tongues) *
-                        (0.86 + 0.14 * curl_noise) * (unit_flame ? 0.72 : 1.0);
+
+    float solidity = 1.0 - smoothstep(0.04, unit_flame ? 0.40 : 0.62, flame_height);
+    float cut = mix(tongues * tongues * (unit_flame ? tongues : 1.0),
+                    1.0,
+                    solidity * (unit_flame ? 0.80 : 0.92));
+
+    float lick_fade =
+        1.0 -
+        smoothstep(mix(0.34, 0.86, v_lick), mix(0.62, 1.05, v_lick), flame_height);
+
+    float flame_alpha = v_alpha * edge_soften * height_fade * cut * lick_fade *
+                        (0.86 + 0.14 * curl_noise) * (unit_flame ? 0.66 : 1.0);
 
     color = clamp(color, 0.0, 2.8);
     frag_color = vec4(color, clamp(flame_alpha, 0.0, 1.0));
@@ -218,16 +229,20 @@ void main() {
 
     float caller_heat =
         dot(u_dust_color, vec3(0.30, 0.55, 0.15)) + 0.35 * u_dust_color.b;
+    float feed = 1.0 - smoothstep(-0.75, 0.55, shell_dir.y);
     float temperature = clamp(core * (0.52 + 0.48 * body) + 0.24 * detail - 0.16 +
-                                  (caller_heat - 0.52) * 0.58,
+                                  (caller_heat - 0.52) * 0.58 + 0.14 * feed,
                               0.0,
                               1.0);
     color = soi_fire_ramp(temperature);
 
     color *= mix(1.0, 0.74 + 0.48 * detail, smoothstep(0.32, 0.88, temperature));
 
-    float soot_mask = (1.0 - core) * smoothstep(0.22, 0.78, soot_noise) *
+    float crown = smoothstep(-0.10, 0.95, shell_dir.y);
+    float soot_mask = (1.0 - core * 0.75) * smoothstep(0.22, 0.78, soot_noise) *
+                      mix(0.35, 1.35, crown) *
                       (1.0 - 0.55 * smoothstep(0.55, 0.95, temperature));
+    soot_mask = clamp(soot_mask, 0.0, 1.0);
     color = mix(color, vec3(0.045, 0.035, 0.032), soot_mask * 0.92);
 
     float sparks = pow(max(detail - 0.68, 0.0) * 3.4, 2.4);

--- a/assets/shaders/combat_dust.vert
+++ b/assets/shaders/combat_dust.vert
@@ -19,6 +19,7 @@ out vec2 v_texcoord;
 out vec3 v_local_pos;
 out float v_intensity;
 out float v_alpha;
+out float v_lick;
 
 float inv_smoothstep(float edge0, float edge1, float x) {
   float lower_edge = min(edge0, edge1);
@@ -39,6 +40,7 @@ float soi_fbm3_fireball(vec3 p) {
 
 void main() {
   vec3 pos = a_position;
+  v_lick = 0.0;
 
   vec3 world_pos = (u_model * vec4(pos, 1.0)).xyz;
   vec3 to_center = world_pos - u_center;
@@ -78,10 +80,17 @@ void main() {
     float lobe = 0.78 + 0.27 * sin(angle * 3.0 + u_time * 2.1 + flow_noise * 2.4) +
                  0.13 * sin(angle * 6.0 - u_time * 3.2 + detail_noise * 3.14159);
 
+    float lick_seed = soi_fbm_23e5ab(vec2(angle_t * 6.5 + 11.0, u_time * 0.85));
+    float lick_fast = soi_fbm_23e5ab(vec2(angle_t * 13.0 - 4.0, u_time * 2.10 + 2.0));
+    float lick = clamp(lick_seed * 0.62 + lick_fast * 0.38, 0.0, 1.0);
+    float reach = mix(unit_flame ? 0.28 : 0.55, unit_flame ? 1.75 : 1.42, lick);
+
     float base_pinch = mix(0.30, 1.0, smoothstep(0.0, 0.20, height));
     float taper =
-        mix(unit_flame ? 0.56 : 1.05, unit_flame ? 0.055 : 0.22, pow(height, 0.64)) *
+        mix(unit_flame ? 0.40 : 1.05, unit_flame ? 0.035 : 0.22, pow(height, 0.52)) *
         base_pinch;
+
+    taper *= mix(unit_flame ? 0.42 : 0.68, unit_flame ? 1.34 : 1.26, lick_fast);
     float smoke_expand =
         smoothstep(0.58, 1.0, height) *
         (unit_flame ? 0.02 : 0.16 + (unit_flame ? 0.04 : 0.10) * curl_noise);
@@ -101,13 +110,15 @@ void main() {
     pos.z += drift_dir.y * sway;
 
     float lift =
-        mix(unit_flame ? 0.74 : 1.2, unit_flame ? 1.12 : 2.05, radius_factor) +
+        mix(unit_flame ? 1.35 : 1.2, unit_flame ? 1.95 : 2.05, radius_factor) +
         height * ((unit_flame ? 0.12 : 0.28) + (unit_flame ? 0.14 : 0.18) * flow_noise);
-    pos.y *= lift;
+    pos.y *= lift * reach;
     pos.y +=
         (detail_noise - 0.5) * (unit_flame ? 0.04 : 0.08) * (0.2 + height * height) +
         smoothstep(unit_flame ? 0.58 : 0.65, 1.0, height) *
             ((unit_flame ? 0.03 : 0.06) + (unit_flame ? 0.03 : 0.08) * curl_noise);
+
+    v_lick = lick;
 
     float base_mask = smoothstep(0.0, 0.17, height);
     float tip_fade = 1.0 - smoothstep(unit_flame ? 0.70 : 0.7,
@@ -194,9 +205,13 @@ void main() {
     float body_noise = soi_fbm3_fireball(roll);
     float detail_noise =
         soi_fbm3_fireball(normal_dir * 5.6 + vec3(u_time * 0.6, -u_time * 1.9, 3.0));
+
+    float lobe_noise =
+        soi_fbm3_fireball(normal_dir * 1.15 + vec3(0.0, -u_time * 0.42, 7.0));
     float pulse = 0.94 + 0.06 * sin(u_time * 8.0 + body_noise * 3.14159);
 
-    float shell_offset = (body_noise - 0.5) * 0.34 + (detail_noise - 0.5) * 0.13 - 0.04;
+    float shell_offset = (lobe_noise - 0.5) * 0.46 + (body_noise - 0.5) * 0.26 +
+                         (detail_noise - 0.5) * 0.13 - 0.04;
     pos += normal_dir * shell_offset * pulse;
 
     vec3 tangent = normalize(vec3(-normal_dir.z, 0.0, normal_dir.x));
@@ -207,9 +222,15 @@ void main() {
     pos += tangent * (detail_noise - 0.5) * 0.07 * pulse;
     pos += bitangent * (body_noise - 0.5) * 0.06 * pulse;
 
-    float rise = smoothstep(-0.6, 1.0, normal_dir.y);
-    pos.y += (0.10 + 0.09 * body_noise) * rise;
-    pos.xz *= mix(0.88, 1.06, rise);
+    float rise = smoothstep(-0.85, 1.0, normal_dir.y);
+    float crown = smoothstep(0.05, 1.0, normal_dir.y);
+    float belly = 1.0 - smoothstep(-1.0, 0.15, normal_dir.y);
+
+    pos.y += (0.16 + 0.13 * body_noise) * rise + 0.14 * crown;
+    pos.y -= 0.10 * belly;
+    pos.xz *= mix(0.72, 1.18, rise) * (1.0 + 0.10 * lobe_noise);
+
+    pos.xz += normalize(pos.xz + vec2(1.0e-4)) * crown * (0.06 + 0.10 * lobe_noise);
 
     v_alpha = clamp((0.55 + 0.45 * body_noise) * u_intensity, 0.0, 1.3);
   }

--- a/design_resources.qrc
+++ b/design_resources.qrc
@@ -47,6 +47,7 @@
         <file alias="controls/IronInspectorSection.qml">ui/qml/design/controls/IronInspectorSection.qml</file>
         <file alias="controls/IronCheckBox.qml">ui/qml/design/controls/IronCheckBox.qml</file>
         <file alias="controls/IronSelectionSummary.qml">ui/qml/design/controls/IronSelectionSummary.qml</file>
+        <file alias="controls/IronSpotlight.qml">ui/qml/design/controls/IronSpotlight.qml</file>
         <file alias="overlays/IronNotification.qml">ui/qml/design/overlays/IronNotification.qml</file>
         <file alias="overlays/NotificationHost.qml">ui/qml/design/overlays/NotificationHost.qml</file>
         <file alias="layouts/GameShell.qml">ui/qml/design/layouts/GameShell.qml</file>

--- a/docs/MISSION_FRAMEWORK.md
+++ b/docs/MISSION_FRAMEWORK.md
@@ -806,6 +806,48 @@ fire while a camp is changing hands are exactly the ones a player needs the map
 for. End-of-mission lines draw above the outcome overlay, so the loser gets the
 last word over the victory banner.
 
+The portrait is framed as a **bust**, and the framing follows the head rather than
+sitting at a fixed height: commander archetypes differ by up to eight percent in
+proportion scaling, which at this distance is the difference between a portrait
+and a cropped chin. Each frame the portrait asks the renderer where the head it
+just drew ended up, then eases the camera onto it.
+
+### The painted face
+
+The humanoid rig has a jaw and a nose and no features at all, and giving it any
+would mean re-baking every clip in every profile. So the speaking face is
+**painted over** the portrait instead: `ui/qml/CommanderFaceOverlay.qml` draws
+eyes, brows, a nose and a mouth on a small `Canvas`, and rides the head through
+an anchor the portrait publishes -- position, one head radius, screen roll, and
+how far the head is turned and tilted away from the camera. The paint squashes
+with the projection and fades out through the profile, so it never lands on the
+back of a head. The model is untouched.
+
+The anchor is measured, not re-derived. `Render::Creature::Pipeline::BoneProbe`
+(`render/creature/pipeline/creature_bone_probe.h`) is a thread-local pointer the
+portrait installs for the duration of one `render_world`; the creature pipeline
+fills it with the head bone's world transform for the instance it is submitting,
+taken from the same baked frame it skins with. Re-posing the rig on the UI side
+would have had to reproduce the per-soldier variation and the renderer's
+proportion scaling, and would drift from what was actually drawn.
+
+Two things the drawing does on purpose. It is spread to about 1.3 head radii,
+because every commander is drawn wearing a helmet wider than the skull inside it
+and painting to the skull leaves a small face rattling around in a large one. And
+it sits **above** the portrait's vignette, because the vignette is there to push
+the portrait behind the text while the face is the one part meant to hold the eye.
+
+The mouth is tied to the panel's typewriter, so it moves for exactly as long as
+the line is still arriving and closes when it stops -- no lip track is authored.
+Blinks and eye saccades are ambient and stop under reduced motion, along with the
+mouth.
+
+`--screenshot-view commander` opens the panel on its own against a stand-in view
+model, which is the only way to look at this without playing a mission to a
+trigger. Note that the screenshot harness does not advance QML animations: it is
+the surface to review framing, anchoring and placement on, not motion. Motion is
+covered by `tests/ui/qml/tst_commander_face.qml`.
+
 ### The tutorial mission
 
 `assets/missions/tutorial.json` is the guided first battle behind the main menu's
@@ -816,7 +858,7 @@ last word over the victory banner.
 ```
 
 When a mission carrying that flag finishes loading, the engine attaches
-`App::Core::TutorialDirector` (`app/mission/tutorial_director.h`), which walks the
+`Game::Mission::TutorialDirector` (`game/mission/tutorial_director.h`), which walks the
 player through fifteen fixed steps — selection, movement, attacking a held scouting
 party, gathering each material, building a Home, recruiting, assembling an army,
 breaking a raid, stances, the commander's aura, camera, speed, objectives and a
@@ -839,6 +881,33 @@ Two things about the mission are load-bearing for the director:
 The map it uses, `assets/maps/map_tutorial.json`, declares
 `"skirmish_hidden": true`; `MapCatalog` skips such maps so a scripted stage never
 appears as a free-play choice.
+
+#### Pointing at what a step is talking about
+
+Prose alone leaves a first-time player hunting a dense HUD for the button a step
+names, so every step also publishes a _focus_: what to ring, and where.
+
+- `focus_actions` is a list of command-grid ids (`collect`, `build`, `aura`, …).
+  `HUDBottom` passes `spotlit` to the matching `IronCommandButton`, which draws a
+  `Design.IronSpotlight` ring around it.
+- `focus_region` names a HUD zone — `production`, `speed`, `camera`, `objective`,
+  `waves` — and the panel or button group in `HUDTop`/`HUDBottom` rings itself.
+- `focus_target` names something on the field (`own_troops`, `builders`,
+  `enemy_scouts`, `timber`, `stone_and_iron`, `barracks`, `commander`,
+  `wave_entry`, `enemy_camp`). The director only names the target; the app layer
+  resolves it to world positions in `App::Mission::resolve_tutorial_focus_points`
+  (units come from the world, harvest nodes from `TerrainService::world_props()`,
+  the wave entry from the live wave alerts) and pushes them back through
+  `set_focus_points`, adding minimap coordinates. `TutorialFocusOverlay.qml`
+  projects each point through the live camera and rings it, `HUDTop` pins them on
+  the minimap, and the card's **Show me** button pans the camera to their centre
+  via `CameraViewModel::look_at_world`.
+
+The focus is recomputed from the same observation as the hint, so it follows what
+the step still needs: _Fell timber_ rings the builders while none is selected, and
+switches to the Collect button and the nearest pines once one is. A completed step
+publishes an empty focus, and changing target drops the stale world points so
+rings never outlive the step that placed them.
 
 ## Campaign Configuration
 

--- a/game/mission/tutorial_director.cpp
+++ b/game/mission/tutorial_director.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <initializer_list>
 
 #include "game/systems/construction_cost_catalog.h"
 #include "game/systems/resource_types.h"
@@ -131,7 +132,7 @@ void TutorialDirector::end() {
   m_step_complete = false;
   m_index = 0;
   std::fill(m_done.begin(), m_done.end(), false);
-  publish(-1.0, {}, {});
+  publish(-1.0, {}, {}, {});
   emit state_changed();
   emit step_changed();
 }
@@ -142,7 +143,7 @@ void TutorialDirector::stop() {
   }
   m_active = false;
   m_step_complete = false;
-  publish(-1.0, {}, {});
+  publish(-1.0, {}, {}, {});
   emit state_changed();
 }
 
@@ -180,6 +181,11 @@ void TutorialDirector::enter_step(std::size_t index, bool from_replay) {
   m_progress = -1.0;
   m_progress_text.clear();
   m_hint.clear();
+  m_focus = TutorialFocus{};
+  if (!m_focus_points.isEmpty()) {
+    m_focus_points.clear();
+    emit focus_points_changed();
+  }
   emit step_changed();
   emit state_changed();
 }
@@ -232,15 +238,61 @@ void TutorialDirector::continue_step() {
 
 void TutorialDirector::publish(qreal progress,
                                const QString& progress_text,
-                               const QString& hint) {
+                               const QString& hint,
+                               const TutorialFocus& focus) {
   const bool changed = !qFuzzyCompare(1.0 + m_progress, 1.0 + progress) ||
-                       m_progress_text != progress_text || m_hint != hint;
+                       m_progress_text != progress_text || m_hint != hint ||
+                       !(m_focus == focus);
+  const bool target_changed = m_focus.target != focus.target;
   m_progress = progress;
   m_progress_text = progress_text;
   m_hint = hint;
+  m_focus = focus;
+  if (target_changed && !m_focus_points.isEmpty()) {
+    m_focus_points.clear();
+    emit focus_points_changed();
+  }
   if (changed) {
     emit state_changed();
   }
+}
+
+void TutorialDirector::set_focus_points(const QVariantList& points) {
+  if (m_focus_points == points) {
+    return;
+  }
+  m_focus_points = points;
+  emit focus_points_changed();
+}
+
+auto TutorialDirector::focus_target() const -> QString {
+  return focus_target_name(m_focus.target);
+}
+
+auto TutorialDirector::focus_target_name(TutorialFocusTarget target) -> QString {
+  switch (target) {
+  case TutorialFocusTarget::None:
+    return {};
+  case TutorialFocusTarget::OwnTroops:
+    return QStringLiteral("own_troops");
+  case TutorialFocusTarget::Builders:
+    return QStringLiteral("builders");
+  case TutorialFocusTarget::EnemyScouts:
+    return QStringLiteral("enemy_scouts");
+  case TutorialFocusTarget::Timber:
+    return QStringLiteral("timber");
+  case TutorialFocusTarget::StoneAndIron:
+    return QStringLiteral("stone_and_iron");
+  case TutorialFocusTarget::Barracks:
+    return QStringLiteral("barracks");
+  case TutorialFocusTarget::Commander:
+    return QStringLiteral("commander");
+  case TutorialFocusTarget::WaveEntry:
+    return QStringLiteral("wave_entry");
+  case TutorialFocusTarget::EnemyCamp:
+    return QStringLiteral("enemy_camp");
+  }
+  return {};
 }
 
 void TutorialDirector::advance(const TutorialObservation& observation, float real_dt) {
@@ -275,7 +327,7 @@ void TutorialDirector::advance(const TutorialObservation& observation, float rea
   QString progress_text;
   const bool completed = evaluate(observation, progress, progress_text);
   if (completed) {
-    publish(1.0, progress_text, {});
+    publish(1.0, progress_text, {}, {});
     mark_step_complete();
     if (step() == TutorialStepId::Assault) {
 
@@ -283,7 +335,7 @@ void TutorialDirector::advance(const TutorialObservation& observation, float rea
     }
     return;
   }
-  publish(progress, progress_text, hint_for(observation));
+  publish(progress, progress_text, hint_for(observation), focus_for(observation));
 }
 
 auto TutorialDirector::evaluate(const TutorialObservation& o,
@@ -505,6 +557,92 @@ auto TutorialDirector::hint_for(const TutorialObservation& o) const -> QString {
   case TutorialStepId::GameSpeed:
   case TutorialStepId::Objectives:
     return {};
+  }
+  return {};
+}
+
+auto TutorialDirector::focus_for(const TutorialObservation& o) const -> TutorialFocus {
+  const auto actions = [](std::initializer_list<const char*> ids) -> QStringList {
+    QStringList list;
+    for (const auto* id : ids) {
+      list.append(QString::fromLatin1(id));
+    }
+    return list;
+  };
+
+  switch (step()) {
+  case TutorialStepId::SelectTroops:
+    return {{}, {}, TutorialFocusTarget::OwnTroops};
+
+  case TutorialStepId::MoveTroops:
+    if (o.selected_troop_count == 0) {
+      return {{}, {}, TutorialFocusTarget::OwnTroops};
+    }
+    return {};
+
+  case TutorialStepId::AttackScouts:
+    if (o.selected_troop_count == 0) {
+      return {{}, {}, TutorialFocusTarget::OwnTroops};
+    }
+    return {actions({"attack"}), {}, TutorialFocusTarget::EnemyScouts};
+
+  case TutorialStepId::GatherWood:
+    if (o.selected_builder_count == 0) {
+      return {{}, {}, TutorialFocusTarget::Builders};
+    }
+    return {actions({"collect", "auto_gather"}), {}, TutorialFocusTarget::Timber};
+
+  case TutorialStepId::GatherStoneAndIron:
+    if (o.selected_builder_count == 0) {
+      return {{}, {}, TutorialFocusTarget::Builders};
+    }
+    return {actions({"collect", "auto_gather"}), {}, TutorialFocusTarget::StoneAndIron};
+
+  case TutorialStepId::BuildHome:
+    if (o.selected_builder_count == 0) {
+      return {{}, {}, TutorialFocusTarget::Builders};
+    }
+    if (o.construction_preview_active) {
+      return {};
+    }
+    return {actions({"build"}), {}, TutorialFocusTarget::None};
+
+  case TutorialStepId::RecruitSoldier:
+  case TutorialStepId::AssembleArmy:
+    if (o.selected_barracks_count == 0) {
+      return {{}, {}, TutorialFocusTarget::Barracks};
+    }
+    return {{}, QStringLiteral("production"), TutorialFocusTarget::None};
+
+  case TutorialStepId::DefendCamp:
+    if (o.wave_live) {
+      return {};
+    }
+    return {{}, QStringLiteral("waves"), TutorialFocusTarget::WaveEntry};
+
+  case TutorialStepId::Stances:
+    if (o.selected_troop_count == 0) {
+      return {{}, {}, TutorialFocusTarget::OwnTroops};
+    }
+    return {actions({"guard", "hold", "patrol"}), {}, TutorialFocusTarget::None};
+
+  case TutorialStepId::Commander:
+    if (!o.commander_selected) {
+      return {{}, {}, TutorialFocusTarget::Commander};
+    }
+    return {actions({"aura"}), {}, TutorialFocusTarget::None};
+
+  case TutorialStepId::Camera:
+    return {{}, QStringLiteral("camera"), TutorialFocusTarget::None};
+
+  case TutorialStepId::GameSpeed:
+    return {{}, QStringLiteral("speed"), TutorialFocusTarget::None};
+
+  case TutorialStepId::Objectives:
+    return {{}, QStringLiteral("objective"), TutorialFocusTarget::None};
+
+  case TutorialStepId::Assault:
+    return {{}, {}, TutorialFocusTarget::EnemyCamp};
   }
   return {};
 }

--- a/game/mission/tutorial_director.h
+++ b/game/mission/tutorial_director.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QVariantList>
 
 #include <cstddef>
@@ -56,6 +57,29 @@ struct TutorialObservation {
   int enemy_commanders_alive = 0;
 };
 
+enum class TutorialFocusTarget {
+  None,
+  OwnTroops,
+  Builders,
+  EnemyScouts,
+  Timber,
+  StoneAndIron,
+  Barracks,
+  Commander,
+  WaveEntry,
+  EnemyCamp,
+};
+
+struct TutorialFocus {
+  QStringList actions;
+  QString region;
+  TutorialFocusTarget target = TutorialFocusTarget::None;
+
+  [[nodiscard]] auto operator==(const TutorialFocus& other) const -> bool {
+    return actions == other.actions && region == other.region && target == other.target;
+  }
+};
+
 enum class TutorialStepId {
   SelectTroops,
   MoveTroops,
@@ -99,6 +123,11 @@ class TutorialDirector : public QObject {
   Q_PROPERTY(bool step_complete READ step_complete NOTIFY state_changed)
   Q_PROPERTY(bool holds_mission_clock READ holds_mission_clock NOTIFY state_changed)
   Q_PROPERTY(QVariantList steps READ steps NOTIFY state_changed)
+  Q_PROPERTY(QStringList focus_actions READ focus_actions NOTIFY state_changed)
+  Q_PROPERTY(QString focus_region READ focus_region NOTIFY state_changed)
+  Q_PROPERTY(QString focus_target READ focus_target NOTIFY state_changed)
+  Q_PROPERTY(QVariantList focus_points READ focus_points NOTIFY focus_points_changed)
+  Q_PROPERTY(bool has_focus_point READ has_focus_point NOTIFY focus_points_changed)
 
 public:
   explicit TutorialDirector(QObject* parent = nullptr);
@@ -133,11 +162,23 @@ public:
   [[nodiscard]] auto step_complete() const -> bool { return m_step_complete; }
   [[nodiscard]] auto holds_mission_clock() const -> bool;
   [[nodiscard]] auto steps() const -> QVariantList;
+  [[nodiscard]] auto focus_actions() const -> QStringList { return m_focus.actions; }
+  [[nodiscard]] auto focus_region() const -> QString { return m_focus.region; }
+  [[nodiscard]] auto focus_target() const -> QString;
+  [[nodiscard]] auto focus_target_id() const -> TutorialFocusTarget {
+    return m_focus.target;
+  }
+  [[nodiscard]] auto focus_points() const -> QVariantList { return m_focus_points; }
+  [[nodiscard]] auto has_focus_point() const -> bool {
+    return !m_focus_points.isEmpty();
+  }
+  void set_focus_points(const QVariantList& points);
 
   [[nodiscard]] static auto step_id_name(TutorialStepId id) -> QString;
   [[nodiscard]] static auto step_title(TutorialStepId id) -> QString;
   [[nodiscard]] static auto step_body(TutorialStepId id) -> QString;
   [[nodiscard]] static auto step_objective(TutorialStepId id) -> QString;
+  [[nodiscard]] static auto focus_target_name(TutorialFocusTarget target) -> QString;
 
 signals:
   void start_requested();
@@ -145,6 +186,7 @@ signals:
   void step_changed();
   void step_completed(int index);
   void tutorial_finished();
+  void focus_points_changed();
 
 private:
   struct Baseline {
@@ -166,7 +208,12 @@ private:
                               qreal& progress,
                               QString& progress_text) const -> bool;
   [[nodiscard]] auto hint_for(const TutorialObservation& observation) const -> QString;
-  void publish(qreal progress, const QString& progress_text, const QString& hint);
+  [[nodiscard]] auto
+  focus_for(const TutorialObservation& observation) const -> TutorialFocus;
+  void publish(qreal progress,
+               const QString& progress_text,
+               const QString& hint,
+               const TutorialFocus& focus);
 
   bool m_active = false;
   bool m_finished = false;
@@ -180,6 +227,8 @@ private:
   qreal m_progress = -1.0;
   QString m_progress_text;
   QString m_hint;
+  TutorialFocus m_focus;
+  QVariantList m_focus_points;
 };
 
 } // namespace Game::Mission

--- a/main.cpp
+++ b/main.cpp
@@ -744,7 +744,7 @@ auto main(int argc, char* argv[]) -> int {
     QCommandLineOption const screenshot_view_opt(
         "screenshot-view",
         "Surface to capture: menu | skirmish | campaign | settings | load | save "
-        "| briefing | hud | rpg.",
+        "| briefing | hud | rpg | commander | tutorial.",
         "view",
         "menu");
     QCommandLineOption const screenshot_delay_opt(

--- a/render/creature/pipeline/creature_bone_probe.cpp
+++ b/render/creature/pipeline/creature_bone_probe.cpp
@@ -1,0 +1,18 @@
+#include "creature_bone_probe.h"
+
+namespace Render::Creature::Pipeline {
+namespace {
+
+thread_local BoneProbe* t_active_probe = nullptr;
+
+} // namespace
+
+void set_active_bone_probe(BoneProbe* probe) noexcept {
+  t_active_probe = probe;
+}
+
+auto active_bone_probe() noexcept -> BoneProbe* {
+  return t_active_probe;
+}
+
+} // namespace Render::Creature::Pipeline

--- a/render/creature/pipeline/creature_bone_probe.h
+++ b/render/creature/pipeline/creature_bone_probe.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QMatrix4x4>
+
+#include <cstdint>
+
+namespace Render::Creature::Pipeline {
+
+struct BoneProbe {
+
+  std::uint32_t entity_id{0};
+  std::uint16_t instance_index{0};
+
+  std::uint16_t bone_index{0};
+
+  bool resolved{false};
+  QMatrix4x4 world{};
+};
+
+void set_active_bone_probe(BoneProbe* probe) noexcept;
+
+[[nodiscard]] auto active_bone_probe() noexcept -> BoneProbe*;
+
+class ScopedBoneProbe {
+public:
+  explicit ScopedBoneProbe(BoneProbe* probe) noexcept
+      : m_previous(active_bone_probe()) {
+    set_active_bone_probe(probe);
+  }
+
+  ~ScopedBoneProbe() { set_active_bone_probe(m_previous); }
+
+  ScopedBoneProbe(const ScopedBoneProbe&) = delete;
+  auto operator=(const ScopedBoneProbe&) -> ScopedBoneProbe& = delete;
+  ScopedBoneProbe(ScopedBoneProbe&&) = delete;
+  auto operator=(ScopedBoneProbe&&) -> ScopedBoneProbe& = delete;
+
+private:
+  BoneProbe* m_previous{nullptr};
+};
+
+} // namespace Render::Creature::Pipeline

--- a/render/creature/pipeline/creature_pipeline.cpp
+++ b/render/creature/pipeline/creature_pipeline.cpp
@@ -18,6 +18,7 @@
 #include "animation/bpat/bpat_registry.h"
 #include "animation/clip_manifest.h"
 #include "creature_asset.h"
+#include "creature_bone_probe.h"
 #include "game/map/terrain_service.h"
 #include "preparation_common.h"
 #include "render/bone_palette_arena.h"
@@ -524,6 +525,45 @@ auto contact_y_for_playback(const ResolvedRequestPlayback& playback) noexcept ->
   }
   float const next = contacts[playback.next_global_frame].sole_y;
   return current * (1.0F - frame_lerp) + next * frame_lerp;
+}
+
+auto bone_global_at(const ResolvedRequestPlayback& playback,
+                    std::uint16_t bone_index) -> QMatrix4x4 {
+  QMatrix4x4 const current =
+      playback.blob->bone_global_matrix(playback.global_frame, bone_index);
+  float const frame_lerp = std::clamp(playback.frame_lerp, 0.0F, 1.0F);
+  if (frame_lerp <= 1.0e-4F || playback.next_global_frame == playback.global_frame) {
+    return current;
+  }
+  QMatrix4x4 const next =
+      playback.blob->bone_global_matrix(playback.next_global_frame, bone_index);
+
+  QMatrix4x4 blended;
+  const float* a = current.constData();
+  const float* b = next.constData();
+  float* out = blended.data();
+  for (int i = 0; i < 16; ++i) {
+    out[i] = a[i] * (1.0F - frame_lerp) + b[i] * frame_lerp;
+  }
+  return blended;
+}
+
+void resolve_bone_probe(const Render::Creature::CreatureRenderRequest& req,
+                        const QMatrix4x4& draw_world,
+                        const ResolvedRequestPlayback& playback) {
+  auto* probe = active_bone_probe();
+  if (probe == nullptr || probe->resolved) {
+    return;
+  }
+  if (probe->entity_id != req.entity_id ||
+      probe->instance_index != req.instance_index) {
+    return;
+  }
+  if (!playback.valid() || probe->bone_index >= playback.blob->bone_count()) {
+    return;
+  }
+  probe->world = draw_world * bone_global_at(playback, probe->bone_index);
+  probe->resolved = true;
 }
 
 void attach_owned_palette(
@@ -1068,6 +1108,8 @@ auto CreaturePipeline::submit_requests(
         draw_world = adjusted;
       }
     }
+    resolve_bone_probe(req, draw_world, primary);
+
     const bool prebaked_lowpoly_required =
         req.lod == CreatureLOD::Minimal && handle->requires_prebaked_minimal_snapshot;
     if (req.full_body_blend.active() && full_body.valid()) {

--- a/render/sources_creature.cmake
+++ b/render/sources_creature.cmake
@@ -56,4 +56,5 @@ set(RENDER_CREATURE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/creature/pipeline/preparation_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/creature/pipeline/humanoid_animation_selection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/creature/pipeline/creature_render_graph.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/creature/pipeline/creature_bone_probe.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -420,6 +420,7 @@ add_executable(
     render/creature/baked_attachment_world_position_test.cpp
     render/creature/baked_horse_attachment_world_position_test.cpp
     render/creature/render_request_batch_parity_test.cpp
+    render/creature/creature_bone_probe_test.cpp
     render/creature/template_prewarm_regression_test.cpp
     render/software/software_rasterizer_test.cpp
     render/software/software_backend_integration_test.cpp

--- a/tests/core/tutorial_director_test.cpp
+++ b/tests/core/tutorial_director_test.cpp
@@ -1,4 +1,6 @@
 #include <QSet>
+#include <QStringList>
+#include <QVariantList>
 #include <QVariantMap>
 
 #include <gtest/gtest.h>
@@ -333,4 +335,102 @@ TEST(TutorialDirectorTest, StartAsksTheEngineToLaunchTheMission) {
   EXPECT_EQ(requests, 1);
   EXPECT_FALSE(director.active())
       << "the director only becomes active once the mission has loaded";
+}
+
+TEST(TutorialDirectorTest, EveryStepPointsAtSomethingUntilItIsDone) {
+  TutorialDirector director;
+  director.begin();
+
+  QSet<QString> unpointed;
+  for (int i = 0; i < TutorialDirector::step_count(); ++i) {
+    director.advance(running(), 0.2F);
+    const bool points_somewhere = !director.focus_actions().isEmpty() ||
+                                  !director.focus_region().isEmpty() ||
+                                  !director.focus_target().isEmpty();
+    if (!points_somewhere) {
+      unpointed.insert(director.step_id());
+    }
+    director.skip_step();
+  }
+
+  EXPECT_TRUE(unpointed.isEmpty())
+      << "a step with nothing to point at leaves a new player hunting: "
+      << unpointed.values().join(QStringLiteral(", ")).toStdString();
+}
+
+TEST(TutorialDirectorTest, FocusFollowsWhatTheStepStillNeeds) {
+  TutorialDirector director;
+  director.begin();
+
+  director.advance(running(), 0.2F);
+  EXPECT_EQ(director.focus_target(), QStringLiteral("own_troops"))
+      << "with nothing selected, the ring belongs on the troops themselves";
+
+  while (director.step() != TutorialStepId::GatherWood) {
+    director.skip_step();
+  }
+
+  TutorialObservation o = running();
+  director.advance(o, 0.2F);
+  EXPECT_EQ(director.focus_target(), QStringLiteral("builders"))
+      << "no builder selected: point at the builders, not at the trees";
+  EXPECT_TRUE(director.focus_actions().isEmpty());
+
+  o.selected_builder_count = 1;
+  director.advance(o, 0.2F);
+  EXPECT_EQ(director.focus_target(), QStringLiteral("timber"));
+  EXPECT_TRUE(director.focus_actions().contains(QStringLiteral("collect")));
+
+  while (director.step() != TutorialStepId::RecruitSoldier) {
+    director.skip_step();
+  }
+  o = running();
+  o.selected_barracks_count = 1;
+  director.advance(o, 0.2F);
+  EXPECT_EQ(director.focus_region(), QStringLiteral("production"));
+
+  while (director.step() != TutorialStepId::Commander) {
+    director.skip_step();
+  }
+  o = running();
+  director.advance(o, 0.2F);
+  EXPECT_EQ(director.focus_target(), QStringLiteral("commander"));
+  o.commander_selected = true;
+  director.advance(o, 0.2F);
+  EXPECT_EQ(director.focus_actions(), QStringList{QStringLiteral("aura")});
+  EXPECT_TRUE(director.focus_target().isEmpty());
+}
+
+TEST(TutorialDirectorTest, FocusPointsAreDroppedWhenTheTargetChanges) {
+  TutorialDirector director;
+  director.begin();
+  director.advance(running(), 0.2F);
+  ASSERT_EQ(director.focus_target(), QStringLiteral("own_troops"));
+
+  QVariantMap point;
+  point["world_x"] = 12.0;
+  point["world_z"] = 34.0;
+  director.set_focus_points(QVariantList{point});
+  EXPECT_TRUE(director.has_focus_point());
+
+  TutorialObservation o = running();
+  o.selected_troop_count = 1;
+  director.advance(o, 0.2F);
+  director.advance(running(), 10.0F);
+  ASSERT_EQ(director.step(), TutorialStepId::MoveTroops);
+  EXPECT_FALSE(director.has_focus_point())
+      << "stale world rings must not survive the step they belonged to";
+}
+
+TEST(TutorialDirectorTest, CompletedStepStopsPointing) {
+  TutorialDirector director;
+  director.begin();
+
+  TutorialObservation o = running();
+  o.selected_troop_count = 1;
+  director.advance(o, 0.2F);
+  ASSERT_TRUE(director.step_complete());
+  EXPECT_TRUE(director.focus_actions().isEmpty());
+  EXPECT_TRUE(director.focus_region().isEmpty());
+  EXPECT_TRUE(director.focus_target().isEmpty());
 }

--- a/tests/render/creature/creature_bone_probe_test.cpp
+++ b/tests/render/creature/creature_bone_probe_test.cpp
@@ -1,0 +1,60 @@
+
+#include <QMatrix4x4>
+
+#include <gtest/gtest.h>
+
+#include "render/creature/pipeline/creature_bone_probe.h"
+
+namespace {
+
+using Render::Creature::Pipeline::active_bone_probe;
+using Render::Creature::Pipeline::BoneProbe;
+using Render::Creature::Pipeline::ScopedBoneProbe;
+using Render::Creature::Pipeline::set_active_bone_probe;
+
+TEST(CreatureBoneProbe, NoProbeIsInstalledByDefault) {
+  EXPECT_EQ(active_bone_probe(), nullptr);
+}
+
+TEST(CreatureBoneProbe, ScopeInstallsAndClears) {
+  BoneProbe probe{};
+  {
+    ScopedBoneProbe const scope(&probe);
+    EXPECT_EQ(active_bone_probe(), &probe);
+  }
+  EXPECT_EQ(active_bone_probe(), nullptr)
+      << "a probe that outlives its scope would be a dangling pointer the "
+         "pipeline writes through on the next frame";
+}
+
+TEST(CreatureBoneProbe, NestedScopesRestoreTheOuterProbe) {
+  BoneProbe outer{};
+  BoneProbe inner{};
+
+  ScopedBoneProbe const outer_scope(&outer);
+  {
+    ScopedBoneProbe const inner_scope(&inner);
+    EXPECT_EQ(active_bone_probe(), &inner);
+  }
+  EXPECT_EQ(active_bone_probe(), &outer);
+}
+
+TEST(CreatureBoneProbe, ScopeSurvivesAnEarlyManualClear) {
+  BoneProbe probe{};
+  {
+    ScopedBoneProbe const scope(&probe);
+    set_active_bone_probe(nullptr);
+    EXPECT_EQ(active_bone_probe(), nullptr);
+  }
+  EXPECT_EQ(active_bone_probe(), nullptr);
+}
+
+TEST(CreatureBoneProbe, StartsUnresolvedWithAnIdentityTransform) {
+  BoneProbe const probe{};
+  EXPECT_FALSE(probe.resolved);
+  EXPECT_EQ(probe.entity_id, 0U);
+  EXPECT_EQ(probe.instance_index, 0U);
+  EXPECT_TRUE(probe.world.isIdentity());
+}
+
+} // namespace

--- a/tests/ui/qml/tst_campaign_outcome.qml
+++ b/tests/ui/qml/tst_campaign_outcome.qml
@@ -77,14 +77,15 @@ TestCase {
     }
 
     function test_every_outcome_names_itself() {
-        var kinds = ["victory", "defeat", "campaign"];
+        var kinds = ["victory", "defeat", "campaign", "training"];
         var headlines = [];
         var subtitles = [];
         for (var i = 0; i < kinds.length; ++i) {
             var overlay = makeOverlay({
                     "victoryState": kinds[i] === "defeat" ? "defeat" : "victory",
                     "isCampaignMission": kinds[i] === "campaign",
-                    "campaignCompleted": kinds[i] === "campaign"
+                    "campaignCompleted": kinds[i] === "campaign",
+                    "isTutorial": kinds[i] === "training"
                 });
             compare(overlay.outcomeKind, kinds[i]);
             verify(overlay.headline.length > 0, kinds[i] + " has no headline");
@@ -95,6 +96,35 @@ TestCase {
             subtitles.push(overlay.subtitle);
             overlay.destroy();
         }
+    }
+
+    function test_a_finished_tutorial_offers_the_campaign() {
+        var overlay = makeOverlay({
+                "victoryState": "victory",
+                "isTutorial": true
+            });
+        compare(overlay.outcomeKind, "training");
+        verify(overlay.secondaryAction.length > 0, "a finished tutorial must say where to go next");
+        var spy = spyComponent.createObject(testCase, {
+                "target": overlay,
+                "signalName": "secondaryRequested"
+            });
+        var banner = findChild(overlay, "outcomeBanner");
+        banner.item.secondaryActivated();
+        compare(spy.count, 1);
+        verify(!overlay.showingSummary, "the campaign shortcut must not open the battle report");
+        spy.destroy();
+        overlay.destroy();
+    }
+
+    function test_a_lost_tutorial_is_still_a_defeat() {
+        var overlay = makeOverlay({
+                "victoryState": "defeat",
+                "isTutorial": true
+            });
+        compare(overlay.outcomeKind, "defeat");
+        compare(overlay.secondaryAction, "");
+        overlay.destroy();
     }
 
     function test_the_banner_shows_until_the_report_is_asked_for() {

--- a/tests/ui/qml/tst_commander_face.qml
+++ b/tests/ui/qml/tst_commander_face.qml
@@ -1,0 +1,119 @@
+import QtQuick 2.15
+import QtTest 1.15
+import StandardOfIron.Design 1.0 as Design
+import "../../../ui/qml"
+
+TestCase {
+    id: testCase
+
+    name: "CommanderFaceOverlay"
+    when: windowShown
+    width: 640
+    height: 480
+    visible: true
+
+    Item {
+        id: stubAnchor
+
+        width: 160
+        height: 200
+
+        property bool faceValid: true
+        property real faceX: 0.5
+        property real faceY: 0.4
+        property real faceRadius: 0.25
+        property real faceRoll: 0
+        property real faceTurn: 0
+        property real faceTilt: 0
+        property real faceFacing: 1
+    }
+
+    CommanderFaceOverlay {
+        id: face
+
+        anchorSource: stubAnchor
+    }
+
+    function init() {
+        stubAnchor.faceValid = true;
+        stubAnchor.faceX = 0.5;
+        stubAnchor.faceY = 0.4;
+        stubAnchor.faceRadius = 0.25;
+        stubAnchor.faceRoll = 0;
+        stubAnchor.faceTurn = 0;
+        stubAnchor.faceTilt = 0;
+        stubAnchor.faceFacing = 1;
+        face.talking = false;
+    }
+
+    function test_it_centres_on_the_published_head() {
+        compare(face.headRadius, 50 * face.headScale, "head radius follows the portrait height");
+        compare(face.width, face.headRadius * face.span, "the drawing is sized in head radii");
+        compare(face.height, face.width, "the face is drawn square");
+        compare(face.x, (0.5 * 160) - (face.width / 2));
+        compare(face.y, (0.4 * 200) - (face.height / 2));
+    }
+
+    function test_it_follows_the_head_as_the_anchor_moves() {
+        stubAnchor.faceX = 0.25;
+        stubAnchor.faceY = 0.75;
+        compare(face.x, (0.25 * 160) - (face.width / 2));
+        compare(face.y, (0.75 * 200) - (face.height / 2));
+    }
+
+    function test_no_paint_without_an_anchor() {
+        stubAnchor.faceValid = false;
+        verify(!face.anchored);
+        verify(!face.visible, "paint must not linger where the head was");
+    }
+
+    function test_it_hides_when_the_speaker_turns_away() {
+        stubAnchor.faceFacing = -0.5;
+        verify(!face.visible, "a painted face on the back of a head is worse than none");
+        stubAnchor.faceFacing = 0.10;
+        verify(face.visible);
+        verify(face.opacity < 1.0, "it fades out through the profile rather than popping");
+        stubAnchor.faceFacing = 1.0;
+        compare(face.opacity, 1.0);
+    }
+
+    function test_projection_squashes_the_drawing() {
+        stubAnchor.faceTurn = 0.6;
+        fuzzyCompare(face.squashX, 0.8, 0.001);
+        compare(face.squashY, 1.0);
+        stubAnchor.faceTurn = 0;
+        stubAnchor.faceTilt = -0.6;
+        compare(face.squashX, 1.0);
+        fuzzyCompare(face.squashY, 0.8, 0.001);
+    }
+
+    function test_a_tiny_head_is_not_worth_painting() {
+        stubAnchor.faceRadius = 0.005;
+        verify(!face.visible, "below a couple of pixels the paint is only noise");
+    }
+
+    function test_the_mouth_moves_while_the_line_arrives() {
+        if (Design.A11y.reducedMotion)
+            skip("reduced motion holds the face still on purpose");
+        face.talking = true;
+        tryVerify(function () {
+                return face.mouthOpen > 0.05;
+            }, 3000, "a speaking commander has to move their mouth");
+    }
+
+    function test_the_helmet_allowance_only_scales_the_drawing() {
+        var before = face.x + (face.width / 2);
+        face.headScale = 1.0;
+        compare(face.headRadius, 50);
+        compare(face.x + (face.width / 2), before, "the centre does not move");
+        face.headScale = 1.3;
+    }
+
+    function test_the_mouth_closes_when_the_line_ends() {
+        face.talking = true;
+        face.mouthOpen = 0.8;
+        face.talking = false;
+        compare(face.mouthOpen, 0, "the mouth must not be left hanging open");
+        compare(face.mouthWide, 0.4);
+    }
+}

--- a/tests/ui/qml/tst_component_library.qml
+++ b/tests/ui/qml/tst_component_library.qml
@@ -103,6 +103,9 @@ TestCase {
                 "tag": "IronSelectionSummary",
                 "qml": "IronSelectionSummary {}"
             }, {
+                "tag": "IronSpotlight",
+                "qml": "IronSpotlight {}"
+            }, {
                 "tag": "IronNotification",
                 "qml": "IronNotification { message: \"Ready\" }"
             }, {

--- a/ui/commander_portrait_view.cpp
+++ b/ui/commander_portrait_view.cpp
@@ -1,13 +1,18 @@
 #include "commander_portrait_view.h"
 
+#include <QMatrix4x4>
 #include <QOpenGLContext>
 #include <QOpenGLFramebufferObject>
 #include <QOpenGLFramebufferObjectFormat>
+#include <QPointF>
 #include <QVector3D>
+#include <QtMath>
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 
+#include "animation/rig/humanoid_proportions.h"
 #include "animation/showcase_pose_manifest.h"
 #include "game/core/component.h"
 #include "game/core/entity.h"
@@ -17,22 +22,32 @@
 #include "game/units/factory.h"
 #include "game/units/troop_type.h"
 #include "game/units/unit.h"
+#include "render/creature/pipeline/creature_bone_probe.h"
 #include "render/graphics_settings.h"
+#include "render/humanoid/skeleton.h"
 #include "render/scene_renderer.h"
 #include "scene/camera.h"
 #include "scene/environment_lighting.h"
 
 namespace {
 
-constexpr float k_camera_height = 1.34F;
-constexpr float k_camera_distance = 2.02F;
-constexpr float k_camera_side = 0.62F;
-constexpr float k_target_height = 1.22F;
 constexpr float k_field_of_view = 32.0F;
+
+constexpr float k_bust_distance = 1.16F;
+constexpr QVector3D k_bust_direction = QVector3D(0.30F, 0.09F, 0.95F);
+
+constexpr float k_bust_drop = 0.075F;
+
+constexpr float k_default_focus_height = 1.31F;
+
+constexpr float k_focus_tau = 0.30F;
 
 constexpr float k_body_yaw_degrees = 14.0F;
 
 constexpr float k_max_frame_seconds = 0.1F;
+
+constexpr float k_head_radius = Render::GL::HumanProportions::HEAD_RADIUS;
+constexpr float k_cranium_rise = k_head_radius * 0.06F;
 
 auto portrait_lighting() -> Render::EnvironmentLightingState {
   Render::EnvironmentLightingState lighting;
@@ -81,6 +96,7 @@ public:
     if (view == nullptr) {
       return;
     }
+    m_item = view;
     const QString troop_type = view->troop_type();
     const QString pose = view->pose();
     m_speaking = view->speaking();
@@ -102,7 +118,17 @@ private:
   auto ensure_scene() -> bool;
   void apply_pose();
 
+  void measure_face_anchor(const QMatrix4x4& head_world);
+  void post_face_anchor();
+  [[nodiscard]] auto advance_focus(float delta) -> QVector3D;
+
   QSize m_size;
+  CommanderPortraitView* m_item = nullptr;
+  CommanderPortraitView::FaceAnchor m_face{};
+  CommanderPortraitView::FaceAnchor m_published{};
+  QVector3D m_focus{0.0F, k_default_focus_height, 0.0F};
+  QVector3D m_focus_target{0.0F, k_default_focus_height, 0.0F};
+  bool m_focus_settled = false;
   QString m_troop_type;
   QString m_pose;
   bool m_speaking = false;
@@ -121,6 +147,9 @@ private:
 };
 
 void CommanderPortraitView::PortraitRenderer::release_scene() {
+  m_focus = QVector3D(0.0F, k_default_focus_height, 0.0F);
+  m_focus_target = m_focus;
+  m_focus_settled = false;
   m_unit.reset();
   m_world.reset();
   m_factory.reset();
@@ -232,6 +261,96 @@ void CommanderPortraitView::PortraitRenderer::apply_pose() {
   m_pose_dirty = false;
 }
 
+void CommanderPortraitView::PortraitRenderer::measure_face_anchor(
+    const QMatrix4x4& head_world) {
+  m_face = {};
+  if (m_camera == nullptr || m_size.width() <= 0 || m_size.height() <= 0) {
+    return;
+  }
+
+  const auto width = static_cast<qreal>(m_size.width());
+  const auto height = static_cast<qreal>(m_size.height());
+
+  const QVector3D centre = head_world.map(QVector3D(0.0F, k_cranium_rise, 0.0F));
+  const QVector3D above =
+      head_world.map(QVector3D(0.0F, k_cranium_rise + k_head_radius, 0.0F));
+
+  QPointF centre_screen;
+  QPointF above_screen;
+  if (!m_camera->world_to_screen(centre, width, height, centre_screen) ||
+      !m_camera->world_to_screen(above, width, height, above_screen)) {
+    return;
+  }
+
+  const qreal dx = above_screen.x() - centre_screen.x();
+  const qreal dy = above_screen.y() - centre_screen.y();
+  const qreal up_length = std::hypot(dx, dy);
+  if (!(up_length > 0.5)) {
+    return;
+  }
+
+  const QVector3D origin = head_world.map(QVector3D(0.0F, 0.0F, 0.0F));
+  auto axis = [&](const QVector3D& local) {
+    QVector3D const world = head_world.map(local) - origin;
+    return world.lengthSquared() > 1.0e-12F ? world.normalized() : world;
+  };
+  const QVector3D head_right = axis(QVector3D(1.0F, 0.0F, 0.0F));
+  const QVector3D head_up = axis(QVector3D(0.0F, 1.0F, 0.0F));
+  const QVector3D head_forward = axis(QVector3D(0.0F, 0.0F, 1.0F));
+
+  QVector3D view_dir = centre - m_camera->get_position();
+  if (view_dir.lengthSquared() <= 1.0e-12F) {
+    return;
+  }
+  view_dir.normalize();
+
+  m_face.valid = true;
+  m_face.x = centre_screen.x() / width;
+  m_face.y = centre_screen.y() / height;
+  m_face.radius = up_length / height;
+
+  m_face.roll = qRadiansToDegrees(std::atan2(dx, -dy));
+  m_face.turn = QVector3D::dotProduct(head_right, view_dir);
+  m_face.tilt = QVector3D::dotProduct(head_up, view_dir);
+  m_face.facing = -QVector3D::dotProduct(head_forward, view_dir);
+}
+
+auto CommanderPortraitView::PortraitRenderer::advance_focus(float delta) -> QVector3D {
+  if (!m_focus_settled) {
+    m_focus = m_focus_target;
+    m_focus_settled = true;
+    return m_focus;
+  }
+  float const alpha = delta > 0.0F ? 1.0F - std::exp(-delta / k_focus_tau) : 0.0F;
+  m_focus += (m_focus_target - m_focus) * alpha;
+  return m_focus;
+}
+
+void CommanderPortraitView::PortraitRenderer::post_face_anchor() {
+  if (m_item == nullptr) {
+    return;
+  }
+
+  constexpr qreal k_epsilon = 1.0e-4;
+  auto same = [](qreal lhs, qreal rhs) {
+    return std::abs(lhs - rhs) < k_epsilon;
+  };
+  if (m_published.valid == m_face.valid && same(m_published.x, m_face.x) &&
+      same(m_published.y, m_face.y) && same(m_published.radius, m_face.radius) &&
+      same(m_published.roll, m_face.roll) && same(m_published.turn, m_face.turn) &&
+      same(m_published.tilt, m_face.tilt) && same(m_published.facing, m_face.facing)) {
+    return;
+  }
+  m_published = m_face;
+
+  auto* item = m_item;
+  const auto anchor = m_face;
+  QMetaObject::invokeMethod(
+      item,
+      [item, anchor]() { item->publish_face_anchor(anchor); },
+      Qt::QueuedConnection);
+}
+
 void CommanderPortraitView::PortraitRenderer::render() {
   const auto now = std::chrono::steady_clock::now();
   float delta = 0.0F;
@@ -243,6 +362,8 @@ void CommanderPortraitView::PortraitRenderer::render() {
 
   if (!m_speaking) {
 
+    m_face = {};
+    post_face_anchor();
     release_scene();
     return;
   }
@@ -257,8 +378,9 @@ void CommanderPortraitView::PortraitRenderer::render() {
   const float aspect = m_size.height() > 0 ? static_cast<float>(m_size.width()) /
                                                  static_cast<float>(m_size.height())
                                            : 1.0F;
-  m_camera->look_at(QVector3D(k_camera_side, k_camera_height, k_camera_distance),
-                    QVector3D(0.0F, k_target_height, 0.0F),
+  const QVector3D focus = advance_focus(delta);
+  m_camera->look_at(focus + (k_bust_direction.normalized() * k_bust_distance),
+                    focus,
                     QVector3D(0.0F, 1.0F, 0.0F));
   m_camera->set_perspective(k_field_of_view, aspect, 0.05F, 40.0F);
 
@@ -270,9 +392,29 @@ void CommanderPortraitView::PortraitRenderer::render() {
   m_renderer->set_local_owner_id(1);
   m_renderer->set_force_full_creature_lod(true);
   m_renderer->update_animation_time(delta);
+  Render::Creature::Pipeline::BoneProbe head_probe{};
+  head_probe.entity_id = static_cast<std::uint32_t>(m_entity);
+  head_probe.instance_index = 0U;
+  head_probe.bone_index =
+      static_cast<std::uint16_t>(Render::Humanoid::HumanoidBone::Head);
+
   m_renderer->begin_frame();
-  m_renderer->render_world(m_world.get());
+  {
+    Render::Creature::Pipeline::ScopedBoneProbe const probe_scope(&head_probe);
+    m_renderer->render_world(m_world.get());
+  }
   m_renderer->end_frame();
+
+  if (head_probe.resolved) {
+    measure_face_anchor(head_probe.world);
+  } else {
+    m_face = {};
+  }
+  if (head_probe.resolved) {
+    QVector3D const head = head_probe.world.map(QVector3D(0.0F, k_cranium_rise, 0.0F));
+    m_focus_target = QVector3D(head.x(), head.y() - k_bust_drop, head.z());
+  }
+  post_face_anchor();
 
   update();
 }
@@ -287,6 +429,22 @@ CommanderPortraitView::~CommanderPortraitView() = default;
 auto CommanderPortraitView::createRenderer() const
     -> QQuickFramebufferObject::Renderer* {
   return new PortraitRenderer();
+}
+
+void CommanderPortraitView::publish_face_anchor(const FaceAnchor& anchor) {
+  constexpr qreal k_epsilon = 1.0e-4;
+  auto same = [](qreal lhs, qreal rhs) {
+    return std::abs(lhs - rhs) < k_epsilon;
+  };
+
+  if (m_face.valid == anchor.valid && same(m_face.x, anchor.x) &&
+      same(m_face.y, anchor.y) && same(m_face.radius, anchor.radius) &&
+      same(m_face.roll, anchor.roll) && same(m_face.turn, anchor.turn) &&
+      same(m_face.tilt, anchor.tilt) && same(m_face.facing, anchor.facing)) {
+    return;
+  }
+  m_face = anchor;
+  emit face_anchor_changed();
 }
 
 void CommanderPortraitView::set_troop_type(const QString& value) {

--- a/ui/commander_portrait_view.h
+++ b/ui/commander_portrait_view.h
@@ -29,6 +29,15 @@ class CommanderPortraitView : public QQuickFramebufferObject {
   Q_PROPERTY(QString pose READ pose WRITE set_pose NOTIFY pose_changed)
   Q_PROPERTY(bool speaking READ speaking WRITE set_speaking NOTIFY speaking_changed)
 
+  Q_PROPERTY(bool faceValid READ face_valid NOTIFY face_anchor_changed)
+  Q_PROPERTY(qreal faceX READ face_x NOTIFY face_anchor_changed)
+  Q_PROPERTY(qreal faceY READ face_y NOTIFY face_anchor_changed)
+  Q_PROPERTY(qreal faceRadius READ face_radius NOTIFY face_anchor_changed)
+  Q_PROPERTY(qreal faceRoll READ face_roll NOTIFY face_anchor_changed)
+  Q_PROPERTY(qreal faceTurn READ face_turn NOTIFY face_anchor_changed)
+  Q_PROPERTY(qreal faceTilt READ face_tilt NOTIFY face_anchor_changed)
+  Q_PROPERTY(qreal faceFacing READ face_facing NOTIFY face_anchor_changed)
+
 public:
   CommanderPortraitView();
   ~CommanderPortraitView() override;
@@ -47,11 +56,40 @@ public:
   [[nodiscard]] auto speaking() const -> bool { return m_speaking; }
   void set_speaking(bool value);
 
+  struct FaceAnchor {
+    bool valid{false};
+
+    qreal x{0.0};
+    qreal y{0.0};
+
+    qreal radius{0.0};
+
+    qreal roll{0.0};
+
+    qreal turn{0.0};
+
+    qreal tilt{0.0};
+
+    qreal facing{0.0};
+  };
+
+  void publish_face_anchor(const FaceAnchor& anchor);
+
+  [[nodiscard]] auto face_valid() const -> bool { return m_face.valid; }
+  [[nodiscard]] auto face_x() const -> qreal { return m_face.x; }
+  [[nodiscard]] auto face_y() const -> qreal { return m_face.y; }
+  [[nodiscard]] auto face_radius() const -> qreal { return m_face.radius; }
+  [[nodiscard]] auto face_roll() const -> qreal { return m_face.roll; }
+  [[nodiscard]] auto face_turn() const -> qreal { return m_face.turn; }
+  [[nodiscard]] auto face_tilt() const -> qreal { return m_face.tilt; }
+  [[nodiscard]] auto face_facing() const -> qreal { return m_face.facing; }
+
 signals:
   void troop_type_changed();
   void nation_changed();
   void pose_changed();
   void speaking_changed();
+  void face_anchor_changed();
 
 private:
   class PortraitRenderer;
@@ -60,4 +98,5 @@ private:
   QString m_nation;
   QString m_pose;
   bool m_speaking = false;
+  FaceAnchor m_face{};
 };

--- a/ui/gl_view.cpp
+++ b/ui/gl_view.cpp
@@ -148,6 +148,16 @@ void GLView::notify_renderer_ready() {
 
 namespace {
 
+struct FrameGate {
+  GameEngine* engine = nullptr;
+
+  ~FrameGate() {
+    if (engine != nullptr) {
+      engine->end_render_frame();
+    }
+  }
+};
+
 auto render_thread_cpu_ms() -> double {
   timespec now{};
   if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &now) != 0) {
@@ -221,6 +231,14 @@ void GLView::GLRenderer::render() {
         }
       }
     }
+
+    if (!m_engine->try_begin_render_frame()) {
+
+      update();
+      return;
+    }
+    const FrameGate frame_gate{m_engine};
+
     m_engine->ensure_initialized();
     if (!m_engine->renderer_initialized()) {
       qCritical() << "GLRenderer::render() - gameplay renderer initialization failed";

--- a/ui/preferences.cpp
+++ b/ui/preferences.cpp
@@ -43,6 +43,7 @@ UiPreferences::UiPreferences(QObject* parent)
     , m_camera_motion_scale(UserSettings::load_ui_camera_motion_scale())
     , m_damage_numbers(UserSettings::load_ui_damage_numbers())
     , m_camera_legend_seen(UserSettings::load_ui_camera_legend_seen())
+    , m_tutorial_completed(UserSettings::load_ui_tutorial_completed())
     , m_screen_effect_intensity(UserSettings::load_ui_screen_effect_intensity()) {
 
   Game::Accessibility::TeamIdentity::set_palette_variant_from_mode(
@@ -230,6 +231,16 @@ void UiPreferences::set_camera_legend_seen(bool seen) {
   m_camera_legend_seen = seen;
   UserSettings::save_ui_camera_legend_seen(seen);
   emit camera_legend_seen_changed();
+}
+
+void UiPreferences::set_tutorial_completed(bool completed) {
+  if (completed == m_tutorial_completed) {
+    return;
+  }
+
+  m_tutorial_completed = completed;
+  UserSettings::save_ui_tutorial_completed(completed);
+  emit tutorial_completed_changed();
 }
 
 void UiPreferences::set_damage_numbers(bool enabled) {

--- a/ui/preferences.h
+++ b/ui/preferences.h
@@ -32,6 +32,8 @@ class UiPreferences : public QObject {
                  damage_numbers_changed)
   Q_PROPERTY(bool cameraLegendSeen READ camera_legend_seen WRITE set_camera_legend_seen
                  NOTIFY camera_legend_seen_changed)
+  Q_PROPERTY(bool tutorialCompleted READ tutorial_completed WRITE set_tutorial_completed
+                 NOTIFY tutorial_completed_changed)
   Q_PROPERTY(qreal screenEffectIntensity READ screen_effect_intensity WRITE
                  set_screen_effect_intensity NOTIFY screen_effect_intensity_changed)
   Q_PROPERTY(QStringList colorVisionModes READ color_vision_modes CONSTANT)
@@ -63,6 +65,7 @@ public:
   }
   [[nodiscard]] auto damage_numbers() const -> bool { return m_damage_numbers; }
   [[nodiscard]] auto camera_legend_seen() const -> bool { return m_camera_legend_seen; }
+  [[nodiscard]] auto tutorial_completed() const -> bool { return m_tutorial_completed; }
   [[nodiscard]] auto screen_effect_intensity() const -> qreal {
     return m_screen_effect_intensity;
   }
@@ -86,6 +89,7 @@ public:
   void set_camera_motion_scale(qreal scale);
   void set_damage_numbers(bool enabled);
   void set_camera_legend_seen(bool seen);
+  void set_tutorial_completed(bool completed);
   void set_screen_effect_intensity(qreal intensity);
 
   Q_INVOKABLE void reset_to_defaults();
@@ -102,6 +106,7 @@ signals:
   void camera_motion_scale_changed();
   void damage_numbers_changed();
   void camera_legend_seen_changed();
+  void tutorial_completed_changed();
   void screen_effect_intensity_changed();
 
 private:
@@ -120,6 +125,7 @@ private:
   qreal m_camera_motion_scale;
   bool m_damage_numbers;
   bool m_camera_legend_seen;
+  bool m_tutorial_completed;
   qreal m_screen_effect_intensity;
 };
 

--- a/ui/qml/CommanderFaceOverlay.qml
+++ b/ui/qml/CommanderFaceOverlay.qml
@@ -1,0 +1,317 @@
+import QtQuick 2.15
+import StandardOfIron.Design 1.0 as Design
+
+Item {
+    id: faceRoot
+
+    property Item anchorSource: null
+
+    property bool talking: false
+
+    property string pose: ""
+
+    property color accent: "#c8a061"
+
+    readonly property bool anchored: anchorSource !== null && anchorSource.faceValid
+
+    property real headScale: 1.3
+
+    readonly property real headRadius: anchorSource ? anchorSource.faceRadius * anchorSource.height * headScale : 0
+
+    readonly property real squashX: anchorSource ? Math.sqrt(Math.max(0.0, 1.0 - (anchorSource.faceTurn * anchorSource.faceTurn))) : 1
+    readonly property real squashY: anchorSource ? Math.sqrt(Math.max(0.0, 1.0 - (anchorSource.faceTilt * anchorSource.faceTilt))) : 1
+
+    readonly property real facing: anchorSource ? anchorSource.faceFacing : 1
+
+    readonly property bool animated: !Design.A11y.reducedMotion
+    readonly property bool ambient: Design.Motion.allowAmbientLoops && faceRoot.animated
+
+    property real blink: 0
+    property real mouthOpen: 0
+    property real mouthWide: 0.4
+    property real gazeX: 0
+    property real gazeY: 0
+
+    readonly property real span: 2.6
+
+    width: headRadius * span
+    height: width
+    x: (anchorSource ? anchorSource.faceX * anchorSource.width : 0) - (width / 2)
+    y: (anchorSource ? anchorSource.faceY * anchorSource.height : 0) - (height / 2)
+
+    visible: anchored && headRadius > 2 && facing > -0.05
+    opacity: Math.max(0.0, Math.min(1.0, (facing - 0.02) / 0.30))
+
+    transform: [
+        Scale {
+            origin.x: faceRoot.width / 2
+            origin.y: faceRoot.height / 2
+            xScale: Math.max(0.05, faceRoot.squashX)
+            yScale: Math.max(0.05, faceRoot.squashY)
+        },
+        Rotation {
+            origin.x: faceRoot.width / 2
+            origin.y: faceRoot.height / 2
+            angle: faceRoot.anchorSource ? faceRoot.anchorSource.faceRoll : 0
+        }
+    ]
+
+    onBlinkChanged: canvas.requestPaint()
+    onMouthOpenChanged: canvas.requestPaint()
+    onMouthWideChanged: canvas.requestPaint()
+    onGazeXChanged: canvas.requestPaint()
+    onGazeYChanged: canvas.requestPaint()
+    onPoseChanged: canvas.requestPaint()
+    onAccentChanged: canvas.requestPaint()
+    onTalkingChanged: {
+        if (!faceRoot.talking) {
+            mouthTarget.stop();
+            mouthOpenTo.stop();
+            mouthWideTo.stop();
+            faceRoot.mouthOpen = 0;
+            faceRoot.mouthWide = 0.4;
+        }
+    }
+
+    Timer {
+        id: blinkClock
+
+        interval: 2200 + Math.random() * 3600
+        repeat: true
+        running: faceRoot.ambient && faceRoot.visible
+        onTriggered: {
+            interval = 2200 + Math.random() * 3600;
+            blinkRun.restart();
+        }
+    }
+
+    SequentialAnimation {
+        id: blinkRun
+
+        NumberAnimation {
+            target: faceRoot
+            property: "blink"
+            to: 1
+            duration: 70
+            easing.type: Easing.InQuad
+        }
+
+        NumberAnimation {
+            target: faceRoot
+            property: "blink"
+            to: 0
+            duration: 130
+            easing.type: Easing.OutQuad
+        }
+    }
+
+    Timer {
+        id: mouthTarget
+
+        readonly property var apertures: [0.18, 0.72, 0.34, 0.95, 0.10, 0.58, 0.26, 0.80, 0.42, 0.14]
+        readonly property var widths: [0.30, 0.75, 0.45, 0.25, 0.55, 0.85, 0.35, 0.60, 0.20, 0.50]
+        property int step: 0
+
+        interval: 78 + Math.random() * 62
+        repeat: true
+        running: faceRoot.talking && faceRoot.animated && faceRoot.visible
+        onTriggered: {
+            interval = 78 + Math.random() * 62;
+            step = (step + 1) % apertures.length;
+            mouthOpenTo.to = apertures[step];
+            mouthWideTo.to = widths[step];
+            mouthOpenTo.restart();
+            mouthWideTo.restart();
+        }
+    }
+
+    NumberAnimation {
+        id: mouthOpenTo
+
+        target: faceRoot
+        property: "mouthOpen"
+        duration: 64
+        easing.type: Easing.OutQuad
+    }
+
+    NumberAnimation {
+        id: mouthWideTo
+
+        target: faceRoot
+        property: "mouthWide"
+        duration: 80
+        easing.type: Easing.OutQuad
+    }
+
+    Timer {
+        interval: 1400 + Math.random() * 2600
+        repeat: true
+        running: faceRoot.ambient && faceRoot.visible
+        onTriggered: {
+            interval = 1400 + Math.random() * 2600;
+            gazeXTo.to = (Math.random() - 0.5) * 0.16;
+            gazeYTo.to = (Math.random() - 0.5) * 0.09;
+            gazeXTo.restart();
+            gazeYTo.restart();
+        }
+    }
+
+    NumberAnimation {
+        id: gazeXTo
+
+        target: faceRoot
+        property: "gazeX"
+        duration: 130
+        easing.type: Easing.OutCubic
+    }
+
+    NumberAnimation {
+        id: gazeYTo
+
+        target: faceRoot
+        property: "gazeY"
+        duration: 130
+        easing.type: Easing.OutCubic
+    }
+
+    Canvas {
+        id: canvas
+
+        anchors.fill: parent
+
+        renderStrategy: Canvas.Immediate
+        renderTarget: Canvas.Image
+        onWidthChanged: requestPaint()
+        onHeightChanged: requestPaint()
+        onPaint: {
+            var ctx = getContext("2d");
+            ctx.reset();
+            if (faceRoot.width <= 0)
+                return;
+            var unit = faceRoot.width / faceRoot.span;
+            ctx.translate(faceRoot.width / 2, faceRoot.height / 2);
+            ctx.scale(unit, unit);
+            ctx.lineJoin = "round";
+            ctx.lineCap = "round";
+            var cynical = faceRoot.pose !== "dismissive";
+            var lineInk = Qt.rgba(0.11, 0.07, 0.04, 0.95);
+            var softInk = Qt.rgba(0.17, 0.10, 0.06, 0.60);
+            var scleraTone = Qt.rgba(0.86, 0.79, 0.66, 0.94);
+            var irisTone = Qt.rgba(0.27, 0.18, 0.10, 1.0);
+            var mouthDark = Qt.rgba(0.11, 0.05, 0.04, 0.96);
+            var lipTone = Qt.rgba(0.47, 0.25, 0.19, 0.90);
+            var socket = ctx.createRadialGradient(0, -0.06, 0.05, 0, -0.06, 0.95);
+            socket.addColorStop(0.0, Qt.rgba(0.26, 0.16, 0.09, 0.42));
+            socket.addColorStop(0.62, Qt.rgba(0.26, 0.16, 0.09, 0.20));
+            socket.addColorStop(1.0, Qt.rgba(0.26, 0.16, 0.09, 0.0));
+            ctx.fillStyle = socket;
+            ctx.beginPath();
+            ctx.ellipse(-0.95, -0.85, 1.90, 1.70);
+            ctx.fill();
+            var eyeY = -0.02;
+            var eyeDx = 0.40;
+            var lidOpen = 1.0 - faceRoot.blink;
+            for (var side = -1; side <= 1; side += 2) {
+                var ex = side * eyeDx;
+                var openH = 0.150 * lidOpen;
+                if (openH > 0.006) {
+                    ctx.fillStyle = scleraTone;
+                    ctx.beginPath();
+                    ctx.ellipse(ex - 0.215, eyeY - openH, 0.43, openH * 2);
+                    ctx.fill();
+                    ctx.save();
+                    ctx.beginPath();
+                    ctx.ellipse(ex - 0.215, eyeY - openH, 0.43, openH * 2);
+                    ctx.clip();
+                    var ix = ex + (faceRoot.gazeX * 0.9);
+                    var iy = eyeY + (faceRoot.gazeY * 0.7);
+                    ctx.fillStyle = irisTone;
+                    ctx.beginPath();
+                    ctx.ellipse(ix - 0.108, iy - 0.108, 0.216, 0.216);
+                    ctx.fill();
+                    ctx.fillStyle = Qt.rgba(0.04, 0.02, 0.02, 1.0);
+                    ctx.beginPath();
+                    ctx.ellipse(ix - 0.050, iy - 0.050, 0.100, 0.100);
+                    ctx.fill();
+                    ctx.fillStyle = Qt.rgba(0.55 + (faceRoot.accent.r * 0.45), 0.55 + (faceRoot.accent.g * 0.45), 0.55 + (faceRoot.accent.b * 0.45), 0.80);
+                    ctx.beginPath();
+                    ctx.ellipse(ix - 0.092, iy - 0.096, 0.056, 0.056);
+                    ctx.fill();
+                    ctx.restore();
+                }
+                ctx.strokeStyle = lineInk;
+                ctx.lineWidth = 0.042;
+                ctx.beginPath();
+                ctx.moveTo(ex - 0.225, eyeY + 0.010);
+                ctx.quadraticCurveTo(ex, eyeY - (0.225 * lidOpen) - 0.012, ex + 0.225, eyeY + 0.010);
+                ctx.stroke();
+                ctx.strokeStyle = softInk;
+                ctx.lineWidth = 0.028;
+                ctx.beginPath();
+                ctx.moveTo(ex - 0.19, eyeY + 0.028);
+                ctx.quadraticCurveTo(ex, eyeY + (0.130 * lidOpen) + 0.028, ex + 0.20, eyeY + 0.018);
+                ctx.stroke();
+                var innerDrop = cynical ? 0.095 : 0.0;
+                var outerLift = cynical ? 0.0 : (side > 0 ? 0.115 : 0.02);
+                ctx.strokeStyle = lineInk;
+                ctx.lineWidth = 0.075;
+                ctx.beginPath();
+                ctx.moveTo(ex - (side * 0.235), eyeY - 0.285 + innerDrop);
+                ctx.quadraticCurveTo(ex, eyeY - 0.375 - (outerLift * 0.5), ex + (side * 0.245), eyeY - 0.300 - outerLift);
+                ctx.stroke();
+            }
+            ctx.strokeStyle = softInk;
+            ctx.lineWidth = 0.036;
+            ctx.beginPath();
+            ctx.moveTo(-0.055, eyeY + 0.08);
+            ctx.quadraticCurveTo(-0.105, eyeY + 0.30, -0.020, eyeY + 0.355);
+            ctx.stroke();
+            ctx.fillStyle = Qt.rgba(0.14, 0.08, 0.05, 0.55);
+            ctx.beginPath();
+            ctx.ellipse(-0.075, eyeY + 0.325, 0.070, 0.045);
+            ctx.fill();
+            ctx.beginPath();
+            ctx.ellipse(0.020, eyeY + 0.325, 0.070, 0.045);
+            ctx.fill();
+            var mouthY = 0.46;
+            var halfW = 0.24 + (0.155 * faceRoot.mouthWide);
+            var gap = 0.34 * faceRoot.mouthOpen;
+            if (gap > 0.012) {
+                ctx.fillStyle = mouthDark;
+                ctx.beginPath();
+                ctx.moveTo(-halfW, mouthY);
+                ctx.quadraticCurveTo(0, mouthY - (gap * 0.60), halfW, mouthY);
+                ctx.quadraticCurveTo(0, mouthY + gap, -halfW, mouthY);
+                ctx.fill();
+                ctx.strokeStyle = lipTone;
+                ctx.lineWidth = 0.052;
+                ctx.beginPath();
+                ctx.moveTo(-halfW * 0.92, mouthY + (gap * 0.60));
+                ctx.quadraticCurveTo(0, mouthY + gap + 0.062, halfW * 0.92, mouthY + (gap * 0.60));
+                ctx.stroke();
+            } else {
+                var setDown = cynical ? 0.070 : 0.018;
+                ctx.strokeStyle = lineInk;
+                ctx.lineWidth = 0.070;
+                ctx.beginPath();
+                ctx.moveTo(-halfW, mouthY - setDown);
+                ctx.quadraticCurveTo(0, mouthY + 0.055, halfW, mouthY + setDown);
+                ctx.stroke();
+                ctx.strokeStyle = Qt.rgba(lipTone.r, lipTone.g, lipTone.b, 0.45);
+                ctx.lineWidth = 0.040;
+                ctx.beginPath();
+                ctx.moveTo(-halfW * 0.85, mouthY + 0.075 - setDown);
+                ctx.quadraticCurveTo(0, mouthY + 0.125, halfW * 0.85, mouthY + 0.075 + setDown);
+                ctx.stroke();
+            }
+            var jaw = ctx.createLinearGradient(0, mouthY + 0.20, 0, mouthY + 0.78);
+            jaw.addColorStop(0.0, Qt.rgba(0.16, 0.09, 0.05, 0.0));
+            jaw.addColorStop(1.0, Qt.rgba(0.16, 0.09, 0.05, 0.34));
+            ctx.fillStyle = jaw;
+            ctx.beginPath();
+            ctx.moveTo(-0.62, mouthY + 0.20);
+            ctx.quadraticCurveTo(0, mouthY + 0.86, 0.62, mouthY + 0.20);
+            ctx.fill();
+        }
+    }
+}

--- a/ui/qml/CommanderMessagePanel.qml
+++ b/ui/qml/CommanderMessagePanel.qml
@@ -184,6 +184,15 @@ Item {
                             }
                         }
                     }
+
+                    CommanderFaceOverlay {
+                        id: face
+
+                        anchorSource: portrait
+                        pose: messageRoot.speakerPose
+                        accent: messageRoot.accent
+                        talking: messageRoot.showing && messageRoot.revealed < fullText.length
+                    }
                 }
             }
 

--- a/ui/qml/HUD.qml
+++ b/ui/qml/HUD.qml
@@ -35,6 +35,7 @@ Item {
     signal command_mode_changed(string mode)
     signal recruit_unit(string unit_type)
     signal return_to_main_menu_requested
+    signal campaign_requested
     signal hud_became_visible
     signal help_requested
 
@@ -291,6 +292,18 @@ Item {
         visible: hud.commander_rpg_mode && !hud.commander_rally_overlay_blocked && Design.A11y.damageNumbers
     }
 
+    TutorialFocusOverlay {
+        id: tutorialFocusOverlay
+
+        anchors.fill: parent
+        camera: typeof game !== 'undefined' ? game.camera : null
+        points: (typeof game !== 'undefined' && game.tutorial && game.tutorial.active) ? game.tutorial.focus_points : []
+        topInset: topPanel.height
+        bottomInset: bottomPanel.height
+        z: 1
+        visible: !hud.commander_rpg_mode && points.length > 0
+    }
+
     CombatDamageNumbers {
         id: combatDamageNumbers
 
@@ -317,6 +330,9 @@ Item {
         anchors.fill: parent
         onReturn_to_main_menu_requested: {
             hud.return_to_main_menu_requested();
+        }
+        onCampaign_requested: {
+            hud.campaign_requested();
         }
 
         Connections {

--- a/ui/qml/HUDBottom.qml
+++ b/ui/qml/HUDBottom.qml
@@ -88,6 +88,14 @@ RowLayout {
         return entry.details || [];
     }
 
+    readonly property var tutorial: (typeof game !== 'undefined' && game && game.tutorial) ? game.tutorial : null
+    readonly property var tutorialFocusActions: (bottomRoot.tutorial && bottomRoot.tutorial.active) ? bottomRoot.tutorial.focus_actions : []
+    readonly property string tutorialFocusRegion: (bottomRoot.tutorial && bottomRoot.tutorial.active) ? bottomRoot.tutorial.focus_region : ""
+
+    function tutorial_spotlights(actionId) {
+        return bottomRoot.tutorialFocusActions.indexOf(actionId) >= 0;
+    }
+
     readonly property var gatherPriorities: ["", "cut_tree", "collect_stone", "collect_iron_ore"]
 
     function gather_priority_label(priority) {
@@ -681,6 +689,8 @@ RowLayout {
                     eligibleCount: state.eligibleCount
                     activeCount: state.activeCount
 
+                    spotlit: bottomRoot.tutorial_spotlights(modelData.id)
+
                     onClicked: bottomRoot.invoke_command(modelData)
                 }
             }
@@ -692,6 +702,12 @@ RowLayout {
         Layout.preferredWidth: Math.max(280, bottomRoot.width * 0.32)
         Layout.fillHeight: true
         Layout.alignment: Qt.AlignTop
+
+        Design.IronSpotlight {
+            active: bottomRoot.tutorialFocusRegion === "production"
+            inset: -Design.Metrics.space4
+            cornerRadius: Design.Metrics.radiusMedium
+        }
         selection_tick: bottomRoot.selection_tick
         production: bottomRoot.game_ready() ? game.production : null
         placement: bottomRoot.game_ready() ? game.placement : null

--- a/ui/qml/HUDTop.qml
+++ b/ui/qml/HUDTop.qml
@@ -13,6 +13,9 @@ Item {
     readonly property bool compact: width < 1000
     readonly property bool ultraCompact: width < 620
     readonly property var speedOptions: GameSpeeds.options
+    readonly property var tutorial: (typeof game !== 'undefined' && game && game.tutorial) ? game.tutorial : null
+    readonly property string tutorialFocusRegion: (topRoot.tutorial && topRoot.tutorial.active) ? topRoot.tutorial.focus_region : ""
+    readonly property var tutorialFocusPoints: (topRoot.tutorial && topRoot.tutorial.active) ? topRoot.tutorial.focus_points : []
 
     readonly property real minimapLegendHeight: fogLegend.visible ? Design.Metrics.space4 + fogLegend.implicitHeight + Design.Metrics.space8 : 0
 
@@ -179,10 +182,62 @@ Item {
                 spacing: Design.Metrics.space8
                 Layout.alignment: Qt.AlignVCenter
 
-                Design.IronIconButton {
-                    iconText: topRoot.game_is_paused ? Design.Icons.play : Design.Icons.pause
-                    tooltip: topRoot.game_is_paused ? qsTr("Resume") : qsTr("Pause")
-                    onClicked: topRoot.pause_toggled()
+                Item {
+                    id: speedZone
+
+                    Layout.fillHeight: true
+                    implicitWidth: speedGroup.implicitWidth
+                    implicitHeight: speedGroup.implicitHeight
+
+                    RowLayout {
+                        id: speedGroup
+
+                        anchors.fill: parent
+                        spacing: Design.Metrics.space8
+
+                        Design.IronIconButton {
+                            iconText: topRoot.game_is_paused ? Design.Icons.play : Design.Icons.pause
+                            tooltip: topRoot.game_is_paused ? qsTr("Resume") : qsTr("Pause")
+                            onClicked: topRoot.pause_toggled()
+                        }
+
+                        Design.IronDivider {
+                            vertical: true
+                            Layout.fillHeight: true
+                            visible: !topRoot.ultraCompact
+                        }
+
+                        Repeater {
+                            model: topRoot.speedOptions
+
+                            delegate: Design.IronButton {
+                                required property var modelData
+
+                                visible: !topRoot.compact
+                                Layout.preferredWidth: Design.Metrics.space24 * 2
+                                implicitWidth: Design.Metrics.space24 * 2
+                                text: topRoot.speed_label(modelData)
+                                tone: topRoot.current_speed === modelData ? "primary" : "secondary"
+                                accessibleName: qsTr("Battle speed %1").arg(topRoot.speed_label(modelData))
+                                onClicked: topRoot.speed_changed(modelData)
+                            }
+                        }
+
+                        Design.IronDropdown {
+                            visible: topRoot.compact
+                            Layout.preferredWidth: Design.Metrics.space24 * 4
+                            model: topRoot.speed_labels()
+                            currentIndex: topRoot.speed_index(topRoot.current_speed)
+                            accessibleName: qsTr("Battle speed")
+                            onActivated: function (index) {
+                                topRoot.speed_changed(topRoot.speedOptions[index]);
+                            }
+                        }
+                    }
+
+                    Design.IronSpotlight {
+                        active: topRoot.tutorialFocusRegion === "speed"
+                    }
                 }
 
                 Design.IronDivider {
@@ -191,67 +246,53 @@ Item {
                     visible: !topRoot.ultraCompact
                 }
 
-                Repeater {
-                    model: topRoot.speedOptions
+                Item {
+                    id: cameraZone
 
-                    delegate: Design.IronButton {
-                        required property var modelData
-
-                        visible: !topRoot.compact
-                        Layout.preferredWidth: Design.Metrics.space24 * 2
-                        implicitWidth: Design.Metrics.space24 * 2
-                        text: topRoot.speed_label(modelData)
-                        tone: topRoot.current_speed === modelData ? "primary" : "secondary"
-                        accessibleName: qsTr("Battle speed %1").arg(topRoot.speed_label(modelData))
-                        onClicked: topRoot.speed_changed(modelData)
-                    }
-                }
-
-                Design.IronDropdown {
-                    visible: topRoot.compact
-                    Layout.preferredWidth: Design.Metrics.space24 * 4
-                    model: topRoot.speed_labels()
-                    currentIndex: topRoot.speed_index(topRoot.current_speed)
-                    accessibleName: qsTr("Battle speed")
-                    onActivated: function (index) {
-                        topRoot.speed_changed(topRoot.speedOptions[index]);
-                    }
-                }
-
-                Design.IronDivider {
-                    vertical: true
                     Layout.fillHeight: true
-                    visible: !topRoot.ultraCompact
-                }
+                    implicitWidth: cameraGroup.implicitWidth
+                    implicitHeight: cameraGroup.implicitHeight
 
-                Design.IronIconButton {
-                    iconText: Design.Icons.follow
-                    tooltip: qsTr("Follow the selection with the camera")
-                    checkable: true
-                    tone: checked ? "primary" : "secondary"
-                    onToggled: {
-                        if (topRoot.game_ready() && game.camera.follow_selection)
-                            game.camera.follow_selection(checked);
+                    RowLayout {
+                        id: cameraGroup
+
+                        anchors.fill: parent
+                        spacing: Design.Metrics.space8
+
+                        Design.IronIconButton {
+                            iconText: Design.Icons.follow
+                            tooltip: qsTr("Follow the selection with the camera")
+                            checkable: true
+                            tone: checked ? "primary" : "secondary"
+                            onToggled: {
+                                if (topRoot.game_ready() && game.camera.follow_selection)
+                                    game.camera.follow_selection(checked);
+                            }
+                        }
+
+                        Design.IronIconButton {
+                            iconText: Design.Icons.reset
+                            tooltip: qsTr("Return the camera to your camp (%1)").arg(InputBindings.display_shortcut_for("rts.camera_reset"))
+                            onClicked: {
+                                if (topRoot.game_ready() && game.camera.reset)
+                                    game.camera.reset();
+                            }
+                        }
+
+                        Design.IronIconButton {
+                            iconText: Design.Icons.objective
+                            tooltip: topRoot.camera_legend_visible ? qsTr("Hide the camera controls") : qsTr("Show how to move the camera")
+                            accessibleName: qsTr("Camera controls")
+                            checkable: true
+                            checked: topRoot.camera_legend_visible
+                            tone: checked ? "primary" : "secondary"
+                            onToggled: topRoot.camera_legend_toggled()
+                        }
                     }
-                }
 
-                Design.IronIconButton {
-                    iconText: Design.Icons.reset
-                    tooltip: qsTr("Return the camera to your camp (%1)").arg(InputBindings.display_shortcut_for("rts.camera_reset"))
-                    onClicked: {
-                        if (topRoot.game_ready() && game.camera.reset)
-                            game.camera.reset();
+                    Design.IronSpotlight {
+                        active: topRoot.tutorialFocusRegion === "camera"
                     }
-                }
-
-                Design.IronIconButton {
-                    iconText: Design.Icons.objective
-                    tooltip: topRoot.camera_legend_visible ? qsTr("Hide the camera controls") : qsTr("Show how to move the camera")
-                    accessibleName: qsTr("Camera controls")
-                    checkable: true
-                    checked: topRoot.camera_legend_visible
-                    tone: checked ? "primary" : "secondary"
-                    onToggled: topRoot.camera_legend_toggled()
                 }
 
                 Design.IronIconButton {
@@ -312,6 +353,12 @@ Item {
                     ToolTip.text: topRoot.missionStaged ? (game.mission.active_hint !== "" ? game.mission.active_hint + "\n" + qsTr("Click to look at the objective.") : qsTr("Click to look at the objective.")) : ""
 
                     onClicked: game.mission.focus_active_stage()
+                }
+
+                Design.IronSpotlight {
+                    target: objectiveRow
+                    active: topRoot.tutorialFocusRegion === "objective" && objectiveRow.visible
+                    cornerRadius: Design.Metrics.radiusSmall
                 }
 
                 Design.IronBadge {
@@ -573,6 +620,57 @@ Item {
                         height: width
                         radius: width / 2
                         color: Design.Theme.accent
+                    }
+                }
+            }
+
+            Repeater {
+                id: tutorialPins
+
+                model: topRoot.tutorialFocusPoints
+
+                delegate: Item {
+                    id: tutorialPin
+
+                    required property var modelData
+
+                    readonly property real paintedW: minimapImage.paintedWidth
+                    readonly property real paintedH: minimapImage.paintedHeight
+
+                    property real pulse: 1
+
+                    SequentialAnimation on pulse  {
+                        running: tutorialPin.visible && !Design.A11y.reducedMotion
+                        loops: Animation.Infinite
+
+                        NumberAnimation {
+                            from: 1
+                            to: 0.25
+                            duration: 900
+                            easing.type: Easing.InOutQuad
+                        }
+
+                        NumberAnimation {
+                            to: 1
+                            duration: 900
+                            easing.type: Easing.InOutQuad
+                        }
+                    }
+
+                    visible: paintedW > 0 && paintedH > 0 && modelData.nx !== undefined
+                    x: ((minimapImage.width - paintedW) / 2) + (modelData.nx || 0) * paintedW
+                    y: ((minimapImage.height - paintedH) / 2) + (modelData.ny || 0) * paintedH
+                    z: 13
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: Design.Metrics.space12
+                        height: width
+                        radius: width / 2
+                        color: "transparent"
+                        border.width: Design.Metrics.borderFocus
+                        border.color: Design.Theme.focus
+                        opacity: tutorialPin.pulse
                     }
                 }
             }

--- a/ui/qml/HUDVictory.qml
+++ b/ui/qml/HUDVictory.qml
@@ -7,6 +7,7 @@ Design.IronOutcomeOverlay {
     id: victoryOverlay
 
     signal return_to_main_menu_requested
+    signal campaign_requested
 
     function game_ready() {
         return typeof game !== 'undefined' && game !== null;
@@ -26,11 +27,16 @@ Design.IronOutcomeOverlay {
 
     held: victoryOverlay.game_ready() && game.commander_message && game.commander_message.holds_outcome
     victoryState: victoryOverlay.victory_state()
+    isTutorial: victoryOverlay.game_ready() && !!game.tutorial && game.tutorial.finished
     isCampaignMission: victoryOverlay.game_ready() && game.setup.is_campaign_mission
     campaignCompleted: victoryOverlay.game_ready() && game.setup.campaign_completed === true
     factionId: victoryOverlay.game_ready() ? game.local_player_nation : ""
 
     onReportRequested: battleSummary.show()
+    onSecondaryRequested: {
+        victoryOverlay.reset();
+        victoryOverlay.campaign_requested();
+    }
 
     Connections {
         function onVictory_state_changed() {

--- a/ui/qml/HelpPanel.qml
+++ b/ui/qml/HelpPanel.qml
@@ -288,7 +288,7 @@ Item {
 
                         Text {
                             width: parent.width
-                            text: qsTr("The tutorial is a guided first battle on a small meadow. Each step names one goal, tells you when it is done, and explains why an order is refused. Steps can be paused, skipped and replayed at any time.")
+                            text: qsTr("The tutorial is a guided first battle on a small meadow. Each step names one goal, tells you when it is done, and explains why an order is refused. It also points: the button a step is talking about lights up in the command bar, and what you are meant to act on is ringed on the field and pinned on the minimap - press Show me to swing the camera onto it. Steps can be paused, skipped and replayed at any time.")
                             color: Design.Theme.textPrimary
                             font.family: Design.Typography.family
                             font.pixelSize: Design.Typography.body

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Window 2.15
 import StandardOfIron 1.0
+import StandardOfIron.Core 1.0 as Core
 import StandardOfIron.Design 1.0 as Design
 
 ApplicationWindow {
@@ -17,6 +18,7 @@ ApplicationWindow {
 
     property bool capture_view_ready: false
     property bool capture_view_settled: false
+    property bool capture_tutorial_requested: false
 
     function show_view(name) {
         mainWindow.suppress_modals = true;
@@ -31,9 +33,20 @@ ApplicationWindow {
         save_game_panel.visible = (name === "save");
         objectivesPanel.visible = (name === "briefing");
         help_panel.visible = (name === "help");
-        if (name === "hud" || name === "rpg") {
+        commander_preview.visible = (name === "commander");
+        if (name === "hud" || name === "rpg" || name === "tutorial") {
             mainWindow.game_started = true;
             mainWindow.menu_visible = false;
+        }
+        if (name === "tutorial") {
+            var tutorial = (typeof game !== 'undefined') ? game.tutorial : null;
+            if (tutorial && !mainWindow.capture_tutorial_requested) {
+                mainWindow.capture_tutorial_requested = true;
+                mainWindow.start_tutorial();
+            }
+            mainWindow.capture_view_ready = !!tutorial && tutorial.active && !game.is_loading;
+            mainWindow.sync_audio_context();
+            return;
         }
         if (name === "rpg") {
             mainWindow.game_paused = false;
@@ -158,6 +171,11 @@ ApplicationWindow {
         }
         onReturn_to_main_menu_requested: {
             mainWindow.menu_visible = true;
+        }
+        onCampaign_requested: {
+            mainWindow.menu_visible = false;
+            campaign_screen.visible = true;
+            mainWindow.sync_audio_context();
         }
         onHelp_requested: mainWindow.open_help(false)
         onCamera_settings_requested: mainWindow.show_view("settings")
@@ -543,6 +561,41 @@ ApplicationWindow {
         }
     }
 
+    Item {
+        id: commander_preview
+
+        anchors.fill: parent
+        z: 40
+        visible: false
+
+        readonly property QtObject stub: QtObject {
+            property bool active: true
+            property string message_id: "preview"
+            property string speaker_name: "Marcus Claudius Marcellus"
+            property string speaker_role: "Roman field commander"
+            property string nation: "roman_republic"
+            property string speaker_id: "roman_field_commander"
+            property string pose: "dismissive"
+            property string text: qsTr("A new standard in the valley, and nobody under it who has held a spear more than twice.")
+            property real duration: 9.0
+            property bool holds_outcome: false
+
+            function dismiss() {
+            }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: Design.Theme.backgroundDeep
+        }
+
+        CommanderMessagePanel {
+            anchors.centerIn: parent
+            scale: 2.0
+            source: commander_preview.stub
+        }
+    }
+
     SaveProgressOverlay {
         id: save_progress_overlay
 
@@ -677,6 +730,14 @@ ApplicationWindow {
             if (game)
                 game.clear_error();
         }
+    }
+
+    Connections {
+        function onTutorial_finished() {
+            Core.UiPreferences.tutorialCompleted = true;
+        }
+
+        target: (typeof game !== 'undefined' && game) ? game.tutorial : null
     }
 
     Connections {

--- a/ui/qml/MainMenu.qml
+++ b/ui/qml/MainMenu.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import StandardOfIron 1.0
+import StandardOfIron.Core 1.0 as Core
 import StandardOfIron.Design 1.0 as Design
 import "ui_audio.js" as UiAudio
 
@@ -17,6 +18,7 @@ Item {
     readonly property var hs: StyleGuide.historical
     readonly property int command_row_spacing: commandList.height < menuModel.count * 70 ? 4 : 9
     readonly property int command_row_height: Math.max(60, Math.min(root.narrow ? 62 : 70, Math.floor((commandList.height - command_row_spacing * (menuModel.count - 1)) / Math.max(1, menuModel.count))))
+    readonly property bool tutorial_pending: !Core.UiPreferences.tutorialCompleted
     readonly property color ink: "#0B0806"
     readonly property color bronze: hs.bronze
 
@@ -524,6 +526,17 @@ Item {
                 Layout.fillHeight: true
                 model: menuModel
                 currentIndex: 0
+
+                Component.onCompleted: {
+                    if (!root.tutorial_pending)
+                        return;
+                    for (var i = 0; i < menuModel.count; ++i) {
+                        if (menuModel.get(i).idStr === "tutorial") {
+                            commandList.currentIndex = i;
+                            return;
+                        }
+                    }
+                }
                 spacing: root.command_row_spacing
                 clip: true
                 boundsBehavior: Flickable.StopAtBounds
@@ -694,21 +707,23 @@ Item {
                             }
 
                             Rectangle {
+                                readonly property bool recommends_tutorial: commandItem.idStr === "tutorial" && root.tutorial_pending
+
                                 Layout.alignment: Qt.AlignVCenter
                                 Layout.preferredHeight: 20
                                 Layout.preferredWidth: detailLabel.implicitWidth + 16
                                 radius: 2
-                                color: commandItem.selected ? "#AA2C1811" : "transparent"
+                                color: recommends_tutorial ? "#AA3E4A1E" : (commandItem.selected ? "#AA2C1811" : "transparent")
                                 border.width: 1
-                                border.color: commandItem.selected ? Qt.rgba(0.91, 0.79, 0.55, 0.6) : Qt.rgba(0.65, 0.49, 0.28, 0.32)
+                                border.color: recommends_tutorial ? Theme.accentBright : (commandItem.selected ? Qt.rgba(0.91, 0.79, 0.55, 0.6) : Qt.rgba(0.65, 0.49, 0.28, 0.32))
                                 visible: commandItem.width > 400
 
                                 Text {
                                     id: detailLabel
 
                                     anchors.centerIn: parent
-                                    text: qsTr(commandItem.detail).toUpperCase()
-                                    color: commandItem.selected ? Theme.accentBright : Theme.textDim
+                                    text: (parent.recommends_tutorial ? qsTr("Start here") : qsTr(commandItem.detail)).toUpperCase()
+                                    color: parent.recommends_tutorial || commandItem.selected ? Theme.accentBright : Theme.textDim
                                     font.pixelSize: Design.Typography.caption
                                     font.bold: true
                                     font.letterSpacing: 1.4

--- a/ui/qml/TutorialFocusOverlay.qml
+++ b/ui/qml/TutorialFocusOverlay.qml
@@ -1,0 +1,94 @@
+import QtQuick 2.15
+import StandardOfIron.Design 1.0 as Design
+
+Item {
+    id: root
+
+    property var camera: null
+    property var points: []
+    property real topInset: 0
+    property real bottomInset: 0
+
+    readonly property bool hasCamera: root.camera !== null && !!root.camera.project_world
+
+    anchors.fill: parent
+    visible: root.hasCamera && root.points.length > 0
+
+    Accessible.ignored: true
+
+    property real pulse: 1
+
+    SequentialAnimation on pulse  {
+        running: root.visible && !Design.A11y.reducedMotion
+        loops: Animation.Infinite
+
+        NumberAnimation {
+            from: 1
+            to: 0.3
+            duration: 900
+            easing.type: Easing.InOutQuad
+        }
+
+        NumberAnimation {
+            to: 1
+            duration: 900
+            easing.type: Easing.InOutQuad
+        }
+    }
+
+    property int projectionTick: 0
+
+    Timer {
+        interval: Design.A11y.reducedMotion ? 200 : 66
+        repeat: true
+        running: root.visible
+        triggeredOnStart: true
+        onTriggered: root.projectionTick++
+    }
+
+    Repeater {
+        model: root.points
+
+        delegate: Item {
+            id: marker
+
+            required property var modelData
+
+            readonly property var projection: {
+                root.projectionTick;
+                if (!root.hasCamera)
+                    return null;
+                return root.camera.project_world(modelData.world_x || 0, 0, modelData.world_z || 0);
+            }
+            readonly property bool projected: !!projection && projection.valid === true
+            readonly property real screenX: projected ? projection.x : 0
+            readonly property real screenY: projected ? projection.y : 0
+
+            width: Design.Metrics.space24 * 2
+            height: width
+            x: screenX - width / 2
+            y: screenY - height / 2
+            visible: projected && screenX >= 0 && screenX <= root.width && screenY >= root.topInset && screenY <= root.height - root.bottomInset
+
+            Rectangle {
+                anchors.fill: parent
+                radius: width / 2
+                color: "transparent"
+                border.width: Design.Metrics.borderFocus
+                border.color: Design.Theme.focus
+                opacity: root.pulse * 0.9
+            }
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: parent.width * (Design.A11y.reducedMotion ? 0.6 : (0.45 + (1 - root.pulse) * 0.55))
+                height: width
+                radius: width / 2
+                color: "transparent"
+                border.width: Design.Metrics.borderThin
+                border.color: Design.Theme.focus
+                opacity: Design.A11y.reducedMotion ? 0.6 : root.pulse * 0.5
+            }
+        }
+    }
+}

--- a/ui/qml/TutorialOverlay.qml
+++ b/ui/qml/TutorialOverlay.qml
@@ -18,6 +18,23 @@ Item {
     signal pause_requested
     signal help_requested
 
+    readonly property bool can_show_target: tutorial !== null && tutorial.has_focus_point
+
+    function look_at_focus() {
+        if (!root.can_show_target || typeof game === 'undefined' || !game.camera || !game.camera.look_at_world)
+            return;
+        var points = root.tutorial.focus_points;
+        if (!points || points.length === 0)
+            return;
+        var sum_x = 0;
+        var sum_z = 0;
+        for (var i = 0; i < points.length; ++i) {
+            sum_x += points[i].world_x || 0;
+            sum_z += points[i].world_z || 0;
+        }
+        game.camera.look_at_world(sum_x / points.length, sum_z / points.length);
+    }
+
     visible: active
     implicitWidth: panelWidth
     implicitHeight: collapsed ? collapsedBar.implicitHeight : Math.min(card.implicitHeight, max_height)
@@ -225,6 +242,14 @@ Item {
                         tone: root.game_is_paused ? "primary" : "secondary"
                         implicitWidth: Math.max(88, contentItem.implicitWidth + Design.Metrics.space16)
                         onClicked: root.pause_requested()
+                    }
+
+                    Design.IronButton {
+                        text: qsTr("Show me")
+                        tone: "secondary"
+                        implicitWidth: Math.max(88, contentItem.implicitWidth + Design.Metrics.space16)
+                        visible: root.can_show_target && !root.tutorial.step_complete
+                        onClicked: root.look_at_focus()
                     }
 
                     Design.IronButton {

--- a/ui/qml/design/controls/IronCommandButton.qml
+++ b/ui/qml/design/controls/IronCommandButton.qml
@@ -31,6 +31,8 @@ AbstractButton {
     property string statusText: ""
 
     property bool blocked: false
+
+    property bool spotlit: false
     readonly property bool interactive: enabled && !blocked
 
     property string shortLabel: ""
@@ -98,6 +100,11 @@ AbstractButton {
 
     Keys.onReturnPressed: control.clicked()
     Keys.onEnterPressed: control.clicked()
+
+    Design.IronSpotlight {
+        active: control.spotlit
+        cornerRadius: Design.Metrics.radiusMedium
+    }
 
     Design.IronCommandTooltip {
         id: commandTooltip

--- a/ui/qml/design/controls/IronOutcomeOverlay.qml
+++ b/ui/qml/design/controls/IronOutcomeOverlay.qml
@@ -7,6 +7,7 @@ Item {
     property string victoryState: ""
     property bool isCampaignMission: false
     property bool campaignCompleted: false
+    property bool isTutorial: false
 
     default property alias detail: detailHost.data
 
@@ -24,6 +25,8 @@ Item {
     readonly property string outcomeKind: {
         if (root.victoryState !== "victory")
             return "defeat";
+        if (root.isTutorial)
+            return "training";
         return (root.isCampaignMission && root.campaignCompleted) ? "campaign" : "victory";
     }
 
@@ -31,6 +34,8 @@ Item {
         switch (root.outcomeKind) {
         case "campaign":
             return qsTr("The Campaign is Won");
+        case "training":
+            return qsTr("Training Complete");
         case "victory":
             return qsTr("Victory Secured");
         }
@@ -41,13 +46,18 @@ Item {
         switch (root.outcomeKind) {
         case "campaign":
             return qsTr("Every mission has fallen to your standard.");
+        case "training":
+            return qsTr("You can run an army now. The Barcid Road is waiting.");
         case "victory":
             return qsTr("Enemy command has fallen.");
         }
         return qsTr("Your command has collapsed.");
     }
 
+    property string secondaryAction: root.outcomeKind === "training" ? qsTr("March the Campaign") : ""
+
     signal reportRequested
+    signal secondaryRequested
 
     function reset() {
         root.showingSummary = false;
@@ -90,10 +100,12 @@ Item {
             headline: root.headline
             subtitle: root.subtitle
             primaryAction: root.primaryAction
+            secondaryAction: root.secondaryAction
             onPrimaryActivated: {
                 root.showingSummary = true;
                 root.reportRequested();
             }
+            onSecondaryActivated: root.secondaryRequested()
         }
     }
 

--- a/ui/qml/design/controls/IronSpotlight.qml
+++ b/ui/qml/design/controls/IronSpotlight.qml
@@ -1,0 +1,68 @@
+import QtQuick 2.15
+import ".." as Design
+
+Item {
+    id: root
+
+    property bool active: false
+    property color tone: Design.Theme.focus
+    property real inset: -Design.Metrics.space4
+    property real cornerRadius: Design.Metrics.radiusMedium
+    property bool halo: true
+
+    property Item target: root.parent
+
+    readonly property bool animating: root.active && !Design.A11y.reducedMotion
+
+    anchors.fill: root.target
+    anchors.margins: root.inset
+    visible: root.active
+    z: 40
+
+    Accessible.ignored: true
+
+    property real pulse: 1
+
+    SequentialAnimation on pulse  {
+        running: root.animating
+        loops: Animation.Infinite
+
+        NumberAnimation {
+            from: 1
+            to: 0.35
+            duration: 900
+            easing.type: Easing.InOutQuad
+        }
+
+        NumberAnimation {
+            to: 1
+            duration: 900
+            easing.type: Easing.InOutQuad
+        }
+    }
+
+    onAnimatingChanged: {
+        if (!root.animating)
+            root.pulse = 1;
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: root.cornerRadius + Math.abs(root.inset)
+        color: "transparent"
+        border.width: Design.Metrics.borderFocus
+        border.color: root.tone
+        opacity: root.pulse
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        anchors.margins: -Design.Metrics.space4
+        visible: root.halo && root.animating
+        radius: root.cornerRadius + Math.abs(root.inset) + Design.Metrics.space4
+        color: "transparent"
+        border.width: Design.Metrics.borderThin
+        border.color: root.tone
+        opacity: (1 - root.pulse) * 0.7
+    }
+}

--- a/ui/qml/design/qmldir
+++ b/ui/qml/design/qmldir
@@ -44,6 +44,7 @@ IronResourceCounter 1.0 controls/IronResourceCounter.qml
 IronInspectorSection 1.0 controls/IronInspectorSection.qml
 IronCheckBox 1.0 controls/IronCheckBox.qml
 IronSelectionSummary 1.0 controls/IronSelectionSummary.qml
+IronSpotlight 1.0 controls/IronSpotlight.qml
 
 IronNotification 1.0 overlays/IronNotification.qml
 NotificationHost 1.0 overlays/NotificationHost.qml


### PR DESCRIPTION
…der face

Tutorial steps now point at what they talk about. Each step publishes a focus: the command-grid buttons it names light up via a new IronSpotlight ring, a HUD zone rings itself, and a field target resolves to world positions (units, harvest props, live wave entries) that are ringed on the battlefield and pinned on the minimap, with a Show me button that pans the camera onto them. Focus is recomputed from the observation each frame so it follows what the step still needs and drops once the step is complete.

The commander portrait is reframed as a bust that eases onto the head each frame, and a thread-local bone probe captures the head bone's world transform from the presentation the renderer actually draws. A new CommanderFaceOverlay paints eyes, brows, nose and mouth over the portrait, squashing with the projection and fading through the profile, with the mouth tied to the panel's typewriter and motion disabled under reduced motion. The main menu highlights the tutorial as "Start here" until it is completed.

Also reworks the combat dust shader (tongues, crown and belly shaping, lick variation, soot feed) and adds a WorldFreeze guard that coordinates world rebuilds against the render thread.

Includes tests for focus targeting, the bone probe, the painted face, and the new spotlight component.