### PR TITLE
fix(audio,render): close resource unload/reload races, unblock prebak…

### DIFF
--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -277,6 +277,7 @@ void GameEngine::cleanup_opengl_resources() {
 
   m_renderer.reset();
   m_resources.reset();
+  m_runtime.initialized = false;
 
   qInfo() << "OpenGL resources cleaned up";
 }
@@ -432,6 +433,9 @@ auto GameEngine::global_cursor_y() const -> qreal {
 }
 
 void GameEngine::ensure_initialized() {
+  if (!m_renderer || (m_camera == nullptr)) {
+    return;
+  }
   const bool was_initialized = m_runtime.initialized;
   QString error;
   App::Core::WorldBootstrap::ensure_initialized(m_runtime.initialized,

--- a/assets/shaders/terrain_field_bake.frag
+++ b/assets/shaders/terrain_field_bake.frag
@@ -1,4 +1,5 @@
 #version 330 core
+#include "noise.glsl"
 #include "terrain_noise.glsl"
 
 in vec2 v_uv;

--- a/game/audio/audio_system.cpp
+++ b/game/audio/audio_system.cpp
@@ -228,6 +228,7 @@ auto AudioSystem::load_sound(const std::string& sound_id,
                              const AudioResourceConfig& config) -> bool {
   std::lock_guard<std::mutex> const lock(resource_mutex);
   if (sounds.find(sound_id) != sounds.end()) {
+    cancel_pending_unload_locked(sound_id);
     return true;
   }
 
@@ -241,6 +242,7 @@ auto AudioSystem::load_sound(const std::string& sound_id,
 
   sounds[sound_id] = std::move(sound);
   resource_configs[sound_id] = config;
+  cancel_pending_unload_locked(sound_id);
   active_resources.insert(sound_id);
   return true;
 }
@@ -259,6 +261,7 @@ auto AudioSystem::load_music(const std::string& music_id,
   AudioResourceConfig music_config = config;
   music_config.category = AudioCategory::MUSIC;
   resource_configs[music_id] = music_config;
+  cancel_pending_unload_locked(music_id);
   active_resources.insert(music_id);
   return true;
 }
@@ -277,16 +280,40 @@ void AudioSystem::register_alias(const std::string& alias_id,
 auto AudioSystem::has_resource(const std::string& resource_id) const -> bool {
   std::lock_guard<std::mutex> const lock(resource_mutex);
   const std::string resolved_id = resolve_resource_id_locked(resource_id);
+  if (pending_unloads.find(resolved_id) != pending_unloads.end()) {
+    return false;
+  }
   return sounds.find(resolved_id) != sounds.end() ||
          resource_configs.find(resolved_id) != resource_configs.end();
 }
 
 void AudioSystem::unload_sound(const std::string& sound_id) {
-  enqueue(AudioEvent(AudioEventType::UNLOAD_RESOURCE, sound_id));
+  enqueue_unload(sound_id);
 }
 
 void AudioSystem::unload_music(const std::string& music_id) {
-  enqueue(AudioEvent(AudioEventType::UNLOAD_RESOURCE, music_id));
+  enqueue_unload(music_id);
+}
+
+void AudioSystem::enqueue_unload(const std::string& resource_id) {
+  AudioEvent event(AudioEventType::UNLOAD_RESOURCE, resource_id);
+  {
+    std::lock_guard<std::mutex> const lock(resource_mutex);
+    event.load_serial = current_load_serial_locked(resource_id);
+    pending_unloads.insert(resolve_resource_id_locked(resource_id));
+  }
+  enqueue(std::move(event));
+}
+
+void AudioSystem::cancel_pending_unload_locked(const std::string& resource_id) {
+  ++resource_load_serials[resource_id];
+  pending_unloads.erase(resource_id);
+}
+
+auto AudioSystem::current_load_serial_locked(const std::string& resource_id) const
+    -> std::uint64_t {
+  const auto it = resource_load_serials.find(resolve_resource_id_locked(resource_id));
+  return it == resource_load_serials.end() ? 0U : it->second;
 }
 
 void AudioSystem::unload_all_sounds() {
@@ -300,7 +327,7 @@ void AudioSystem::unload_all_sounds() {
   }
 
   for (const auto& sound_id : sound_resources) {
-    enqueue(AudioEvent(AudioEventType::UNLOAD_RESOURCE, sound_id));
+    enqueue_unload(sound_id);
   }
 }
 
@@ -316,7 +343,7 @@ void AudioSystem::unload_all_music() {
   }
 
   for (const auto& music_id : music_resources) {
-    enqueue(AudioEvent(AudioEventType::UNLOAD_RESOURCE, music_id));
+    enqueue_unload(music_id);
   }
 }
 
@@ -472,6 +499,9 @@ void AudioSystem::process_event(const AudioEvent& event) {
   case AudioEventType::UNLOAD_RESOURCE: {
     std::lock_guard<std::mutex> const lock(resource_mutex);
     const std::string resource_id = resolve_resource_id_locked(event.resource_id);
+    if (current_load_serial_locked(resource_id) != event.load_serial) {
+      break;
+    }
     const AudioResourceConfig config = get_resource_config_locked(resource_id);
     auto sound_it = sounds.find(resource_id);
     if (sound_it != sounds.end()) {
@@ -500,6 +530,8 @@ void AudioSystem::process_event(const AudioEvent& event) {
     }
 
     resource_configs.erase(resource_id);
+    resource_load_serials.erase(resource_id);
+    pending_unloads.erase(resource_id);
     resource_last_played_at.erase(resource_id);
     active_resources.erase(resource_id);
 

--- a/game/audio/audio_system.h
+++ b/game/audio/audio_system.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -58,6 +59,7 @@ struct AudioEvent {
   int priority = AudioConstants::DEFAULT_PRIORITY;
   AudioCategory category = AudioCategory::SFX;
   bool crossfade = false;
+  std::uint64_t load_serial = 0;
 
   AudioEvent(AudioEventType t,
              std::string id = "",
@@ -138,6 +140,10 @@ private:
   void process_event(const AudioEvent& event);
   void enqueue(AudioEvent&& event);
   void cleanup_inactive_sounds_locked();
+  void enqueue_unload(const std::string& resource_id);
+  void cancel_pending_unload_locked(const std::string& resource_id);
+  auto
+  current_load_serial_locked(const std::string& resource_id) const -> std::uint64_t;
   auto resolve_resource_id_locked(const std::string& resource_id) const -> std::string;
   auto should_accept_sound_locked(int priority) -> bool;
   auto get_active_instance_count_locked(const std::string& resource_id) const -> size_t;
@@ -155,6 +161,8 @@ private:
 
   std::unordered_map<std::string, std::unique_ptr<Sound>> sounds;
   std::unordered_map<std::string, AudioResourceConfig> resource_configs;
+  std::unordered_map<std::string, std::uint64_t> resource_load_serials;
+  std::unordered_set<std::string> pending_unloads;
   std::unordered_map<std::string, std::string> resource_aliases;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point>
       resource_last_played_at;

--- a/game/audio/miniaudio_backend.cpp
+++ b/game/audio/miniaudio_backend.cpp
@@ -357,6 +357,15 @@ auto MiniaudioBackend::is_track_ready(const QString& id) const -> bool {
   return slot >= 0 && m_track_table[slot].load(std::memory_order_acquire) != nullptr;
 }
 
+auto MiniaudioBackend::is_track_decode_pending(const QString& id) const -> bool {
+  const int slot = find_track_slot(id);
+  if (slot < 0) {
+    return false;
+  }
+  QMutexLocker const locker(&m_decode_mutex);
+  return m_pending_slots.contains(slot);
+}
+
 auto MiniaudioBackend::decode_into_slot(const DecodeJob& job) -> bool {
   QFile file(job.path);
   if (!file.open(QIODevice::ReadOnly)) {
@@ -646,7 +655,11 @@ auto MiniaudioBackend::channel_playing(int channel) const -> bool {
 void MiniaudioBackend::play_sound(const QString& id, float volume, bool loop) {
   const int slot = find_track_slot(id);
   if (slot < 0 || m_track_table[slot].load(std::memory_order_acquire) == nullptr) {
-    qWarning() << "MiniaudioBackend: Sound not ready:" << id;
+    if (is_track_decode_pending(id)) {
+      qDebug() << "MiniaudioBackend: Sound still decoding, skipping play:" << id;
+    } else {
+      qWarning() << "MiniaudioBackend: Sound not ready:" << id;
+    }
     return;
   }
   Game::Audio::AudioCommand command;

--- a/game/audio/miniaudio_backend.h
+++ b/game/audio/miniaudio_backend.h
@@ -70,6 +70,7 @@ public:
   auto is_sound_active(const QString& id) const -> bool;
 
   auto is_track_ready(const QString& id) const -> bool;
+  auto is_track_decode_pending(const QString& id) const -> bool;
 
   void on_audio(float* output, unsigned frames);
 

--- a/game/audio/music_player.cpp
+++ b/game/audio/music_player.cpp
@@ -96,7 +96,10 @@ void MusicPlayer::shutdown() {
     m_backend->deleteLater();
     m_backend = nullptr;
   }
-  m_tracks.clear();
+  {
+    std::lock_guard<std::mutex> const lock(m_tracks_mutex);
+    m_tracks.clear();
+  }
   m_channel_count = 0;
   m_current_music_channel = -1;
   m_initialized = false;
@@ -104,48 +107,36 @@ void MusicPlayer::shutdown() {
 
 void MusicPlayer::register_track(const std::string& track_id,
                                  const std::string& file_path) {
-
-  if ((QCoreApplication::instance() != nullptr) &&
-      QThread::currentThread() != QCoreApplication::instance()->thread()) {
-    QMetaObject::invokeMethod(
-        this,
-        [this, track_id, file_path]() { register_track(track_id, file_path); },
-        Qt::QueuedConnection);
-    return;
-  }
-  ensure_on_gui_thread("MusicPlayer::register_track");
-
   QFileInfo const fi(QString::fromStdString(file_path));
   if (!fi.exists()) {
     qWarning() << "MusicPlayer: Missing asset" << QString::fromStdString(track_id)
                << "->" << fi.absoluteFilePath();
     return;
   }
-  m_tracks[track_id] = fi.absoluteFilePath();
 
-  if (m_backend != nullptr &&
-      !m_backend->request_track(QString::fromStdString(track_id),
-                                fi.absoluteFilePath(),
-                                Game::Audio::Mastering::Material::Music)) {
+  MiniaudioBackend* const backend = m_backend.data();
+  if (backend != nullptr &&
+      !backend->request_track(QString::fromStdString(track_id),
+                              fi.absoluteFilePath(),
+                              Game::Audio::Mastering::Material::Music)) {
     qWarning() << "MusicPlayer: could not register" << fi.absoluteFilePath();
-    m_tracks.erase(track_id);
+    return;
   }
+
+  std::lock_guard<std::mutex> const lock(m_tracks_mutex);
+  m_tracks[track_id] = fi.absoluteFilePath();
 }
 
 void MusicPlayer::unregister_track(const std::string& track_id) {
-  if ((QCoreApplication::instance() != nullptr) &&
-      QThread::currentThread() != QCoreApplication::instance()->thread()) {
-    QMetaObject::invokeMethod(
-        this, [this, track_id]() { unregister_track(track_id); }, Qt::QueuedConnection);
-    return;
+  {
+    std::lock_guard<std::mutex> const lock(m_tracks_mutex);
+    if (m_tracks.erase(track_id) == 0) {
+      return;
+    }
   }
-  ensure_on_gui_thread("MusicPlayer::unregister_track");
-
-  if (m_tracks.erase(track_id) == 0) {
-    return;
-  }
-  if (m_backend != nullptr) {
-    m_backend->unload(QString::fromStdString(track_id));
+  MiniaudioBackend* const backend = m_backend.data();
+  if (backend != nullptr) {
+    backend->unload(QString::fromStdString(track_id));
   }
 }
 
@@ -379,10 +370,12 @@ void MusicPlayer::play_gui(
   if (m_backend == nullptr) {
     return;
   }
-  auto it = m_tracks.find(id);
-  if (it == m_tracks.end()) {
-    qWarning() << "Unknown track_id:" << QString::fromStdString(id);
-    return;
+  {
+    std::lock_guard<std::mutex> const lock(m_tracks_mutex);
+    if (m_tracks.find(id) == m_tracks.end()) {
+      qWarning() << "Unknown track_id:" << QString::fromStdString(id);
+      return;
+    }
   }
   m_backend->play(ch, QString::fromStdString(id), vol, loop, fade_ms);
 }

--- a/game/audio/music_player.h
+++ b/game/audio/music_player.h
@@ -5,6 +5,7 @@
 #include <QThread>
 #include <QVector>
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -73,6 +74,7 @@ private:
   auto find_free_channel_excluding(int excluded_channel) const -> int;
 
   QPointer<MiniaudioBackend> m_backend;
+  mutable std::mutex m_tracks_mutex;
   std::unordered_map<std::string, QString> m_tracks;
   int m_channel_count{0};
   int m_default_channel{0};

--- a/main.cpp
+++ b/main.cpp
@@ -547,7 +547,10 @@ auto main(int argc, char* argv[]) -> int {
             fprintf(out,
                     "[CRITICAL] Do not use QT_QUICK_BACKEND=software; the game "
                     "requires Qt Quick's OpenGL backend\n");
-          } else {
+          } else if (msg.contains("OpenGL", Qt::CaseInsensitive) ||
+                     msg.contains("scene graph", Qt::CaseInsensitive) ||
+                     msg.contains("RHI", Qt::CaseInsensitive) ||
+                     msg.contains("graphics", Qt::CaseInsensitive)) {
             fprintf(out,
                     "[CRITICAL] Try running with software OpenGL if this persists\n");
           }

--- a/render/creature/runtime_bake_guard.cpp
+++ b/render/creature/runtime_bake_guard.cpp
@@ -36,8 +36,6 @@ auto runtime_bake_operation_name(RuntimeBakeOperation operation) -> std::string_
     return "rigged_mesh_bake";
   case RuntimeBakeOperation::SnapshotMeshBake:
     return "snapshot_mesh_bake";
-  case RuntimeBakeOperation::SnapshotMeshLoad:
-    return "snapshot_mesh_load";
   case RuntimeBakeOperation::SkinUboUpload:
     return "skin_ubo_upload";
   case RuntimeBakeOperation::CreatureSubmitMiss:

--- a/render/creature/runtime_bake_guard.h
+++ b/render/creature/runtime_bake_guard.h
@@ -10,7 +10,6 @@ namespace Render::Creature {
 enum class RuntimeBakeOperation : std::uint8_t {
   RiggedMeshBake,
   SnapshotMeshBake,
-  SnapshotMeshLoad,
   SkinUboUpload,
   CreatureSubmitMiss,
   StaticArchetypeBuild

--- a/render/gl/mesh.cpp
+++ b/render/gl/mesh.cpp
@@ -61,6 +61,14 @@ void Mesh::setup_buffers() {
     return;
   }
   initializeOpenGLFunctions();
+  bool reported_stale = false;
+  for (GLenum stale = glGetError(); stale != GL_NO_ERROR; stale = glGetError()) {
+    if (!reported_stale) {
+      reported_stale = true;
+      qWarning() << "Mesh::setup_buffers inherited GL error" << stale
+                 << "from an earlier call";
+    }
+  }
   m_vao = std::make_unique<VertexArray>();
   m_vbo = std::make_unique<Buffer>(Buffer::Type::Vertex);
   m_ebo = std::make_unique<Buffer>(Buffer::Type::Index);

--- a/render/snapshot_mesh_cache.cpp
+++ b/render/snapshot_mesh_cache.cpp
@@ -130,13 +130,6 @@ auto SnapshotMeshCache::get_or_load(
     ++m_frame_stats.hits;
     return &it->second;
   }
-  if (Render::Creature::runtime_bake_forbidden()) {
-    ++m_frame_stats.misses;
-    Render::Creature::report_runtime_bake_violation(
-        Render::Creature::RuntimeBakeOperation::SnapshotMeshLoad,
-        describe_snapshot_key(key, global_frame));
-    return nullptr;
-  }
 
   const auto vertices = source.frame_vertices_view(global_frame);
   const auto indices = source.indices_view();

--- a/tests/render/creature/snapshot_mesh_cache_test.cpp
+++ b/tests/render/creature/snapshot_mesh_cache_test.cpp
@@ -3,14 +3,18 @@
 #include <QMatrix4x4>
 #include <QVector3D>
 
+#include <array>
 #include <gtest/gtest.h>
 #include <memory>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include "render/bone_palette_arena.h"
 #include "render/creature/pipeline/creature_asset.h"
 #include "render/creature/render_request.h"
 #include "render/creature/runtime_bake_guard.h"
+#include "render/creature/snapshot_mesh_asset.h"
 #include "render/rigged_mesh.h"
 #include "render/rigged_mesh_cache.h"
 #include "render/snapshot_mesh_cache.h"
@@ -68,6 +72,34 @@ auto make_two_bone_quad_entry() -> std::unique_ptr<RiggedMeshEntry> {
   entry->skin_atlas->palettes = palettes;
 
   return entry;
+}
+
+auto make_prebaked_blob() -> Render::Creature::Snapshot::SnapshotMeshBlob {
+  const std::array<std::uint32_t, 3> indices{0U, 1U, 2U};
+  Render::Creature::Snapshot::SnapshotMeshWriter writer(
+      Render::Creature::Bpat::k_species_sheep,
+      Render::Creature::CreatureLOD::Minimal,
+      3U,
+      indices);
+  writer.add_clip(Render::Creature::Snapshot::ClipDescriptor{"idle", 2U});
+
+  std::vector<RiggedVertex> frame(3);
+  for (std::uint32_t frame_index = 0; frame_index < 2U; ++frame_index) {
+    for (std::size_t vertex = 0; vertex < frame.size(); ++vertex) {
+      frame[vertex].position_bone_local = {
+          static_cast<float>(vertex), static_cast<float>(frame_index), 0.0F};
+      frame[vertex].normal_bone_local = {0.0F, 1.0F, 0.0F};
+      frame[vertex].bone_indices = {0, 0, 0, 0};
+      frame[vertex].bone_weights = {1.0F, 0.0F, 0.0F, 0.0F};
+    }
+    writer.append_clip_vertices(frame);
+  }
+
+  std::stringstream stream(std::ios::out | std::ios::binary | std::ios::in);
+  EXPECT_TRUE(writer.write(stream));
+  const std::string bytes = stream.str();
+  return Render::Creature::Snapshot::SnapshotMeshBlob::from_bytes(
+      std::vector<std::uint8_t>(bytes.begin(), bytes.end()));
 }
 
 TEST(SnapshotMeshCache, IdentityPaletteIsAllIdentity) {
@@ -276,6 +308,29 @@ TEST(SnapshotMeshCache, RuntimeBakeGuardAllowsHitsButRejectsMisses) {
   missing.frame_in_clip = 1U;
   EXPECT_EQ(cache.get_or_bake(missing, *source, 1U), nullptr)
       << "warmed gameplay must not bake a missing snapshot mesh";
+  EXPECT_EQ(cache.size(), 1U);
+}
+
+TEST(SnapshotMeshCache, PrebakedFramesLoadWhileRuntimeBakesAreForbidden) {
+  RuntimeBakeGuardReset guard_reset;
+  auto blob = make_prebaked_blob();
+  ASSERT_TRUE(blob.loaded()) << blob.last_error();
+
+  SnapshotMeshCache cache;
+  Render::Creature::set_runtime_bake_forbidden(true);
+
+  SnapshotMeshCache::Key key{};
+  key.frame_in_clip = 1U;
+  const auto* snap = cache.get_or_load(key, blob, 1U);
+  ASSERT_NE(snap, nullptr)
+      << "a prebaked snapshot frame is uploaded, not baked, so gameplay must "
+         "still be able to draw it";
+  ASSERT_NE(snap->mesh, nullptr);
+  EXPECT_EQ(snap->mesh->index_count(), 3U);
+  EXPECT_EQ(cache.frame_stats().loads, 1U);
+
+  EXPECT_EQ(cache.get_or_load(key, blob, 1U), snap);
+  EXPECT_EQ(cache.frame_stats().hits, 1U);
   EXPECT_EQ(cache.size(), 1U);
 }
 

--- a/ui/gl_view.cpp
+++ b/ui/gl_view.cpp
@@ -192,6 +192,7 @@ GLView::GLRenderer::GLRenderer(QPointer<GLView> view, QPointer<GameEngine> engin
 GLView::GLRenderer::~GLRenderer() {
   if (m_engine != nullptr) {
     m_engine->stop_simulation_thread();
+    m_engine->cleanup_opengl_resources();
   }
   if (m_continuity_probe != nullptr) {
     Render::Profiling::CombatAnimationDiagnostics::instance().set_enabled(false);


### PR DESCRIPTION
…ed snapshot loads, and guard renderer teardown

Audio system: unload_sound/unload_music enqueue a deferred UNLOAD_RESOURCE event, but if the same resource was reloaded before the queued unload drained, the stale event would tear down the freshly loaded resource out from under active playback. Every resource now carries a monotonically increasing load_serial; load_sound/load_music bump it and clear the resource's pending-unload marker, enqueue_unload snapshots the serial at enqueue time, and process_event's UNLOAD_RESOURCE handler only proceeds if the serial it captured still matches the resource's current serial, otherwise it's a no-op because a newer load has already superseded it. has_resource now also treats a resource with a pending unload as absent so callers don't get a false positive between the unload request and the worker thread actually processing it.

MiniaudioBackend::play_sound previously logged every not-yet-uploaded sound as "Sound not ready", which was indistinguishable from a genuinely missing/failed asset. It now checks is_track_decode_pending first and logs those as a quieter, expected "still decoding" debug message, keeping the warning reserved for tracks that are actually missing.

MusicPlayer::register_track/unregister_track used to marshal themselves onto the Qt GUI thread via QMetaObject::invokeMethod before touching m_tracks, which meant a caller on a worker thread would get silently deferred and couldn't rely on the call having completed synchronously. m_tracks is now protected by its own mutex (m_tracks_mutex) instead, so register_track, unregister_track, and play_gui can all touch the track map directly from whatever thread calls them without a thread hop, while requests to the backend itself still happen without holding that lock.

Render: SnapshotMeshCache::get_or_load rejected cache misses while runtime baking was forbidden by reporting a SnapshotMeshLoad violation, but that also blocked legitimately prebaked (pre-baked-and-shipped) snapshot mesh frames from being uploaded to the GPU on first use, since an upload is not a bake. The forbidden-bake check and the RuntimeBakeOperation::SnapshotMeshLoad enum value/name are removed so a prebaked blob can still be loaded and cached on a cache miss even when runtime baking is locked down; a new test (PrebakedFramesLoadWhileRuntimeBakesAreForbidden) builds a small two-frame prebaked blob, forbids runtime bakes, and asserts the frame still loads, caches, and hits on the second lookup.

Mesh::setup_buffers now drains and reports any GL error that was already pending when it starts, so an error inherited from an earlier unrelated GL call doesn't get silently attributed to buffer setup.

GameEngine::ensure_initialized now bails out early if the renderer or camera isn't present yet instead of proceeding into WorldBootstrap initialization with a null dependency, and cleanup_opengl_resources resets m_runtime.initialized so a subsequent re-init attempt doesn't think the world is still initialized after the GL resources backing it were torn down. GLView::GLRenderer's destructor now calls
engine->cleanup_opengl_resources() after stopping the simulation thread so GL objects are released deterministically during renderer teardown instead of relying on later destruction order.

main.cpp narrows the "[CRITICAL] Try running with software OpenGL if this persists" hint to only fire for messages that actually mention OpenGL, scene graph, RHI, or graphics, instead of appending it to every Qt warning that isn't the QT_QUICK_BACKEND=software case.

terrain_field_bake.frag adds the missing #include "noise.glsl" that terrain_noise.glsl depends on.