### PR TITLE
fix(render): keep selection rings under running soldiers (#1291)

### DIFF
--- a/render/entity/commander_aura_renderer.cpp
+++ b/render/entity/commander_aura_renderer.cpp
@@ -2,10 +2,13 @@
 
 #include <algorithm>
 #include <cmath>
+#include <span>
 
 #include "game/core/component.h"
 #include "game/core/world.h"
 #include "game/systems/nation_id.h"
+#include "render/humanoid/cache_control.h"
+#include "render/humanoid/pose_cache_components.h"
 #include "render/scene_renderer.h"
 #include "render/selection_ring_layout.h"
 
@@ -131,12 +134,19 @@ void render_commander_auras(Renderer* renderer,
     }
     const float footprint = std::max(transform->scale.x, transform->scale.z);
     const float glow_radius = std::clamp(0.72F + footprint * 0.35F, 0.78F, 1.15F);
+    std::span<const Render::Humanoid::SoldierTurnSmoothingState> soldier_anchors;
+    if (auto const* layout_cache =
+            entity->get_component<Render::Humanoid::HumanoidLayoutCacheComponent>()) {
+      soldier_anchors = layout_cache->turn_states;
+    }
     const auto placements = build_selection_ring_layout(
         {.soldiers = soldiers,
          .ring_size = glow_radius,
          .position = QVector3D(
              transform->position.x, transform->position.y, transform->position.z),
-         .yaw_degrees = transform->rotation.y});
+         .yaw_degrees = transform->rotation.y,
+         .soldier_anchors = soldier_anchors,
+         .anchor_frame = humanoid_current_frame() + 1U});
     for (auto const& placement : placements) {
       renderer->healer_aura(QVector3D(placement.world_x,
                                       transform->position.y + 0.35F,

--- a/render/humanoid/prepare_submission.cpp
+++ b/render/humanoid/prepare_submission.cpp
@@ -543,7 +543,20 @@ void prepare_humanoid_instances(const HumanoidRendererBase& owner,
     turn_cache.turn_time = anim.time;
     turn_cache.turn_time_valid = true;
     float const unit_speed = unit_comp != nullptr ? unit_comp->speed : 2.0F;
-    turn_smoothing_cap = std::max(1.6F, unit_speed * 1.25F);
+
+    float travel_speed = unit_speed;
+    if (Render::Creature::is_running_animation(anim.movement_state)) {
+      travel_speed =
+          std::max(travel_speed,
+                   unit_speed * Engine::Core::StaminaComponent::k_run_speed_multiplier);
+    }
+    if (ctx.entity != nullptr) {
+      if (const auto* motion =
+              ctx.entity->get_component<Engine::Core::MotionPresentationComponent>()) {
+        travel_speed = std::max(travel_speed, motion->speed);
+      }
+    }
+    turn_smoothing_cap = soldier_catch_up_speed(travel_speed);
     bool const combat_active =
         anim.is_attacking || formation_fight_active || anim.is_in_melee_lock;
     if (combat_active) {
@@ -666,6 +679,8 @@ void prepare_humanoid_instances(const HumanoidRendererBase& owner,
       smoothing_inputs.max_speed = turn_smoothing_cap * cap_jitter;
       smoothing_inputs.turn_rate_degrees = is_mounted_spawn ? 240.0F : 540.0F;
       smoothing_inputs.allow_travel_yaw = turn_smoothing_travel_yaw;
+
+      smoothing_inputs.frame_index = frame_index + 1U;
       turn_smoothing = resolve_soldier_turn_smoothing(
           layout_cache_comp->turn_states[static_cast<std::size_t>(idx)],
           smoothing_inputs);

--- a/render/humanoid/soldier_turn_smoothing.cpp
+++ b/render/humanoid/soldier_turn_smoothing.cpp
@@ -30,6 +30,7 @@ auto resolve_soldier_turn_smoothing(SoldierTurnSmoothingState& state,
                                     const SoldierTurnSmoothingInputs& inputs)
     -> SoldierTurnSmoothingResult {
   SoldierTurnSmoothingResult result{};
+  state.updated_frame = inputs.frame_index;
 
   float const to_target_x = inputs.target_x - state.world_x;
   float const to_target_z = inputs.target_z - state.world_z;

--- a/render/humanoid/soldier_turn_smoothing.h
+++ b/render/humanoid/soldier_turn_smoothing.h
@@ -1,11 +1,23 @@
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+
 namespace Render::Humanoid {
+
+constexpr float k_soldier_catch_up_margin = 1.25F;
+constexpr float k_soldier_catch_up_floor = 1.6F;
+
+[[nodiscard]] constexpr auto soldier_catch_up_speed(float travel_speed) -> float {
+  return std::max(k_soldier_catch_up_floor, travel_speed * k_soldier_catch_up_margin);
+}
 
 struct SoldierTurnSmoothingState {
   float world_x{0.0F};
   float world_z{0.0F};
   float body_yaw_degrees{0.0F};
+
+  std::uint32_t updated_frame{0U};
   bool valid{false};
   bool relocating{false};
 };
@@ -30,6 +42,8 @@ struct SoldierTurnSmoothingInputs {
   float relocate_distance{0.30F};
 
   bool allow_travel_yaw{true};
+
+  std::uint32_t frame_index{0U};
 };
 
 struct SoldierTurnSmoothingResult {

--- a/render/scene_walk.cpp
+++ b/render/scene_walk.cpp
@@ -374,12 +374,23 @@ void Renderer::enqueue_selection_ring(Engine::Core::Entity* entity,
         soldiers = formation_presentation->soldiers;
       }
 
+      auto const* layout_cache =
+          entity != nullptr
+              ? entity->get_component<Render::Humanoid::HumanoidLayoutCacheComponent>()
+              : nullptr;
+      std::span<const Render::Humanoid::SoldierTurnSmoothingState> soldier_anchors;
+      if (layout_cache != nullptr) {
+        soldier_anchors = layout_cache->turn_states;
+      }
+
       placements = build_selection_ring_layout(
           {.soldiers = soldiers,
            .ring_size = ring_size,
            .position = QVector3D(
                transform->position.x, transform->position.y, transform->position.z),
-           .yaw_degrees = transform->rotation.y});
+           .yaw_degrees = transform->rotation.y,
+           .soldier_anchors = soldier_anchors,
+           .anchor_frame = humanoid_current_frame() + 1U});
     } else {
 
       ring_size = config.get_selection_ring_size(unit_comp->spawn_type);

--- a/render/selection_ring_layout.h
+++ b/render/selection_ring_layout.h
@@ -4,12 +4,15 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <numbers>
 #include <span>
 #include <vector>
 
 #include "game/core/component.h"
 #include "game/units/spawn_type.h"
+#include "humanoid/soldier_turn_smoothing.h"
 #include "humanoid/unit_layout_spacing.h"
 
 namespace Render::GL {
@@ -20,6 +23,10 @@ struct SelectionRingLayoutInput {
   float ring_size{0.5F};
   QVector3D position{0.0F, 0.0F, 0.0F};
   float yaw_degrees{0.0F};
+
+  std::span<const Render::Humanoid::SoldierTurnSmoothingState> soldier_anchors{};
+
+  std::uint32_t anchor_frame{0U};
 };
 
 struct SelectionRingPlacement {
@@ -50,6 +57,20 @@ selection_ring_visual_size(const Game::Units::TroopConfig& config,
   return std::min(unit_ring_size * 0.25F, max_visual_size);
 }
 
+[[nodiscard]] inline auto anchor_for_soldier(const SelectionRingLayoutInput& input,
+                                             std::uint16_t slot_index)
+    -> const Render::Humanoid::SoldierTurnSmoothingState* {
+  if (input.anchor_frame == 0U || slot_index >= input.soldier_anchors.size()) {
+    return nullptr;
+  }
+
+  const auto& anchor = input.soldier_anchors[slot_index];
+  if (!anchor.valid || anchor.updated_frame != input.anchor_frame) {
+    return nullptr;
+  }
+  return &anchor;
+}
+
 } // namespace Detail
 
 [[nodiscard]] inline auto build_selection_ring_layout(
@@ -68,6 +89,13 @@ selection_ring_visual_size(const Game::Units::TroopConfig& config,
     if (!soldier.alive) {
       continue;
     }
+
+    const auto* anchor = Detail::anchor_for_soldier(input, soldier.slot_index);
+    if (anchor != nullptr) {
+      placements.push_back({anchor->world_x, anchor->world_z, input.ring_size});
+      continue;
+    }
+
     float const world_x =
         input.position.x() + cos_yaw * soldier.local_x + sin_yaw * soldier.local_z;
     float const world_z =

--- a/tests/render/creature/soldier_turn_smoothing_test.cpp
+++ b/tests/render/creature/soldier_turn_smoothing_test.cpp
@@ -136,6 +136,71 @@ TEST(SoldierTurnSmoothing, SlotMicroWobbleNeverFlapsTheWalkState) {
   }
 }
 
+TEST(SoldierTurnSmoothing, TheCatchUpSpeedOutrunsTheUnitItFollows) {
+
+  constexpr float k_unit_speed = 2.0F;
+  constexpr float k_run_speed = k_unit_speed * 1.5F;
+
+  EXPECT_GT(Render::Humanoid::soldier_catch_up_speed(k_run_speed), k_run_speed);
+  EXPECT_FLOAT_EQ(Render::Humanoid::soldier_catch_up_speed(0.5F), 1.6F);
+}
+
+TEST(SoldierTurnSmoothing, ARunningFormationDoesNotDriftAwayFromItsSlots) {
+
+  constexpr float k_run_speed = 3.0F;
+  SoldierTurnSmoothingState state{};
+  auto inputs = default_inputs();
+  inputs.max_speed = Render::Humanoid::soldier_catch_up_speed(k_run_speed);
+  std::ignore = resolve_soldier_turn_smoothing(state, inputs);
+
+  float slot_x = 0.0F;
+  Render::Humanoid::SoldierTurnSmoothingResult result{};
+  for (int frame = 0; frame < 600; ++frame) {
+    slot_x += k_run_speed * inputs.dt;
+    inputs.target_x = slot_x;
+    result = resolve_soldier_turn_smoothing(state, inputs);
+  }
+
+  EXPECT_LT(std::abs(slot_x - result.x), 0.1F);
+}
+
+TEST(SoldierTurnSmoothing, ACappedFormationWouldFallBehindWhileRunning) {
+
+  constexpr float k_run_speed = 3.0F;
+  SoldierTurnSmoothingState state{};
+  auto inputs = default_inputs();
+  inputs.max_speed = 2.5F;
+  std::ignore = resolve_soldier_turn_smoothing(state, inputs);
+
+  float slot_x = 0.0F;
+  Render::Humanoid::SoldierTurnSmoothingResult result{};
+  for (int frame = 0; frame < 600; ++frame) {
+    slot_x += k_run_speed * inputs.dt;
+    inputs.target_x = slot_x;
+    result = resolve_soldier_turn_smoothing(state, inputs);
+  }
+
+  EXPECT_GT(slot_x - result.x, 1.0F);
+}
+
+TEST(SoldierTurnSmoothing, EveryResolveStampsTheFrameThatMovedTheSoldier) {
+  SoldierTurnSmoothingState state{};
+  auto inputs = default_inputs();
+  inputs.frame_index = 7U;
+  std::ignore = resolve_soldier_turn_smoothing(state, inputs);
+  EXPECT_EQ(state.updated_frame, 7U);
+
+  inputs.frame_index = 8U;
+  inputs.target_x = 0.5F;
+  std::ignore = resolve_soldier_turn_smoothing(state, inputs);
+  EXPECT_EQ(state.updated_frame, 8U);
+
+  inputs.frame_index = 9U;
+  inputs.dt = 0.0F;
+  std::ignore = resolve_soldier_turn_smoothing(state, inputs);
+  EXPECT_EQ(state.updated_frame, 9U);
+}
+
 TEST(SoldierTurnSmoothing, AHalfTurnWalksThroughInsteadOfSweepingTheArc) {
 
   SoldierTurnSmoothingState state{};

--- a/tests/render/selection_ring_layout_test.cpp
+++ b/tests/render/selection_ring_layout_test.cpp
@@ -100,6 +100,97 @@ TEST(SelectionRingLayout, MatchesGameplayPublishedFormationSlotPositions) {
   }
 }
 
+TEST(SelectionRingLayout, RenderedAnchorsPlaceRingsUnderMovingSoldiers) {
+  std::vector<Engine::Core::FormationSoldierPresentation> soldiers(2);
+  soldiers[0].slot_index = 0;
+  soldiers[0].local_x = -1.0F;
+  soldiers[0].alive = true;
+  soldiers[1].slot_index = 1;
+  soldiers[1].local_x = 1.0F;
+  soldiers[1].alive = true;
+
+  std::vector<Render::Humanoid::SoldierTurnSmoothingState> anchors(2);
+  anchors[0].world_x = 3.4F;
+  anchors[0].world_z = 6.1F;
+  anchors[0].updated_frame = 42U;
+  anchors[0].valid = true;
+  anchors[1].world_x = 5.9F;
+  anchors[1].world_z = 6.4F;
+  anchors[1].updated_frame = 42U;
+  anchors[1].valid = true;
+
+  auto const placements = Render::GL::build_selection_ring_layout({
+      .soldiers = soldiers,
+      .ring_size = 0.3F,
+      .position = QVector3D(5.0F, 0.0F, 7.0F),
+      .soldier_anchors = anchors,
+      .anchor_frame = 42U,
+  });
+
+  ASSERT_EQ(placements.size(), 2U);
+  EXPECT_FLOAT_EQ(placements[0].world_x, 3.4F);
+  EXPECT_FLOAT_EQ(placements[0].world_z, 6.1F);
+  EXPECT_FLOAT_EQ(placements[1].world_x, 5.9F);
+  EXPECT_FLOAT_EQ(placements[1].world_z, 6.4F);
+}
+
+TEST(SelectionRingLayout, StaleOrUnsetAnchorsFallBackToFormationSlots) {
+  std::vector<Engine::Core::FormationSoldierPresentation> soldiers(2);
+  soldiers[0].slot_index = 0;
+  soldiers[0].local_x = -1.0F;
+  soldiers[0].alive = true;
+  soldiers[1].slot_index = 1;
+  soldiers[1].local_x = 1.0F;
+  soldiers[1].alive = true;
+
+  std::vector<Render::Humanoid::SoldierTurnSmoothingState> anchors(2);
+  anchors[0].world_x = 100.0F;
+  anchors[0].world_z = 100.0F;
+  anchors[0].updated_frame = 41U;
+  anchors[0].valid = true;
+  anchors[1].world_x = 200.0F;
+  anchors[1].world_z = 200.0F;
+  anchors[1].updated_frame = 42U;
+  anchors[1].valid = false;
+
+  auto const placements = Render::GL::build_selection_ring_layout({
+      .soldiers = soldiers,
+      .ring_size = 0.3F,
+      .position = QVector3D(5.0F, 0.0F, 7.0F),
+      .soldier_anchors = anchors,
+      .anchor_frame = 42U,
+  });
+
+  ASSERT_EQ(placements.size(), 2U);
+  EXPECT_FLOAT_EQ(placements[0].world_x, 4.0F);
+  EXPECT_FLOAT_EQ(placements[0].world_z, 7.0F);
+  EXPECT_FLOAT_EQ(placements[1].world_x, 6.0F);
+  EXPECT_FLOAT_EQ(placements[1].world_z, 7.0F);
+}
+
+TEST(SelectionRingLayout, AnchorsAreIgnoredWithoutAnAnchorFrame) {
+  std::vector<Engine::Core::FormationSoldierPresentation> soldiers(1);
+  soldiers[0].slot_index = 0;
+  soldiers[0].local_x = -1.0F;
+  soldiers[0].alive = true;
+
+  std::vector<Render::Humanoid::SoldierTurnSmoothingState> anchors(1);
+  anchors[0].world_x = 100.0F;
+  anchors[0].world_z = 100.0F;
+  anchors[0].valid = true;
+
+  auto const placements = Render::GL::build_selection_ring_layout({
+      .soldiers = soldiers,
+      .ring_size = 0.3F,
+      .position = QVector3D(5.0F, 0.0F, 7.0F),
+      .soldier_anchors = anchors,
+  });
+
+  ASSERT_EQ(placements.size(), 1U);
+  EXPECT_FLOAT_EQ(placements[0].world_x, 4.0F);
+  EXPECT_FLOAT_EQ(placements[0].world_z, 7.0F);
+}
+
 TEST(SelectionRingLayout, MultiSoldierRingsUseCompactVisualSize) {
   float const size = Render::GL::Detail::selection_ring_visual_size(
       Game::Units::TroopConfig::instance(), Game::Units::SpawnType::Archer, 20, 1.2F);


### PR DESCRIPTION
Soldier bodies are drawn at a smoothed position that chases their formation slot at a capped speed, while the selection rings were drawn at the slot itself. The cap was max(1.6, unit speed * 1.25), but running multiplies actual travel by StaminaComponent::k_run_speed_multiplier (1.5), so every soldier fell behind his slot by a quarter of his speed per second and the rings detached and floated ahead of the troops for as long as the order lasted.

Derive the catch-up cap from the speed the unit is really travelling at - the run multiplier when the run gait is playing, and MotionPresentationComponent's measured speed when that is higher - through a soldier_catch_up_speed() helper, so a running formation can hold its slots.

Then stop guessing where the soldiers are: resolve_soldier_turn_smoothing() stamps the frame it moved each soldier, and build_selection_ring_layout() puts each ring on that frame's rendered anchor, falling back to the formation slot when the anchor is stale, invalid or absent. The commander aura glow rides the same anchors for the same reason.

Covered by new tests for the ring layout (anchors used, stale ones ignored) and for the smoothing cap (the old cap drifts more than a unit behind a running formation in ten seconds, the new one converges).