### PR TITLE
feat(render): give minimal-LOD creatures a full body instead of a sin…

### DIFF
--- a/render/creature/part_graph.cpp
+++ b/render/creature/part_graph.cpp
@@ -47,7 +47,7 @@ auto submit_part_graph(const SkeletonTopology& topology,
     QMatrix4x4 const& tail_m =
         (tail != k_invalid_bone && tail < palette.size()) ? palette[tail] : anchor_m;
 
-    Render::GL::Mesh* mesh_ptr = primitive_unit_mesh(prim);
+    Render::GL::Mesh* mesh_ptr = primitive_unit_mesh(prim, lod);
     QMatrix4x4 unit_model;
     if (mesh_ptr == nullptr ||
         !primitive_unit_model(prim, anchor_m, tail_m, unit_model)) {

--- a/render/creature/primitive_geometry.cpp
+++ b/render/creature/primitive_geometry.cpp
@@ -53,45 +53,50 @@ auto oriented_span_model(const PrimitiveInstance& prim,
 struct ShapeTraits {
   bool spans_two_bones;
   Render::GL::Mesh* (*unit_mesh)();
+  Render::GL::Mesh* (*minimal_unit_mesh)();
 };
 
 constexpr std::size_t k_shape_count =
     static_cast<std::size_t>(PrimitiveShape::TaperedCylinder) + 1U;
 
 auto shape_traits(PrimitiveShape shape) noexcept -> const ShapeTraits& {
+  static const auto sphere = +[]() {
+    return Render::GL::get_unit_sphere();
+  };
+  static const auto minimal_sphere = +[]() {
+    return Render::GL::get_unit_sphere(k_minimal_latitude_segments,
+                                       k_minimal_radial_segments);
+  };
+  static const auto cylinder = +[]() {
+    return Render::GL::get_unit_cylinder();
+  };
+  static const auto minimal_cylinder = +[]() {
+    return Render::GL::get_unit_cylinder(k_minimal_radial_segments);
+  };
   static const std::array<ShapeTraits, k_shape_count> k_traits{{
-      {false, nullptr},
-      {false,
+      {false, nullptr, nullptr},
+      {false, sphere, minimal_sphere},
+      {true, cylinder, minimal_cylinder},
+      {true,
+       +[]() { return Render::GL::get_unit_capsule(); },
        +[]() {
-         return Render::GL::get_unit_sphere();
+         return Render::GL::get_unit_capsule(k_minimal_radial_segments);
        }},
       {true,
+       +[]() { return Render::GL::get_unit_cone(); },
        +[]() {
-         return Render::GL::get_unit_cylinder();
-       }},
-      {true,
-       +[]() {
-         return Render::GL::get_unit_capsule();
-       }},
-      {true,
-       +[]() {
-         return Render::GL::get_unit_cone();
+         return Render::GL::get_unit_cone(k_minimal_radial_segments);
        }},
       {false,
+       +[]() { return Render::GL::get_unit_cube(); },
        +[]() {
          return Render::GL::get_unit_cube();
        }},
-      {false, nullptr},
-      {false, nullptr},
-      {true,
-       +[]() {
-         return Render::GL::get_unit_cylinder();
-       }},
-      {false,
-       +[]() {
-         return Render::GL::get_unit_sphere();
-       }},
-      {true, nullptr},
+      {false, nullptr, nullptr},
+      {false, nullptr, nullptr},
+      {true, cylinder, minimal_cylinder},
+      {false, sphere, minimal_sphere},
+      {true, nullptr, nullptr},
   }};
   auto const index = static_cast<std::size_t>(shape);
   return index < k_traits.size() ? k_traits[index] : k_traits[0];
@@ -115,19 +120,26 @@ auto bone_world_offset(const QMatrix4x4& bone,
   return origin + x * local_offset.x() + y * local_offset.y() + z * local_offset.z();
 }
 
-auto primitive_unit_mesh(const PrimitiveInstance& prim) noexcept -> Render::GL::Mesh* {
+auto primitive_unit_mesh(const PrimitiveInstance& prim,
+                         CreatureLOD lod) noexcept -> Render::GL::Mesh* {
   if (prim.custom_mesh != nullptr) {
     return prim.custom_mesh;
   }
+
+  const bool minimal = lod == CreatureLOD::Minimal;
 
   if (prim.shape == PrimitiveShape::TaperedCylinder) {
     float const anchor = std::max(prim.params.radius, 1.0e-4F);
     float const tail =
         prim.params.tail_radius > 0.0F ? prim.params.tail_radius : anchor;
-    return Render::GL::get_unit_tapered_cylinder(1.0F, tail / anchor);
+    return Render::GL::get_unit_tapered_cylinder(
+        1.0F,
+        tail / anchor,
+        minimal ? k_minimal_radial_segments : Render::GL::k_default_radial_segments);
   }
 
-  auto const getter = shape_traits(prim.shape).unit_mesh;
+  auto const& traits = shape_traits(prim.shape);
+  auto const getter = minimal ? traits.minimal_unit_mesh : traits.unit_mesh;
   return getter != nullptr ? getter() : nullptr;
 }
 

--- a/render/creature/primitive_geometry.h
+++ b/render/creature/primitive_geometry.h
@@ -17,8 +17,12 @@ namespace Render::Creature {
 bone_world_offset(const QMatrix4x4& bone,
                   const QVector3D& local_offset) noexcept -> QVector3D;
 
+inline constexpr int k_minimal_radial_segments = 8;
+inline constexpr int k_minimal_latitude_segments = 5;
+
 [[nodiscard]] auto
-primitive_unit_mesh(const PrimitiveInstance& prim) noexcept -> Render::GL::Mesh*;
+primitive_unit_mesh(const PrimitiveInstance& prim,
+                    CreatureLOD lod = CreatureLOD::Full) noexcept -> Render::GL::Mesh*;
 
 [[nodiscard]] auto primitive_unit_model(const PrimitiveInstance& prim,
                                         const QMatrix4x4& anchor_bone,

--- a/render/gl/primitives.cpp
+++ b/render/gl/primitives.cpp
@@ -834,29 +834,31 @@ auto get_unit_cube() -> Mesh* {
 }
 
 auto get_unit_sphere(int lat_segments, int lon_segments) -> Mesh* {
-  (void)lat_segments;
-  (void)lon_segments;
+  lat_segments = std::max(lat_segments, 3);
+  lon_segments = std::max(lon_segments, 3);
+  std::uint64_t const variant = (static_cast<std::uint64_t>(lat_segments) << 32U) |
+                                static_cast<std::uint64_t>(lon_segments);
   return SharedGeometryCache::instance().get_or_build(
-      geometry_key("gl/unit_sphere"), [] {
-        return create_unit_sphere_mesh(k_default_latitude_segments,
-                                       k_default_radial_segments);
+      geometry_key("gl/unit_sphere", variant), [lat_segments, lon_segments] {
+        return create_unit_sphere_mesh(lat_segments, lon_segments);
       });
 }
 
 auto get_unit_cone(int radial_segments) -> Mesh* {
-  (void)radial_segments;
-  return SharedGeometryCache::instance().get_or_build(geometry_key("gl/unit_cone"), [] {
-    return create_unit_cone_mesh(k_default_radial_segments);
-  });
+  radial_segments = std::max(radial_segments, 3);
+  return SharedGeometryCache::instance().get_or_build(
+      geometry_key("gl/unit_cone", static_cast<std::uint64_t>(radial_segments)),
+      [radial_segments] { return create_unit_cone_mesh(radial_segments); });
 }
 
 auto get_unit_capsule(int radial_segments, int height_segments) -> Mesh* {
-  (void)radial_segments;
-  (void)height_segments;
+  radial_segments = std::max(radial_segments, 3);
+  height_segments = std::max(height_segments, 1);
+  std::uint64_t const variant = (static_cast<std::uint64_t>(radial_segments) << 32U) |
+                                static_cast<std::uint64_t>(height_segments);
   return SharedGeometryCache::instance().get_or_build(
-      geometry_key("gl/unit_capsule"), [] {
-        return create_capsule_mesh(k_default_radial_segments,
-                                   k_default_capsule_height_segments);
+      geometry_key("gl/unit_capsule", variant), [radial_segments, height_segments] {
+        return create_capsule_mesh(radial_segments, height_segments);
       });
 }
 

--- a/render/humanoid/humanoid_spec.cpp
+++ b/render/humanoid/humanoid_spec.cpp
@@ -48,24 +48,6 @@ void fill_humanoid_role_colors_impl(
   out[ClothDark - 1] = v.palette.cloth * 0.92F;
 }
 
-constexpr auto make_minimal_capsule() noexcept -> Creature::PrimitiveInstance {
-  Creature::PrimitiveInstance p{};
-  p.debug_name = "humanoid_minimal_body";
-  p.shape = Creature::PrimitiveShape::Capsule;
-  p.params.anchor_bone = static_cast<Creature::BoneIndex>(HumanoidBone::Head);
-  p.params.head_offset = QVector3D(0.0F, HP::HEAD_RADIUS, 0.0F);
-  p.params.tail_bone = static_cast<Creature::BoneIndex>(HumanoidBone::FootL);
-  p.params.tail_offset = QVector3D(0.0F, 0.0F, 0.0F);
-  p.params.radius = HP::TORSO_TOP_R;
-  p.color_role = Cloth;
-  p.lod_mask = Creature::k_lod_minimal;
-  return p;
-}
-
-constexpr std::array<Creature::PrimitiveInstance, 1> k_minimal_parts = {
-    make_minimal_capsule(),
-};
-
 constexpr auto bone(HumanoidBone b) noexcept -> Creature::BoneIndex {
   return static_cast<Creature::BoneIndex>(b);
 }
@@ -438,6 +420,80 @@ constexpr auto make_full_foot(bool left) noexcept -> Creature::PrimitiveInstance
   p.lod_mask = Creature::k_lod_full;
   return p;
 }
+
+constexpr auto
+as_minimal(Creature::PrimitiveInstance p) noexcept -> Creature::PrimitiveInstance {
+  p.lod_mask = Creature::k_lod_minimal;
+  return p;
+}
+
+constexpr auto
+make_minimal_upper_arm(bool left) noexcept -> Creature::PrimitiveInstance {
+  return as_minimal(make_limb_end_segment(
+      left ? "humanoid_minimal_upper_arm_l" : "humanoid_minimal_upper_arm_r",
+      left ? HumanoidBone::UpperArmL : HumanoidBone::UpperArmR,
+      left ? HumanoidBone::ForearmL : HumanoidBone::ForearmR,
+      0.0F,
+      HP::UPPER_ARM_R * 1.18F,
+      HP::UPPER_ARM_R * 0.86F,
+      Cloth));
+}
+
+constexpr auto make_minimal_forearm(bool left) noexcept -> Creature::PrimitiveInstance {
+  return as_minimal(make_limb_end_segment(
+      left ? "humanoid_minimal_forearm_l" : "humanoid_minimal_forearm_r",
+      left ? HumanoidBone::ForearmL : HumanoidBone::ForearmR,
+      left ? HumanoidBone::HandL : HumanoidBone::HandR,
+      0.0F,
+      HP::FORE_ARM_R * 1.10F,
+      HP::FORE_ARM_R * 0.80F,
+      Skin));
+}
+
+constexpr auto make_minimal_thigh(bool left) noexcept -> Creature::PrimitiveInstance {
+  return as_minimal(make_limb_end_segment(
+      left ? "humanoid_minimal_thigh_l" : "humanoid_minimal_thigh_r",
+      left ? HumanoidBone::HipL : HumanoidBone::HipR,
+      left ? HumanoidBone::KneeL : HumanoidBone::KneeR,
+      0.0F,
+      HP::UPPER_LEG_R * 1.34F,
+      HP::UPPER_LEG_R * 0.96F,
+      ClothDark));
+}
+
+constexpr auto make_minimal_calf(bool left) noexcept -> Creature::PrimitiveInstance {
+  return as_minimal(make_limb_end_segment(
+      left ? "humanoid_minimal_calf_l" : "humanoid_minimal_calf_r",
+      left ? HumanoidBone::KneeL : HumanoidBone::KneeR,
+      left ? HumanoidBone::FootL : HumanoidBone::FootR,
+      0.0F,
+      HP::LOWER_LEG_R * 1.34F,
+      HP::LOWER_LEG_R * 0.78F,
+      Skin));
+}
+
+constexpr std::array<Creature::PrimitiveInstance, 17> k_minimal_parts = {
+    as_minimal(make_full_chest()),
+    as_minimal(make_full_abdomen()),
+    as_minimal(make_full_pelvis_block()),
+
+    as_minimal(make_full_neck()),
+    as_minimal(make_full_cranium()),
+
+    make_minimal_upper_arm(true),
+    make_minimal_upper_arm(false),
+    make_minimal_forearm(true),
+    make_minimal_forearm(false),
+    as_minimal(make_full_hand(true)),
+    as_minimal(make_full_hand(false)),
+
+    make_minimal_thigh(true),
+    make_minimal_thigh(false),
+    make_minimal_calf(true),
+    make_minimal_calf(false),
+    as_minimal(make_full_foot(true)),
+    as_minimal(make_full_foot(false)),
+};
 
 constexpr std::array<Creature::PrimitiveInstance, 41> k_full_parts = {
 

--- a/render/render_archetype.cpp
+++ b/render/render_archetype.cpp
@@ -239,7 +239,7 @@ void RenderArchetypeBuilder::add_cone(const QVector3D& base,
                                       float alpha,
                                       int material_id,
                                       Material* material) {
-  add_mesh(get_unit_cone(8),
+  add_mesh(get_unit_cone(),
            cylinder_local_model(base, tip, radius),
            color,
            texture,

--- a/render/rigged_mesh_bake.cpp
+++ b/render/rigged_mesh_bake.cpp
@@ -447,7 +447,7 @@ auto bake_rigged_mesh_cpu(const BakeInput& in) -> BakedRiggedMeshCpu {
       if (prim.shape == PrimitiveShape::None) {
         continue;
       }
-      Mesh* unit_mesh = Render::Creature::primitive_unit_mesh(prim);
+      Mesh* unit_mesh = Render::Creature::primitive_unit_mesh(prim, in.lod);
       if (unit_mesh == nullptr) {
         continue;
       }

--- a/render/rigged_mesh_bake.h
+++ b/render/rigged_mesh_bake.h
@@ -22,6 +22,8 @@ struct BakeInput {
   std::span<const BoneWorldMatrix> bind_pose{};
 
   std::span<const StaticAttachmentSpec> attachments{};
+
+  CreatureLOD lod{CreatureLOD::Full};
 };
 
 struct BakedRiggedMeshCpu {

--- a/render/rigged_mesh_cache.cpp
+++ b/render/rigged_mesh_cache.cpp
@@ -155,16 +155,13 @@ auto RiggedMeshCache::get_or_bake_prehashed(
       Render::Creature::Rigged::RiggedMeshRegistry::instance().blob(skin_species_id,
                                                                     lod);
 
-  const bool split_full_mesh = lod == Render::Creature::CreatureLOD::Full;
   const BaseMeshKey base_key{&spec, lod, skin_species_id};
   const AttachmentMeshKey attachment_key{&spec, skin_species_id, attachments_hash};
   const bool base_is_cached = m_base_meshes.find(base_key) != m_base_meshes.end();
   const bool attachments_are_cached =
       attachments.empty() || m_attachment_meshes.contains(attachment_key);
   if (Render::Creature::runtime_bake_forbidden() &&
-      ((split_full_mesh &&
-        ((!base_is_cached && prebaked == nullptr) || !attachments_are_cached)) ||
-       (!split_full_mesh && (prebaked == nullptr || !attachments.empty())))) {
+      ((!base_is_cached && prebaked == nullptr) || !attachments_are_cached)) {
     ++m_frame_stats.misses;
     Render::Creature::report_runtime_bake_violation(
         Render::Creature::RuntimeBakeOperation::RiggedMeshBake,
@@ -177,7 +174,7 @@ auto RiggedMeshCache::get_or_bake_prehashed(
     return nullptr;
   }
 
-  if (split_full_mesh) {
+  {
     auto [base_it, inserted] = m_base_meshes.try_emplace(base_key);
     if (inserted || base_it->second == nullptr) {
       if (prebaked != nullptr) {
@@ -190,14 +187,16 @@ auto RiggedMeshCache::get_or_bake_prehashed(
         Render::Creature::BakeInput input{};
         input.graph = &Render::Creature::part_graph_for(spec, lod);
         input.bind_pose = rest_palette;
+        input.lod = lod;
         base_it->second = std::shared_ptr<RiggedMesh>(
             Render::Creature::bake_rigged_mesh(input).release());
       }
     }
     entry.mesh = base_it->second;
     if (!attachments.empty()) {
-      auto [attachment_it, inserted] = m_attachment_meshes.try_emplace(attachment_key);
-      if (inserted || attachment_it->second == nullptr) {
+      auto [attachment_it, attachment_inserted] =
+          m_attachment_meshes.try_emplace(attachment_key);
+      if (attachment_inserted || attachment_it->second == nullptr) {
         Render::Creature::BakeInput input{};
         input.bind_pose = rest_palette;
         input.attachments = attachments;
@@ -209,20 +208,6 @@ auto RiggedMeshCache::get_or_bake_prehashed(
         entry.attachment_meshes.push_back(attachment_it->second);
       }
     }
-  } else if (prebaked != nullptr && attachments.empty()) {
-    auto const vertices = prebaked->vertices_view();
-    auto const indices = prebaked->indices_view();
-    entry.mesh = std::make_shared<RiggedMesh>(
-        std::vector<RiggedVertex>(vertices.begin(), vertices.end()),
-        std::vector<std::uint32_t>(indices.begin(), indices.end()));
-  } else {
-    Render::Creature::BakeInput input{};
-    input.graph = &Render::Creature::part_graph_for(spec, lod);
-    input.bind_pose = rest_palette;
-    input.attachments = attachments;
-
-    entry.mesh = std::shared_ptr<RiggedMesh>(
-        Render::Creature::bake_rigged_mesh(input).release());
   }
 
   const SkinAtlasKey atlas_key{&spec, skin_species_id};

--- a/render/scene_walk.cpp
+++ b/render/scene_walk.cpp
@@ -809,12 +809,9 @@ auto Renderer::plan_unit_entry(UnitRenderEntry& entry,
     const auto tier = ctx.full_creature_detail ? Render::Pipeline::LodTier::Full
                                                : Render::Pipeline::select_lod(lod_in);
 
-    if (!entry.selected && !entry.hovered && !ctx.full_creature_detail) {
-      if (tier == Render::Pipeline::LodTier::Minimal) {
-        draw_ctx.max_rendered_individuals = 4;
-      } else if (tier == Render::Pipeline::LodTier::Simplified) {
-        draw_ctx.max_rendered_individuals = 8;
-      }
+    if (!entry.selected && !entry.hovered && !ctx.full_creature_detail &&
+        tier == Render::Pipeline::LodTier::Minimal) {
+      draw_ctx.max_rendered_individuals = 8;
     }
 
     if (ctx.full_creature_detail) {

--- a/tests/render/building_archetype_desc_test.cpp
+++ b/tests/render/building_archetype_desc_test.cpp
@@ -106,7 +106,7 @@ TEST(BuildingArchetypeDesc, BuildsPointedConePartsForTimberSilhouettes) {
       build_building_archetype(desc, BuildingState::Normal);
 
   ASSERT_EQ(archetype.lods[0].draws.size(), 1U);
-  EXPECT_EQ(archetype.lods[0].draws[0].mesh, get_unit_cone(8));
+  EXPECT_EQ(archetype.lods[0].draws[0].mesh, get_unit_cone());
 }
 
 TEST(BuildingArchetypeDesc, ArchetypeSetSelectsStateVariant) {

--- a/tests/render/creature/rigged_mesh_asset_test.cpp
+++ b/tests/render/creature/rigged_mesh_asset_test.cpp
@@ -125,6 +125,7 @@ TEST(RiggedMeshAssetTest, BakedBodiesMatchTheirPartGraphs) {
       Render::Creature::BakeInput input{};
       input.graph = &Render::Creature::part_graph_for(item.spec(), lod);
       input.bind_pose = item.bind();
+      input.lod = lod;
       auto const expected = Render::Creature::bake_rigged_mesh_cpu(input);
 
       EXPECT_EQ(blob.vertices_view().size(), expected.vertices.size()) << name;

--- a/tests/render/humanoid/humanoid_spec_test.cpp
+++ b/tests/render/humanoid/humanoid_spec_test.cpp
@@ -3,13 +3,16 @@
 #include <QMatrix4x4>
 #include <QVector3D>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <gtest/gtest.h>
+#include <limits>
 #include <span>
 #include <string_view>
 
 #include "render/creature/pipeline/unit_visual_spec.h"
+#include "render/creature/primitive_geometry.h"
 #include "render/creature/spec.h"
 #include "render/humanoid/humanoid_spec.h"
 #include "render/humanoid/skeleton.h"
@@ -160,6 +163,7 @@ TEST(HumanoidSpecTest, SpecReferenceIsStable) {
 #include "animation/rig/humanoid_proportions.h"
 #include "render/creature/part_graph.h"
 #include "render/geom/transforms.h"
+#include "render/gl/mesh.h"
 #include "render/gl/primitives.h"
 #include "render/humanoid/humanoid_math.h"
 
@@ -252,7 +256,7 @@ auto find_primitive(std::span<const PrimitiveInstance> primitives,
 
 } // namespace
 
-TEST(HumanoidSpecTest, MinimalLodEmitsExactlyOneCapsule) {
+TEST(HumanoidSpecTest, MinimalLodDrawsAWholeBody) {
   CreatureSpec const& s = humanoid_creature_spec();
   HumanoidPose const pose = make_upright_pose();
 
@@ -265,12 +269,43 @@ TEST(HumanoidSpecTest, MinimalLodEmitsExactlyOneCapsule) {
   auto stats = Render::Creature::submit_creature(
       s, palette_view, CreatureLOD::Minimal, identity, sub);
 
-  EXPECT_EQ(stats.submitted, 1U);
   EXPECT_EQ(stats.skipped_invalid, 0U);
-  EXPECT_EQ(sub.parts.size(), 1U);
+  EXPECT_EQ(stats.submitted, s.lod_minimal.primitives.size());
+  EXPECT_EQ(sub.parts.size(), s.lod_minimal.primitives.size());
   EXPECT_EQ(sub.mesh_calls, 0U);
-  ASSERT_FALSE(sub.parts.empty());
-  EXPECT_EQ(sub.parts[0].mesh, Render::GL::get_unit_capsule());
+
+  for (auto const* name : {"humanoid_full_cranium",
+                           "humanoid_full_chest",
+                           "humanoid_full_pelvis_block",
+                           "humanoid_minimal_upper_arm_l",
+                           "humanoid_minimal_upper_arm_r",
+                           "humanoid_minimal_forearm_l",
+                           "humanoid_minimal_forearm_r",
+                           "humanoid_minimal_thigh_l",
+                           "humanoid_minimal_thigh_r",
+                           "humanoid_minimal_calf_l",
+                           "humanoid_minimal_calf_r",
+                           "humanoid_full_foot_l",
+                           "humanoid_full_foot_r"}) {
+    EXPECT_NE(find_primitive(s.lod_minimal.primitives, name), nullptr)
+        << "minimal body is missing " << name;
+  }
+}
+
+TEST(HumanoidSpecTest, MinimalLodIsCheaperThanTheFullBody) {
+  CreatureSpec const& s = humanoid_creature_spec();
+
+  EXPECT_LT(s.lod_minimal.primitives.size(), s.lod_full.primitives.size());
+
+  auto const* chest = find_primitive(s.lod_minimal.primitives, "humanoid_full_chest");
+  ASSERT_NE(chest, nullptr);
+  auto* full_mesh = Render::Creature::primitive_unit_mesh(*chest, CreatureLOD::Full);
+  auto* minimal_mesh =
+      Render::Creature::primitive_unit_mesh(*chest, CreatureLOD::Minimal);
+  ASSERT_NE(full_mesh, nullptr);
+  ASSERT_NE(minimal_mesh, nullptr);
+  EXPECT_NE(full_mesh, minimal_mesh);
+  EXPECT_LT(minimal_mesh->get_indices().size(), full_mesh->get_indices().size());
 }
 
 TEST(HumanoidSpecTest, MinimalLodOtherLodsEmitNothing) {
@@ -496,7 +531,7 @@ TEST(HumanoidSpecTest, SkeletonProportionLayerSeatsSkullCloserToRibCage) {
   EXPECT_LT(after, before - 0.08F);
 }
 
-TEST(HumanoidSpecTest, MinimalLodMatchesLegacyCapsuleEndpointsInUprightPose) {
+TEST(HumanoidSpecTest, MinimalLodSpansHeadToFootInUprightPose) {
   CreatureSpec const& s = humanoid_creature_spec();
   HumanoidPose const pose = make_upright_pose();
 
@@ -508,55 +543,26 @@ TEST(HumanoidSpecTest, MinimalLodMatchesLegacyCapsuleEndpointsInUprightPose) {
   RecordingSubmitter sub;
   Render::Creature::submit_creature(
       s, palette_view, CreatureLOD::Minimal, identity, sub);
-  ASSERT_EQ(sub.parts.size(), 1U);
-  QMatrix4x4 const& v2_model = sub.parts[0].model;
+  ASSERT_FALSE(sub.parts.empty());
 
-  QVector3D const expected_top = pose.head_pos + QVector3D(0.0F, HP::HEAD_RADIUS, 0.0F);
-  QVector3D const expected_bot = pose.foot_l;
-  QMatrix4x4 const expected_model = Render::Geom::capsule_between(
-      identity, expected_top, expected_bot, HP::TORSO_TOP_R);
-
-  const float* a = v2_model.constData();
-  const float* b = expected_model.constData();
-  for (int i = 0; i < 16; ++i) {
-    EXPECT_NEAR(a[i], b[i], 1.0e-4F) << "model[" << i << "] mismatch";
+  float lowest = std::numeric_limits<float>::max();
+  float highest = std::numeric_limits<float>::lowest();
+  float leftmost = std::numeric_limits<float>::max();
+  float rightmost = std::numeric_limits<float>::lowest();
+  for (auto const& part : sub.parts) {
+    for (float const y : {0.5F, -0.5F}) {
+      QVector3D const endpoint = part.model.map(QVector3D(0.0F, y, 0.0F));
+      lowest = std::min(lowest, endpoint.y());
+      highest = std::max(highest, endpoint.y());
+      leftmost = std::min(leftmost, endpoint.x());
+      rightmost = std::max(rightmost, endpoint.x());
+    }
   }
-}
 
-TEST(HumanoidSpecTest, MinimalLodTopEndpointIsHeadCrownInUprightPose) {
-
-  CreatureSpec const& s = humanoid_creature_spec();
-  HumanoidPose const pose = make_upright_pose();
-
-  std::array<QMatrix4x4, k_bone_count> palette;
-  Render::Humanoid::evaluate_skeleton(pose, QVector3D(1.0F, 0.0F, 0.0F), palette);
-  std::span<const QMatrix4x4> const palette_view(palette);
-
-  QMatrix4x4 const identity;
-  RecordingSubmitter sub;
-  Render::Creature::submit_creature(
-      s, palette_view, CreatureLOD::Minimal, identity, sub);
-  ASSERT_EQ(sub.parts.size(), 1U);
-  QMatrix4x4 const& v2_model = sub.parts[0].model;
-
-  QVector3D const ep_a = v2_model.map(QVector3D(0.0F, 0.5F, 0.0F));
-  QVector3D const ep_b = v2_model.map(QVector3D(0.0F, -0.5F, 0.0F));
-  QVector3D const expected_head_crown =
-      pose.head_pos + QVector3D(0.0F, HP::HEAD_RADIUS, 0.0F);
-  QVector3D const expected_foot = pose.foot_l;
-
-  auto near = [](const QVector3D& a, const QVector3D& b) {
-    return (a - b).lengthSquared() < 1.0e-7F;
-  };
-  bool const matched = (near(ep_a, expected_head_crown) && near(ep_b, expected_foot)) ||
-                       (near(ep_b, expected_head_crown) && near(ep_a, expected_foot));
-  EXPECT_TRUE(matched) << "Endpoints (" << ep_a.x() << "," << ep_a.y() << ","
-                       << ep_a.z() << ") and (" << ep_b.x() << "," << ep_b.y() << ","
-                       << ep_b.z() << ") don't cover head_crown=("
-                       << expected_head_crown.x() << "," << expected_head_crown.y()
-                       << "," << expected_head_crown.z() << ") and foot=("
-                       << expected_foot.x() << "," << expected_foot.y() << ","
-                       << expected_foot.z() << ")";
+  EXPECT_LE(lowest, pose.foot_l.y() + 0.05F);
+  EXPECT_GE(highest, pose.head_pos.y() - 0.05F);
+  EXPECT_LE(leftmost, pose.hand_l.x() + 0.05F);
+  EXPECT_GE(rightmost, pose.hand_r.x() - 0.05F);
 }
 
 TEST(HumanoidSpecTest, MinimalLodRespectsWorldFromUnit) {
@@ -572,20 +578,22 @@ TEST(HumanoidSpecTest, MinimalLodRespectsWorldFromUnit) {
   QMatrix4x4 const identity;
   Render::Creature::submit_creature(
       s, palette_view, CreatureLOD::Minimal, identity, base_sub);
-  ASSERT_EQ(base_sub.parts.size(), 1U);
+  ASSERT_FALSE(base_sub.parts.empty());
 
   QMatrix4x4 world;
   world.translate(10.0F, 0.0F, 0.0F);
   RecordingSubmitter moved_sub;
   Render::Creature::submit_creature(
       s, palette_view, CreatureLOD::Minimal, world, moved_sub);
-  ASSERT_EQ(moved_sub.parts.size(), 1U);
+  ASSERT_EQ(moved_sub.parts.size(), base_sub.parts.size());
 
-  for (float const y : {0.5F, -0.5F}) {
-    QVector3D const base = base_sub.parts[0].model.map(QVector3D(0.0F, y, 0.0F));
-    QVector3D const moved = moved_sub.parts[0].model.map(QVector3D(0.0F, y, 0.0F));
-    EXPECT_NEAR(moved.x() - base.x(), 10.0F, 1.0e-4F);
-    EXPECT_NEAR(moved.y() - base.y(), 0.0F, 1.0e-4F);
-    EXPECT_NEAR(moved.z() - base.z(), 0.0F, 1.0e-4F);
+  for (std::size_t i = 0; i < base_sub.parts.size(); ++i) {
+    for (float const y : {0.5F, -0.5F}) {
+      QVector3D const base = base_sub.parts[i].model.map(QVector3D(0.0F, y, 0.0F));
+      QVector3D const moved = moved_sub.parts[i].model.map(QVector3D(0.0F, y, 0.0F));
+      EXPECT_NEAR(moved.x() - base.x(), 10.0F, 1.0e-4F);
+      EXPECT_NEAR(moved.y() - base.y(), 0.0F, 1.0e-4F);
+      EXPECT_NEAR(moved.z() - base.z(), 0.0F, 1.0e-4F);
+    }
   }
 }

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -3557,7 +3557,8 @@ void ArenaViewport::load_scenario(const QString& scenario_id) {
     m_renderer->set_clear_color(0.70F, 0.73F, 0.80F, 1.0F);
   }
   reset_arena();
-  Render::GraphicsSettings::instance().set_quality(definition->graphics_quality);
+  Render::GraphicsSettings::instance().set_quality(
+      m_graphics_quality_override.value_or(definition->graphics_quality));
   m_environment_definition = definition->environment;
   m_environment_hour = definition->environment.start_time;
   if (m_environment_hour_override.has_value()) {

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -87,6 +87,9 @@ public:
 
 public:
   void set_scenario_distance_scale(float scale) { m_scenario_distance_scale = scale; }
+  void set_graphics_quality_override(Render::GraphicsQuality quality) {
+    m_graphics_quality_override = quality;
+  }
 
 public slots:
   void regenerate_terrain();
@@ -380,6 +383,7 @@ private:
   Game::Map::TimeOfDay m_time_of_day = Game::Map::TimeOfDay::Day;
   float m_environment_hour = 13.0F;
   std::optional<float> m_environment_hour_override;
+  std::optional<Render::GraphicsQuality> m_graphics_quality_override;
   QString m_lighting_profile = QStringLiteral("mediterranean_summer");
   Game::Map::EnvironmentDefinition m_environment_definition;
   Game::Map::EnvironmentClock m_environment_clock;

--- a/tools/arena/main.cpp
+++ b/tools/arena/main.cpp
@@ -54,6 +54,24 @@ auto parse_time_of_day(const QString& value) -> std::optional<Game::Map::TimeOfD
   return std::nullopt;
 }
 
+auto parse_graphics_quality(const QString& value)
+    -> std::optional<Render::GraphicsQuality> {
+  const QString normalized = value.trimmed().toLower();
+  if (normalized == QStringLiteral("low")) {
+    return Render::GraphicsQuality::Low;
+  }
+  if (normalized == QStringLiteral("medium")) {
+    return Render::GraphicsQuality::Medium;
+  }
+  if (normalized == QStringLiteral("high")) {
+    return Render::GraphicsQuality::High;
+  }
+  if (normalized == QStringLiteral("ultra")) {
+    return Render::GraphicsQuality::Ultra;
+  }
+  return std::nullopt;
+}
+
 auto graphics_quality_name(Render::GraphicsQuality quality) -> QString {
   switch (quality) {
   case Render::GraphicsQuality::Low:
@@ -269,6 +287,11 @@ auto main(int argc, char** argv) -> int {
       QStringLiteral("Exact decimal environment hour (0-24); overrides "
                      "--time-of-day and any hour a scenario locks."),
       QStringLiteral("hour"));
+  QCommandLineOption const graphics_quality_option(
+      QStringList{QStringLiteral("graphics-quality")},
+      QStringLiteral("Override the scenario's graphics preset: low, medium, high, "
+                     "or ultra."),
+      QStringLiteral("preset"));
   QCommandLineOption const lighting_profile_option(
       QStringList{QStringLiteral("lighting-profile")},
       QStringLiteral("Environment lighting profile."),
@@ -338,6 +361,7 @@ auto main(int argc, char** argv) -> int {
                      seed_option,
                      time_of_day_option,
                      environment_time_option,
+                     graphics_quality_option,
                      lighting_profile_option,
                      artifact_option,
                      capture_interval_option,
@@ -385,6 +409,17 @@ auto main(int argc, char** argv) -> int {
       return 2;
     }
   }
+  std::optional<Render::GraphicsQuality> graphics_quality_override;
+  if (parser.isSet(graphics_quality_option)) {
+    graphics_quality_override =
+        parse_graphics_quality(parser.value(graphics_quality_option));
+    if (!graphics_quality_override.has_value()) {
+      qCritical().noquote() << QStringLiteral(
+          "Invalid --graphics-quality value; expected low, medium, high, or ultra");
+      return 2;
+    }
+  }
+
   const QString lighting_profile = parser.value(lighting_profile_option).trimmed();
 
   const bool include_map_preview_content = parser.isSet(map_preview_content_option);
@@ -406,6 +441,9 @@ auto main(int argc, char** argv) -> int {
     window.viewport()->set_environment_hour_override(environment_hour);
   } else {
     window.viewport()->set_environment_time(environment_hour);
+  }
+  if (graphics_quality_override.has_value()) {
+    window.viewport()->set_graphics_quality_override(*graphics_quality_override);
   }
   window.viewport()->set_terrain_review_content_enabled(include_map_preview_content);
   window.viewport()->set_clean_capture(parser.isSet(clean_capture_option));
@@ -746,7 +784,8 @@ auto main(int argc, char** argv) -> int {
                  watchdog_multiplier,
                  environment_hour,
                  environment_hour_forced,
-                 lighting_profile]() {
+                 lighting_profile,
+                 graphics_quality_override]() {
     if (state->next_index >= state->scenarios.size()) {
       qInfo().noquote()
           << QStringLiteral(
@@ -807,8 +846,11 @@ auto main(int argc, char** argv) -> int {
       QJsonObject const config{
           {QStringLiteral("scenario"), id},
           {QStringLiteral("graphics_quality"),
-           scenario != nullptr ? graphics_quality_name(scenario->graphics_quality)
-                               : QStringLiteral("Unknown")},
+           graphics_quality_override.has_value()
+               ? graphics_quality_name(*graphics_quality_override)
+               : (scenario != nullptr
+                      ? graphics_quality_name(scenario->graphics_quality)
+                      : QStringLiteral("Unknown"))},
           {QStringLiteral("seed"), seed},
           {QStringLiteral("time_of_day"),
            QString::fromLatin1(Game::Map::time_of_day_name(

--- a/tools/bpat_baker/main.cpp
+++ b/tools/bpat_baker/main.cpp
@@ -210,6 +210,7 @@ bool bake_species_manifest(const std::filesystem::path& out_dir,
     Render::Creature::BakeInput body_input{};
     body_input.graph = &Render::Creature::part_graph_for(manifest.creature_spec(), lod);
     body_input.bind_pose = bind_palette;
+    body_input.lod = lod;
     auto const body = Render::Creature::bake_rigged_mesh_cpu(body_input);
     if (body.vertices.empty() || body.indices.empty()) {
       std::cerr << "[bpat_baker] warning: " << manifest.species_name
@@ -239,6 +240,7 @@ bool bake_species_manifest(const std::filesystem::path& out_dir,
   mesh_input.graph = &Render::Creature::part_graph_for(
       manifest.creature_spec(), Render::Creature::CreatureLOD::Minimal);
   mesh_input.bind_pose = bind_palette;
+  mesh_input.lod = Render::Creature::CreatureLOD::Minimal;
   auto source = Render::Creature::bake_rigged_mesh_cpu(mesh_input);
   snapshot::SnapshotMeshWriter snapshot_writer(
       manifest.species_id,


### PR DESCRIPTION
…gle capsule blob

Replace the old Minimal creature LOD, which collapsed the entire humanoid body into one head-to-foot capsule, with a reduced-tessellation version of the actual body: torso, head, both arms, and both legs, built from the same part list as the full-detail body. Fine detail parts that fall under a pixel at LOD viewing distance (pectorals, buttocks, elbows, knees, jaw, brow, nose) are dropped, and paired limb segments that only exist to taper a limb are collapsed into a single span per limb segment. The silhouette and per-part color roles match the full body, so a soldier still reads as a soldier and equipment still sits on a body at range instead of floating around a blob.

The actual triangle savings come from tessellation, not from replacing shapes with stand-ins. primitive_unit_mesh() and the primitive shape table now carry a minimal-tessellation mesh getter alongside the full one, and get_unit_sphere/get_unit_cone/get_unit_capsule in render/gl/primitives.cpp now honor their segment-count arguments (they were previously ignored, always returning the default-tessellation cached mesh regardless of what was requested) and key their shared geometry cache entries on segment count so different tessellations of the same primitive coexist in the cache. BakeInput gains an explicit lod field so CPU baking and the rigged mesh cache bake bodies at the tessellation that matches the LOD being baked, and RiggedMeshCache::get_or_bake_prehashed drops its separate non-split code path for the Minimal tier now that both LODs share the same base-mesh-plus-attachments caching scheme.

Since the minimal body no longer reads as a featureless blob, scene_walk's formation-thinning (which reduces how many individual soldiers in a large formation get rendered) is scoped down to only fire at the coarser Simplified/Minimal distance tier reserved for very distant or very large formations, rather than also thinning formations at the nearer tier where players are more likely to notice bodies disappearing and mistake it for casualties.

Also thread a --graphics-quality CLI override through the arena preview tool (tools/arena) so a scenario's preset can be overridden without editing scenario definitions, which is what was used to compare the LOD tiers side by side while iterating on this change. Updated the humanoid spec, rigged mesh asset, and building archetype tests to match, and ran `make format` on the full tree.