### PR TITLE
fix(nav): send gate crossings single file through the middle tile

### DIFF
--- a/game/systems/gate_service.cpp
+++ b/game/systems/gate_service.cpp
@@ -43,35 +43,48 @@ auto GateService::passage_extent(float rotation_y) -> GateExtent {
                             : GateComponent::k_passage_half_width};
 }
 
+auto GateService::lane_half_width() -> float {
+  auto* pathfinder = NavGrid::get_pathfinder();
+  constexpr float k_fallback_cell_size = 1.0F;
+  const float cell_size =
+      pathfinder != nullptr ? pathfinder->grid_cell_size() : k_fallback_cell_size;
+  return cell_size * 0.5F;
+}
+
+auto GateService::lane_center(float center_x, float center_z) -> QVector3D {
+  auto* pathfinder = NavGrid::get_pathfinder();
+  if (pathfinder == nullptr) {
+    return {center_x, 0.0F, center_z};
+  }
+  return pathfinder->grid_to_world(pathfinder->world_to_grid(center_x, center_z));
+}
+
+auto GateService::lane_extent(float rotation_y) -> GateExtent {
+  const bool spans_x = GateComponent::spans_x_axis(rotation_y);
+  const float lane_half = lane_half_width();
+
+  const float crossing_half = GateComponent::k_cross_half_extent +
+                              BuildingCollisionRegistry::get_grid_padding();
+  return {.half_x = spans_x ? lane_half : crossing_half,
+          .half_z = spans_x ? crossing_half : lane_half};
+}
+
 auto GateService::passage_blocker_bounds(float center_x,
                                          float center_z,
                                          float rotation_y) -> WorldRect {
-  const auto extent = passage_extent(rotation_y);
-  WorldRect bounds{.min_x = center_x - extent.half_x,
-                   .max_x = center_x + extent.half_x,
-                   .min_z = center_z - extent.half_z,
-                   .max_z = center_z + extent.half_z};
+  const QVector3D lane = lane_center(center_x, center_z);
+  const float lane_half = lane_half_width();
+  const bool spans_x = GateComponent::spans_x_axis(rotation_y);
 
-  auto* pathfinder = NavGrid::get_pathfinder();
-  if (pathfinder == nullptr) {
-    return bounds;
-  }
+  const float half_x = spans_x ? lane_half : GateComponent::k_cross_half_extent;
+  const float half_z = spans_x ? GateComponent::k_cross_half_extent : lane_half;
+  const float axis_x = spans_x ? lane.x() : center_x;
+  const float axis_z = spans_x ? center_z : lane.z();
 
-  const auto snapped = pathfinder->cell_range_world_bounds(
-      pathfinder->cells_covering(center_x, center_z, extent.half_x, extent.half_z));
-  if (Engine::Core::GateComponent::spans_x_axis(rotation_y)) {
-    bounds.min_x = snapped.min_x;
-    bounds.max_x = snapped.max_x;
-  } else {
-    bounds.min_z = snapped.min_z;
-    bounds.max_z = snapped.max_z;
-  }
-  return bounds;
-}
-
-void GateService::mark_gate_footprint_navigable(Engine::Core::EntityID entity_id) {
-  BuildingCollisionRegistry::instance().set_building_navigation_blocking(entity_id,
-                                                                         false);
+  return {.min_x = axis_x - half_x,
+          .max_x = axis_x + half_x,
+          .min_z = axis_z - half_z,
+          .max_z = axis_z + half_z};
 }
 
 void GateService::sync_gate_footprint(Engine::Core::EntityID entity_id,

--- a/game/systems/gate_service.h
+++ b/game/systems/gate_service.h
@@ -42,10 +42,16 @@ public:
 
   [[nodiscard]] static auto passage_extent(float rotation_y) -> GateExtent;
 
+  // Units cross a gate one behind the other: only the middle navigation cell of
+  // the gatehouse is walkable, so the lane below is a single cell wide.
+  [[nodiscard]] static auto lane_half_width() -> float;
+
+  [[nodiscard]] static auto lane_center(float center_x, float center_z) -> QVector3D;
+
+  [[nodiscard]] static auto lane_extent(float rotation_y) -> GateExtent;
+
   [[nodiscard]] static auto
   passage_blocker_bounds(float center_x, float center_z, float rotation_y) -> WorldRect;
-
-  static void mark_gate_footprint_navigable(Engine::Core::EntityID entity_id);
 
   static void sync_gate_footprint(Engine::Core::EntityID entity_id, float rotation_y);
 

--- a/game/systems/pathfinding.h
+++ b/game/systems/pathfinding.h
@@ -59,6 +59,8 @@ public:
   auto get_grid_offset_x() const -> float { return m_grid_offset_x; }
   auto get_grid_offset_z() const -> float { return m_grid_offset_z; }
 
+  [[nodiscard]] auto grid_cell_size() const -> float { return m_grid_cell_size; }
+
   auto world_to_grid(float world_x, float world_z) const -> Point;
   auto grid_to_world(const Point& grid_pos) const -> QVector3D;
 

--- a/game/systems/wall_network_service.cpp
+++ b/game/systems/wall_network_service.cpp
@@ -752,13 +752,14 @@ auto collect_navigation_passages(
              .second) {
       continue;
     }
-    const bool spans_x = GateComponent::spans_x_axis(transform->rotation.y);
-    const float opening = GateComponent::k_passage_half_width * 2.0F;
+    const auto lane =
+        GateService::lane_center(transform->position.x, transform->position.z);
+    const auto extent = GateService::lane_extent(transform->rotation.y);
 
-    passages.push_back(NavigationPassage{.center_x = transform->position.x,
-                                         .center_z = transform->position.z,
-                                         .width = spans_x ? opening : crossing_depth,
-                                         .depth = spans_x ? crossing_depth : opening,
+    passages.push_back(NavigationPassage{.center_x = lane.x(),
+                                         .center_z = lane.z(),
+                                         .width = extent.half_x * 2.0F,
+                                         .depth = extent.half_z * 2.0F,
                                          .source_entity_id = entity->get_id()});
   }
 

--- a/game/systems/world_restore.cpp
+++ b/game/systems/world_restore.cpp
@@ -3,7 +3,6 @@
 #include "../core/component.h"
 #include "../core/world.h"
 #include "../systems/building_collision_registry.h"
-#include "../systems/gate_service.h"
 #include "../systems/global_stats_registry.h"
 #include "../systems/nav_grid.h"
 #include "../systems/owner_registry.h"
@@ -80,10 +79,6 @@ void rebuild_building_collisions(Engine::Core::World* world) {
                                transform->position.x,
                                transform->position.z,
                                unit->owner_id);
-
-    if (entity->has_component<Engine::Core::GateComponent>()) {
-      Game::Systems::GateService::mark_gate_footprint_navigable(entity->get_id());
-    }
   }
 
   Game::Systems::WallNetworkService::refresh_world(*world);

--- a/tests/headless/gate_traversal_test.cpp
+++ b/tests/headless/gate_traversal_test.cpp
@@ -12,6 +12,7 @@
 #include "game/session/simulation_clock.h"
 #include "game/systems/building_collision_registry.h"
 #include "game/systems/command_service.h"
+#include "game/systems/gate_service.h"
 #include "game/systems/nav_grid.h"
 #include "game/systems/owner_registry.h"
 #include "game/systems/pathfinding.h"
@@ -102,15 +103,20 @@ auto add_wall_piece(SessionContext& session,
                                                  center.z(),
                                                  k_defender);
   if (is_gate) {
-    session.building_collision().set_building_navigation_blocking(entity->get_id(),
-                                                                  false);
+    Game::Systems::GateService::sync_gate_footprint(entity->get_id(),
+                                                    transform->rotation.y);
   }
   return entity->get_id();
 }
 
 auto build_gated_wall(SessionContext& session) -> EntityID {
+
+  // A gatehouse claims its own wall cell plus the neighbour on either side, so
+  // the run has to leave that much room for it.
+  constexpr float k_gatehouse_half_span =
+      static_cast<float>(Game::Systems::WallNetworkService::k_segment_spacing);
   for (float x = -30.0F; x <= 30.0F; x += 2.0F) {
-    if (std::fabs(x - k_gate_x) < 0.01F) {
+    if (std::fabs(x - k_gate_x) <= k_gatehouse_half_span + 0.01F) {
       continue;
     }
     add_wall_piece(session, Game::Units::SpawnType::WallSegment, x, k_gate_z);
@@ -119,6 +125,19 @@ auto build_gated_wall(SessionContext& session) -> EntityID {
       add_wall_piece(session, Game::Units::SpawnType::WallGate, k_gate_x, k_gate_z);
   Game::Systems::WallNetworkService::refresh_world(session.world());
   return gate;
+}
+
+auto walkable_wall_line_cells(const QVector3D& gate_position) -> std::vector<int> {
+  const Game::Systems::Point gate_cell =
+      Game::Systems::NavGrid::world_to_grid(gate_position.x(), gate_position.z());
+  std::vector<int> walkable;
+  for (int offset = -4; offset <= 4; ++offset) {
+    if (Game::Systems::NavGrid::is_grid_walkable(
+            Game::Systems::Point(gate_cell.x + offset, gate_cell.y))) {
+      walkable.push_back(offset);
+    }
+  }
+  return walkable;
 }
 
 auto spawn_troop(SessionContext& session, int owner_id, float x, float z) -> EntityID {
@@ -187,33 +206,46 @@ TEST_F(GateTraversalTest, OwnerTroopWalksThroughItsOwnGate) {
   EXPECT_FLOAT_EQ(gate_component->open_amount, 0.0F);
 }
 
+TEST_F(GateTraversalTest, OnlyTheMiddleTileOfTheGatehouseIsWalkable) {
+  auto session = make_match();
+  const ScopedSession scope(*session);
+  const EntityID gate = build_gated_wall(*session);
+  const QVector3D gate_position = entity_position(*session, gate);
+
+  EXPECT_EQ(walkable_wall_line_cells(gate_position), std::vector<int>{0});
+}
+
 TEST_F(GateTraversalTest, GroupMembersIndividuallyUseTheGateCenterline) {
   auto session = make_match();
   const ScopedSession scope(*session);
   const EntityID gate = build_gated_wall(*session);
   const QVector3D gate_position = entity_position(*session, gate);
 
+  constexpr int k_group_size = 24;
+  constexpr int k_rank_width = 8;
   std::vector<EntityID> troops;
   std::vector<QVector3D> targets;
-  for (int index = 0; index < 8; ++index) {
-    const float offset = (static_cast<float>(index) - 3.5F) * 0.6F;
-    troops.push_back(spawn_troop(*session,
-                                 k_defender,
-                                 gate_position.x() + offset,
-                                 gate_position.z() - 8.0F - float(index / 4)));
+  for (int index = 0; index < k_group_size; ++index) {
+    const float offset = (static_cast<float>(index % k_rank_width) - 3.5F) * 0.6F;
+    troops.push_back(
+        spawn_troop(*session,
+                    k_defender,
+                    gate_position.x() + offset,
+                    gate_position.z() - 8.0F - float(index / k_rank_width)));
     targets.emplace_back(gate_position.x(), 0.0F, gate_position.z() + 8.0F);
   }
   Game::Systems::CommandService::move_units(session->world(), troops, targets);
 
+  const float lane_half = Game::Systems::GateService::lane_half_width();
   std::vector<bool> used_centerline(troops.size(), false);
   const double step = session->clock().tick_seconds();
-  for (double elapsed = 0.0; elapsed < 20.0; elapsed += step) {
+  for (double elapsed = 0.0; elapsed < 45.0; elapsed += step) {
     run_for(*session, step);
     for (std::size_t index = 0; index < troops.size(); ++index) {
       const QVector3D position = entity_position(*session, troops[index]);
       if (std::abs(position.z() - gate_position.z()) <= 1.0F) {
         used_centerline[index] = true;
-        EXPECT_LE(std::abs(position.x() - gate_position.x()), 0.75F)
+        EXPECT_LE(std::abs(position.x() - gate_position.x()), lane_half)
             << "unit " << index << " crossed off the gate centerline";
       }
     }

--- a/tests/systems/gate_system_test.cpp
+++ b/tests/systems/gate_system_test.cpp
@@ -14,6 +14,7 @@
 #include "systems/owner_registry.h"
 #include "systems/pathfinding.h"
 #include "systems/wall_network_service.h"
+#include "systems/world_restore.h"
 #include "units/spawn_type.h"
 #include "units/troop_config.h"
 #include "units/troop_type.h"
@@ -32,7 +33,10 @@ protected:
   void SetUp() override {
     BuildingCollisionRegistry::instance().clear();
     Game::Map::TerrainService::instance().clear();
-    NavGrid::initialize(32, 32);
+
+    // Odd extents put the cell centres on integers, which is where wall
+    // placement snaps gates in a real map.
+    NavGrid::initialize(33, 33);
 
     auto& owners = OwnerRegistry::instance();
     owners.clear();
@@ -109,6 +113,16 @@ protected:
   }
 };
 
+auto walkable_cells_across(const Point& gate_cell) -> std::vector<int> {
+  std::vector<int> walkable;
+  for (int offset = -4; offset <= 4; ++offset) {
+    if (NavGrid::is_grid_walkable(Point(gate_cell.x + offset, gate_cell.y))) {
+      walkable.push_back(offset);
+    }
+  }
+  return walkable;
+}
+
 void expect_passage_on_gate(const NavigationPassage& passage,
                             const Entity& gate_entity) {
   const auto* transform = gate_entity.get_component<TransformComponent>();
@@ -143,16 +157,23 @@ TEST_F(GateSystemTest, GatehouseIsSolidAcrossThreeCellsAndOpensOnlyInTheMiddle) 
   WallNetworkService::refresh_world(world);
   const auto& passages = BuildingCollisionRegistry::instance().navigation_passages();
   ASSERT_EQ(passages.size(), 1U);
-  EXPECT_FLOAT_EQ(passages.front().width, GateComponent::k_passage_half_width * 2.0F);
+  EXPECT_FLOAT_EQ(passages.front().width, GateService::lane_half_width() * 2.0F);
   EXPECT_LT(passages.front().width, footprint->width);
+
+  EXPECT_EQ(walkable_cells_across(NavGrid::world_to_grid(0.0F, 0.0F)),
+            std::vector<int>{0});
 }
 
-TEST_F(GateSystemTest, GateOpeningIsWideEnoughForTheLargestUnit) {
+TEST_F(GateSystemTest, SingleFileLaneKeepsTheLargestUnitClearOfTheJambs) {
 
   const float elephant_width =
       Game::Units::TroopConfig::instance().get_selection_ring_size(
           Game::Units::TroopType::Elephant);
+
   EXPECT_GT(GateComponent::k_passage_half_width * 2.0F, elephant_width * 1.5F);
+
+  const float widest_reach = GateService::lane_half_width() + (elephant_width * 0.5F);
+  EXPECT_LT(widest_reach, GateComponent::k_passage_half_width);
 }
 
 TEST_F(GateSystemTest, OpensForOwnerTroopInRange) {
@@ -355,6 +376,21 @@ TEST_F(GateSystemTest, GateAcrossAVerticalRunTurnsToFaceIt) {
   WallNetworkService::refresh_world(world);
 
   EXPECT_FLOAT_EQ(gate_entity->get_component<TransformComponent>()->rotation.y, 90.0F);
+}
+
+TEST_F(GateSystemTest, AReloadedGateKeepsItsSingleFileLane) {
+  World world;
+  make_wall(world, -4.0F, 0.0F, k_gate_owner);
+  make_wall(world, 4.0F, 0.0F, k_gate_owner);
+  make_gate(world, 0.0F, 0.0F, k_gate_owner);
+  WallNetworkService::refresh_world(world);
+
+  const Point gate_cell = NavGrid::world_to_grid(0.0F, 0.0F);
+  ASSERT_EQ(walkable_cells_across(gate_cell), std::vector<int>{0});
+
+  Game::Persistence::rebuild_building_collisions(&world);
+
+  EXPECT_EQ(walkable_cells_across(gate_cell), std::vector<int>{0});
 }
 
 TEST_F(GateSystemTest, ManualModeSurvivesASaveRoundTrip) {


### PR DESCRIPTION
A gate published a navigation passage as wide as its visual doorway (k_passage_half_width * 2 = 3.8), which forced five nav cells walkable across the wall line. The jambs sit at +/-1.9, so a unit centred on either outer cell walked with its body inside the gatehouse pier, and a group ordered through the gate fanned out over all five cells -- measured drift was 1.67 off centre.

Gates now carve exactly one nav cell, snapped to the cell holding the gate centre and as deep as the gate's blocked band, so A* has a single tile to route through and the group crosses one behind the other. Local avoidance already suppresses lateral separation for units following a path, so they queue instead of shouldering each other into the piers. The closed-gate barrier is derived from the same lane rather than snapping the full doorway.

world_restore turned navigation blocking off for the whole 6x2 gatehouse on load, so a reloaded wall had a five-tile hole no matter how narrow the passage was; reloaded gates now block exactly like freshly built ones.

Verified: half a cell plus the largest unit's radius (elephant, 1.025) is 1.525, inside the 1.9 jamb, so nothing clips even at full width; 24 units cross without jamming; none of the 77 gates in the eight shipped maps has a wall segment on its centre cell.

GateSystemTest now initialises a 33x33 grid -- NavGrid's offset is -(w*0.5 - 0.5), so on the old even extent the tests' literal 0.0 was a cell boundary rather than a centre.