### PR TITLE
perf(sim): answer proximity questions with a spatial index, and measu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,46 @@ may change in any release — see [Save compatibility](#save-compatibility).
   never showed. Footer keys spell out `↑ ↓`, `Enter` and `Esc`, and **Play**
   explains in a tooltip why it is refusing when the setup is not startable.
 
+### Changed
+
+- **Large battles cost a fraction of what they did, and the engine can now say
+  why.** A thousand-unit battle line spent about half a second of CPU on every
+  simulation tick. Nearly all of it came from one line: the combat mode
+  processor asked "is there an enemy in melee reach?" by walking every unit in
+  the world, once per attacking unit, computing formation contact geometry for
+  each — roughly 620 full-world scans and 620,000 entity handles resolved per
+  tick. It now asks the world's spatial index for the units actually inside the
+  attacker's reach. The same battle line ticks in about a fifth of the time,
+  with the world digest unchanged.
+
+    The scaffolding around that fix is the more durable part.
+    `Engine::Core::WorldSpatialIndex` belongs to the world it indexes, is
+    rebuilt once per tick, and now answers the patrol, healing and combat
+    proximity questions that used to scan everything.
+    `World::view<A, B>()` iterates matching entities without allocating, and the
+    materialising query it replaces was renamed `collect_entities_with` so that
+    its cost is visible at the call site. `scripts/check-world-scans.py` keeps
+    the number of full-world scans from growing back.
+
+    `Engine::Core::SystemProfiler` reports per-system tick times, the queries
+    each system opened and how many candidates they examined, and attributes
+    materialising scans to the source line that made them — which is how the
+    line above was found. `build/bin/sim_benchmark` is the repeatable 1k/5k/10k
+    workload behind those numbers.
+
+    Simulation phases are now named (`Engine::Core::SystemPhase`), structural
+    changes can be deferred to the barriers between them
+    (`Engine::Core::DeferredMutations`), and a system may declare what it reads
+    and writes so a future scheduler can check rather than assume. Nothing
+    reordered: a test asserts the phases only ever advance down the registry.
+
+    The renderer's battle optimiser stopped pretending to cull. Its
+    `should_render_unit` hook had been `return true` with a counter behind a
+    mutex; the real culling is frustum and fog, well before it. What remains —
+    animation throttling and the batching ratio — reads one immutable
+    per-frame snapshot instead of a lock and three atomics per unit, and the
+    object belongs to the renderer rather than to the process.
+
 ### Fixed
 
 - **Animals beside a campfire no longer shine like reflectors, and the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,6 +464,19 @@ if(Python3_Interpreter_FOUND)
         COMMENT "Checking the ambient-lookup budget"
         VERBATIM
     )
+    # A radius question answered by a full entity scan costs O(units) per asker,
+    # so a system that asks one per unit costs O(units^2) per tick. Local queries
+    # go through `world.spatial_index()`; the number of full scans may only go
+    # down. See scripts/check-world-scans.py and scripts/world_scan_budget.json.
+    add_custom_target(
+        check_world_scans
+        ALL
+        COMMAND
+            ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/check-world-scans.py
+            ${CMAKE_SOURCE_DIR}
+        COMMENT "Checking the full-world-scan budget"
+        VERBATIM
+    )
 else()
     message(STATUS "Python3 not found; skipping the layering and module checks")
 endif()

--- a/app/commander/commander_control_controller.cpp
+++ b/app/commander/commander_control_controller.cpp
@@ -279,7 +279,7 @@ void separate_commander_from_bodies(Engine::Core::World& world,
   const QVector3D origin(transform.position.x, 0.0F, transform.position.z);
   QVector3D push(0.0F, 0.0F, 0.0F);
 
-  for (auto* candidate : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == nullptr || candidate->get_id() == commander_id ||
         candidate->has_component<Engine::Core::BuildingComponent>() ||
         candidate->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -677,7 +677,7 @@ void CommanderControlController::cycle_lock_on_target(
   };
   std::vector<Candidate> candidates;
 
-  for (auto* candidate : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == nullptr || candidate->get_id() == commander_id) {
       continue;
     }
@@ -1088,7 +1088,7 @@ auto CommanderControlController::find_primary_target(
 
   std::optional<Target> best;
   float best_score = -1000000.0F;
-  for (auto* candidate : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == nullptr || candidate == commander) {
       continue;
     }
@@ -1261,7 +1261,7 @@ void CommanderControlController::try_activate_shield_bash(
   auto& owners = Game::Systems::OwnerRegistry::instance();
   const QVector3D cmd_pos(
       transform->position.x, transform->position.y, transform->position.z);
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr || entity->get_id() == commander_id) {
       continue;
     }

--- a/app/economy/economy_overview.cpp
+++ b/app/economy/economy_overview.cpp
@@ -71,7 +71,7 @@ auto scan_owner(Engine::Core::World* world, int owner_id) -> OwnerScan {
     return scan;
   }
 
-  for (auto* entity : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/app/persistence/game_state_restorer.cpp
+++ b/app/persistence/game_state_restorer.cpp
@@ -43,7 +43,7 @@ void GameStateRestorer::rebuild_entity_cache(Engine::Core::World* world,
   entity_cache.reset();
 
   auto& owners = Game::Systems::OwnerRegistry::instance();
-  auto entities = world->get_entities_with<Engine::Core::UnitComponent>();
+  auto entities = world->collect_entities_with<Engine::Core::UnitComponent>();
   for (auto* e : entities) {
     auto* unit = e->get_component<Engine::Core::UnitComponent>();
     if ((unit == nullptr) || unit->health <= 0) {

--- a/app/session/level_loader.cpp
+++ b/app/session/level_loader.cpp
@@ -105,7 +105,7 @@ auto LevelLoader::loadFromAssets(const QString& map_path,
 
     if (allow_default_player_barracks) {
       bool has_barracks = false;
-      for (auto* e : world.get_entities_with<Engine::Core::UnitComponent>()) {
+      for (auto* e : world.collect_entities_with<Engine::Core::UnitComponent>()) {
         if (auto* u = e->get_component<Engine::Core::UnitComponent>()) {
           if (u->spawn_type == Game::Units::SpawnType::Barracks &&
               owners.is_player(u->owner_id)) {

--- a/app/session/skirmish_loader.cpp
+++ b/app/session/skirmish_loader.cpp
@@ -560,7 +560,7 @@ auto SkirmishLoader::start(const QString& map_path,
 
   Engine::Core::Entity* focus_entity = nullptr;
 
-  auto candidates = m_world.get_entities_with<Engine::Core::UnitComponent>();
+  auto candidates = m_world.collect_entities_with<Engine::Core::UnitComponent>();
   for (auto* entity : candidates) {
     if (entity == nullptr) {
       continue;

--- a/app/session/skirmish_runtime_coordinator.cpp
+++ b/app/session/skirmish_runtime_coordinator.cpp
@@ -49,7 +49,7 @@ void SkirmishRuntimeCoordinator::center_camera_on_local_forces(
   int troops_count = 0;
   int structures_count = 0;
 
-  for (auto* entity : ctx.world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : ctx.world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/app/viewmodels/commander_view_model.cpp
+++ b/app/viewmodels/commander_view_model.cpp
@@ -61,7 +61,8 @@ auto CommanderViewModel::find_local_commander() const -> Engine::Core::Entity* {
     return nullptr;
   }
   const int owner = m_context.local_owner_id;
-  for (auto* entity : world->get_entities_with<Engine::Core::CommanderComponent>()) {
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::CommanderComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/app/world/ambient_state_manager.cpp
+++ b/app/world/ambient_state_manager.cpp
@@ -53,7 +53,7 @@ auto AmbientStateManager::is_player_in_combat(Engine::Core::World* world,
     return false;
   }
 
-  auto units = world->get_entities_with<Engine::Core::UnitComponent>();
+  auto units = world->collect_entities_with<Engine::Core::UnitComponent>();
   const float combat_check_radius = 15.0F;
 
   for (auto* entity : units) {

--- a/app/world/focus_target.cpp
+++ b/app/world/focus_target.cpp
@@ -92,7 +92,8 @@ auto count_units_attacking(Engine::Core::World* world,
     return 0;
   }
   int count = 0;
-  for (auto* entity : world->get_entities_with<Engine::Core::AttackTargetComponent>()) {
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::AttackTargetComponent>()) {
     const auto* attack = entity->get_component<Engine::Core::AttackTargetComponent>();
     const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (attack == nullptr || unit == nullptr || unit->health <= 0) {
@@ -124,7 +125,8 @@ auto count_enemies_attacking(Engine::Core::World* world,
     return 0;
   }
   int count = 0;
-  for (auto* entity : world->get_entities_with<Engine::Core::AttackTargetComponent>()) {
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::AttackTargetComponent>()) {
     const auto* attack = entity->get_component<Engine::Core::AttackTargetComponent>();
     const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (attack == nullptr || unit == nullptr || unit->health <= 0) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -378,6 +378,118 @@ with a wrapper that adds commander-mode input; `soi_headless` calls it with
 none. That is the dedicated-server shape: a session, `soi_runtime`'s system
 registry, `soi_ai`, and a loop — no Qt Quick, no renderer linked in.
 
+## Querying the world
+
+Three ways to ask the world a question, in order of what they cost:
+
+| Question                              | API                                          | Cost                                                   |
+| ------------------------------------- | -------------------------------------------- | ------------------------------------------------------ |
+| "every entity with these components"  | `world.view<A, B>()` / `entity_view<A, B>()` | walks the smallest component set; allocates nothing    |
+| "what is near this point?"            | `world.spatial_index()`                      | proportional to what is actually nearby                |
+| "give me a vector of them I can keep" | `world.collect_entities_with<T>()`           | walks the set _and_ allocates a `std::vector<Entity*>` |
+
+The names say which is which on purpose. `get_entities_with<T>()` looked free
+and was not: it allocated a vector and resolved every handle in it, and because
+it looked free it spread. At one point the combat pipeline ran about 620 of
+them per tick at a thousand units -- roughly 620,000 entity handles resolved per
+frame -- because a per-unit helper answered a radius question with a full scan.
+It is now `collect_entities_with`, which is a mouthful, which is the point.
+
+**The engine rule: a local, radius-bounded gameplay query goes through the
+spatial index, not through a full entity scan.** A full scan is for questions
+that genuinely concern every entity -- counting an owner's army, sweeping
+components whose timer expired. `scripts/check-world-scans.py` counts the scans
+per directory and fails the build if any directory grows more of them;
+`scripts/world_scan_budget.json` is the ceiling, and `--write` lowers it after a
+clean-up.
+
+`Engine::Core::WorldSpatialIndex` belongs to the world it indexes, not to a
+process-wide singleton, so two worlds in one process never see each other's
+entities. It is rebuilt at most once per tick — `refresh()` is a no-op if the
+index was already built for the tick that is running — and each entry carries
+the fields proximity queries filter on (owner, health, building/wildlife/undead
+flags) so a caller can reject a candidate without touching the entity at all.
+
+A view borrows the component set it iterates. Adding or removing a component of
+one of the viewed types while the loop runs invalidates it; record the change in
+`world.deferred()` instead and let the phase barrier apply it.
+
+Two details of the index are worth knowing before you use it:
+
+- `refresh()` compares against `World::tick_id()`. A world that has never ticked
+  — a test or a tool driving systems by hand — has no tick to compare against,
+  so `refresh()` rebuilds every call there rather than hand back a stale answer.
+- A bounded search has to be wide enough that it cannot miss what a full scan
+  would have found. Combat compares _surface_ distance, which sits inside the
+  centre distance by at most one formation half-width per side, so the combat
+  paths widen their radius by `2 * FormationCombat::max_contact_extent()` —
+  derived from the troop catalogue, not guessed, so widening a formation in data
+  cannot silently make a bounded search start missing enemies.
+
+## Simulation phases and structural change
+
+The systems a match owns run in one order, listed once, in
+`register_runtime_systems`. `Engine::Core::SystemPhase` groups that list into
+stages — input, movement, combat, strategy, economy, ambient, presentation,
+cleanup — and the phases are non-decreasing down the list, enforced by
+`tests/systems/runtime_phase_order_test.cpp`: naming the stages must not reorder
+a single system.
+
+The phase boundary is a barrier. `World::update` applies whatever structural
+change has accumulated in `world.deferred()` each time the phase advances, and
+once more at the end of the tick, so the instants at which the world's _shape_
+can change are these boundaries rather than "anywhere, at any time".
+
+`Engine::Core::SystemAccess` is the other half. A system may declare the
+component types it reads and writes; one that has not declared them is
+`exclusive`, meaning "assume it touches everything". `plan_phase_batches` groups
+the systems of a phase into batches that do not collide, preserving registration
+order. Nothing runs in parallel yet — that waits on the single-writer work
+below — but the question "may these two run together?" now has an answer that is
+checked rather than assumed.
+
+## Measuring the simulation
+
+`Engine::Core::SystemProfiler`, reached as `world.system_profiler()`, records
+per-system microseconds and the queries each system opened: views and their
+candidate counts, materialising scans and how many entities they built, spatial
+queries and how many candidates they examined. It is off by default. Materialising
+scans are additionally attributed to the source line that made them, which is
+the difference between knowing that combat is slow and knowing which line to
+change.
+
+Draw-queue sorting was measured the same way, in
+`tests/render/draw_queue_sort_cost_test.cpp`. `DrawQueue` already buckets by
+pass, pipeline and transparency as commands are submitted, sorts within those
+buckets, and skips the sort entirely for kinds that preserve append order, so a
+realistic frame never sorts the whole queue. The cost of what remains, on the
+development machine:
+
+| Draw commands |    Sort |
+| ------------: | ------: |
+|         2,080 | 0.06 ms |
+|        20,080 |  1.1 ms |
+|       100,080 |   18 ms |
+
+The game submits low thousands, where sorting is well under one percent of a
+frame, so the queue does not need restructuring. The growth is worth knowing
+about: it is superlinear, and at a hundred thousand commands sorting alone
+exceeds a 16.67 ms frame on its own.
+
+The test prints these numbers rather than asserting them. A wall-clock bound in
+the suite measures whatever else the machine is doing -- the 2,080-command
+figure above has been seen anywhere between 0.06 ms and 0.73 ms on the same
+build. What it does assert is machine-independent: that a realistically ordered
+frame comes out of `sort_for_batching` still partitioned by bucket, which is
+only true if the bucketed path ran, and that sorting still yields the long
+instanceable runs it exists to produce.
+
+`build/bin/sim_benchmark` is the repeatable workload: two armies deployed as
+battle lines at 1k, 5k and 10k units, a fixed number of ticks, reporting
+simulation ms per tick, peak RSS, the per-system table and a world digest. The
+digest is the guard — if it moves between runs, the workload changed and the
+numbers are not comparable.
+
 ## Simulation and presentation ownership
 
 Mutable entities belong to the simulation thread. In the Qt Quick client that
@@ -397,10 +509,26 @@ world mutex while culling, sorting, or invoking renderer callbacks. Unchanged
 idle entities are retained in the reusable snapshot buffer by a presentation
 signature; active entities are refreshed every tick.
 
+The simulation thread is the world's single writer. The renderer reads the
+published snapshot rather than live entities; the minimap still reads the live
+world under its lock, which is safe because it runs inside
+`update_presentation`, and that holds the same frame mutex the simulation tick
+does — the two never overlap.
+
+`World::update` takes the
+entity mutex once and holds it for the whole tick, so every lookup a system
+makes inside that tick is a recursive re-acquire by the thread that already owns
+it -- two atomic read-modify-writes per `get_entity`, per unit, per system, per
+tick. `World::EntityLock` records the owning thread, so those calls cost one
+relaxed load instead. Nothing about the guarantee changes; the lock really is
+held throughout. A reader on another thread still blocks exactly as before, and
+code that takes `get_entity_mutex()` directly still works -- it simply does not
+get the fast path, because it did not record itself as the owner.
+
 Headless callers disable creature and motion presentation with
 `World::set_presentation_enabled(false)`. Commands remain the write boundary for
 external producers. Sparse ECS membership is exposed as non-owning entity-ID
-spans, and hot systems either iterate components directly with `World::each()`
+spans, and hot systems either iterate components directly with `World::view()`
 or resolve IDs into retained scratch storage.
 
 ## Persistence

--- a/docs/COMBAT_SYSTEM.md
+++ b/docs/COMBAT_SYSTEM.md
@@ -68,7 +68,7 @@ The context contains:
 Combat processors should receive and reuse this context instead of repeatedly calling:
 
 ```cpp
-World::get_entities_with<UnitComponent>()
+World::collect_entities_with<UnitComponent>()
 ```
 
 Using the shared context:

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -39,6 +39,10 @@ add_library(
     core/component.cpp
     core/system.cpp
     core/world.cpp
+    core/world_spatial_index.cpp
+    core/system_profiler.cpp
+    core/system_schedule.cpp
+    core/deferred_mutations.cpp
     core/ambient_session.cpp
     core/event_manager.cpp
     core/simulation_timing.cpp

--- a/game/core/deferred_mutations.cpp
+++ b/game/core/deferred_mutations.cpp
@@ -1,0 +1,44 @@
+#include "deferred_mutations.h"
+
+#include "world.h"
+
+namespace Engine::Core {
+
+namespace Detail {
+
+auto entity_in(World& world, EntityID entity_id) -> Entity* {
+  return world.get_entity(entity_id);
+}
+
+void destroy_in(World& world, EntityID entity_id) {
+  world.destroy_entity(entity_id);
+}
+
+} // namespace Detail
+
+void DeferredMutations::destroy_entity(EntityID entity_id) {
+  m_actions.emplace_back(
+      [entity_id](World& world) { Detail::destroy_in(world, entity_id); });
+}
+
+void DeferredMutations::run(Action action) {
+  if (action) {
+    m_actions.emplace_back(std::move(action));
+  }
+}
+
+void DeferredMutations::apply(World& world) {
+  if (m_actions.empty()) {
+    return;
+  }
+
+  m_applying.swap(m_actions);
+  m_actions.clear();
+
+  for (Action& action : m_applying) {
+    action(world);
+  }
+  m_applying.clear();
+}
+
+} // namespace Engine::Core

--- a/game/core/deferred_mutations.h
+++ b/game/core/deferred_mutations.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "entity.h"
+
+namespace Engine::Core {
+
+class World;
+
+namespace Detail {
+
+auto entity_in(World& world, EntityID entity_id) -> Entity*;
+void destroy_in(World& world, EntityID entity_id);
+
+} // namespace Detail
+
+class DeferredMutations {
+public:
+  using Action = std::function<void(World&)>;
+
+  void destroy_entity(EntityID entity_id);
+
+  template <typename T, typename... Args>
+  void add_component(EntityID entity_id, Args&&... args) {
+    m_actions.emplace_back(
+        [entity_id,
+         packed = std::make_tuple(std::forward<Args>(args)...)](World& world) mutable {
+          if (Entity* entity = Detail::entity_in(world, entity_id)) {
+            std::apply(
+                [entity](auto&&... unpacked) {
+                  entity->template add_component<T>(
+                      std::forward<decltype(unpacked)>(unpacked)...);
+                },
+                std::move(packed));
+          }
+        });
+  }
+
+  template <typename T>
+  void remove_component(EntityID entity_id) {
+    m_actions.emplace_back([entity_id](World& world) {
+      if (Entity* entity = Detail::entity_in(world, entity_id)) {
+        entity->template remove_component<T>();
+      }
+    });
+  }
+
+  void run(Action action);
+
+  [[nodiscard]] auto empty() const noexcept -> bool { return m_actions.empty(); }
+  [[nodiscard]] auto pending() const noexcept -> std::size_t {
+    return m_actions.size();
+  }
+
+  void apply(World& world);
+
+  void clear() noexcept { m_actions.clear(); }
+
+private:
+  std::vector<Action> m_actions;
+  std::vector<Action> m_applying;
+};
+
+} // namespace Engine::Core

--- a/game/core/system.h
+++ b/game/core/system.h
@@ -2,6 +2,8 @@
 
 #include <memory>
 
+#include "system_schedule.h"
+
 namespace Engine::Core {
 
 class World;
@@ -15,6 +17,14 @@ public:
   auto operator=(System&&) noexcept -> System& = default;
   virtual ~System() = default;
   virtual void update(World* world, float delta_time) = 0;
+
+  [[nodiscard]] virtual auto phase() const -> SystemPhase {
+    return SystemPhase::Combat;
+  }
+
+  [[nodiscard]] virtual auto access() const -> SystemAccess {
+    return SystemAccess::everything();
+  }
 };
 
 } // namespace Engine::Core

--- a/game/core/system_profiler.cpp
+++ b/game/core/system_profiler.cpp
@@ -1,0 +1,182 @@
+#include "system_profiler.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string_view>
+
+namespace Engine::Core {
+
+void SystemProfiler::begin_tick(std::uint64_t tick_index, std::size_t entity_count) {
+  if (!m_enabled) {
+    return;
+  }
+  m_last_tick.tick_index = tick_index;
+  m_last_tick.entity_count = entity_count;
+  m_last_tick.queries = {};
+  m_last_tick.total_us = 0;
+}
+
+void SystemProfiler::record_system(std::size_t slot,
+                                   const char* name,
+                                   std::uint64_t elapsed_us,
+                                   const QueryCounters& delta) {
+  if (!m_enabled) {
+    return;
+  }
+  if (slot >= m_systems.size()) {
+    m_systems.resize(slot + 1U);
+  }
+  SystemRecord& record = m_systems[slot];
+  if (record.name.empty() && name != nullptr) {
+    record.name = name;
+  }
+  record.last_us = elapsed_us;
+  record.total_us += elapsed_us;
+  record.peak_us = std::max(record.peak_us, elapsed_us);
+  ++record.calls;
+
+  record.last_views = delta.views;
+  record.last_view_candidates = delta.view_candidates;
+  record.last_collects = delta.collects;
+  record.last_collected_entities = delta.collected_entities;
+  record.last_spatial_queries = delta.spatial_queries;
+  record.last_spatial_candidates = delta.spatial_candidates;
+
+  m_last_tick.queries.views += delta.views;
+  m_last_tick.queries.view_candidates += delta.view_candidates;
+  m_last_tick.queries.collects += delta.collects;
+  m_last_tick.queries.collected_entities += delta.collected_entities;
+  m_last_tick.queries.spatial_queries += delta.spatial_queries;
+  m_last_tick.queries.spatial_candidates += delta.spatial_candidates;
+}
+
+void SystemProfiler::end_tick(std::uint64_t total_us) {
+  if (!m_enabled) {
+    return;
+  }
+  m_last_tick.total_us = total_us;
+  ++m_ticks;
+}
+
+void SystemProfiler::note_collect_call_site(const char* file,
+                                            unsigned line,
+                                            std::size_t entities) {
+  if (!m_enabled || file == nullptr) {
+    return;
+  }
+
+  std::string_view path(file);
+  const std::size_t slash = path.find_last_of('/');
+  if (slash != std::string_view::npos) {
+    path.remove_prefix(slash + 1U);
+  }
+
+  std::string key(path);
+  key += ':';
+  key += std::to_string(line);
+
+  CallSite& site = m_collect_call_sites[key];
+  ++site.calls;
+  site.entities += entities;
+}
+
+void SystemProfiler::clear() {
+  m_systems.clear();
+  m_collect_call_sites.clear();
+  m_last_tick = {};
+  m_ticks = 0;
+}
+
+auto SystemProfiler::format_report() const -> std::string {
+  std::vector<const SystemRecord*> ordered;
+  ordered.reserve(m_systems.size());
+  for (const SystemRecord& record : m_systems) {
+    if (record.calls > 0) {
+      ordered.push_back(&record);
+    }
+  }
+  std::sort(ordered.begin(), ordered.end(), [](const auto* lhs, const auto* rhs) {
+    return lhs->average_us() > rhs->average_us();
+  });
+
+  std::string out;
+  char line[256];
+
+  std::snprintf(line,
+                sizeof(line),
+                "%-34s %10s %10s %8s %10s %10s\n",
+                "system",
+                "avg us",
+                "peak us",
+                "queries",
+                "candidates",
+                "collected");
+  out += line;
+  out += std::string(88, '-');
+  out += '\n';
+
+  for (const SystemRecord* record : ordered) {
+    std::snprintf(line,
+                  sizeof(line),
+                  "%-34s %10.1f %10llu %8llu %10llu %10llu\n",
+                  record->name.c_str(),
+                  record->average_us(),
+                  static_cast<unsigned long long>(record->peak_us),
+                  static_cast<unsigned long long>(record->last_views +
+                                                  record->last_collects +
+                                                  record->last_spatial_queries),
+                  static_cast<unsigned long long>(record->last_view_candidates +
+                                                  record->last_spatial_candidates),
+                  static_cast<unsigned long long>(record->last_collected_entities));
+    out += line;
+  }
+
+  if (!m_collect_call_sites.empty()) {
+    std::vector<std::pair<const std::string*, const CallSite*>> sites;
+    sites.reserve(m_collect_call_sites.size());
+    for (const auto& [where, site] : m_collect_call_sites) {
+      sites.emplace_back(&where, &site);
+    }
+    std::sort(sites.begin(), sites.end(), [](const auto& lhs, const auto& rhs) {
+      return lhs.second->entities > rhs.second->entities;
+    });
+
+    out += "\nmaterialising queries by call site (whole run, worst first)\n";
+    const std::size_t shown = std::min<std::size_t>(sites.size(), 12U);
+    for (std::size_t i = 0; i < shown; ++i) {
+      std::snprintf(line,
+                    sizeof(line),
+                    "  %-44s %10llu calls %14llu entities\n",
+                    sites[i].first->c_str(),
+                    static_cast<unsigned long long>(sites[i].second->calls),
+                    static_cast<unsigned long long>(sites[i].second->entities));
+      out += line;
+    }
+  }
+
+  const QueryCounters& queries = m_last_tick.queries;
+  const double spatial_efficiency =
+      queries.spatial_queries == 0 ? 0.0
+                                   : static_cast<double>(queries.spatial_candidates) /
+                                         static_cast<double>(queries.spatial_queries);
+  std::snprintf(line,
+                sizeof(line),
+                "\nlast tick %llu: %llu entities, %llu us total\n"
+                "  views %llu (%llu candidates)  collects %llu (%llu entities)\n"
+                "  spatial queries %llu (%llu candidates, %.1f per query)\n",
+                static_cast<unsigned long long>(m_last_tick.tick_index),
+                static_cast<unsigned long long>(m_last_tick.entity_count),
+                static_cast<unsigned long long>(m_last_tick.total_us),
+                static_cast<unsigned long long>(queries.views),
+                static_cast<unsigned long long>(queries.view_candidates),
+                static_cast<unsigned long long>(queries.collects),
+                static_cast<unsigned long long>(queries.collected_entities),
+                static_cast<unsigned long long>(queries.spatial_queries),
+                static_cast<unsigned long long>(queries.spatial_candidates),
+                spatial_efficiency);
+  out += line;
+
+  return out;
+}
+
+} // namespace Engine::Core

--- a/game/core/system_profiler.h
+++ b/game/core/system_profiler.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Engine::Core {
+
+class SystemProfiler {
+public:
+  struct SystemRecord {
+    std::string name;
+    std::uint64_t last_us{0};
+    std::uint64_t total_us{0};
+    std::uint64_t peak_us{0};
+    std::uint64_t calls{0};
+
+    std::uint64_t last_views{0};
+    std::uint64_t last_view_candidates{0};
+    std::uint64_t last_collects{0};
+    std::uint64_t last_collected_entities{0};
+    std::uint64_t last_spatial_queries{0};
+    std::uint64_t last_spatial_candidates{0};
+
+    [[nodiscard]] auto average_us() const -> double {
+      return calls == 0 ? 0.0
+                        : static_cast<double>(total_us) / static_cast<double>(calls);
+    }
+  };
+
+  struct QueryCounters {
+    std::uint64_t views{0};
+    std::uint64_t view_candidates{0};
+    std::uint64_t collects{0};
+    std::uint64_t collected_entities{0};
+    std::uint64_t spatial_queries{0};
+    std::uint64_t spatial_candidates{0};
+
+    auto operator-(const QueryCounters& other) const -> QueryCounters {
+      return QueryCounters{
+          .views = views - other.views,
+          .view_candidates = view_candidates - other.view_candidates,
+          .collects = collects - other.collects,
+          .collected_entities = collected_entities - other.collected_entities,
+          .spatial_queries = spatial_queries - other.spatial_queries,
+          .spatial_candidates = spatial_candidates - other.spatial_candidates};
+    }
+  };
+
+  struct CallSite {
+    std::uint64_t calls{0};
+    std::uint64_t entities{0};
+  };
+
+  struct TickSummary {
+    std::uint64_t tick_index{0};
+    std::uint64_t total_us{0};
+    std::size_t entity_count{0};
+    QueryCounters queries;
+  };
+
+  void set_enabled(bool enabled) noexcept { m_enabled = enabled; }
+  [[nodiscard]] auto enabled() const noexcept -> bool { return m_enabled; }
+
+  void begin_tick(std::uint64_t tick_index, std::size_t entity_count);
+  void record_system(std::size_t slot,
+                     const char* name,
+                     std::uint64_t elapsed_us,
+                     const QueryCounters& delta);
+  void end_tick(std::uint64_t total_us);
+
+  [[nodiscard]] auto systems() const -> const std::vector<SystemRecord>& {
+    return m_systems;
+  }
+  [[nodiscard]] auto last_tick() const -> const TickSummary& { return m_last_tick; }
+  [[nodiscard]] auto ticks_recorded() const -> std::uint64_t { return m_ticks; }
+
+  void note_collect_call_site(const char* file, unsigned line, std::size_t entities);
+
+  [[nodiscard]] auto
+  collect_call_sites() const -> const std::map<std::string, CallSite>& {
+    return m_collect_call_sites;
+  }
+
+  void clear();
+
+  [[nodiscard]] auto format_report() const -> std::string;
+
+private:
+  bool m_enabled{false};
+  std::uint64_t m_ticks{0};
+  std::vector<SystemRecord> m_systems;
+  std::map<std::string, CallSite> m_collect_call_sites;
+  TickSummary m_last_tick;
+};
+
+} // namespace Engine::Core

--- a/game/core/system_schedule.cpp
+++ b/game/core/system_schedule.cpp
@@ -1,0 +1,80 @@
+#include "system_schedule.h"
+
+#include <algorithm>
+
+namespace Engine::Core {
+
+auto phase_name(SystemPhase phase) noexcept -> const char* {
+  switch (phase) {
+  case SystemPhase::Input:
+    return "input";
+  case SystemPhase::Movement:
+    return "movement";
+  case SystemPhase::Combat:
+    return "combat";
+  case SystemPhase::Strategy:
+    return "strategy";
+  case SystemPhase::Economy:
+    return "economy";
+  case SystemPhase::Ambient:
+    return "ambient";
+  case SystemPhase::Presentation:
+    return "presentation";
+  case SystemPhase::Cleanup:
+    return "cleanup";
+  case SystemPhase::_Count:
+    break;
+  }
+  return "?";
+}
+
+namespace {
+
+auto intersects(const std::vector<ComponentTypeId>& lhs,
+                const std::vector<ComponentTypeId>& rhs) -> bool {
+  for (const ComponentTypeId id : lhs) {
+    if (std::find(rhs.begin(), rhs.end(), id) != rhs.end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+auto SystemAccess::conflicts_with(const SystemAccess& other) const -> bool {
+
+  if (exclusive || other.exclusive) {
+    return true;
+  }
+
+  return intersects(writes, other.writes) || intersects(writes, other.reads) ||
+         intersects(reads, other.writes);
+}
+
+auto plan_phase_batches(std::span<const SystemAccess> systems)
+    -> std::vector<std::vector<std::size_t>> {
+  std::vector<std::vector<std::size_t>> batches;
+  if (systems.empty()) {
+    return batches;
+  }
+
+  std::vector<std::size_t> current;
+  for (std::size_t index = 0; index < systems.size(); ++index) {
+    const bool collides =
+        std::any_of(current.begin(), current.end(), [&](std::size_t member) {
+          return systems[index].conflicts_with(systems[member]);
+        });
+    if (collides && !current.empty()) {
+      batches.push_back(std::move(current));
+      current.clear();
+    }
+    current.push_back(index);
+  }
+  if (!current.empty()) {
+    batches.push_back(std::move(current));
+  }
+  return batches;
+}
+
+} // namespace Engine::Core

--- a/game/core/system_schedule.h
+++ b/game/core/system_schedule.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "component_registry.h"
+
+namespace Engine::Core {
+
+enum class SystemPhase : std::uint8_t {
+
+  Input = 0,
+
+  Movement = 1,
+
+  Combat = 2,
+
+  Strategy = 3,
+
+  Economy = 4,
+
+  Ambient = 5,
+
+  Presentation = 6,
+
+  Cleanup = 7,
+
+  _Count = 8
+};
+
+[[nodiscard]] auto phase_name(SystemPhase phase) noexcept -> const char*;
+
+struct SystemAccess {
+  std::vector<ComponentTypeId> reads;
+  std::vector<ComponentTypeId> writes;
+  bool exclusive = true;
+
+  [[nodiscard]] static auto everything() -> SystemAccess { return SystemAccess{}; }
+
+  template <typename... Reads>
+  [[nodiscard]] static auto reads_only() -> SystemAccess {
+    return SystemAccess{
+        .reads = {component_type_id<Reads>()...}, .writes = {}, .exclusive = false};
+  }
+
+  [[nodiscard]] auto conflicts_with(const SystemAccess& other) const -> bool;
+};
+
+[[nodiscard]] auto plan_phase_batches(std::span<const SystemAccess> systems)
+    -> std::vector<std::vector<std::size_t>>;
+
+} // namespace Engine::Core

--- a/game/core/world.cpp
+++ b/game/core/world.cpp
@@ -2,11 +2,21 @@
 
 #include <algorithm>
 #include <bit>
+#include <chrono>
 #include <cmath>
+#include <cstdlib>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <numbers>
+#include <string>
 #include <string_view>
+#include <typeinfo>
+
+#if defined(__GNUC__) && __has_include(<cxxabi.h>)
+#include <cxxabi.h>
+#define SOI_HAS_CXA_DEMANGLE 1
+#endif
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -925,7 +935,7 @@ void World::on_component_changed(EntityID entity_id,
                                  std::type_index component_type,
                                  bool added) {
 
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
 
   if (m_component_sets.size() <= type_id) {
     m_component_sets.resize(static_cast<std::size_t>(type_id) + 1);
@@ -951,9 +961,13 @@ void World::setup_entity_callback(Entity* entity) {
   });
 }
 
-auto World::collect_entities_with(ComponentTypeId type_id) -> std::vector<Entity*> {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+auto World::collect_entities_with_type(ComponentTypeId type_id,
+                                       const std::source_location& where)
+    -> std::vector<Entity*> {
+  const EntityLock lock(*this);
+  ++m_query_counters.collects;
   if (type_id >= m_component_sets.size()) {
+    m_system_profiler.note_collect_call_site(where.file_name(), where.line(), 0);
     return {};
   }
 
@@ -965,11 +979,14 @@ auto World::collect_entities_with(ComponentTypeId type_id) -> std::vector<Entity
       result.push_back(entity);
     }
   }
+  m_query_counters.collected_entities += result.size();
+  m_system_profiler.note_collect_call_site(
+      where.file_name(), where.line(), result.size());
   return result;
 }
 
 auto World::entities_with(ComponentTypeId type_id) const -> std::span<const EntityID> {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   if (type_id >= m_component_sets.size()) {
     return {};
   }
@@ -978,7 +995,7 @@ auto World::entities_with(ComponentTypeId type_id) const -> std::span<const Enti
 
 void World::resolve_entities_into(std::span<const EntityID> ids,
                                   std::vector<Entity*>& output) const {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   output.clear();
   if (output.capacity() < ids.size()) {
     output.reserve(ids.size());
@@ -991,7 +1008,7 @@ void World::resolve_entities_into(std::span<const EntityID> ids,
 }
 
 auto World::create_entity() -> Entity* {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
 
   std::uint32_t index = 0;
   if (!m_free_slots.empty()) {
@@ -1011,7 +1028,7 @@ auto World::create_entity() -> Entity* {
 }
 
 auto World::create_entity_with_id(EntityID entity_id) -> Entity* {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   if (entity_id == NULL_ENTITY) {
     return nullptr;
   }
@@ -1047,7 +1064,7 @@ auto World::create_entity_with_id(EntityID entity_id) -> Entity* {
 }
 
 void World::destroy_entity(EntityID entity_id) {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
 
   const std::uint32_t index = Handle::index_of(entity_id);
   if (index != 0 && index < m_slots.size()) {
@@ -1074,7 +1091,7 @@ void World::destroy_entity(EntityID entity_id) {
 }
 
 void World::clear() {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
 
   for (std::size_t i = 1; i < m_slots.size(); ++i) {
     if (m_slots[i].entity != nullptr) {
@@ -1087,6 +1104,8 @@ void World::clear() {
     m_free_slots.push_back(static_cast<std::uint32_t>(i));
   }
   m_live_count = 0;
+  m_deferred.clear();
+  m_spatial_index.clear();
 
   for (auto& set : m_component_sets) {
     set.clear();
@@ -1099,31 +1118,141 @@ void World::clear() {
 }
 
 auto World::get_entity(EntityID entity_id) -> Entity* {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   return resolve(entity_id);
 }
 
 auto World::is_alive(EntityID entity_id) const -> bool {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   return resolve(entity_id) != nullptr;
 }
 
 auto World::entity_count() const -> std::size_t {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   return m_live_count;
 }
 
 void World::add_system(std::unique_ptr<System> system) {
+  const SystemPhase phase = system != nullptr ? system->phase() : SystemPhase::Combat;
+  add_system(std::move(system), phase);
+}
+
+void World::add_system(std::unique_ptr<System> system, SystemPhase phase) {
   m_systems.push_back(std::move(system));
+  m_system_phases.push_back(phase);
+}
+
+auto World::plan_phase_schedule(SystemPhase phase) const
+    -> std::vector<std::vector<std::size_t>> {
+  std::vector<SystemAccess> declared;
+  std::vector<std::size_t> phase_slots;
+  for (std::size_t slot = 0; slot < m_systems.size(); ++slot) {
+    if (m_system_phases[slot] != phase || m_systems[slot] == nullptr) {
+      continue;
+    }
+    declared.push_back(m_systems[slot]->access());
+    phase_slots.push_back(slot);
+  }
+
+  auto batches = plan_phase_batches(declared);
+  for (auto& batch : batches) {
+    for (std::size_t& index : batch) {
+      index = phase_slots[index];
+    }
+  }
+  return batches;
+}
+
+namespace {
+
+auto demangled_system_name(const std::type_info& type) -> const std::string& {
+  static std::map<std::string, std::string> cache;
+  const std::string key = type.name();
+  auto existing = cache.find(key);
+  if (existing != cache.end()) {
+    return existing->second;
+  }
+
+  std::string readable = key;
+#if defined(SOI_HAS_CXA_DEMANGLE)
+  int status = 0;
+  char* raw = abi::__cxa_demangle(key.c_str(), nullptr, nullptr, &status);
+  if (status == 0 && raw != nullptr) {
+    readable = raw;
+  }
+  std::free(raw);
+#endif
+
+  const std::size_t last_scope = readable.rfind("::");
+  if (last_scope != std::string::npos) {
+    readable = readable.substr(last_scope + 2);
+  }
+  return cache.emplace(key, std::move(readable)).first->second;
+}
+
+} // namespace
+
+auto World::system_display_name(const System& system) -> const char* {
+  return demangled_system_name(typeid(system)).c_str();
+}
+
+auto World::current_query_counters() const -> SystemProfiler::QueryCounters {
+  SystemProfiler::QueryCounters counters = m_query_counters;
+  const WorldSpatialIndex::Stats& spatial = m_spatial_index.stats();
+  counters.spatial_queries = spatial.queries;
+  counters.spatial_candidates = spatial.candidates_examined;
+  return counters;
 }
 
 void World::update(float delta_time) {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
+  ++m_tick_id;
   if (m_presentation_enabled) {
     begin_motion_presentation_frame(*this, delta_time);
   }
-  for (auto& system : m_systems) {
-    system->update(this, delta_time);
+
+  const bool profiling = m_system_profiler.enabled();
+  const auto tick_started = std::chrono::steady_clock::now();
+  if (profiling) {
+    m_system_profiler.begin_tick(m_tick_id, m_live_count);
+  }
+
+  SystemPhase current_phase =
+      m_system_phases.empty() ? SystemPhase::Input : m_system_phases.front();
+
+  for (std::size_t slot = 0; slot < m_systems.size(); ++slot) {
+    System& system = *m_systems[slot];
+
+    const SystemPhase slot_phase = m_system_phases[slot];
+    if (slot_phase != current_phase) {
+      m_deferred.apply(*this);
+      current_phase = slot_phase;
+    }
+
+    if (!profiling) {
+      system.update(this, delta_time);
+      continue;
+    }
+
+    const SystemProfiler::QueryCounters queries_before = current_query_counters();
+    const auto started = std::chrono::steady_clock::now();
+    system.update(this, delta_time);
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    m_system_profiler.record_system(
+        slot,
+        system_display_name(system),
+        static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count()),
+        current_query_counters() - queries_before);
+  }
+
+  m_deferred.apply(*this);
+
+  if (profiling) {
+    m_system_profiler.end_tick(static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - tick_started)
+            .count()));
   }
   if (m_presentation_enabled) {
     finalize_motion_presentation_frame(*this, delta_time);
@@ -1147,7 +1276,7 @@ void World::ensure_render_snapshot() {
   if (m_render_publish_revision != 0) {
     return;
   }
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   if (m_render_publish_revision == 0) {
     publish_render_snapshot();
   }
@@ -1260,12 +1389,12 @@ auto World::get_units_not_owned_by(int owner_id) const -> std::vector<Entity*> {
 }
 
 auto World::get_next_entity_id() const -> EntityID {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   return Handle::make(static_cast<std::uint32_t>(m_slots.size()), 0);
 }
 
 void World::set_next_entity_id(EntityID next_id) {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   const std::uint32_t index = Handle::index_of(next_id);
   if (m_slots.size() < index) {
     const auto previous_size = m_slots.size();
@@ -1278,7 +1407,7 @@ void World::set_next_entity_id(EntityID next_id) {
 
 auto World::add_component_observer(ComponentObserverCallback callback)
     -> ObserverHandle {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   const ObserverHandle handle = m_next_observer_handle++;
   m_component_observers.push_back({handle, std::move(callback)});
   return handle;
@@ -1286,7 +1415,7 @@ auto World::add_component_observer(ComponentObserverCallback callback)
 
 auto World::add_entity_destroyed_observer(EntityDestroyedCallback callback)
     -> ObserverHandle {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   const ObserverHandle handle = m_next_observer_handle++;
   m_entity_destroyed_observers.push_back({handle, std::move(callback)});
   return handle;
@@ -1294,26 +1423,26 @@ auto World::add_entity_destroyed_observer(EntityDestroyedCallback callback)
 
 auto World::add_world_cleared_observer(WorldClearedCallback callback)
     -> ObserverHandle {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   const ObserverHandle handle = m_next_observer_handle++;
   m_world_cleared_observers.push_back({handle, std::move(callback)});
   return handle;
 }
 
 void World::remove_component_observer(ObserverHandle handle) {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   std::erase_if(m_component_observers,
                 [handle](const auto& entry) { return entry.handle == handle; });
 }
 
 void World::remove_entity_destroyed_observer(ObserverHandle handle) {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   std::erase_if(m_entity_destroyed_observers,
                 [handle](const auto& entry) { return entry.handle == handle; });
 }
 
 void World::remove_world_cleared_observer(ObserverHandle handle) {
-  const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+  const EntityLock lock(*this);
   std::erase_if(m_world_cleared_observers,
                 [handle](const auto& entry) { return entry.handle == handle; });
 }

--- a/game/core/world.h
+++ b/game/core/world.h
@@ -3,17 +3,26 @@
 #include <array>
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <source_location>
 #include <span>
+#include <thread>
+#include <tuple>
+#include <type_traits>
 #include <typeindex>
 #include <utility>
 #include <vector>
 
+#include "deferred_mutations.h"
 #include "entity.h"
 #include "system.h"
+#include "system_profiler.h"
+#include "world_spatial_index.h"
 
 namespace Engine::Core {
 
@@ -28,6 +37,17 @@ public:
       std::function<void(EntityID, std::type_index, bool)>;
   using EntityDestroyedCallback = std::function<void(EntityID)>;
   using WorldClearedCallback = std::function<void()>;
+
+  class EntityLock;
+
+  template <bool WithEntity, typename... Components>
+  class BasicView;
+
+  template <typename... Components>
+  using View = BasicView<false, Components...>;
+
+  template <typename... Components>
+  using EntityView = BasicView<true, Components...>;
 
   World();
   ~World();
@@ -46,7 +66,35 @@ public:
   [[nodiscard]] auto is_alive(EntityID entity_id) const -> bool;
 
   void add_system(std::unique_ptr<System> system);
+
+  void add_system(std::unique_ptr<System> system, SystemPhase phase);
+
   void update(float delta_time);
+
+  [[nodiscard]] auto deferred() -> DeferredMutations& { return m_deferred; }
+
+  [[nodiscard]] auto system_phases() const -> std::span<const SystemPhase> {
+    return m_system_phases;
+  }
+
+  [[nodiscard]] auto
+  plan_phase_schedule(SystemPhase phase) const -> std::vector<std::vector<std::size_t>>;
+
+  [[nodiscard]] auto tick_id() const noexcept -> std::uint64_t { return m_tick_id; }
+
+  [[nodiscard]] auto spatial_index() -> WorldSpatialIndex& { return m_spatial_index; }
+  [[nodiscard]] auto spatial_index() const -> const WorldSpatialIndex& {
+    return m_spatial_index;
+  }
+
+  [[nodiscard]] auto system_profiler() -> SystemProfiler& { return m_system_profiler; }
+  [[nodiscard]] auto system_profiler() const -> const SystemProfiler& {
+    return m_system_profiler;
+  }
+
+  [[nodiscard]] auto query_counters() const -> const SystemProfiler::QueryCounters& {
+    return m_query_counters;
+  }
 
   void set_presentation_enabled(bool enabled) noexcept {
     m_presentation_enabled = enabled;
@@ -87,13 +135,25 @@ public:
   }
 
   template <typename T>
-  auto get_entities_with() -> std::vector<Entity*> {
-    return collect_entities_with(component_type_id<T>());
+  [[nodiscard]] auto
+  collect_entities_with(std::source_location where = std::source_location::current())
+      -> std::vector<Entity*> {
+    return collect_entities_with_type(component_type_id<T>(), where);
   }
 
   template <typename T>
   [[nodiscard]] auto entities_with() const -> std::span<const EntityID> {
     return entities_with(component_type_id<T>());
+  }
+
+  template <typename... Components>
+  [[nodiscard]] auto view() -> View<Components...> {
+    return View<Components...>(*this);
+  }
+
+  template <typename... Components>
+  [[nodiscard]] auto entity_view() -> EntityView<Components...> {
+    return EntityView<Components...>(*this);
   }
 
   [[nodiscard]] auto
@@ -105,30 +165,12 @@ public:
   template <typename... Components, typename Fn>
   void each(Fn&& fn) {
     static_assert(sizeof...(Components) > 0);
-    const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
-    const std::array<ComponentTypeId, sizeof...(Components)> type_ids{
-        component_type_id<Components>()...};
-
-    ComponentTypeId smallest_type = 0;
-    std::size_t smallest_size = std::numeric_limits<std::size_t>::max();
-    for (const ComponentTypeId type_id : type_ids) {
-      if (type_id >= m_component_sets.size()) {
-        return;
-      }
-      const ComponentSet& candidate = m_component_sets[type_id];
-      if (candidate.dense.size() < smallest_size) {
-        smallest_type = type_id;
-        smallest_size = candidate.dense.size();
-      }
-    }
-
-    std::span<const EntityID> const ids = m_component_sets[smallest_type].dense;
-    for (const EntityID id : ids) {
-      Entity* entity = resolve(id);
-      if (entity != nullptr &&
-          ((entity->get_component<Components>() != nullptr) && ...)) {
-        std::invoke(std::forward<Fn>(fn), id, *entity->get_component<Components>()...);
-      }
+    for (auto entry : view<Components...>()) {
+      std::apply(
+          [&fn](EntityID id, Components&... components) {
+            std::invoke(fn, id, components...);
+          },
+          entry);
     }
   }
 
@@ -139,7 +181,7 @@ public:
 
   template <typename Fn>
   void for_each_entity(Fn&& fn) const {
-    const std::lock_guard<std::recursive_mutex> lock(m_entity_mutex);
+    const EntityLock lock(*this);
     for (const auto& slot : m_slots) {
       if (slot.entity != nullptr) {
         fn(*slot.entity);
@@ -190,7 +232,17 @@ private:
 
   void setup_entity_callback(Entity* entity);
 
-  auto collect_entities_with(ComponentTypeId type_id) -> std::vector<Entity*>;
+  auto
+  collect_entities_with_type(ComponentTypeId type_id,
+                             const std::source_location& where) -> std::vector<Entity*>;
+
+  static auto system_display_name(const System& system) -> const char*;
+  [[nodiscard]] auto current_query_counters() const -> SystemProfiler::QueryCounters;
+
+  void note_view_opened(std::size_t candidates) {
+    ++m_query_counters.views;
+    m_query_counters.view_candidates += candidates;
+  }
 
   [[nodiscard]] auto resolve(EntityID entity_id) const -> Entity*;
   void detach_from_all_component_sets(EntityID entity_id);
@@ -201,7 +253,11 @@ private:
   std::size_t m_live_count = 0;
 
   std::vector<std::unique_ptr<System>> m_systems;
+  std::vector<SystemPhase> m_system_phases;
+  DeferredMutations m_deferred;
   mutable std::recursive_mutex m_entity_mutex;
+
+  mutable std::atomic<std::uint64_t> m_entity_lock_owner{0};
 
   std::vector<ComponentSet> m_component_sets;
 
@@ -216,6 +272,10 @@ private:
   std::vector<ObserverEntry<EntityDestroyedCallback>> m_entity_destroyed_observers;
   std::vector<ObserverEntry<WorldClearedCallback>> m_world_cleared_observers;
 
+  WorldSpatialIndex m_spatial_index;
+  SystemProfiler m_system_profiler;
+  SystemProfiler::QueryCounters m_query_counters;
+  std::uint64_t m_tick_id{0};
   bool m_presentation_enabled{true};
   bool m_is_render_snapshot{false};
   std::atomic<bool> m_render_snapshots_requested{false};
@@ -227,6 +287,154 @@ private:
   std::vector<EntityID> m_render_other_ids;
   std::vector<std::uint64_t> m_render_entity_signatures;
   std::uint64_t m_render_publish_revision{0};
+};
+
+[[nodiscard]] inline auto this_thread_lock_token() noexcept -> std::uint64_t {
+  static std::atomic<std::uint64_t> next_token{1};
+  static const thread_local std::uint64_t token =
+      next_token.fetch_add(1, std::memory_order_relaxed);
+  return token;
+}
+
+class World::EntityLock {
+public:
+  explicit EntityLock(const World& world)
+      : m_world(&world) {
+    const std::uint64_t token = this_thread_lock_token();
+    if (world.m_entity_lock_owner.load(std::memory_order_relaxed) == token) {
+      return;
+    }
+    world.m_entity_mutex.lock();
+    world.m_entity_lock_owner.store(token, std::memory_order_relaxed);
+    m_acquired = true;
+  }
+
+  EntityLock(const EntityLock&) = delete;
+  EntityLock(EntityLock&&) = delete;
+  auto operator=(const EntityLock&) -> EntityLock& = delete;
+  auto operator=(EntityLock&&) -> EntityLock& = delete;
+
+  ~EntityLock() {
+    if (!m_acquired) {
+      return;
+    }
+
+    m_world->m_entity_lock_owner.store(0, std::memory_order_relaxed);
+    m_world->m_entity_mutex.unlock();
+  }
+
+private:
+  const World* m_world;
+  bool m_acquired{false};
+};
+
+template <bool WithEntity, typename... Components>
+class World::BasicView {
+public:
+  static_assert(sizeof...(Components) > 0, "a view needs at least one component");
+
+  using ComponentPointers = std::tuple<Components*...>;
+  using Head = std::conditional_t<WithEntity, Entity&, EntityID>;
+  using Reference = std::tuple<Head, Components&...>;
+
+  class Iterator {
+  public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = Reference;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+    using reference = Reference;
+
+    Iterator(World* world, std::span<const EntityID> ids, std::size_t index)
+        : m_world(world)
+        , m_ids(ids)
+        , m_index(index) {
+      seek();
+    }
+
+    auto operator*() const -> Reference {
+      return std::apply(
+          [this](auto*... components) {
+            if constexpr (WithEntity) {
+              return Reference(*m_entity, *components...);
+            } else {
+              return Reference(m_ids[m_index], *components...);
+            }
+          },
+          m_components);
+    }
+
+    auto operator++() -> Iterator& {
+      ++m_index;
+      seek();
+      return *this;
+    }
+
+    auto operator==(const Iterator& other) const -> bool {
+      return m_index == other.m_index;
+    }
+
+    auto operator!=(const Iterator& other) const -> bool {
+      return m_index != other.m_index;
+    }
+
+  private:
+    void seek() {
+      while (m_index < m_ids.size()) {
+        if (Entity* entity = m_world->resolve(m_ids[m_index])) {
+          m_components = ComponentPointers(entity->get_component<Components>()...);
+          const bool complete = std::apply(
+              [](auto*... components) { return ((components != nullptr) && ...); },
+              m_components);
+          if (complete) {
+            m_entity = entity;
+            return;
+          }
+        }
+        ++m_index;
+      }
+      m_entity = nullptr;
+    }
+
+    World* m_world{nullptr};
+    std::span<const EntityID> m_ids;
+    std::size_t m_index{0};
+    Entity* m_entity{nullptr};
+    ComponentPointers m_components{};
+  };
+
+  explicit BasicView(World& world)
+      : m_world(&world)
+      , m_lock(world) {
+    const std::array<ComponentTypeId, sizeof...(Components)> type_ids{
+        component_type_id<Components>()...};
+    std::size_t smallest = std::numeric_limits<std::size_t>::max();
+    for (const ComponentTypeId type_id : type_ids) {
+      if (type_id >= world.m_component_sets.size()) {
+        m_ids = {};
+        world.note_view_opened(0);
+        return;
+      }
+      const std::vector<EntityID>& dense = world.m_component_sets[type_id].dense;
+      if (dense.size() < smallest) {
+        smallest = dense.size();
+        m_ids = dense;
+      }
+    }
+    world.note_view_opened(m_ids.size());
+  }
+
+  [[nodiscard]] auto begin() const -> Iterator { return {m_world, m_ids, 0}; }
+  [[nodiscard]] auto end() const -> Iterator { return {m_world, m_ids, m_ids.size()}; }
+
+  [[nodiscard]] auto candidate_count() const -> std::size_t { return m_ids.size(); }
+
+  [[nodiscard]] auto empty() const -> bool { return begin() == end(); }
+
+private:
+  World* m_world{nullptr};
+  std::span<const EntityID> m_ids;
+  EntityLock m_lock;
 };
 
 void copy_authoritative_snapshot_components(const Entity& source, Entity& destination);

--- a/game/core/world_spatial_index.cpp
+++ b/game/core/world_spatial_index.cpp
@@ -1,0 +1,182 @@
+#include "world_spatial_index.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "component.h"
+#include "world.h"
+
+namespace Engine::Core {
+
+namespace {
+
+constexpr int k_max_cells_per_axis = 512;
+constexpr float k_grid_margin = 4.0F;
+
+} // namespace
+
+WorldSpatialIndex::WorldSpatialIndex(float cell_size)
+    : m_cell_size(cell_size > 0.0F ? cell_size : 1.0F)
+    , m_inv_cell_size(1.0F / (cell_size > 0.0F ? cell_size : 1.0F)) {
+}
+
+auto WorldSpatialIndex::cell_of(float value, float origin) const -> int {
+  return static_cast<int>(std::floor((value - origin) * m_inv_cell_size));
+}
+
+auto WorldSpatialIndex::clamp_cell(int cell, int count) -> int {
+  return std::clamp(cell, 0, count - 1);
+}
+
+void WorldSpatialIndex::clear() {
+  m_entries.clear();
+  m_scratch.clear();
+  m_cell_start.clear();
+  m_cell_cursor.clear();
+  m_cell_counts.clear();
+  m_entry_by_slot.clear();
+  m_cells_x = 0;
+  m_cells_z = 0;
+  m_ever_built = false;
+  m_built_for_tick = 0;
+}
+
+void WorldSpatialIndex::refresh(World& world) {
+  const std::uint64_t tick = world.tick_id();
+  if (tick != 0 && m_ever_built && m_built_for_tick == tick) {
+    return;
+  }
+  rebuild(world);
+}
+
+void WorldSpatialIndex::rebuild(World& world) {
+  m_built_for_tick = world.tick_id();
+  m_ever_built = true;
+  ++m_stats.rebuilds;
+
+  m_scratch.clear();
+
+  float min_x = std::numeric_limits<float>::max();
+  float min_z = std::numeric_limits<float>::max();
+  float max_x = std::numeric_limits<float>::lowest();
+  float max_z = std::numeric_limits<float>::lowest();
+
+  for (auto [entity, transform, unit] :
+       world.entity_view<TransformComponent, UnitComponent>()) {
+    Entry entry;
+    entry.id = entity.get_id();
+    entry.x = transform.position.x;
+    entry.z = transform.position.z;
+    entry.owner_id = unit.owner_id;
+    entry.health = unit.health;
+
+    std::uint16_t flags = k_none;
+    if (unit.health > 0) {
+      flags |= k_alive;
+    }
+    if (entity.has_component<BuildingComponent>()) {
+      flags |= k_building;
+    }
+    if (entity.has_component<WildlifeComponent>()) {
+      flags |= k_wildlife;
+    }
+    if (entity.has_component<UndeadComponent>()) {
+      flags |= k_undead;
+    }
+    if (entity.has_component<PendingRemovalComponent>()) {
+      flags |= k_pending_removal;
+    }
+    entry.flags = flags;
+
+    min_x = std::min(min_x, entry.x);
+    max_x = std::max(max_x, entry.x);
+    min_z = std::min(min_z, entry.z);
+    max_z = std::max(max_z, entry.z);
+
+    m_scratch.push_back(entry);
+  }
+
+  m_stats.entries_indexed += m_scratch.size();
+
+  if (m_scratch.empty()) {
+    m_entries.clear();
+    m_cell_start.assign(1, 0);
+    m_entry_by_slot.clear();
+    m_cells_x = 0;
+    m_cells_z = 0;
+    return;
+  }
+
+  m_origin_x = min_x - k_grid_margin;
+  m_origin_z = min_z - k_grid_margin;
+  const float span_x = (max_x + k_grid_margin) - m_origin_x;
+  const float span_z = (max_z + k_grid_margin) - m_origin_z;
+  m_cells_x = std::clamp(
+      static_cast<int>(span_x * m_inv_cell_size) + 1, 1, k_max_cells_per_axis);
+  m_cells_z = std::clamp(
+      static_cast<int>(span_z * m_inv_cell_size) + 1, 1, k_max_cells_per_axis);
+
+  const std::size_t cell_count =
+      static_cast<std::size_t>(m_cells_x) * static_cast<std::size_t>(m_cells_z);
+
+  m_cell_counts.assign(cell_count, 0U);
+  for (const Entry& entry : m_scratch) {
+    const int cx = clamp_cell(cell_of(entry.x, m_origin_x), m_cells_x);
+    const int cz = clamp_cell(cell_of(entry.z, m_origin_z), m_cells_z);
+    ++m_cell_counts[static_cast<std::size_t>(cz) * static_cast<std::size_t>(m_cells_x) +
+                    static_cast<std::size_t>(cx)];
+  }
+
+  m_cell_start.assign(cell_count + 1U, 0U);
+  std::size_t running = 0;
+  for (std::size_t cell = 0; cell < cell_count; ++cell) {
+    m_cell_start[cell] = running;
+    running += m_cell_counts[cell];
+  }
+  m_cell_start[cell_count] = running;
+
+  m_entries.resize(m_scratch.size());
+  m_cell_cursor.assign(m_cell_start.begin(), m_cell_start.end() - 1);
+  for (const Entry& entry : m_scratch) {
+    const int cx = clamp_cell(cell_of(entry.x, m_origin_x), m_cells_x);
+    const int cz = clamp_cell(cell_of(entry.z, m_origin_z), m_cells_z);
+    const std::size_t cell =
+        static_cast<std::size_t>(cz) * static_cast<std::size_t>(m_cells_x) +
+        static_cast<std::size_t>(cx);
+    m_entries[m_cell_cursor[cell]++] = entry;
+  }
+
+  std::uint32_t highest_slot = 0;
+  for (const Entry& entry : m_entries) {
+    highest_slot = std::max(highest_slot, Handle::index_of(entry.id));
+  }
+  m_entry_by_slot.assign(static_cast<std::size_t>(highest_slot) + 1U, k_no_entry);
+  for (std::size_t i = 0; i < m_entries.size(); ++i) {
+    m_entry_by_slot[Handle::index_of(m_entries[i].id)] = static_cast<std::uint32_t>(i);
+  }
+}
+
+void WorldSpatialIndex::query_radius(float x,
+                                     float z,
+                                     float radius,
+                                     std::vector<const Entry*>& out) const {
+  out.clear();
+  for_each_in_radius(
+      x, z, radius, [&out](const Entry& entry) { out.push_back(&entry); });
+}
+
+auto WorldSpatialIndex::find(EntityID id) const -> const Entry* {
+  const std::uint32_t slot = Handle::index_of(id);
+  if (slot >= m_entry_by_slot.size()) {
+    return nullptr;
+  }
+  const std::uint32_t position = m_entry_by_slot[slot];
+  if (position == k_no_entry || position >= m_entries.size()) {
+    return nullptr;
+  }
+  const Entry& entry = m_entries[position];
+  return entry.id == id ? &entry : nullptr;
+}
+
+} // namespace Engine::Core

--- a/game/core/world_spatial_index.h
+++ b/game/core/world_spatial_index.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "entity.h"
+
+namespace Engine::Core {
+
+class World;
+
+class WorldSpatialIndex {
+public:
+  enum Flags : std::uint16_t {
+    k_none = 0U,
+    k_building = 1U << 0U,
+    k_wildlife = 1U << 1U,
+    k_undead = 1U << 2U,
+    k_pending_removal = 1U << 3U,
+    k_alive = 1U << 4U,
+  };
+
+  struct Entry {
+    EntityID id{0};
+    float x{0.0F};
+    float z{0.0F};
+    int owner_id{0};
+    int health{0};
+    std::uint16_t flags{k_none};
+
+    [[nodiscard]] auto is(std::uint16_t flag) const noexcept -> bool {
+      return (flags & flag) != 0U;
+    }
+  };
+
+  explicit WorldSpatialIndex(float cell_size = 8.0F);
+
+  void refresh(World& world);
+
+  void rebuild(World& world);
+
+  void clear();
+
+  void
+  query_radius(float x, float z, float radius, std::vector<const Entry*>& out) const;
+
+  template <typename Fn>
+  void for_each_in_radius(float x, float z, float radius, Fn&& fn) const {
+    visit_cells(x, z, radius, [&](const Entry& entry) {
+      const float dx = entry.x - x;
+      const float dz = entry.z - z;
+      if (dx * dx + dz * dz <= radius * radius) {
+        fn(entry);
+      }
+    });
+  }
+
+  [[nodiscard]] auto find(EntityID id) const -> const Entry*;
+
+  [[nodiscard]] auto entries() const -> const std::vector<Entry>& { return m_entries; }
+
+  [[nodiscard]] auto entry_count() const -> std::size_t { return m_entries.size(); }
+
+  struct Stats {
+    std::uint64_t rebuilds{0};
+    std::uint64_t queries{0};
+    std::uint64_t candidates_examined{0};
+    std::uint64_t entries_indexed{0};
+  };
+
+  [[nodiscard]] auto stats() const -> const Stats& { return m_stats; }
+  void reset_stats() { m_stats = {}; }
+
+private:
+  template <typename Fn>
+  void visit_cells(float x, float z, float radius, Fn&& fn) const {
+    ++m_stats.queries;
+    if (m_cells_x <= 0 || m_cells_z <= 0 || m_entries.empty()) {
+      return;
+    }
+    const int min_cx = clamp_cell(cell_of(x - radius, m_origin_x), m_cells_x);
+    const int max_cx = clamp_cell(cell_of(x + radius, m_origin_x), m_cells_x);
+    const int min_cz = clamp_cell(cell_of(z - radius, m_origin_z), m_cells_z);
+    const int max_cz = clamp_cell(cell_of(z + radius, m_origin_z), m_cells_z);
+
+    for (int cz = min_cz; cz <= max_cz; ++cz) {
+      const std::size_t row =
+          static_cast<std::size_t>(cz) * static_cast<std::size_t>(m_cells_x);
+      for (int cx = min_cx; cx <= max_cx; ++cx) {
+        const std::size_t cell = row + static_cast<std::size_t>(cx);
+        const std::size_t begin = m_cell_start[cell];
+        const std::size_t end = m_cell_start[cell + 1];
+        m_stats.candidates_examined += end - begin;
+        for (std::size_t i = begin; i < end; ++i) {
+          fn(m_entries[i]);
+        }
+      }
+    }
+  }
+
+  [[nodiscard]] auto cell_of(float value, float origin) const -> int;
+  [[nodiscard]] static auto clamp_cell(int cell, int count) -> int;
+
+  float m_cell_size;
+  float m_inv_cell_size;
+
+  float m_origin_x{0.0F};
+  float m_origin_z{0.0F};
+  int m_cells_x{0};
+  int m_cells_z{0};
+
+  static constexpr std::uint32_t k_no_entry = 0xFFFFFFFFU;
+
+  std::vector<Entry> m_entries;
+  std::vector<Entry> m_scratch;
+  std::vector<std::size_t> m_cell_start;
+  std::vector<std::size_t> m_cell_cursor;
+  std::vector<std::uint32_t> m_cell_counts;
+
+  std::vector<std::uint32_t> m_entry_by_slot;
+
+  std::uint64_t m_built_for_tick{0};
+  bool m_ever_built{false};
+
+  mutable Stats m_stats;
+};
+
+} // namespace Engine::Core

--- a/game/map/mission_stage_tracker.cpp
+++ b/game/map/mission_stage_tracker.cpp
@@ -172,7 +172,7 @@ auto MissionStageTracker::update(Game::Session::SessionContext& session,
   std::vector<StageTally> tallies(m_stages.size());
   int enemy_commanders = 0;
 
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit == nullptr || unit->health <= 0) {
       continue;

--- a/game/map/visibility_service.cpp
+++ b/game/map/visibility_service.cpp
@@ -136,7 +136,7 @@ void VisibilityService::compute_immediate(Engine::Core::World& world, int player
 auto VisibilityService::gather_vision_sources(Engine::Core::World& world, int player_id)
     -> std::vector<VisibilityService::VisionSource> {
   std::vector<VisionSource> sources;
-  const auto entities = world.get_entities_with<Engine::Core::TransformComponent>();
+  const auto entities = world.collect_entities_with<Engine::Core::TransformComponent>();
   const float range_padding = m_tile_size * k_half_cell_offset;
 
   auto& owner_registry = Game::Systems::OwnerRegistry::instance();

--- a/game/mission/mission_setup_coordinator.cpp
+++ b/game/mission/mission_setup_coordinator.cpp
@@ -147,7 +147,7 @@ auto MissionSetupCoordinator::apply_mission_setup(
 
   if (has_mission_spawns && !has_map_spawns) {
     std::vector<Engine::Core::EntityID> to_remove;
-    auto entities = ctx.world.get_entities_with<Engine::Core::UnitComponent>();
+    auto entities = ctx.world.collect_entities_with<Engine::Core::UnitComponent>();
     to_remove.reserve(entities.size());
     for (auto* entity : entities) {
       if (entity != nullptr) {
@@ -357,7 +357,7 @@ auto MissionSetupCoordinator::apply_mission_setup(
 
   auto verify_owner_commander = [&](int owner_id, const QString& force_label) {
     for (auto* entity :
-         ctx.world.get_entities_with<Engine::Core::CommanderComponent>()) {
+         ctx.world.collect_entities_with<Engine::Core::CommanderComponent>()) {
       if (entity == nullptr) {
         continue;
       }
@@ -578,7 +578,7 @@ auto MissionSetupCoordinator::apply_skirmish_commander_setup(
 
   auto existing_owner_spawn_anchors = [&](int owner_id) {
     std::vector<Game::Mission::ExistingOwnerSpawnAnchor> anchors;
-    auto entities = ctx.world.get_entities_with<Engine::Core::UnitComponent>();
+    auto entities = ctx.world.collect_entities_with<Engine::Core::UnitComponent>();
     anchors.reserve(entities.size());
     for (auto* entity : entities) {
       if (entity == nullptr) {
@@ -668,7 +668,7 @@ auto MissionSetupCoordinator::apply_skirmish_commander_setup(
     QVector3D existing_position{0.0F, 0.0F, 0.0F};
     bool has_existing_position = false;
     for (auto* entity :
-         ctx.world.get_entities_with<Engine::Core::CommanderComponent>()) {
+         ctx.world.collect_entities_with<Engine::Core::CommanderComponent>()) {
       if (entity == nullptr) {
         continue;
       }

--- a/game/mission/mission_waves.cpp
+++ b/game/mission/mission_waves.cpp
@@ -129,7 +129,7 @@ auto resolve_defense_reference(Engine::Core::World& world,
   int hall_count = 0;
   int troop_count = 0;
 
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/game/render_bridge/camera_service.cpp
+++ b/game/render_bridge/camera_service.cpp
@@ -108,7 +108,7 @@ void CameraService::reset_camera(Render::GL::Camera& camera,
                                  Engine::Core::EntityID player_unit_id) {
   sync_map_bounds(camera);
   Engine::Core::Entity* focus_entity = nullptr;
-  for (auto* e : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* e : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (e == nullptr) {
       continue;
     }

--- a/game/render_bridge/picking_service.cpp
+++ b/game/render_bridge/picking_service.cpp
@@ -178,7 +178,7 @@ auto PickingService::pick_single(float sx,
   float best_building_dist2 = std::numeric_limits<float>::max();
   Engine::Core::EntityID best_unit_id = 0;
   Engine::Core::EntityID best_building_id = 0;
-  auto ents = world.get_entities_with<Engine::Core::TransformComponent>();
+  auto ents = world.collect_entities_with<Engine::Core::TransformComponent>();
   for (auto* e : ents) {
     if (!e->has_component<Engine::Core::UnitComponent>()) {
       continue;
@@ -323,7 +323,7 @@ auto PickingService::pick_in_rect(float x1,
   float const min_y = std::min(y1, y2);
   float const max_y = std::max(y1, y2);
   std::vector<Engine::Core::EntityID> picked;
-  auto ents = world.get_entities_with<Engine::Core::TransformComponent>();
+  auto ents = world.collect_entities_with<Engine::Core::TransformComponent>();
   for (auto* e : ents) {
     if (!e->has_component<Engine::Core::UnitComponent>()) {
       continue;

--- a/game/render_bridge/selection_controller.cpp
+++ b/game/render_bridge/selection_controller.cpp
@@ -192,7 +192,7 @@ void SelectionController::select_all_player_troops(int local_owner_id) {
 
   m_selection_system->clear_selection();
 
-  auto entities = m_world->get_entities_with<Engine::Core::UnitComponent>();
+  auto entities = m_world->collect_entities_with<Engine::Core::UnitComponent>();
   for (auto* e : entities) {
     auto* unit = e->get_component<Engine::Core::UnitComponent>();
     if ((unit == nullptr) || unit->owner_id != local_owner_id) {

--- a/game/systems/attack_targeting.cpp
+++ b/game/systems/attack_targeting.cpp
@@ -148,7 +148,8 @@ auto collect_attack_target_highlights(const AttackTargetingRequest& request)
   };
   std::vector<ScoredMarker> candidates;
 
-  for (auto* entity : request.world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity :
+       request.world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/game/systems/battlefield_capture.cpp
+++ b/game/systems/battlefield_capture.cpp
@@ -308,7 +308,8 @@ void add_overlays(CaptureResult& out, std::uint64_t tick, Engine::Core::World& w
                               "live centroid"});
     }
   }
-  for (auto* entity : world.get_entities_with<Engine::Core::FormationModeComponent>()) {
+  for (auto* entity :
+       world.collect_entities_with<Engine::Core::FormationModeComponent>()) {
     auto const* mode = entity->get_component<Engine::Core::FormationModeComponent>();
     if (mode == nullptr || !mode->active) {
       continue;
@@ -408,7 +409,7 @@ auto run(const RunnerConfig& config, const TickObserver& observer) -> CaptureRes
 
     std::vector<Engine::Core::Entity*> entities;
     for (auto* entity :
-         (*scenario->world).get_entities_with<Engine::Core::UnitComponent>()) {
+         (*scenario->world).collect_entities_with<Engine::Core::UnitComponent>()) {
       entities.push_back(entity);
     }
     std::sort(entities.begin(), entities.end(), [](auto* lhs, auto* rhs) {

--- a/game/systems/capture_system.cpp
+++ b/game/systems/capture_system.cpp
@@ -116,7 +116,7 @@ void CaptureSystem::process_barrack_capture(Engine::Core::World* world,
   constexpr float capture_radius = 8.0F;
   constexpr int troop_advantage_multiplier = 3;
 
-  auto barracks = world->get_entities_with<Engine::Core::BuildingComponent>();
+  auto barracks = world->collect_entities_with<Engine::Core::BuildingComponent>();
   if (barracks.empty()) {
     return;
   }

--- a/game/systems/civilian_delivery_system.cpp
+++ b/game/systems/civilian_delivery_system.cpp
@@ -48,7 +48,8 @@ void CivilianDeliverySystem::update(Engine::Core::World* world, float) {
   }
 
   std::vector<Engine::Core::EntityID> to_remove;
-  auto civilians = world->get_entities_with<Engine::Core::CivilianDeliveryComponent>();
+  auto civilians =
+      world->collect_entities_with<Engine::Core::CivilianDeliveryComponent>();
 
   for (auto* civilian_entity : civilians) {
     if (civilian_entity == nullptr) {

--- a/game/systems/cleanup_system.cpp
+++ b/game/systems/cleanup_system.cpp
@@ -14,7 +14,7 @@ void CleanupSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
   auto blood_stain_entities =
-      world->get_entities_with<Engine::Core::BloodStainComponent>();
+      world->collect_entities_with<Engine::Core::BloodStainComponent>();
   for (auto* entity : blood_stain_entities) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -34,7 +34,8 @@ void CleanupSystem::update(Engine::Core::World* world, float delta_time) {
   }
 
   auto structure_damage_entities =
-      world->get_entities_with<Engine::Core::StructureDamagePresentationComponent>();
+      world
+          ->collect_entities_with<Engine::Core::StructureDamagePresentationComponent>();
   for (auto* entity : structure_damage_entities) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -56,7 +57,7 @@ void CleanupSystem::update(Engine::Core::World* world, float delta_time) {
   }
 
   auto rpg_contact_entities =
-      world->get_entities_with<Engine::Core::RpgContactPresentationComponent>();
+      world->collect_entities_with<Engine::Core::RpgContactPresentationComponent>();
   for (auto* entity : rpg_contact_entities) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -78,7 +79,7 @@ void CleanupSystem::update(Engine::Core::World* world, float delta_time) {
   }
 
   auto casualty_entities =
-      world->get_entities_with<Engine::Core::SoldierCasualtyAnimationComponent>();
+      world->collect_entities_with<Engine::Core::SoldierCasualtyAnimationComponent>();
   for (auto* entity : casualty_entities) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -116,7 +117,7 @@ void CleanupSystem::update(Engine::Core::World* world, float delta_time) {
   }
 
   auto dead_entities =
-      world->get_entities_with<Engine::Core::DeathAnimationComponent>();
+      world->collect_entities_with<Engine::Core::DeathAnimationComponent>();
   for (auto* entity : dead_entities) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -152,7 +153,7 @@ void CleanupSystem::update(Engine::Core::World* world, float delta_time) {
 void CleanupSystem::remove_dead_entities(Engine::Core::World* world) {
   std::vector<Engine::Core::EntityID> entities_to_remove;
 
-  auto entities = world->get_entities_with<Engine::Core::PendingRemovalComponent>();
+  auto entities = world->collect_entities_with<Engine::Core::PendingRemovalComponent>();
 
   entities_to_remove.reserve(entities.size());
   for (auto* entity : entities) {

--- a/game/systems/cohort_system.cpp
+++ b/game/systems/cohort_system.cpp
@@ -38,7 +38,7 @@ void CohortSystem::update(Engine::Core::World* world, float delta_time) {
     m_reform_timer = k_reform_interval;
   }
 
-  auto entities = world->get_entities_with<Engine::Core::UnitComponent>();
+  auto entities = world->collect_entities_with<Engine::Core::UnitComponent>();
 
   if (should_reform) {
 

--- a/game/systems/combat_actions/body_impact.cpp
+++ b/game/systems/combat_actions/body_impact.cpp
@@ -136,7 +136,7 @@ auto find_body_impact_contact(
     }
   }
 
-  for (auto* candidate : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     consider(candidate, best_score, contact);
   }
 

--- a/game/systems/combat_actions/weapon_trace.cpp
+++ b/game/systems/combat_actions/weapon_trace.cpp
@@ -942,7 +942,7 @@ auto find_weapon_trace_contact(
     }
   }
 
-  for (auto* candidate : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     consider(candidate, best_score, contact);
   }
 
@@ -1016,7 +1016,7 @@ auto find_weapon_trace_contact(
     }
   }
 
-  for (auto* candidate : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     consider(candidate, best_score, contact);
   }
 

--- a/game/systems/combat_system/attack_processor.cpp
+++ b/game/systems/combat_system/attack_processor.cpp
@@ -302,7 +302,7 @@ auto should_prioritize_healing(Engine::Core::Entity* healer,
     return false;
   }
 
-  for (auto* target : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* target : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (target == nullptr ||
         target->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;
@@ -1061,7 +1061,7 @@ auto is_formation_reserve(Engine::Core::Entity* entity,
   }
   int front_rank = mode->stable_rank;
   for (auto* member :
-       world->get_entities_with<Engine::Core::FormationModeComponent>()) {
+       world->collect_entities_with<Engine::Core::FormationModeComponent>()) {
     auto const* member_mode =
         member->get_component<Engine::Core::FormationModeComponent>();
     auto const* member_unit = member->get_component<Engine::Core::UnitComponent>();

--- a/game/systems/combat_system/combat_action_processor.cpp
+++ b/game/systems/combat_system/combat_action_processor.cpp
@@ -134,7 +134,7 @@ void apply_commander_signature_effects(
   int const sweep_damage = std::max(1, damage / 2);
   int remaining = commander.signature_max_targets - 1;
 
-  for (auto* candidate : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (remaining <= 0) {
       break;
     }

--- a/game/systems/combat_system/combat_hit_resolver.cpp
+++ b/game/systems/combat_system/combat_hit_resolver.cpp
@@ -718,7 +718,7 @@ auto resolve_projectile_area_impact_hit(Engine::Core::World* world,
           ? special_attack->bonus_damage_multiplier_vs_fire_vulnerable
           : 1.0F;
 
-  for (auto* candidate : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == nullptr ||
         candidate->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;

--- a/game/systems/combat_system/combat_mode_processor.cpp
+++ b/game/systems/combat_system/combat_mode_processor.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <vector>
 
 #include "../../core/component.h"
 #include "../../core/world.h"
@@ -59,13 +60,21 @@ void update_combat_mode(Engine::Core::Entity* attacker,
   }
 
   auto& owner_registry = Game::Systems::OwnerRegistry::instance();
-  auto units = world->get_entities_with<Engine::Core::UnitComponent>();
+
+  const float reach = std::max(attack_comp->range, attack_comp->melee_range);
+  static thread_local std::vector<Engine::Core::EntityID> nearby;
+  collect_unit_ids_near(*world,
+                        attacker_transform->position.x,
+                        attacker_transform->position.z,
+                        reach + 2.0F * FormationCombat::max_contact_extent(),
+                        nearby);
 
   float closest_enemy_dist_sq = std::numeric_limits<float>::max();
   float closest_height_diff = 0.0F;
 
-  for (auto* target : units) {
-    if (target == attacker) {
+  for (const Engine::Core::EntityID target_id : nearby) {
+    auto* target = world->get_entity(target_id);
+    if (target == nullptr || target == attacker) {
       continue;
     }
 

--- a/game/systems/combat_system/combat_state_processor.cpp
+++ b/game/systems/combat_system/combat_state_processor.cpp
@@ -89,7 +89,7 @@ auto resolve_commander_contact_target(Engine::Core::World* world,
 
   Engine::Core::Entity* best = nullptr;
   float best_score = -1000000.0F;
-  for (auto* candidate : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == nullptr || candidate == &commander ||
         !is_valid_enemy_unit(commander_unit, candidate, false) ||
         !target_in_swing_arc(commander, *candidate, reach)) {
@@ -258,7 +258,7 @@ void process_combat_state(Engine::Core::World* world, float delta_time) {
       Engine::Core::Timing::combat_state_update());
   process_spear_brace_state(world, delta_time);
   process_mounted_charge_intents(world, delta_time);
-  auto units = world->get_entities_with<Engine::Core::CombatStateComponent>();
+  auto units = world->collect_entities_with<Engine::Core::CombatStateComponent>();
 
   for (auto* unit : units) {
     if (unit->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -352,7 +352,7 @@ void process_combat_state(Engine::Core::World* world, float delta_time) {
   }
 
   for (auto* unit :
-       world->get_entities_with<Engine::Core::RpgCommanderActionComponent>()) {
+       world->collect_entities_with<Engine::Core::RpgCommanderActionComponent>()) {
     if (unit == nullptr ||
         unit->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;

--- a/game/systems/combat_system/combat_status_effect_processor.cpp
+++ b/game/systems/combat_system/combat_status_effect_processor.cpp
@@ -48,7 +48,8 @@ auto apply_burning_tick_damage(Engine::Core::World* world,
 auto process_cursed_statuses(Engine::Core::World* world,
                              float delta_time,
                              CombatStatusEffectUpdateResult& result) -> void {
-  for (auto* entity : world->get_entities_with<Engine::Core::CursedStatusComponent>()) {
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::CursedStatusComponent>()) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;
@@ -72,7 +73,7 @@ auto process_burning_statuses(Engine::Core::World* world,
                               float delta_time,
                               CombatStatusEffectUpdateResult& result) -> void {
   for (auto* entity :
-       world->get_entities_with<Engine::Core::BurningStatusComponent>()) {
+       world->collect_entities_with<Engine::Core::BurningStatusComponent>()) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;
@@ -128,8 +129,9 @@ auto process_burning_statuses(Engine::Core::World* world,
 auto process_fire_patches(Engine::Core::World* world,
                           float delta_time,
                           CombatStatusEffectUpdateResult& result) -> void {
-  auto units = world->get_entities_with<Engine::Core::UnitComponent>();
-  for (auto* entity : world->get_entities_with<Engine::Core::FirePatchComponent>()) {
+  auto units = world->collect_entities_with<Engine::Core::UnitComponent>();
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::FirePatchComponent>()) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;
@@ -167,7 +169,8 @@ auto process_fire_patches(Engine::Core::World* world,
 } // namespace
 
 void process_stagger_recovery(Engine::Core::World* world, float delta_time) {
-  for (auto* staggered : world->get_entities_with<Engine::Core::StaggerComponent>()) {
+  for (auto* staggered :
+       world->collect_entities_with<Engine::Core::StaggerComponent>()) {
     if (staggered == nullptr ||
         Game::Systems::CombatRules::uses_rpg_combat_rules(staggered)) {
 
@@ -185,7 +188,7 @@ void process_stagger_recovery(Engine::Core::World* world, float delta_time) {
 }
 
 void process_signature_presentations(Engine::Core::World* world, float delta_time) {
-  for (auto* entity : world->get_entities_with<
+  for (auto* entity : world->collect_entities_with<
                       Engine::Core::CommanderSignaturePresentationComponent>()) {
     if (entity == nullptr) {
       continue;

--- a/game/systems/combat_system/combat_utils.cpp
+++ b/game/systems/combat_system/combat_utils.cpp
@@ -6,6 +6,7 @@
 
 #include "../../core/component.h"
 #include "../../core/world.h"
+#include "../../core/world_spatial_index.h"
 #include "../../units/spawn_type.h"
 #include "../building_collision_registry.h"
 #include "../combat_rules.h"
@@ -119,6 +120,21 @@ auto CombatQueryContext::hostile(int attacker_owner_id,
                                                               target_owner_id);
 }
 
+void collect_unit_ids_near(Engine::Core::World& world,
+                           float x,
+                           float z,
+                           float radius,
+                           std::vector<Engine::Core::EntityID>& out) {
+  out.clear();
+  auto& index = world.spatial_index();
+  index.refresh(world);
+  index.for_each_in_radius(
+      x, z, radius, [&out](const Engine::Core::WorldSpatialIndex::Entry& entry) {
+        out.push_back(entry.id);
+      });
+  std::sort(out.begin(), out.end());
+}
+
 auto build_combat_query_context(Engine::Core::World* world) -> CombatQueryContext {
   CombatQueryContext query_context;
   rebuild_combat_query_context(world, query_context);
@@ -132,30 +148,29 @@ void rebuild_combat_query_context(Engine::Core::World* world,
     return;
   }
 
-  auto const world_units = world->get_entities_with<Engine::Core::UnitComponent>();
-  query_context.units.reserve(world_units.size());
+  query_context.units.reserve(
+      world->entities_with<Engine::Core::UnitComponent>().size());
 
-  for (auto* entity : world_units) {
-    auto* unit = entity->get_component<Engine::Core::UnitComponent>();
-    if ((unit == nullptr) || (unit->health <= 0)) {
+  for (auto [entity, unit] : world->entity_view<Engine::Core::UnitComponent>()) {
+    if (unit.health <= 0) {
       continue;
     }
-    if (entity->has_component<Engine::Core::PendingRemovalComponent>()) {
+    if (entity.has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;
     }
 
-    const bool building = is_building(entity);
-    query_context.units.push_back(entity);
-    query_context.record_candidate(entity, unit->owner_id, building);
+    const bool building = is_building(&entity);
+    query_context.units.push_back(&entity);
+    query_context.record_candidate(&entity, unit.owner_id, building);
 
     if (building) {
       continue;
     }
 
-    auto* transform = entity->get_component<Engine::Core::TransformComponent>();
+    auto* transform = entity.get_component<Engine::Core::TransformComponent>();
     if (transform != nullptr) {
       query_context.unit_grid.insert(
-          entity->get_id(), transform->position.x, transform->position.z);
+          entity.get_id(), transform->position.x, transform->position.z);
     }
   }
 

--- a/game/systems/combat_system/combat_utils.h
+++ b/game/systems/combat_system/combat_utils.h
@@ -62,6 +62,12 @@ private:
   std::vector<int> m_present_owner_ids;
 };
 
+void collect_unit_ids_near(Engine::Core::World& world,
+                           float x,
+                           float z,
+                           float radius,
+                           std::vector<Engine::Core::EntityID>& out);
+
 auto build_combat_query_context(Engine::Core::World* world) -> CombatQueryContext;
 
 void rebuild_combat_query_context(Engine::Core::World* world,

--- a/game/systems/combat_system/damage_application.cpp
+++ b/game/systems/combat_system/damage_application.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <numbers>
 #include <optional>
+#include <vector>
 
 #include "../../core/component.h"
 #include "../../core/event_manager.h"
@@ -449,7 +450,7 @@ void fill_formation_front_vacancy(Engine::Core::World* world,
   int best_rank = std::numeric_limits<int>::max();
   float best_distance_sq = std::numeric_limits<float>::max();
   for (auto* candidate :
-       world->get_entities_with<Engine::Core::FormationModeComponent>()) {
+       world->collect_entities_with<Engine::Core::FormationModeComponent>()) {
     auto* mode = candidate->get_component<Engine::Core::FormationModeComponent>();
     auto* unit = candidate->get_component<Engine::Core::UnitComponent>();
     auto* transform = candidate->get_component<Engine::Core::TransformComponent>();
@@ -515,7 +516,8 @@ void prune_oldest_blood_stain(Engine::Core::World* world) {
   }
 
   while (true) {
-    auto blood_stains = world->get_entities_with<Engine::Core::BloodStainComponent>();
+    auto blood_stains =
+        world->collect_entities_with<Engine::Core::BloodStainComponent>();
     if (blood_stains.size() <
         static_cast<std::size_t>(Engine::Core::Defaults::k_blood_stain_max_active)) {
       return;
@@ -676,10 +678,18 @@ void alert_nearby_allies(Engine::Core::World* world,
   float const radius_sq =
       Constants::k_squad_alert_radius * Constants::k_squad_alert_radius;
   int alerted = 0;
-  for (auto* ally : world->get_entities_with<Engine::Core::UnitComponent>()) {
+
+  static thread_local std::vector<Engine::Core::EntityID> nearby;
+  collect_unit_ids_near(*world,
+                        defender_transform->position.x,
+                        defender_transform->position.z,
+                        Constants::k_squad_alert_radius,
+                        nearby);
+  for (const Engine::Core::EntityID ally_id : nearby) {
     if (alerted >= Constants::k_max_squad_alert_allies) {
       break;
     }
+    auto* ally = world->get_entity(ally_id);
     if ((ally == defender) || (ally == nullptr) ||
         ally->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;

--- a/game/systems/combat_system/elephant_special_processor.cpp
+++ b/game/systems/combat_system/elephant_special_processor.cpp
@@ -314,7 +314,7 @@ auto apply_elephant_stomp_impact(Engine::Core::World* world,
   if (elephant_comp == nullptr) {
     return false;
   }
-  auto units = world->get_entities_with<Engine::Core::UnitComponent>();
+  auto units = world->collect_entities_with<Engine::Core::UnitComponent>();
   bool const hit = apply_stomp_damage(
       *elephant, *world, units, std::max(1, elephant_comp->trample_damage), 4.5F);
   if (hit) {

--- a/game/systems/combat_system/formation_contact_processor.cpp
+++ b/game/systems/combat_system/formation_contact_processor.cpp
@@ -227,7 +227,7 @@ void sort_fronts(std::vector<Engine::Core::FormationContactFront>& fronts) {
 
 auto build_fronts(Engine::Core::World& world) -> FrontMap {
   FrontMap result;
-  auto attackers = world.get_entities_with<Engine::Core::AttackTargetComponent>();
+  auto attackers = world.collect_entities_with<Engine::Core::AttackTargetComponent>();
   std::sort(attackers.begin(), attackers.end(), [](auto const* lhs, auto const* rhs) {
     return lhs->get_id() < rhs->get_id();
   });
@@ -281,7 +281,7 @@ void clear_contact(Engine::Core::FormationContactComponent& contact) {
 
 void publish_contacts(Engine::Core::World& world, FrontMap fronts_by_entity) {
   for (auto* entity :
-       world.get_entities_with<Engine::Core::FormationContactComponent>()) {
+       world.collect_entities_with<Engine::Core::FormationContactComponent>()) {
     if (entity != nullptr && !fronts_by_entity.contains(entity->get_id())) {
       clear_contact(*entity->get_component<Engine::Core::FormationContactComponent>());
     }
@@ -519,7 +519,7 @@ void tick_formation_hit(Engine::Core::Entity& entity, float delta_time) {
 }
 
 void publish_formation_presentation(Engine::Core::World& world, float delta_time) {
-  auto const entities = world.get_entities_with<Engine::Core::UnitComponent>();
+  auto const entities = world.collect_entities_with<Engine::Core::UnitComponent>();
   std::unordered_map<Engine::Core::EntityID, FormationCombat::FormationLayout>
       layout_cache;
   layout_cache.reserve(entities.size());

--- a/game/systems/combat_system/hit_feedback_processor.cpp
+++ b/game/systems/combat_system/hit_feedback_processor.cpp
@@ -78,7 +78,7 @@ void apply_knockback_step(Engine::Core::Entity& unit,
 } // namespace
 
 void process_hit_feedback(Engine::Core::World* world, float delta_time) {
-  auto units = world->get_entities_with<Engine::Core::HitFeedbackComponent>();
+  auto units = world->collect_entities_with<Engine::Core::HitFeedbackComponent>();
 
   for (auto* unit : units) {
     if (unit->has_component<Engine::Core::PendingRemovalComponent>()) {

--- a/game/systems/combat_system/mounted_charge_processor.cpp
+++ b/game/systems/combat_system/mounted_charge_processor.cpp
@@ -186,7 +186,7 @@ void process_mounted_charge_intents(Engine::Core::World* world, float delta_time
     return;
   }
 
-  for (auto* entity : world->get_entities_with<Engine::Core::MovementComponent>()) {
+  for (auto* entity : world->collect_entities_with<Engine::Core::MovementComponent>()) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;

--- a/game/systems/combat_system/spear_brace_processor.cpp
+++ b/game/systems/combat_system/spear_brace_processor.cpp
@@ -77,20 +77,20 @@ void process_spear_brace_state(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  for (auto* entity : world->get_entities_with<Engine::Core::UnitComponent>()) {
-    if (entity == nullptr ||
-        entity->has_component<Engine::Core::PendingRemovalComponent>() ||
-        !is_spear_user(*entity)) {
+  for (auto [entity, unit] : world->entity_view<Engine::Core::UnitComponent>()) {
+    (void)unit;
+    if (entity.has_component<Engine::Core::PendingRemovalComponent>() ||
+        !is_spear_user(entity)) {
       continue;
     }
 
-    BraceIntent const intent = resolve_brace_intent(*entity);
-    auto* brace = entity->get_component<Engine::Core::SpearBraceComponent>();
+    BraceIntent const intent = resolve_brace_intent(entity);
+    auto* brace = entity.get_component<Engine::Core::SpearBraceComponent>();
     if (brace == nullptr && !intent.requested) {
       continue;
     }
     if (brace == nullptr) {
-      brace = entity->add_component<Engine::Core::SpearBraceComponent>();
+      brace = entity.add_component<Engine::Core::SpearBraceComponent>();
     }
     if (brace == nullptr) {
       continue;

--- a/game/systems/combat_system/structure_fire.cpp
+++ b/game/systems/combat_system/structure_fire.cpp
@@ -120,7 +120,7 @@ auto process_structure_fires(Engine::Core::World* world,
 
   float const step = std::max(0.0F, delta_time);
   for (auto* entity :
-       world->get_entities_with<Engine::Core::StructureFireComponent>()) {
+       world->collect_entities_with<Engine::Core::StructureFireComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/game/systems/commander_system.cpp
+++ b/game/systems/commander_system.cpp
@@ -186,7 +186,7 @@ auto try_trigger_rally(Engine::Core::World* world,
 
   const float rally_radius_sq = commander.rally_range * commander.rally_range;
   bool restored_any = false;
-  for (auto* candidate : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == commander_entity) {
       continue;
     }
@@ -219,7 +219,7 @@ auto try_trigger_rally(Engine::Core::World* world,
 }
 
 void reset_commander_modified_stats(Engine::Core::World* world) {
-  for (auto* entity : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (!is_living_troop(unit)) {
       continue;
@@ -240,7 +240,7 @@ void reset_commander_modified_stats(Engine::Core::World* world) {
   }
 
   for (auto* entity :
-       world->get_entities_with<Engine::Core::CommanderAuraBuffComponent>()) {
+       world->collect_entities_with<Engine::Core::CommanderAuraBuffComponent>()) {
     auto* buff = entity->get_component<Engine::Core::CommanderAuraBuffComponent>();
     if (buff == nullptr) {
       continue;
@@ -279,7 +279,7 @@ void apply_commander_death_shock(Engine::Core::World* world,
                                  const Engine::Core::TransformComponent& origin) {
   const float shock_radius_sq =
       commander.death_shock_radius * commander.death_shock_radius;
-  for (auto* candidate : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == commander_entity) {
       continue;
     }
@@ -310,7 +310,7 @@ void CommanderSystem::update(Engine::Core::World* world, float delta_time) {
 
   reset_commander_modified_stats(world);
 
-  for (auto* entity : world->get_entities_with<Engine::Core::MoraleComponent>()) {
+  for (auto* entity : world->collect_entities_with<Engine::Core::MoraleComponent>()) {
     auto* morale = entity->get_component<Engine::Core::MoraleComponent>();
     if (morale == nullptr) {
       continue;
@@ -320,7 +320,7 @@ void CommanderSystem::update(Engine::Core::World* world, float delta_time) {
   }
 
   for (auto* commander_entity :
-       world->get_entities_with<Engine::Core::CommanderComponent>()) {
+       world->collect_entities_with<Engine::Core::CommanderComponent>()) {
     auto* commander =
         commander_entity->get_component<Engine::Core::CommanderComponent>();
     auto* unit = commander_entity->get_component<Engine::Core::UnitComponent>();
@@ -421,7 +421,8 @@ void CommanderSystem::update(Engine::Core::World* world, float delta_time) {
           commander->flag_rally_flag_x, 0.0F, commander->flag_rally_flag_z);
       std::vector<Engine::Core::EntityID> rallied_units;
 
-      for (auto* candidate : world->get_entities_with<Engine::Core::UnitComponent>()) {
+      for (auto* candidate :
+           world->collect_entities_with<Engine::Core::UnitComponent>()) {
         if (candidate == commander_entity) {
           continue;
         }
@@ -452,7 +453,8 @@ void CommanderSystem::update(Engine::Core::World* world, float delta_time) {
     const float aura_radius_sq = commander->aura_radius * commander->aura_radius;
     const float rally_radius_sq = commander->rally_range * commander->rally_range;
     bool rallied_this_tick = false;
-    for (auto* candidate : world->get_entities_with<Engine::Core::UnitComponent>()) {
+    for (auto* candidate :
+         world->collect_entities_with<Engine::Core::UnitComponent>()) {
       if (candidate == commander_entity) {
         continue;
       }

--- a/game/systems/dismantle_system.cpp
+++ b/game/systems/dismantle_system.cpp
@@ -25,7 +25,7 @@ auto is_working_on(const Engine::Core::BuilderProductionComponent& builder,
 
 void release_crew(Engine::Core::World* world, Engine::Core::EntityID structure_id) {
   for (auto* worker :
-       world->get_entities_with<Engine::Core::BuilderProductionComponent>()) {
+       world->collect_entities_with<Engine::Core::BuilderProductionComponent>()) {
     auto* builder = worker->get_component<Engine::Core::BuilderProductionComponent>();
     if (builder == nullptr || builder->structure_task_entity_id != structure_id ||
         builder->product_type != k_builder_product_dismantle) {
@@ -47,14 +47,14 @@ void DismantleSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  auto sites = world->get_entities_with<Engine::Core::DismantleSiteComponent>();
+  auto sites = world->collect_entities_with<Engine::Core::DismantleSiteComponent>();
   if (sites.empty()) {
     return;
   }
 
   std::unordered_map<Engine::Core::EntityID, int> crew_by_structure;
   for (auto* worker :
-       world->get_entities_with<Engine::Core::BuilderProductionComponent>()) {
+       world->collect_entities_with<Engine::Core::BuilderProductionComponent>()) {
     const auto* builder =
         worker->get_component<Engine::Core::BuilderProductionComponent>();
     const auto* worker_unit = worker->get_component<Engine::Core::UnitComponent>();

--- a/game/systems/farm_system.cpp
+++ b/game/systems/farm_system.cpp
@@ -13,7 +13,7 @@ void FarmSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  for (auto* entity : world->get_entities_with<Engine::Core::FarmComponent>()) {
+  for (auto* entity : world->collect_entities_with<Engine::Core::FarmComponent>()) {
     auto* farm = entity->get_component<Engine::Core::FarmComponent>();
     if (farm == nullptr || farm->ripe()) {
       continue;

--- a/game/systems/food_targets.cpp
+++ b/game/systems/food_targets.cpp
@@ -60,7 +60,7 @@ auto food_target_claimed(Engine::Core::World& world,
     return false;
   }
   for (auto* worker :
-       world.get_entities_with<Engine::Core::BuilderProductionComponent>()) {
+       world.collect_entities_with<Engine::Core::BuilderProductionComponent>()) {
     if (worker == nullptr || worker->get_id() == except_worker) {
       continue;
     }
@@ -138,14 +138,15 @@ auto find_food_target_near(Engine::Core::World& world,
   };
 
   if (want_grain) {
-    for (auto* entity : world.get_entities_with<Engine::Core::FarmComponent>()) {
+    for (auto* entity : world.collect_entities_with<Engine::Core::FarmComponent>()) {
       if (entity != nullptr && farm_is_harvestable(*entity, owner_id)) {
         consider(*entity, k_builder_product_harvest_grain);
       }
     }
   }
   if (want_sheep) {
-    for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
+    for (auto* entity :
+         world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
       if (entity != nullptr && sheep_is_slaughterable(*entity)) {
         consider(*entity, k_builder_product_slaughter_sheep);
       }
@@ -157,7 +158,7 @@ auto find_food_target_near(Engine::Core::World& world,
 auto owner_has_farm_near(
     Engine::Core::World& world, int owner_id, float x, float z, float radius) -> bool {
   float const radius_sq = radius * radius;
-  for (auto* entity : world.get_entities_with<Engine::Core::FarmComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::FarmComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/game/systems/formation_combat_geometry.cpp
+++ b/game/systems/formation_combat_geometry.cpp
@@ -10,6 +10,7 @@
 #include "../core/component.h"
 #include "../formation/unit_layout_resolver.h"
 #include "../units/spawn_type.h"
+#include "../units/troop_catalog.h"
 #include "../units/troop_config.h"
 #include "troop_profile_service.h"
 
@@ -197,6 +198,25 @@ auto formation_seed(const Engine::Core::Entity& entity) noexcept -> std::uint32_
     seed ^= static_cast<std::uint32_t>(unit->owner_id) * 0x85EBCA6BU;
   }
   return seed;
+}
+
+constexpr float k_max_slot_body_radius = 3.0F;
+
+auto max_contact_extent() -> float {
+
+  static const float extent = [] {
+    float widest = 0.0F;
+    for (const auto& [_, troop_class] :
+         Game::Units::TroopCatalog::instance().get_all_classes()) {
+      const float row_width =
+          static_cast<float>(std::max(1, troop_class.max_units_per_row)) *
+          std::max(0.1F, troop_class.visuals.formation_spacing);
+      widest = std::max(widest, row_width);
+    }
+
+    return widest * 0.5F + k_max_slot_body_radius;
+  }();
+  return extent;
 }
 
 auto resolve_definition(const Engine::Core::UnitComponent& unit)

--- a/game/systems/formation_combat_geometry.h
+++ b/game/systems/formation_combat_geometry.h
@@ -124,4 +124,6 @@ engaged_soldiers(const Engine::Core::Entity& attacker,
 
 [[nodiscard]] auto has_formation_slots(const Engine::Core::Entity& entity) -> bool;
 
+[[nodiscard]] auto max_contact_extent() -> float;
+
 } // namespace Game::Systems::FormationCombat

--- a/game/systems/gate_service.cpp
+++ b/game/systems/gate_service.cpp
@@ -120,7 +120,7 @@ void GateService::refresh_blockers(Engine::Core::World& world) {
   auto& storage = blocker_storage();
   storage.clear();
 
-  for (auto* entity : world.get_entities_with<GateComponent>()) {
+  for (auto* entity : world.collect_entities_with<GateComponent>()) {
     if (entity == nullptr || entity->has_component<PendingRemovalComponent>()) {
       continue;
     }

--- a/game/systems/gate_system.cpp
+++ b/game/systems/gate_system.cpp
@@ -51,7 +51,7 @@ void GateSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  auto gate_entities = world->get_entities_with<GateComponent>();
+  auto gate_entities = world->collect_entities_with<GateComponent>();
   if (gate_entities.empty()) {
     GateService::clear_blockers();
     return;
@@ -88,7 +88,7 @@ void GateSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  for (auto* entity : world->get_entities_with<UnitComponent>()) {
+  for (auto* entity : world->collect_entities_with<UnitComponent>()) {
     if (entity == nullptr || entity->has_component<PendingRemovalComponent>()) {
       continue;
     }

--- a/game/systems/gather_loop_system.cpp
+++ b/game/systems/gather_loop_system.cpp
@@ -331,7 +331,7 @@ void GatherLoopSystem::update(Engine::Core::World* world, float delta_time) {
   auto& terrain = Game::Map::TerrainService::instance();
 
   for (auto* entity :
-       world->get_entities_with<Engine::Core::BuilderProductionComponent>()) {
+       world->collect_entities_with<Engine::Core::BuilderProductionComponent>()) {
     auto* builder = entity->get_component<Engine::Core::BuilderProductionComponent>();
     if (builder == nullptr || (!builder->has_gather_order && !builder->auto_gather)) {
       continue;

--- a/game/systems/global_stats_registry.cpp
+++ b/game/systems/global_stats_registry.cpp
@@ -173,7 +173,7 @@ void GlobalStatsRegistry::rebuild_from_world(Engine::Core::World& world) {
     m_player_stats[owner_id].losses = losses_values[owner_id];
   }
 
-  auto entities = world.get_entities_with<Engine::Core::UnitComponent>();
+  auto entities = world.collect_entities_with<Engine::Core::UnitComponent>();
   for (auto* e : entities) {
     auto* unit = e->get_component<Engine::Core::UnitComponent>();
     if ((unit == nullptr) || unit->health <= 0) {

--- a/game/systems/guard_system.cpp
+++ b/game/systems/guard_system.cpp
@@ -15,7 +15,7 @@ void GuardSystem::update(Engine::Core::World* world, float) {
     return;
   }
 
-  auto entities = world->get_entities_with<Engine::Core::GuardModeComponent>();
+  auto entities = world->collect_entities_with<Engine::Core::GuardModeComponent>();
 
   for (auto* entity : entities) {
     auto* guard_mode = entity->get_component<Engine::Core::GuardModeComponent>();

--- a/game/systems/healing_system.cpp
+++ b/game/systems/healing_system.cpp
@@ -11,6 +11,7 @@
 #include "../core/component.h"
 #include "../core/event_manager.h"
 #include "../core/world.h"
+#include "../core/world_spatial_index.h"
 #include "combat_rules.h"
 #include "healing_beam_system.h"
 #include "healing_colors.h"
@@ -45,8 +46,12 @@ void HealingSystem::update(Engine::Core::World* world, float delta_time) {
 }
 
 void HealingSystem::process_healing(Engine::Core::World* world, float delta_time) {
-  auto healers = world->get_entities_with<Engine::Core::HealerComponent>();
+  auto healers = world->collect_entities_with<Engine::Core::HealerComponent>();
   auto* healing_beam_system = world->get_system<HealingBeamSystem>();
+
+  auto& index = world->spatial_index();
+  index.refresh(*world);
+  std::vector<Engine::Core::EntityID> candidates;
 
   for (auto* healer : healers) {
     if (healer->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -80,9 +85,25 @@ void HealingSystem::process_healing(Engine::Core::World* world, float delta_time
     }
 
     bool healed_any = false;
-    auto units = world->get_entities_with<Engine::Core::UnitComponent>();
-    for (auto* target : units) {
-      if (target->has_component<Engine::Core::PendingRemovalComponent>()) {
+    candidates.clear();
+    index.for_each_in_radius(
+        healer_transform->position.x,
+        healer_transform->position.z,
+        healer_comp->healing_range,
+        [&](const Engine::Core::WorldSpatialIndex::Entry& entry) {
+          if (entry.owner_id != healer_unit->owner_id ||
+              entry.is(Engine::Core::WorldSpatialIndex::k_pending_removal)) {
+            return;
+          }
+          candidates.push_back(entry.id);
+        });
+
+    std::sort(candidates.begin(), candidates.end());
+
+    for (const Engine::Core::EntityID candidate_id : candidates) {
+      auto* target = world->get_entity(candidate_id);
+      if (target == nullptr ||
+          target->has_component<Engine::Core::PendingRemovalComponent>()) {
         continue;
       }
 

--- a/game/systems/home_system.cpp
+++ b/game/systems/home_system.cpp
@@ -33,9 +33,9 @@ void HomeSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  auto home_entities = world->get_entities_with<Engine::Core::HomeComponent>();
+  auto home_entities = world->collect_entities_with<Engine::Core::HomeComponent>();
   auto barracks_entities =
-      world->get_entities_with<Engine::Core::ProductionComponent>();
+      world->collect_entities_with<Engine::Core::ProductionComponent>();
 
   for (auto* home_entity : home_entities) {
     auto* home_comp = home_entity->get_component<Engine::Core::HomeComponent>();

--- a/game/systems/interaction_targeting.cpp
+++ b/game/systems/interaction_targeting.cpp
@@ -113,7 +113,7 @@ void collect_sheep(const InteractionTargetingRequest& request,
                    float max_distance_sq,
                    std::vector<Scored>& out) {
   for (auto* entity :
-       request.world->get_entities_with<Engine::Core::WildlifeComponent>()) {
+       request.world->collect_entities_with<Engine::Core::WildlifeComponent>()) {
     if (entity == nullptr || !sheep_is_slaughterable(*entity) ||
         food_target_claimed(*request.world, entity->get_id())) {
       continue;
@@ -148,7 +148,7 @@ void collect_buildings(const InteractionTargetingRequest& request,
                        float max_distance_sq,
                        std::vector<Scored>& out) {
   for (auto* entity :
-       request.world->get_entities_with<Engine::Core::BuildingComponent>()) {
+       request.world->collect_entities_with<Engine::Core::BuildingComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/game/systems/movement_system.cpp
+++ b/game/systems/movement_system.cpp
@@ -319,7 +319,7 @@ void MovementSystem::update(Engine::Core::World* world, float delta_time) {
       m_obstruction_revision = revision;
 
       pathfinder->update_navigation_grid();
-      auto entities = world->get_entities_with<Engine::Core::MovementComponent>();
+      auto entities = world->collect_entities_with<Engine::Core::MovementComponent>();
       repath_after_obstruction_release(*world, entities);
     }
   }

--- a/game/systems/nation_collapse_service.cpp
+++ b/game/systems/nation_collapse_service.cpp
@@ -42,7 +42,7 @@ void disband_troop(Engine::Core::Entity& entity, Engine::Core::UnitComponent& un
 } // namespace
 
 auto has_living_commander(Engine::Core::World& world, int owner_id) -> bool {
-  for (auto* entity : world.get_entities_with<Engine::Core::CommanderComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::CommanderComponent>()) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;
@@ -61,7 +61,7 @@ auto collapse_owner(Engine::Core::World& world, int owner_id) -> bool {
   }
 
   std::vector<Engine::Core::Entity*> owned;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;

--- a/game/systems/patrol_system.cpp
+++ b/game/systems/patrol_system.cpp
@@ -6,80 +6,81 @@
 
 #include "../core/component.h"
 #include "../core/world.h"
+#include "../core/world_spatial_index.h"
 #include "command_service.h"
 
 namespace Game::Systems {
+
+namespace {
+
+constexpr float k_patrol_engagement_radius = 5.0F;
+
+} // namespace
 
 void PatrolSystem::update(Engine::Core::World* world, float) {
   if (world == nullptr) {
     return;
   }
 
-  auto entities = world->get_entities_with<Engine::Core::PatrolComponent>();
+  auto& index = world->spatial_index();
+  index.refresh(*world);
 
-  for (auto* entity : entities) {
-    auto* patrol = entity->get_component<Engine::Core::PatrolComponent>();
-    auto* movement = entity->get_component<Engine::Core::MovementComponent>();
-    auto* transform = entity->get_component<Engine::Core::TransformComponent>();
-    auto* unit = entity->get_component<Engine::Core::UnitComponent>();
+  for (auto [entity, patrol_ref, movement_ref, transform_ref, unit_ref] :
+       world->entity_view<Engine::Core::PatrolComponent,
+                          Engine::Core::MovementComponent,
+                          Engine::Core::TransformComponent,
+                          Engine::Core::UnitComponent>()) {
+    auto* patrol = &patrol_ref;
+    const auto& transform = transform_ref;
+    const auto& unit = unit_ref;
+    (void)movement_ref;
 
-    if ((patrol == nullptr) || (movement == nullptr) || (transform == nullptr) ||
-        (unit == nullptr)) {
-      continue;
-    }
     if (!patrol->patrolling || patrol->waypoints.size() < 2) {
       continue;
     }
 
-    if (unit->health <= 0) {
+    if (unit.health <= 0) {
       patrol->patrolling = false;
       continue;
     }
 
-    auto* attack_target = entity->get_component<Engine::Core::AttackTargetComponent>();
+    auto* attack_target = entity.get_component<Engine::Core::AttackTargetComponent>();
     if ((attack_target != nullptr) && attack_target->target_id != 0) {
 
       continue;
     }
 
-    bool enemy_nearby = false;
-    auto all_entities = world->get_entities_with<Engine::Core::UnitComponent>();
-    for (auto* other : all_entities) {
-      auto* other_unit = other->get_component<Engine::Core::UnitComponent>();
-      auto* other_transform = other->get_component<Engine::Core::TransformComponent>();
+    Engine::Core::EntityID nearest_enemy = Engine::Core::NULL_ENTITY;
+    float nearest_dist_sq = k_patrol_engagement_radius * k_patrol_engagement_radius;
+    index.for_each_in_radius(
+        transform.position.x,
+        transform.position.z,
+        k_patrol_engagement_radius,
+        [&](const Engine::Core::WorldSpatialIndex::Entry& candidate) {
+          if (!candidate.is(Engine::Core::WorldSpatialIndex::k_alive) ||
+              candidate.is(Engine::Core::WorldSpatialIndex::k_building)) {
+            return;
+          }
+          if (candidate.owner_id == unit.owner_id) {
+            return;
+          }
+          const float dx = candidate.x - transform.position.x;
+          const float dz = candidate.z - transform.position.z;
+          const float dist_sq = dx * dx + dz * dz;
+          if (dist_sq < nearest_dist_sq) {
+            nearest_dist_sq = dist_sq;
+            nearest_enemy = candidate.id;
+          }
+        });
 
-      if ((other_unit == nullptr) || (other_transform == nullptr) ||
-          other_unit->health <= 0) {
-        continue;
+    if (nearest_enemy != Engine::Core::NULL_ENTITY) {
+      if (attack_target == nullptr) {
+        attack_target = entity.add_component<Engine::Core::AttackTargetComponent>();
       }
-      if (other_unit->owner_id == unit->owner_id) {
-        continue;
+      if (attack_target != nullptr) {
+        attack_target->target_id = nearest_enemy;
+        attack_target->should_chase = false;
       }
-
-      if (other->has_component<Engine::Core::BuildingComponent>()) {
-        continue;
-      }
-
-      float const dx = other_transform->position.x - transform->position.x;
-      float const dz = other_transform->position.z - transform->position.z;
-      float const dist_sq = dx * dx + dz * dz;
-
-      if (dist_sq < 25.0F) {
-        enemy_nearby = true;
-
-        if (attack_target == nullptr) {
-          entity->add_component<Engine::Core::AttackTargetComponent>();
-          attack_target = entity->get_component<Engine::Core::AttackTargetComponent>();
-        }
-        if (attack_target != nullptr) {
-          attack_target->target_id = other->get_id();
-          attack_target->should_chase = false;
-        }
-        break;
-      }
-    }
-
-    if (enemy_nearby) {
 
       continue;
     }
@@ -88,8 +89,8 @@ void PatrolSystem::update(Engine::Core::World* world, float) {
     float target_x = waypoint.first;
     float target_z = waypoint.second;
 
-    float const dx = target_x - transform->position.x;
-    float const dz = target_z - transform->position.z;
+    float const dx = target_x - transform.position.x;
+    float const dz = target_z - transform.position.z;
     float const dist_sq = dx * dx + dz * dz;
 
     if (dist_sq < 1.0F) {
@@ -104,7 +105,7 @@ void PatrolSystem::update(Engine::Core::World* world, float) {
     Game::Systems::CommandService::MoveOptions options;
     options.kind = Game::Systems::MoveOrderKind::ScriptedMove;
     Game::Systems::CommandService::move_unit(
-        *world, entity->get_id(), QVector3D(target_x, 0.0F, target_z), options);
+        *world, entity.get_id(), QVector3D(target_x, 0.0F, target_z), options);
   }
 }
 

--- a/game/systems/production_system.cpp
+++ b/game/systems/production_system.cpp
@@ -448,7 +448,7 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  auto entities = world->get_entities_with<Engine::Core::ProductionComponent>();
+  auto entities = world->collect_entities_with<Engine::Core::ProductionComponent>();
   for (auto* e : entities) {
     auto* prod = e->get_component<Engine::Core::ProductionComponent>();
     if (prod == nullptr) {
@@ -556,7 +556,7 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
   constexpr float MAX_CONSTRUCTION_DISTANCE_SQ = 9.0F;
 
   auto builder_entities =
-      world->get_entities_with<Engine::Core::BuilderProductionComponent>();
+      world->collect_entities_with<Engine::Core::BuilderProductionComponent>();
   for (auto* e : builder_entities) {
     auto* builder_prod = e->get_component<Engine::Core::BuilderProductionComponent>();
     if (builder_prod == nullptr) {

--- a/game/systems/resource_delivery_system.cpp
+++ b/game/systems/resource_delivery_system.cpp
@@ -49,7 +49,7 @@ auto find_nearest_depot(Engine::Core::World* world,
   Engine::Core::Entity* nearest = nullptr;
   float nearest_dist_sq = std::numeric_limits<float>::max();
 
-  for (auto* candidate : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (!is_live_depot(candidate, owner_id)) {
       continue;
     }
@@ -91,7 +91,7 @@ void approach_fill(float& current, float target, float delta_time) {
 void sync_stockpile_displays(Engine::Core::World* world, float delta_time) {
   auto& resources = PlayerResourceRegistry::instance();
 
-  for (auto* entity : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit == nullptr || unit->spawn_type != Game::Units::SpawnType::Barracks) {
       continue;
@@ -152,7 +152,7 @@ void ResourceDeliverySystem::update(Engine::Core::World* world, float delta_time
   sync_stockpile_displays(world, delta_time);
 
   std::vector<Engine::Core::EntityID> unloaded;
-  auto haulers = world->get_entities_with<Engine::Core::ResourceCarryComponent>();
+  auto haulers = world->collect_entities_with<Engine::Core::ResourceCarryComponent>();
 
   for (auto* hauler : haulers) {
     if (hauler == nullptr) {

--- a/game/systems/rpg_combat_system/rpg_bow_aim.cpp
+++ b/game/systems/rpg_combat_system/rpg_bow_aim.cpp
@@ -268,7 +268,7 @@ auto raycast_enemy_bodies(Engine::Core::World& world,
   }
 
   std::optional<AimHit> best;
-  for (auto* candidate : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == nullptr || candidate == &commander ||
         !Game::Systems::Combat::is_valid_enemy_unit(commander_unit, candidate, false)) {
       continue;

--- a/game/systems/rpg_combat_system/rpg_combat_processor.cpp
+++ b/game/systems/rpg_combat_system/rpg_combat_processor.cpp
@@ -122,7 +122,7 @@ void refresh_commander_engagement(Engine::Core::World* world,
   auto& owners = Game::Systems::OwnerRegistry::instance();
 
   bool has_formation_opponent = false;
-  for (auto* candidate : world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate : world->collect_entities_with<Engine::Core::UnitComponent>()) {
     if (candidate == nullptr || candidate->get_id() == commander_id) {
       continue;
     }
@@ -247,7 +247,8 @@ void tick_rpg_combat(Engine::Core::World* world,
 
   refresh_commander_engagement(world, commander_id);
 
-  for (auto* staggered : world->get_entities_with<Engine::Core::StaggerComponent>()) {
+  for (auto* staggered :
+       world->collect_entities_with<Engine::Core::StaggerComponent>()) {
     auto* stagger = staggered->get_component<Engine::Core::StaggerComponent>();
     if (stagger == nullptr) {
       continue;
@@ -303,7 +304,7 @@ void tick_rpg_combat(Engine::Core::World* world,
   }
 
   for (auto* telegraphed :
-       world->get_entities_with<Engine::Core::EnemyTelegraphComponent>()) {
+       world->collect_entities_with<Engine::Core::EnemyTelegraphComponent>()) {
     auto* telegraph =
         telegraphed->get_component<Engine::Core::EnemyTelegraphComponent>();
     if (telegraph == nullptr ||

--- a/game/systems/rpg_combat_system/rpg_engagement_system.cpp
+++ b/game/systems/rpg_combat_system/rpg_engagement_system.cpp
@@ -11,7 +11,8 @@ void RpgEngagementSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  for (auto* entity : world->get_entities_with<Engine::Core::CommanderComponent>()) {
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::CommanderComponent>()) {
     auto const* commander =
         entity != nullptr ? entity->get_component<Engine::Core::CommanderComponent>()
                           : nullptr;

--- a/game/systems/runtime_system_registry.cpp
+++ b/game/systems/runtime_system_registry.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "../command/command_system.h"
+#include "../core/system_schedule.h"
 #include "../core/world.h"
 #include "../formation/army_formation_registry.h"
 #include "../formation/unit_layout_state_system.h"
@@ -43,43 +44,71 @@ namespace Game::Systems {
 
 void register_runtime_systems(Engine::Core::World& world) {
 
-  world.add_system(std::make_unique<Game::Command::CommandSystem>());
-  world.add_system(std::make_unique<ArrowSystem>());
-  world.add_system(std::make_unique<CombatStatusEffectSystem>());
-  world.add_system(std::make_unique<ProjectileSystem>());
-  world.add_system(std::make_unique<StaminaSystem>());
+  world.add_system(std::make_unique<Game::Command::CommandSystem>(),
+                   Engine::Core::SystemPhase::Input);
+  world.add_system(std::make_unique<ArrowSystem>(), Engine::Core::SystemPhase::Input);
+  world.add_system(std::make_unique<CombatStatusEffectSystem>(),
+                   Engine::Core::SystemPhase::Input);
+  world.add_system(std::make_unique<ProjectileSystem>(),
+                   Engine::Core::SystemPhase::Input);
+  world.add_system(std::make_unique<StaminaSystem>(), Engine::Core::SystemPhase::Input);
 
-  world.add_system(std::make_unique<GateSystem>());
-  world.add_system(std::make_unique<LocalAvoidanceSystem>());
-  world.add_system(std::make_unique<MovementSystem>());
-  world.add_system(std::make_unique<PatrolSystem>());
-  world.add_system(std::make_unique<GuardSystem>());
-  world.add_system(std::make_unique<Game::Formation::ArmyFormationRuntime>());
-  world.add_system(std::make_unique<FormationMoveDispatchSystem>());
-  world.add_system(std::make_unique<Game::Formation::UnitLayoutStateSystem>());
+  world.add_system(std::make_unique<GateSystem>(), Engine::Core::SystemPhase::Movement);
+  world.add_system(std::make_unique<LocalAvoidanceSystem>(),
+                   Engine::Core::SystemPhase::Movement);
+  world.add_system(std::make_unique<MovementSystem>(),
+                   Engine::Core::SystemPhase::Movement);
+  world.add_system(std::make_unique<PatrolSystem>(),
+                   Engine::Core::SystemPhase::Movement);
+  world.add_system(std::make_unique<GuardSystem>(),
+                   Engine::Core::SystemPhase::Movement);
+  world.add_system(std::make_unique<Game::Formation::ArmyFormationRuntime>(),
+                   Engine::Core::SystemPhase::Movement);
+  world.add_system(std::make_unique<FormationMoveDispatchSystem>(),
+                   Engine::Core::SystemPhase::Movement);
+  world.add_system(std::make_unique<Game::Formation::UnitLayoutStateSystem>(),
+                   Engine::Core::SystemPhase::Movement);
 
-  world.add_system(std::make_unique<EngagementSlotSystem>());
-  world.add_system(std::make_unique<RpgEngagementSystem>());
-  world.add_system(std::make_unique<CombatSystem>());
-  world.add_system(std::make_unique<CommanderSystem>());
-  world.add_system(std::make_unique<HealingBeamSystem>());
-  world.add_system(std::make_unique<HealingSystem>());
-  world.add_system(std::make_unique<CaptureSystem>());
-  world.add_system(std::make_unique<AISystem>());
-  world.add_system(std::make_unique<UndeadAwakeningSystem>());
-  world.add_system(std::make_unique<ProductionSystem>());
-  world.add_system(std::make_unique<DismantleSystem>());
-  world.add_system(std::make_unique<HomeSystem>());
-  world.add_system(std::make_unique<FarmSystem>());
-  world.add_system(std::make_unique<CivilianDeliverySystem>());
-  world.add_system(std::make_unique<ResourceDeliverySystem>());
-  world.add_system(std::make_unique<GatherLoopSystem>());
-  world.add_system(std::make_unique<SettlementLifeSystem>());
-  world.add_system(std::make_unique<Game::Wildlife::WildlifeSystem>());
-  world.add_system(std::make_unique<ShowcaseRoutineSystem>());
-  world.add_system(std::make_unique<TerrainAlignmentSystem>());
-  world.add_system(std::make_unique<CleanupSystem>());
-  world.add_system(std::make_unique<SelectionSystem>());
+  world.add_system(std::make_unique<EngagementSlotSystem>(),
+                   Engine::Core::SystemPhase::Combat);
+  world.add_system(std::make_unique<RpgEngagementSystem>(),
+                   Engine::Core::SystemPhase::Combat);
+  world.add_system(std::make_unique<CombatSystem>(), Engine::Core::SystemPhase::Combat);
+  world.add_system(std::make_unique<CommanderSystem>(),
+                   Engine::Core::SystemPhase::Combat);
+  world.add_system(std::make_unique<HealingBeamSystem>(),
+                   Engine::Core::SystemPhase::Combat);
+  world.add_system(std::make_unique<HealingSystem>(),
+                   Engine::Core::SystemPhase::Combat);
+  world.add_system(std::make_unique<CaptureSystem>(),
+                   Engine::Core::SystemPhase::Combat);
+  world.add_system(std::make_unique<AISystem>(), Engine::Core::SystemPhase::Strategy);
+  world.add_system(std::make_unique<UndeadAwakeningSystem>(),
+                   Engine::Core::SystemPhase::Strategy);
+  world.add_system(std::make_unique<ProductionSystem>(),
+                   Engine::Core::SystemPhase::Economy);
+  world.add_system(std::make_unique<DismantleSystem>(),
+                   Engine::Core::SystemPhase::Economy);
+  world.add_system(std::make_unique<HomeSystem>(), Engine::Core::SystemPhase::Economy);
+  world.add_system(std::make_unique<FarmSystem>(), Engine::Core::SystemPhase::Economy);
+  world.add_system(std::make_unique<CivilianDeliverySystem>(),
+                   Engine::Core::SystemPhase::Economy);
+  world.add_system(std::make_unique<ResourceDeliverySystem>(),
+                   Engine::Core::SystemPhase::Economy);
+  world.add_system(std::make_unique<GatherLoopSystem>(),
+                   Engine::Core::SystemPhase::Economy);
+  world.add_system(std::make_unique<SettlementLifeSystem>(),
+                   Engine::Core::SystemPhase::Economy);
+  world.add_system(std::make_unique<Game::Wildlife::WildlifeSystem>(),
+                   Engine::Core::SystemPhase::Ambient);
+  world.add_system(std::make_unique<ShowcaseRoutineSystem>(),
+                   Engine::Core::SystemPhase::Ambient);
+  world.add_system(std::make_unique<TerrainAlignmentSystem>(),
+                   Engine::Core::SystemPhase::Presentation);
+  world.add_system(std::make_unique<CleanupSystem>(),
+                   Engine::Core::SystemPhase::Cleanup);
+  world.add_system(std::make_unique<SelectionSystem>(),
+                   Engine::Core::SystemPhase::Cleanup);
 }
 
 } // namespace Game::Systems

--- a/game/systems/settlement_life_system.cpp
+++ b/game/systems/settlement_life_system.cpp
@@ -156,7 +156,7 @@ void collect_settlement_candidates(Engine::Core::World& world,
   out.clear();
 
   float const radius_sq = resident.roam_radius * resident.roam_radius;
-  for (auto* entity : world.get_entities_with<Engine::Core::BuildingComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::BuildingComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     auto* transform = entity->get_component<Engine::Core::TransformComponent>();
     if ((unit == nullptr) || (transform == nullptr) || unit->health <= 0) {
@@ -211,7 +211,7 @@ auto find_settlement_anchor(Engine::Core::World& world,
   std::optional<QVector3D> nearest;
   float nearest_distance_sq = search_radius * search_radius;
 
-  for (auto* entity : world.get_entities_with<Engine::Core::BuildingComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::BuildingComponent>()) {
     auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
     auto const* transform = entity->get_component<Engine::Core::TransformComponent>();
     if ((unit == nullptr) || (transform == nullptr) || unit->health <= 0 ||
@@ -253,7 +253,7 @@ auto endangers_residents(Game::Units::SpawnType type) -> bool {
 void collect_armed_units(Engine::Core::World& world,
                          std::vector<SettlementLifeSystem::ArmedUnit>& out) {
   out.clear();
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
     if ((unit == nullptr) || unit->health <= 0 ||
         !endangers_residents(unit->spawn_type)) {
@@ -342,7 +342,7 @@ void run_from(Engine::Core::World& world,
 }
 
 void adopt_idle_civilians(Engine::Core::World& world) {
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto const* unit = entity->get_component<Engine::Core::UnitComponent>();
     if ((unit == nullptr) || unit->spawn_type != Game::Units::SpawnType::Civilian ||
         unit->health <= 0) {
@@ -389,7 +389,7 @@ void SettlementLifeSystem::update(Engine::Core::World* world, float delta_time) 
     adopt_idle_civilians(*world);
   }
 
-  auto residents = world->get_entities_with<SettlementResidentComponent>();
+  auto residents = world->collect_entities_with<SettlementResidentComponent>();
   if (residents.empty()) {
     return;
   }

--- a/game/systems/showcase_routine_system.cpp
+++ b/game/systems/showcase_routine_system.cpp
@@ -82,7 +82,7 @@ void ShowcaseRoutineSystem::update(Engine::Core::World* world, float delta_time)
   }
 
   for (auto* entity :
-       world->get_entities_with<Engine::Core::ShowcaseRoutineComponent>()) {
+       world->collect_entities_with<Engine::Core::ShowcaseRoutineComponent>()) {
     auto* routine = entity->get_component<Engine::Core::ShowcaseRoutineComponent>();
     if (routine == nullptr || routine->steps.empty() || routine->finished) {
       if (routine != nullptr) {

--- a/game/systems/stamina_system.cpp
+++ b/game/systems/stamina_system.cpp
@@ -31,14 +31,13 @@ void StaminaSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
-  for (auto* entity : world->get_entities_with<Engine::Core::StaminaComponent>()) {
-    auto* stamina = entity->get_component<Engine::Core::StaminaComponent>();
-    if (stamina == nullptr) {
-      continue;
-    }
+  for (auto [entity, stamina_ref, unit_ref] :
+       world->entity_view<Engine::Core::StaminaComponent,
+                          Engine::Core::UnitComponent>()) {
+    auto* stamina = &stamina_ref;
+    const auto* unit = &unit_ref;
 
-    const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
-    if (unit == nullptr || unit->health <= 0) {
+    if (unit->health <= 0) {
       stamina->is_running = false;
       continue;
     }
@@ -50,8 +49,8 @@ void StaminaSystem::update(Engine::Core::World* world, float delta_time) {
     }
 
     const auto* motion =
-        entity->get_component<Engine::Core::MotionPresentationComponent>();
-    const auto* movement = entity->get_component<Engine::Core::MovementComponent>();
+        entity.get_component<Engine::Core::MotionPresentationComponent>();
+    const auto* movement = entity.get_component<Engine::Core::MovementComponent>();
     const bool is_moving = has_locomotion_intent(motion, movement);
 
     if (stamina->run_requested && is_moving) {

--- a/game/systems/target_focus.cpp
+++ b/game/systems/target_focus.cpp
@@ -139,7 +139,8 @@ auto collect_target_focus_markers(const TargetFocusRequest& request)
   }
 
   std::size_t incoming_count = 0;
-  for (auto* entity : world->get_entities_with<Engine::Core::AttackTargetComponent>()) {
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::AttackTargetComponent>()) {
     if (incoming_count >= request.max_incoming_attackers) {
       break;
     }

--- a/game/systems/terrain_alignment_system.cpp
+++ b/game/systems/terrain_alignment_system.cpp
@@ -16,23 +16,18 @@ void TerrainAlignmentSystem::update(Engine::Core::World* world, float) {
     return;
   }
 
-  auto entities = world->get_entities_with<Engine::Core::TransformComponent>();
-  for (auto* entity : entities) {
-    align_entity_to_terrain(entity);
+  for (auto [entity_id, transform] : world->view<Engine::Core::TransformComponent>()) {
+    (void)entity_id;
+    align_transform_to_terrain(transform, terrain_service);
   }
 }
 
-void TerrainAlignmentSystem::align_entity_to_terrain(Engine::Core::Entity* entity) {
-  auto* transform = entity->get_component<Engine::Core::TransformComponent>();
-  if (transform == nullptr) {
-    return;
-  }
-
-  auto& terrain_service = Game::Map::TerrainService::instance();
-
+void TerrainAlignmentSystem::align_transform_to_terrain(
+    Engine::Core::TransformComponent& transform,
+    Game::Map::TerrainService& terrain_service) {
   QVector3D const aligned = terrain_service.resolve_surface_world_position(
-      transform->position.x, transform->position.z, 0.0F, transform->position.y);
-  transform->position.y = aligned.y();
+      transform.position.x, transform.position.z, 0.0F, transform.position.y);
+  transform.position.y = aligned.y();
 }
 
 } // namespace Game::Systems

--- a/game/systems/terrain_alignment_system.h
+++ b/game/systems/terrain_alignment_system.h
@@ -3,7 +3,11 @@
 #include "../core/system.h"
 
 namespace Engine::Core {
-class Entity;
+class TransformComponent;
+}
+
+namespace Game::Map {
+class TerrainService;
 }
 
 namespace Game::Systems {
@@ -13,7 +17,8 @@ public:
   void update(Engine::Core::World* world, float delta_time) override;
 
 private:
-  static void align_entity_to_terrain(Engine::Core::Entity* entity);
+  static void align_transform_to_terrain(Engine::Core::TransformComponent& transform,
+                                         Game::Map::TerrainService& terrain_service);
 };
 
 } // namespace Game::Systems

--- a/game/systems/troop_count_registry.cpp
+++ b/game/systems/troop_count_registry.cpp
@@ -61,7 +61,7 @@ void TroopCountRegistry::on_unit_died(const Engine::Core::UnitDiedEvent& event) 
 void TroopCountRegistry::rebuild_from_world(Engine::Core::World& world) {
   m_troop_counts.clear();
 
-  auto entities = world.get_entities_with<Engine::Core::UnitComponent>();
+  auto entities = world.collect_entities_with<Engine::Core::UnitComponent>();
   for (auto* e : entities) {
     auto* unit = e->get_component<Engine::Core::UnitComponent>();
     if ((unit == nullptr) || unit->health <= 0) {

--- a/game/systems/undead_awakening_system.cpp
+++ b/game/systems/undead_awakening_system.cpp
@@ -287,7 +287,7 @@ auto UndeadAwakeningSystem::should_awaken_zone(Engine::Core::World& world,
     }
 
     float const radius_sq = zone.definition.radius * zone.definition.radius;
-    for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+    for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
       if (entity == nullptr) {
         continue;
       }

--- a/game/systems/victory_service.cpp
+++ b/game/systems/victory_service.cpp
@@ -474,7 +474,7 @@ auto VictoryService::summarize_world(Engine::Core::World& world) const -> WorldS
       (local_nation != nullptr) ? local_nation->id
                                 : nation_registry.default_nation_id();
 
-  auto entities = world.get_entities_with<Engine::Core::UnitComponent>();
+  auto entities = world.collect_entities_with<Engine::Core::UnitComponent>();
   for (auto* entity : entities) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if ((unit == nullptr) || unit->health <= 0) {

--- a/game/systems/wall_network_service.cpp
+++ b/game/systems/wall_network_service.cpp
@@ -262,7 +262,7 @@ auto is_wall_key_occupied(Engine::Core::World& world,
                           int grid_z,
                           bool include_construction_sites,
                           Engine::Core::EntityID ignore_entity_id = 0) -> bool {
-  auto entities = world.get_entities_with<WallSegmentComponent>();
+  auto entities = world.collect_entities_with<WallSegmentComponent>();
   for (auto* entity : entities) {
     if (entity == nullptr || entity->get_id() == ignore_entity_id ||
         !is_live_wall_entity(entity, include_construction_sites)) {
@@ -460,7 +460,7 @@ auto WallNetworkService::encode_key(int grid_x, int grid_z) -> std::uint64_t {
 void WallNetworkService::add_world_occupancy(Engine::Core::World& world,
                                              OccupancySet& out,
                                              bool include_construction_sites) {
-  auto entities = world.get_entities_with<WallSegmentComponent>();
+  auto entities = world.collect_entities_with<WallSegmentComponent>();
   for (auto* entity : entities) {
     if (!is_live_wall_entity(entity, include_construction_sites)) {
       continue;
@@ -488,7 +488,7 @@ void WallNetworkService::build_connection_occupancy(Engine::Core::World& world,
                                                     bool include_towers) {
   out.clear();
 
-  auto wall_entities = world.get_entities_with<WallSegmentComponent>();
+  auto wall_entities = world.collect_entities_with<WallSegmentComponent>();
   for (auto* entity : wall_entities) {
     if (!is_live_wall_entity(entity, include_construction_sites)) {
       continue;
@@ -514,7 +514,7 @@ void WallNetworkService::build_connection_occupancy(Engine::Core::World& world,
     return;
   }
 
-  auto unit_entities = world.get_entities_with<UnitComponent>();
+  auto unit_entities = world.collect_entities_with<UnitComponent>();
   for (auto* entity : unit_entities) {
     if (!is_live_tower_socket_entity(entity)) {
       continue;
@@ -738,7 +738,7 @@ auto collect_navigation_passages(
                           .depth = spans_east_west ? crossing_depth : 2.0F});
   };
 
-  for (auto* entity : world.get_entities_with<GateComponent>()) {
+  for (auto* entity : world.collect_entities_with<GateComponent>()) {
     if (!is_live_wall_entity(entity, false)) {
       continue;
     }
@@ -811,7 +811,7 @@ void WallNetworkService::refresh_world(Engine::Core::World& world) {
   build_connection_occupancy(world, connection_occupancy, true, true);
   OccupancySet const empty_occupancy;
 
-  auto entities = world.get_entities_with<WallSegmentComponent>();
+  auto entities = world.collect_entities_with<WallSegmentComponent>();
   for (auto* entity : entities) {
     if (!is_live_wall_entity(entity, true)) {
       continue;

--- a/game/systems/world_restore.cpp
+++ b/game/systems/world_restore.cpp
@@ -38,7 +38,7 @@ auto rebuild_registries_after_load(Engine::Core::World* world,
 
   rebuild_building_collisions(world);
 
-  auto units = world->get_entities_with<Engine::Core::UnitComponent>();
+  auto units = world->collect_entities_with<Engine::Core::UnitComponent>();
   for (auto* entity : units) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit == nullptr) {
@@ -60,7 +60,7 @@ void rebuild_building_collisions(Engine::Core::World* world) {
     return;
   }
 
-  auto buildings = world->get_entities_with<Engine::Core::BuildingComponent>();
+  auto buildings = world->collect_entities_with<Engine::Core::BuildingComponent>();
   for (auto* entity : buildings) {
     auto* transform = entity->get_component<Engine::Core::TransformComponent>();
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();

--- a/game/units/factory.cpp
+++ b/game/units/factory.cpp
@@ -34,7 +34,7 @@ namespace Game::Units {
 namespace {
 
 auto owner_has_living_commander(Engine::Core::World& world, int owner_id) -> bool {
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr) {
       continue;
     }

--- a/game/wildlife/wildlife_system.cpp
+++ b/game/wildlife/wildlife_system.cpp
@@ -446,7 +446,7 @@ void WildlifeSystem::release_due_packs(Engine::Core::World& world, float delta_t
 void WildlifeSystem::rebuild_threats(Engine::Core::World& world) {
   m_threats.clear();
   m_quarry.clear();
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr || is_wildlife_entity(*entity)) {
       continue;
     }
@@ -486,7 +486,7 @@ void WildlifeSystem::collect_animals(Engine::Core::World& world) {
   std::vector<float> sum_x(m_groups.size(), 0.0F);
   std::vector<float> sum_z(m_groups.size(), 0.0F);
 
-  for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;

--- a/render/battle_render_optimizer.h
+++ b/render/battle_render_optimizer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <mutex>
 
@@ -9,7 +8,8 @@
 namespace Render {
 
 struct BattleRenderConfig {
-  int temporal_culling_threshold = 15;
+
+  int battle_mode_unit_threshold = 15;
   int animation_throttle_threshold = 30;
   float animation_throttle_distance = 40.0F;
   float combat_render_priority_distance = 50.0F;
@@ -20,159 +20,135 @@ struct BattleRenderConfig {
 
 class BattleRenderOptimizer {
 public:
-  static auto instance() noexcept -> BattleRenderOptimizer& {
-    static BattleRenderOptimizer inst;
-    return inst;
-  }
+  struct FrameStats {
+    int animations_updated = 0;
+    int animations_throttled = 0;
+  };
 
-  void begin_frame() noexcept {
-    m_frame_counter.fetch_add(1, std::memory_order_relaxed);
-    m_units_rendered_this_frame.store(0, std::memory_order_relaxed);
-    m_units_skipped_temporal.store(0, std::memory_order_relaxed);
-    m_animations_throttled.store(0, std::memory_order_relaxed);
-  }
+  struct FrameSnapshot {
+    BattleRenderConfig config{};
+    std::uint32_t frame = 0;
+    int visible_unit_count = 0;
 
-  void set_visible_unit_count(int count) noexcept {
-    m_visible_unit_count.store(count, std::memory_order_relaxed);
-  }
+    [[nodiscard]] auto battle_mode() const noexcept -> bool {
+      return config.enabled && visible_unit_count >= config.battle_mode_unit_threshold;
+    }
 
-  void set_config(const BattleRenderConfig& config) noexcept {
-    std::lock_guard<std::mutex> lock(m_config_mutex);
+    [[nodiscard]] auto batching_boost() const noexcept -> float {
+      if (!config.enabled || visible_unit_count < config.battle_mode_unit_threshold) {
+        return 1.0F;
+      }
+      const float excess_ratio =
+          static_cast<float>(visible_unit_count - config.battle_mode_unit_threshold) /
+          static_cast<float>(config.battle_mode_unit_threshold);
+      return 1.0F + excess_ratio * 0.5F;
+    }
+
+    [[nodiscard]] auto
+    should_update_animation(std::uint32_t entity_id,
+                            float distance_sq,
+                            bool is_selected,
+                            bool is_combat_active,
+                            const Engine::Core::MotionPresentationComponent* motion,
+                            FrameStats& stats) const noexcept -> bool {
+      const bool update = evaluate_animation_update(
+          entity_id, distance_sq, is_selected, is_combat_active, motion);
+      if (update) {
+        ++stats.animations_updated;
+      } else {
+        ++stats.animations_throttled;
+      }
+      return update;
+    }
+
+  private:
+    [[nodiscard]] auto
+    evaluate_animation_update(std::uint32_t entity_id,
+                              float distance_sq,
+                              bool is_selected,
+                              bool is_combat_active,
+                              const Engine::Core::MotionPresentationComponent* motion)
+        const noexcept -> bool {
+      if (!config.enabled || is_selected) {
+        return true;
+      }
+      if (motion != nullptr && motion->has_locomotion()) {
+        return true;
+      }
+      if (visible_unit_count < config.animation_throttle_threshold) {
+        return true;
+      }
+      if (is_combat_active) {
+        return true;
+      }
+      const float priority_distance = config.animation_throttle_distance;
+      if (distance_sq < priority_distance * priority_distance) {
+        return true;
+      }
+      return ((entity_id + frame) %
+              static_cast<std::uint32_t>(config.animation_skip_frames + 1)) == 0;
+    }
+  };
+
+  void set_config(const BattleRenderConfig& config) {
+    const std::lock_guard<std::mutex> lock(m_config_mutex);
     m_config = config;
   }
 
-  [[nodiscard]] auto config() const noexcept -> BattleRenderConfig {
-    std::lock_guard<std::mutex> lock(m_config_mutex);
+  [[nodiscard]] auto config() const -> BattleRenderConfig {
+    const std::lock_guard<std::mutex> lock(m_config_mutex);
     return m_config;
   }
 
-  [[nodiscard]] auto is_battle_mode() const noexcept -> bool {
-    std::lock_guard<std::mutex> lock(m_config_mutex);
-    return m_config.enabled && m_visible_unit_count.load(std::memory_order_relaxed) >=
-                                   m_config.temporal_culling_threshold;
-  }
-
-  [[nodiscard]] auto
-  should_render_unit(uint32_t entity_id,
-                     const Engine::Core::MotionPresentationComponent* motion,
-                     bool is_selected,
-                     bool is_hovered,
-                     bool is_combat_active = false,
-                     float distance_sq = 0.0F) const noexcept -> bool {
-    (void)entity_id;
-    (void)motion;
-    (void)is_selected;
-    (void)is_hovered;
-    (void)is_combat_active;
-    (void)distance_sq;
-    m_units_rendered_this_frame.fetch_add(1, std::memory_order_relaxed);
-    return true;
-  }
-
-  [[nodiscard]] auto should_update_animation(
-      uint32_t entity_id,
-      float distance_sq,
-      bool is_selected,
-      bool is_combat_active,
-      const Engine::Core::MotionPresentationComponent* motion) const noexcept {
-    BattleRenderConfig cfg;
+  void begin_frame() {
+    BattleRenderConfig snapshot;
     {
-      std::lock_guard<std::mutex> lock(m_config_mutex);
-      cfg = m_config;
+      const std::lock_guard<std::mutex> lock(m_config_mutex);
+      snapshot = m_config;
     }
 
-    if (!cfg.enabled) {
-      return true;
-    }
-
-    if (is_selected) {
-      return true;
-    }
-
-    bool const is_moving = motion != nullptr && motion->has_locomotion();
-    if (is_moving) {
-      return true;
-    }
-
-    int visible_count = m_visible_unit_count.load(std::memory_order_relaxed);
-    if (visible_count < cfg.animation_throttle_threshold) {
-      return true;
-    }
-
-    if (is_combat_active) {
-      return true;
-    }
-
-    float priority_distance = cfg.animation_throttle_distance;
-
-    float const priority_distance_sq = priority_distance * priority_distance;
-    if (distance_sq < priority_distance_sq) {
-      return true;
-    }
-
-    uint32_t frame = m_frame_counter.load(std::memory_order_relaxed);
-    bool update = ((entity_id + frame) %
-                   static_cast<uint32_t>(cfg.animation_skip_frames + 1)) == 0;
-
-    if (!update) {
-      m_animations_throttled.fetch_add(1, std::memory_order_relaxed);
-    }
-
-    return update;
+    m_frame = FrameSnapshot{.config = snapshot,
+                            .frame = m_frame.frame + 1U,
+                            .visible_unit_count = m_frame.visible_unit_count};
+    m_stats = {};
   }
 
-  [[nodiscard]] auto get_batching_boost() const noexcept -> float {
-    BattleRenderConfig cfg;
-    {
-      std::lock_guard<std::mutex> lock(m_config_mutex);
-      cfg = m_config;
-    }
-
-    if (!cfg.enabled) {
-      return 1.0F;
-    }
-
-    int visible_count = m_visible_unit_count.load(std::memory_order_relaxed);
-    if (visible_count < cfg.temporal_culling_threshold) {
-      return 1.0F;
-    }
-
-    float excess_ratio =
-        static_cast<float>(visible_count - cfg.temporal_culling_threshold) /
-        static_cast<float>(cfg.temporal_culling_threshold);
-    return 1.0F + excess_ratio * 0.5F;
+  void set_visible_unit_count(int count) noexcept {
+    m_frame.visible_unit_count = count;
   }
 
-  [[nodiscard]] auto frame_counter() const noexcept -> uint32_t {
-    return m_frame_counter.load(std::memory_order_relaxed);
+  [[nodiscard]] auto frame() const noexcept -> const FrameSnapshot& { return m_frame; }
+
+  void commit_frame_stats(const FrameStats& stats) noexcept {
+    m_stats.animations_updated += stats.animations_updated;
+    m_stats.animations_throttled += stats.animations_throttled;
   }
 
-  [[nodiscard]] auto units_rendered_this_frame() const noexcept -> int {
-    return m_units_rendered_this_frame.load(std::memory_order_relaxed);
+  [[nodiscard]] auto frame_counter() const noexcept -> std::uint32_t {
+    return m_frame.frame;
   }
-
-  [[nodiscard]] auto units_skipped_temporal() const noexcept -> int {
-    return m_units_skipped_temporal.load(std::memory_order_relaxed);
-  }
-
-  [[nodiscard]] auto animations_throttled() const noexcept -> int {
-    return m_animations_throttled.load(std::memory_order_relaxed);
-  }
-
   [[nodiscard]] auto visible_unit_count() const noexcept -> int {
-    return m_visible_unit_count.load(std::memory_order_relaxed);
+    return m_frame.visible_unit_count;
+  }
+  [[nodiscard]] auto is_battle_mode() const noexcept -> bool {
+    return m_frame.battle_mode();
+  }
+  [[nodiscard]] auto get_batching_boost() const noexcept -> float {
+    return m_frame.batching_boost();
+  }
+  [[nodiscard]] auto animations_throttled() const noexcept -> int {
+    return m_stats.animations_throttled;
+  }
+  [[nodiscard]] auto animations_updated() const noexcept -> int {
+    return m_stats.animations_updated;
   }
 
 private:
-  BattleRenderOptimizer() = default;
-
   mutable std::mutex m_config_mutex;
   BattleRenderConfig m_config;
-  std::atomic<uint32_t> m_frame_counter{0};
-  std::atomic<int> m_visible_unit_count{0};
-  mutable std::atomic<int> m_units_rendered_this_frame{0};
-  mutable std::atomic<int> m_units_skipped_temporal{0};
-  mutable std::atomic<int> m_animations_throttled{0};
+
+  FrameSnapshot m_frame;
+  FrameStats m_stats;
 };
 
 } // namespace Render

--- a/render/entity/carried_load_renderer.cpp
+++ b/render/entity/carried_load_renderer.cpp
@@ -299,7 +299,7 @@ auto submit_carried_loads(Engine::Core::World* world,
       (camera != nullptr) ? camera->get_position() : QVector3D();
 
   for (auto* hauler :
-       world->get_entities_with<Engine::Core::ResourceCarryComponent>()) {
+       world->collect_entities_with<Engine::Core::ResourceCarryComponent>()) {
     if (hauler == nullptr) {
       continue;
     }

--- a/render/entity/combat_dust_renderer.cpp
+++ b/render/entity/combat_dust_renderer.cpp
@@ -153,7 +153,7 @@ void render_blood_stains(Renderer* renderer,
            Game::Map::should_render_combat_effect(*fog_snapshot, world_x, world_z);
   };
 
-  auto blood_stains = world->get_entities_with<Engine::Core::BloodStainComponent>();
+  auto blood_stains = world->collect_entities_with<Engine::Core::BloodStainComponent>();
   for (auto* blood_entity : blood_stains) {
     if (blood_entity == nullptr ||
         blood_entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -213,7 +213,7 @@ void render_combat_dust(Renderer* renderer,
            Game::Map::should_render_combat_effect(*fog_snapshot, world_x, world_z);
   };
 
-  auto units = world->get_entities_with<Engine::Core::AttackComponent>();
+  auto units = world->collect_entities_with<Engine::Core::AttackComponent>();
 
   for (auto* unit : units) {
     if (unit->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -257,7 +257,8 @@ void render_combat_dust(Renderer* renderer,
                           animation_time);
   }
 
-  auto builders = world->get_entities_with<Engine::Core::BuilderProductionComponent>();
+  auto builders =
+      world->collect_entities_with<Engine::Core::BuilderProductionComponent>();
 
   for (auto* builder : builders) {
     if (builder->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -302,7 +303,7 @@ void render_combat_dust(Renderer* renderer,
   }
 
   auto burning_structures =
-      world->get_entities_with<Engine::Core::StructureFireComponent>();
+      world->collect_entities_with<Engine::Core::StructureFireComponent>();
 
   for (auto* building : burning_structures) {
     if (building == nullptr ||
@@ -342,7 +343,8 @@ void render_combat_dust(Renderer* renderer,
   }
 
   auto structure_impacts =
-      world->get_entities_with<Engine::Core::StructureDamagePresentationComponent>();
+      world
+          ->collect_entities_with<Engine::Core::StructureDamagePresentationComponent>();
   for (auto* building : structure_impacts) {
     if (building == nullptr ||
         building->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -403,7 +405,7 @@ void render_combat_dust(Renderer* renderer,
   }
 
   auto rpg_contacts =
-      world->get_entities_with<Engine::Core::RpgContactPresentationComponent>();
+      world->collect_entities_with<Engine::Core::RpgContactPresentationComponent>();
   for (auto* entity : rpg_contacts) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -447,7 +449,7 @@ void render_combat_dust(Renderer* renderer,
   }
 
   auto casters =
-      world->get_entities_with<Engine::Core::CreaturePresentationComponent>();
+      world->collect_entities_with<Engine::Core::CreaturePresentationComponent>();
   for (auto* caster : casters) {
     if (caster == nullptr ||
         caster->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -510,7 +512,7 @@ void render_combat_dust(Renderer* renderer,
     renderer->local_light(charge_light);
   }
 
-  for (auto* commander : world->get_entities_with<
+  for (auto* commander : world->collect_entities_with<
                          Engine::Core::CommanderSignaturePresentationComponent>()) {
     if (commander == nullptr) {
       continue;
@@ -619,7 +621,8 @@ void render_combat_dust(Renderer* renderer,
     }
   }
 
-  auto burning_units = world->get_entities_with<Engine::Core::BurningStatusComponent>();
+  auto burning_units =
+      world->collect_entities_with<Engine::Core::BurningStatusComponent>();
   for (auto* burning_entity : burning_units) {
     if (burning_entity == nullptr ||
         burning_entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -725,7 +728,7 @@ void render_combat_dust(Renderer* renderer,
     }
   }
 
-  auto fire_patches = world->get_entities_with<Engine::Core::FirePatchComponent>();
+  auto fire_patches = world->collect_entities_with<Engine::Core::FirePatchComponent>();
   for (auto* fire_patch_entity : fire_patches) {
     if (fire_patch_entity == nullptr ||
         fire_patch_entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -797,7 +800,7 @@ void render_combat_dust(Renderer* renderer,
   auto& impact_tracker = StoneImpactTracker::instance();
 
   auto elephants =
-      world->get_entities_with<Engine::Core::ElephantStompImpactComponent>();
+      world->collect_entities_with<Engine::Core::ElephantStompImpactComponent>();
   for (auto* elephant : elephants) {
     auto* stomp_impact =
         elephant->get_component<Engine::Core::ElephantStompImpactComponent>();
@@ -1026,7 +1029,7 @@ void RpgTelegraphRenderer::render(Renderer* renderer,
   std::vector<Engine::Core::EntityID> seen;
   seen.reserve(16);
 
-  for (auto* entity : world->get_entities_with<CombatStateComponent>()) {
+  for (auto* entity : world->collect_entities_with<CombatStateComponent>()) {
     const auto id = entity->get_id();
     if (id == commander_id) {
       continue;
@@ -1150,7 +1153,7 @@ void RpgTelegraphRenderer::render(Renderer* renderer,
                     .color = ring_color});
   }
 
-  for (auto* entity : world->get_entities_with<StaggerComponent>()) {
+  for (auto* entity : world->collect_entities_with<StaggerComponent>()) {
     if (entity->get_id() == commander_id) {
       continue;
     }

--- a/render/entity/commander_aura_renderer.cpp
+++ b/render/entity/commander_aura_renderer.cpp
@@ -38,7 +38,7 @@ void render_commander_auras(Renderer* renderer,
 
   float const animation_time = renderer->get_animation_time();
 
-  auto commanders = world->get_entities_with<Engine::Core::CommanderComponent>();
+  auto commanders = world->collect_entities_with<Engine::Core::CommanderComponent>();
 
   for (auto* entity : commanders) {
     if (entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -102,7 +102,7 @@ void render_commander_auras(Renderer* renderer,
   }
 
   for (auto* entity :
-       world->get_entities_with<Engine::Core::CommanderAuraBuffComponent>()) {
+       world->collect_entities_with<Engine::Core::CommanderAuraBuffComponent>()) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
       continue;

--- a/render/entity/healer_aura_renderer.cpp
+++ b/render/entity/healer_aura_renderer.cpp
@@ -17,7 +17,7 @@ void render_healer_auras(Renderer* renderer,
 
   float const animation_time = renderer->get_animation_time();
 
-  auto healers = world->get_entities_with<Engine::Core::HealerComponent>();
+  auto healers = world->collect_entities_with<Engine::Core::HealerComponent>();
 
   for (auto* healer : healers) {
     if (healer->has_component<Engine::Core::PendingRemovalComponent>()) {

--- a/render/geom/patrol_flags.cpp
+++ b/render/geom/patrol_flags.cpp
@@ -92,7 +92,7 @@ void render_patrol_flags(Renderer* renderer,
     rendered_positions.insert(pos_hash);
   }
 
-  auto patrol_entities = world.get_entities_with<Engine::Core::PatrolComponent>();
+  auto patrol_entities = world.collect_entities_with<Engine::Core::PatrolComponent>();
 
   for (auto* entity : patrol_entities) {
     auto* patrol = entity->get_component<Engine::Core::PatrolComponent>();
@@ -153,7 +153,8 @@ void render_commander_rally_flags(Renderer* renderer,
   if (world == nullptr) {
     return;
   }
-  for (auto* entity : world->get_entities_with<Engine::Core::CommanderComponent>()) {
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::CommanderComponent>()) {
     auto* commander = entity->get_component<Engine::Core::CommanderComponent>();
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if ((commander == nullptr) || (unit == nullptr) ||

--- a/render/scene_renderer.cpp
+++ b/render/scene_renderer.cpp
@@ -199,9 +199,8 @@ void Renderer::begin_frame() {
   reset_elephant_render_stats();
 
   Render::VisibilityBudgetTracker::instance().reset_frame();
-  auto& battle_optimizer = Render::BattleRenderOptimizer::instance();
-  battle_optimizer.begin_frame();
-  prune_animation_time_cache(battle_optimizer.frame_counter());
+  m_battle_optimizer.begin_frame();
+  prune_animation_time_cache(m_battle_optimizer.frame_counter());
 
   m_active_queue = &m_queues[m_fill_queue_index];
   m_active_queue->clear();

--- a/render/scene_renderer.h
+++ b/render/scene_renderer.h
@@ -14,6 +14,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "battle_render_optimizer.h"
 #include "bone_palette_arena.h"
 #include "draw_queue.h"
 #include "entity/registry.h"
@@ -544,6 +545,8 @@ private:
   RiggedMeshCache m_rigged_mesh_cache;
   SnapshotMeshCache m_snapshot_mesh_cache;
   std::uint32_t m_frame_counter{0};
+
+  Render::BattleRenderOptimizer m_battle_optimizer;
 
   Engine::Core::World* m_cached_world{nullptr};
 

--- a/render/scene_walk.cpp
+++ b/render/scene_walk.cpp
@@ -293,7 +293,10 @@ struct UnitSubmitContext {
   Engine::Core::World* world{nullptr};
   ResourceManager* resources{nullptr};
   ISubmitter* batch_submitter{nullptr};
-  Render::BattleRenderOptimizer* optimizer{nullptr};
+
+  const Render::BattleRenderOptimizer::FrameSnapshot* optimizer{nullptr};
+
+  Render::BattleRenderOptimizer::FrameStats* optimizer_stats{nullptr};
   float batching_ratio{0.0F};
   float full_shader_max_distance_sq{0.0F};
   std::uint32_t optimizer_frame{0};
@@ -731,14 +734,6 @@ auto Renderer::plan_unit_entry(UnitRenderEntry& entry,
     return plan;
   }
 
-  bool const should_update_temporal =
-      ctx.full_creature_detail || ctx.optimizer->should_render_unit(entry.entity_id,
-                                                                    entry.motion,
-                                                                    entry.selected,
-                                                                    entry.hovered,
-                                                                    entry.combat_active,
-                                                                    entry.distance_sq);
-
   UnitRenderCache::update_model_matrix(*entry.cache);
   const QMatrix4x4& model_matrix = entry.cache->model_matrix;
 
@@ -772,15 +767,14 @@ auto Renderer::plan_unit_entry(UnitRenderEntry& entry,
     draw_ctx.selected = entry.selected;
     draw_ctx.hovered = entry.hovered;
     bool should_update_animation = ctx.full_creature_detail;
-    if (!ctx.full_creature_detail && should_update_temporal) {
+    if (!ctx.full_creature_detail) {
       should_update_animation =
           ctx.optimizer->should_update_animation(entry.entity_id,
                                                  entry.distance_sq,
                                                  entry.selected,
                                                  entry.combat_active,
-                                                 entry.motion);
-    } else if (!ctx.full_creature_detail) {
-      should_update_animation = false;
+                                                 entry.motion,
+                                                 *ctx.optimizer_stats);
     }
 
     float const animation_time = resolve_animation_time(entry.entity_id,
@@ -1129,15 +1123,16 @@ void Renderer::render_world(Engine::Core::World* world) {
 
   m_unit_render_cache.prune(m_frame_counter);
   m_model_matrix_cache.prune(m_frame_counter);
-  auto& battle_optimizer = Render::BattleRenderOptimizer::instance();
-  battle_optimizer.set_visible_unit_count(visible_unit_count);
+  m_battle_optimizer.set_visible_unit_count(visible_unit_count);
+  const auto& optimizer_frame_snapshot = m_battle_optimizer.frame();
+  Render::BattleRenderOptimizer::FrameStats optimizer_stats;
   auto& frame_profile = Render::Profiling::global_profile();
-  uint32_t const optimizer_frame = battle_optimizer.frame_counter();
+  uint32_t const optimizer_frame = optimizer_frame_snapshot.frame;
 
   float batching_ratio =
       gfx_settings.calculate_batching_ratio(visible_unit_count, camera_height);
 
-  float const batching_boost = battle_optimizer.get_batching_boost();
+  float const batching_boost = optimizer_frame_snapshot.batching_boost();
   batching_ratio = std::min(1.0F, batching_ratio * batching_boost);
 
   static thread_local PrimitiveBatcher batcher;
@@ -1157,7 +1152,8 @@ void Renderer::render_world(Engine::Core::World* world) {
   const UnitSubmitContext submit_ctx{.world = world,
                                      .resources = res,
                                      .batch_submitter = &batch_submitter,
-                                     .optimizer = &battle_optimizer,
+                                     .optimizer = &optimizer_frame_snapshot,
+                                     .optimizer_stats = &optimizer_stats,
                                      .batching_ratio = batching_ratio,
                                      .full_shader_max_distance_sq =
                                          full_shader_max_distance_sq,
@@ -1185,6 +1181,8 @@ void Renderer::render_world(Engine::Core::World* world) {
                           ? &m_unit_preparations[i]
                           : nullptr);
   }
+
+  m_battle_optimizer.commit_frame_stats(optimizer_stats);
 
   frame_profile.visible_soldiers = get_humanoid_render_stats().soldiers_rendered;
 
@@ -1351,7 +1349,7 @@ void Renderer::render_construction_previews(Engine::Core::World* world,
   };
 
   auto preview_entities =
-      world->get_entities_with<Engine::Core::ConstructionPreviewComponent>();
+      world->collect_entities_with<Engine::Core::ConstructionPreviewComponent>();
   for (auto* entity : preview_entities) {
     auto* preview = entity->get_component<Engine::Core::ConstructionPreviewComponent>();
     if (preview == nullptr) {
@@ -1366,7 +1364,7 @@ void Renderer::render_construction_previews(Engine::Core::World* world,
   }
 
   auto site_entities =
-      world->get_entities_with<Engine::Core::WallConstructionSiteComponent>();
+      world->collect_entities_with<Engine::Core::WallConstructionSiteComponent>();
   for (auto* entity : site_entities) {
     auto* site = entity->get_component<Engine::Core::WallConstructionSiteComponent>();
     if (site == nullptr ||

--- a/render/template_prewarm_runner.cpp
+++ b/render/template_prewarm_runner.cpp
@@ -301,10 +301,9 @@ void Renderer::process_async_template_prewarm() {
   std::size_t max_items = prewarm_budget.items_per_tick;
   std::chrono::microseconds time_budget(prewarm_budget.tick_budget_us);
 
-  const auto& battle_optimizer = Render::BattleRenderOptimizer::instance();
-  const int visible_units = battle_optimizer.visible_unit_count();
+  const int visible_units = m_battle_optimizer.visible_unit_count();
   if (visible_units >= 300) {
-    if ((battle_optimizer.frame_counter() & 1U) != 0U) {
+    if ((m_battle_optimizer.frame_counter() & 1U) != 0U) {
       return;
     }
     max_items = std::min<std::size_t>(max_items, 12);
@@ -496,7 +495,7 @@ void Renderer::prewarm_unit_templates(
   };
 
   if (world != nullptr) {
-    auto world_units = world->get_entities_with<Engine::Core::UnitComponent>();
+    auto world_units = world->collect_entities_with<Engine::Core::UnitComponent>();
     for (auto* entity : world_units) {
       if (entity == nullptr ||
           entity->has_component<Engine::Core::PendingRemovalComponent>()) {

--- a/scripts/check-world-scans.py
+++ b/scripts/check-world-scans.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Ratchet the number of full-world entity scans down, never up.
+
+`world->collect_entities_with<T>()` walks every entity carrying `T` and
+materialises a `std::vector<Entity*>` of them. That is the right shape for a
+question that genuinely concerns every entity -- counting an owner's army,
+sweeping components whose timer expired. It is the wrong shape for "what is near
+me?", and the difference does not show up until a battle is large: one radius
+question answered by a full scan costs O(units) per asker, so a system that asks
+it once per unit costs O(units^2) per tick.
+
+The engine rule is therefore:
+
+    A local, radius-bounded gameplay query goes through the world's spatial
+    index (`Engine::Core::WorldSpatialIndex`, reached as `world.spatial_index()`),
+    not through a full entity scan.
+
+The index is rebuilt once per tick and answers a query in proportion to what is
+actually nearby. `Game::Systems::Combat::collect_unit_ids_near` is the
+convenience wrapper the combat paths use.
+
+This check keeps the rule from eroding. It counts the scan call sites per
+directory and fails if any directory has *more* than the budget recorded in
+scripts/world_scan_budget.json. When you remove some, lower the budget
+(`--write` rewrites it to the current counts) so the gain is kept.
+
+DEFINITION_FILES below lists where the query itself is defined, plus the one
+place a full scan is the whole point: the index's own rebuild has to look at
+every entity in order to index it.
+
+  usage: check-world-scans.py [repo-root] [--write]
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+BUDGET_FILE = "scripts/world_scan_budget.json"
+
+SCAN = re.compile(r"\bcollect_entities_with\s*<")
+
+DEFINITION_FILES = {
+    "game/core/world.h",
+    "game/core/world.cpp",
+    "game/core/world_spatial_index.cpp",
+}
+
+LAYERS = ("game", "app", "ui", "render", "tools")
+SOURCE_SUFFIXES = (".h", ".cpp")
+
+
+def bucket(relative: str) -> str:
+    parts = relative.split("/")
+
+    return "/".join(parts[:2]) if len(parts) > 2 else parts[0]
+
+
+def count(root: Path) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for layer in LAYERS:
+        directory = root / layer
+        if not directory.is_dir():
+            continue
+        for source in sorted(directory.rglob("*")):
+            if source.suffix not in SOURCE_SUFFIXES:
+                continue
+            relative = source.relative_to(root).as_posix()
+            if relative in DEFINITION_FILES:
+                continue
+            for line in source.read_text(errors="ignore").splitlines():
+                stripped = line.lstrip()
+                if stripped.startswith("//") or stripped.startswith("*"):
+                    continue
+                hits = len(SCAN.findall(line))
+                if hits:
+                    counts[bucket(relative)] += hits
+    return counts
+
+
+def main(argv: list[str]) -> int:
+    args = [a for a in argv[1:] if not a.startswith("--")]
+    write = "--write" in argv
+    root = Path(args[0]).resolve() if args else Path(__file__).resolve().parents[1]
+    counts = count(root)
+    budget_path = root / BUDGET_FILE
+
+    if write or not budget_path.exists():
+        budget_path.write_text(
+            json.dumps(dict(sorted(counts.items())), indent=2) + "\n"
+        )
+        print(f"check-world-scans: wrote {BUDGET_FILE} ({sum(counts.values())} scans)")
+        return 0
+
+    budget = json.loads(budget_path.read_text())
+    over = {k: (v, budget.get(k, 0)) for k, v in counts.items() if v > budget.get(k, 0)}
+    under = {k: (v, budget[k]) for k, v in counts.items() if v < budget.get(k, 0)}
+    gone = {k: v for k, v in budget.items() if k not in counts and v > 0}
+
+    if over:
+        print("check-world-scans: more full-world scans than the budget allows:")
+        for k, (now, allowed) in sorted(over.items()):
+            print(f"  {k}: {now} (budget {allowed})")
+        print(
+            "\nIf the new query is radius-bounded, ask the spatial index instead:\n"
+            "  world.spatial_index().refresh(world);\n"
+            "  world.spatial_index().for_each_in_radius(x, z, radius, ...);\n"
+            "If it genuinely concerns every entity, raise the budget in\n"
+            f"{BUDGET_FILE} in the same change and say why."
+        )
+        return 1
+    if under or gone:
+        print(
+            "check-world-scans: fewer scans than budgeted -- run with --write to keep the gain:"
+        )
+        for k, (now, allowed) in sorted(under.items()):
+            print(f"  {k}: {now} (budget {allowed})")
+        for k, allowed in sorted(gone.items()):
+            print(f"  {k}: 0 (budget {allowed})")
+    print(f"check-world-scans: ok ({sum(counts.values())} scans within budget)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/promo-edit.py
+++ b/scripts/promo-edit.py
@@ -333,26 +333,32 @@ TRANSITIONS = {
 DEFAULT_TRANSITION = "dissolve"
 DEFAULT_TRANSITION_SECONDS = 0.35
 
-FONT_CANDIDATES = (
-    "/usr/share/fonts/truetype/ebgaramond/EBGaramond12-Bold.ttf",
-    "/usr/share/texmf/fonts/opentype/public/lm/lmromancaps10-regular.otf",
-    "/usr/share/fonts/opentype/ebgaramond/EBGaramondSC12-Regular.otf",
-    "/usr/share/fonts/opentype/linux-libertine/LinLibertine_RB.otf",
-    "/usr/share/fonts/truetype/adf/AccanthisADFStd-Bold.otf",
-    "/usr/share/fonts/truetype/noto/NotoSerifDisplay-Bold.ttf",
-    "/usr/share/fonts/truetype/dejavu/DejaVuSerif-Bold.ttf",
-    "/usr/share/fonts/truetype/liberation/LiberationSerif-Bold.ttf",
-)
-"""Preferred caption faces, most period-appropriate first.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUNDLED_FONT_DIR = REPO_ROOT / "assets" / "fonts"
 
-The order is a compromise between two things the cards have to do at once. An
-ancient-looking card wants inscriptional Roman capitals -- high stroke
-contrast, fine bracketed serifs, the shapes cut on a Trajanic base -- and
-`lmromancaps10` is exactly that. But captions here are drawn over moving
-footage with a 4 px black border, and hairline serifs disappear under it. EB
-Garamond's bold is old-style enough to read as carved rather than typed while
-keeping stem weight the border cannot swallow, so it leads and the pure
-inscriptional face is the fallback."""
+FONT_CANDIDATES = (
+    BUNDLED_FONT_DIR / "StandardIronDisplay-Bold.ttf",
+    BUNDLED_FONT_DIR / "EBGaramond12-Bold.ttf",
+)
+"""Preferred caption faces, most brand-specific first.
+
+These are the faces the repository ships, not the ones the host happens to
+have installed, and that is the whole point. This used to be an eight-deep
+walk down /usr/share/fonts that started at EB Garamond and ended at Liberation
+Serif, which meant the same promo spec rendered in a different typeface
+depending on which machine cut it -- a build box, a laptop and CI could each
+publish a differently-lettered reel from identical inputs and nothing in the
+output said so. Reels are the game's most-seen surface; they cannot be a
+function of the packages installed.
+
+The order is also a compromise between two things the cards have to do at
+once. An ancient-looking card wants inscriptional Roman capitals -- high
+stroke contrast, fine bracketed serifs, the shapes cut on a Trajanic base.
+But captions here are drawn over moving footage with a 4 px black border, and
+hairline serifs disappear under it. So the display face leads, and EB
+Garamond's bold -- old-style enough to read as carved rather than typed, with
+stem weight the border cannot swallow -- backs it up and covers everything the
+display face has no glyph for."""
 
 
 def fail(message: str) -> None:
@@ -390,11 +396,19 @@ def reject(staged: Path, output: Path, message: str) -> None:
 
 
 def resolve_font(requested: str | None) -> str:
-    candidates = (requested, *FONT_CANDIDATES) if requested else FONT_CANDIDATES
-    for candidate in candidates:
-        if candidate and Path(candidate).is_file():
-            return candidate
-    fail("no usable bold font found; pass --font with a .ttf path")
+    if requested:
+        if Path(requested).is_file():
+            return requested
+        fail(f"--font {requested} is not a file")
+    for candidate in FONT_CANDIDATES:
+        if candidate.is_file():
+            return str(candidate)
+    fail(
+        "no bundled caption face found under "
+        f"{BUNDLED_FONT_DIR}; the repository ships one so that every machine "
+        "cuts the same lettering. Restore it, or pass --font explicitly and "
+        "accept that the reel will not match the others."
+    )
     raise AssertionError("unreachable")
 
 

--- a/scripts/world_scan_budget.json
+++ b/scripts/world_scan_budget.json
@@ -1,0 +1,18 @@
+{
+  "app/commander": 4,
+  "app/economy": 1,
+  "app/persistence": 1,
+  "app/session": 3,
+  "app/viewmodels": 1,
+  "app/world": 3,
+  "game/map": 2,
+  "game/mission": 5,
+  "game/render_bridge": 4,
+  "game/systems": 95,
+  "game/units": 1,
+  "game/wildlife": 2,
+  "render": 3,
+  "render/entity": 17,
+  "render/geom": 2,
+  "tools/arena": 11
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,9 @@ add_executable(
     command/command_pipeline_test.cpp
     command/command_codec_test.cpp
     core/entity_handle_test.cpp
+    core/world_view_test.cpp
+    core/world_spatial_index_test.cpp
+    core/system_schedule_test.cpp
     core/ground_type_test.cpp
     core/building_spawn_setup_test.cpp
     map/terrain_profiles_test.cpp
@@ -159,6 +162,7 @@ add_executable(
     formation/formation_data_loader_test.cpp
     formation/formation_movement_test.cpp
     formation/formation_terrain_navigation_test.cpp
+    systems/runtime_phase_order_test.cpp
     systems/formation_combat_geometry_test.cpp
     systems/defensive_unit_layout_test.cpp
     systems/structure_combat_test.cpp
@@ -349,6 +353,7 @@ add_executable(
     render/unit_render_cache_test.cpp
     render/render_archetype_test.cpp
     render/draw_queue_sort_order_test.cpp
+    render/draw_queue_sort_cost_test.cpp
     render/effect_batch_dispatch_test.cpp
     render/spark_direction_test.cpp
     render/linear_feature_geometry_test.cpp

--- a/tests/command/command_pipeline_test.cpp
+++ b/tests/command/command_pipeline_test.cpp
@@ -587,15 +587,16 @@ TEST(CommandPipelineTest, WallPlanRaisesSitesChargesWoodAndSeatsTheCrew) {
                                                      .target_x = 12,
                                                      .target_z = 4});
   EXPECT_TRUE(match.session.world()
-                  .get_entities_with<Engine::Core::WallConstructionSiteComponent>()
+                  .collect_entities_with<Engine::Core::WallConstructionSiteComponent>()
                   .empty());
   drain(match);
 
-  EXPECT_EQ(static_cast<int>(
-                match.session.world()
-                    .get_entities_with<Engine::Core::WallConstructionSiteComponent>()
-                    .size()),
-            plan.valid_count);
+  EXPECT_EQ(
+      static_cast<int>(
+          match.session.world()
+              .collect_entities_with<Engine::Core::WallConstructionSiteComponent>()
+              .size()),
+      plan.valid_count);
   EXPECT_TRUE(builder->has_construction_site);
   EXPECT_EQ(builder->product_type, "wall_segment");
   EXPECT_EQ(economy.get(1, Game::Systems::ResourceType::Wood), 500 - plan.wood_cost());
@@ -617,7 +618,7 @@ TEST(CommandPipelineTest, WallPlanFromSomeoneElsesBuilderIsIgnored) {
   drain(match);
 
   EXPECT_TRUE(match.session.world()
-                  .get_entities_with<Engine::Core::WallConstructionSiteComponent>()
+                  .collect_entities_with<Engine::Core::WallConstructionSiteComponent>()
                   .empty());
   EXPECT_FALSE(builder->has_construction_site);
   EXPECT_EQ(match.session.economy().get(1, Game::Systems::ResourceType::Wood), 500);
@@ -627,7 +628,7 @@ TEST(CommandPipelineTest, PlaceBuildingRefusesAUnitTypeThatIsNotAStructure) {
   Match match;
   match.session.economy().add(1, Game::Systems::ResourceType::Wood, 500);
   const auto before =
-      match.session.world().get_entities_with<Engine::Core::UnitComponent>().size();
+      match.session.world().collect_entities_with<Engine::Core::UnitComponent>().size();
 
   Game::Command::submit(
       match.session.world(),
@@ -638,7 +639,7 @@ TEST(CommandPipelineTest, PlaceBuildingRefusesAUnitTypeThatIsNotAStructure) {
   drain(match);
 
   EXPECT_EQ(
-      match.session.world().get_entities_with<Engine::Core::UnitComponent>().size(),
+      match.session.world().collect_entities_with<Engine::Core::UnitComponent>().size(),
       before);
   EXPECT_EQ(Game::Systems::StructurePlacementService::ruling(
                 match.session.world(), 1, "archer", QVector3D(3.0F, 0.0F, 3.0F)),

--- a/tests/core/campaign_wave_assault_test.cpp
+++ b/tests/core/campaign_wave_assault_test.cpp
@@ -190,7 +190,8 @@ public:
   [[nodiscard]] auto
   living_commanders_by_owner() -> std::map<int, std::vector<QString>> {
     std::map<int, std::vector<QString>> by_owner;
-    for (auto* entity : m_world.get_entities_with<Engine::Core::CommanderComponent>()) {
+    for (auto* entity :
+         m_world.collect_entities_with<Engine::Core::CommanderComponent>()) {
       if (entity == nullptr) {
         continue;
       }

--- a/tests/core/entity_handle_test.cpp
+++ b/tests/core/entity_handle_test.cpp
@@ -106,11 +106,11 @@ TEST(ComponentIndexTest, TracksMembershipAcrossAddAndRemove) {
   b->add_component<TransformComponent>();
   c->add_component<UnitComponent>();
 
-  EXPECT_EQ(world.get_entities_with<TransformComponent>().size(), 2U);
-  EXPECT_EQ(world.get_entities_with<UnitComponent>().size(), 1U);
+  EXPECT_EQ(world.collect_entities_with<TransformComponent>().size(), 2U);
+  EXPECT_EQ(world.collect_entities_with<UnitComponent>().size(), 1U);
 
   b->remove_component<TransformComponent>();
-  auto transforms = world.get_entities_with<TransformComponent>();
+  auto transforms = world.collect_entities_with<TransformComponent>();
   ASSERT_EQ(transforms.size(), 1U);
   EXPECT_EQ(transforms.front(), a);
 }
@@ -331,8 +331,8 @@ TEST(ComponentIndexTest, DestroyingAnEntityDropsItFromEveryIndex) {
 
   world.destroy_entity(id);
 
-  EXPECT_TRUE(world.get_entities_with<TransformComponent>().empty());
-  EXPECT_TRUE(world.get_entities_with<UnitComponent>().empty());
+  EXPECT_TRUE(world.collect_entities_with<TransformComponent>().empty());
+  EXPECT_TRUE(world.collect_entities_with<UnitComponent>().empty());
   EXPECT_EQ(world.entity_count(), 0U);
 }
 
@@ -349,7 +349,7 @@ TEST(ComponentIndexTest, SwapRemoveKeepsEveryOtherMemberReachable) {
   entities[3]->remove_component<TransformComponent>();
   entities[0]->remove_component<TransformComponent>();
 
-  auto remaining = world.get_entities_with<TransformComponent>();
+  auto remaining = world.collect_entities_with<TransformComponent>();
   EXPECT_EQ(remaining.size(), 6U);
   for (std::size_t i = 0; i < entities.size(); ++i) {
     const bool expected = i != 0 && i != 3;
@@ -371,8 +371,8 @@ TEST(ComponentIndexTest, RecycledSlotsDoNotInheritTheOldEntitysComponents) {
   ASSERT_EQ(Handle::index_of(second->get_id()), Handle::index_of(stale));
   second->add_component<TransformComponent>();
 
-  EXPECT_TRUE(world.get_entities_with<UnitComponent>().empty());
-  auto transforms = world.get_entities_with<TransformComponent>();
+  EXPECT_TRUE(world.collect_entities_with<UnitComponent>().empty());
+  auto transforms = world.collect_entities_with<TransformComponent>();
   ASSERT_EQ(transforms.size(), 1U);
   EXPECT_EQ(transforms.front(), second);
 }
@@ -383,14 +383,14 @@ TEST(ComponentIndexTest, ReplacingAnIdClearsTheOldOccupantsIndexEntries) {
   auto* original = world.create_entity_with_id(7);
   ASSERT_NE(original, nullptr);
   original->add_component<UnitComponent>();
-  ASSERT_EQ(world.get_entities_with<UnitComponent>().size(), 1U);
+  ASSERT_EQ(world.collect_entities_with<UnitComponent>().size(), 1U);
 
   auto* replacement = world.create_entity_with_id(7);
   ASSERT_NE(replacement, nullptr);
   replacement->add_component<TransformComponent>();
 
-  EXPECT_TRUE(world.get_entities_with<UnitComponent>().empty());
-  EXPECT_EQ(world.get_entities_with<TransformComponent>().size(), 1U);
+  EXPECT_TRUE(world.collect_entities_with<UnitComponent>().empty());
+  EXPECT_EQ(world.collect_entities_with<TransformComponent>().size(), 1U);
   EXPECT_EQ(world.entity_count(), 1U);
 }
 

--- a/tests/core/production_manager_test.cpp
+++ b/tests/core/production_manager_test.cpp
@@ -103,11 +103,11 @@ protected:
   }
 
   auto preview_entities() -> std::vector<Engine::Core::Entity*> {
-    return world.get_entities_with<Engine::Core::ConstructionPreviewComponent>();
+    return world.collect_entities_with<Engine::Core::ConstructionPreviewComponent>();
   }
 
   auto find_spawned_unit(Game::Units::SpawnType spawn_type) -> Engine::Core::Entity* {
-    for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+    for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
       auto* unit = entity->get_component<Engine::Core::UnitComponent>();
       if (unit != nullptr && unit->spawn_type == spawn_type) {
         return entity;
@@ -117,7 +117,8 @@ protected:
   }
 
   auto find_wall_construction_site() -> Engine::Core::Entity* {
-    auto sites = world.get_entities_with<Engine::Core::WallConstructionSiteComponent>();
+    auto sites =
+        world.collect_entities_with<Engine::Core::WallConstructionSiteComponent>();
     return sites.empty() ? nullptr : sites.front();
   }
 

--- a/tests/core/serialization_test.cpp
+++ b/tests/core/serialization_test.cpp
@@ -345,15 +345,15 @@ TEST_F(SerializationTest, ReplacingEntityIdClearsOldComponentIndex) {
   ASSERT_NE(original, nullptr);
   original->add_component<UnitComponent>();
 
-  ASSERT_EQ(world->get_entities_with<UnitComponent>().size(), 1U);
+  ASSERT_EQ(world->collect_entities_with<UnitComponent>().size(), 1U);
 
   auto* replacement = world->create_entity_with_id(42);
   ASSERT_NE(replacement, nullptr);
   replacement->add_component<TransformComponent>();
 
-  EXPECT_TRUE(world->get_entities_with<UnitComponent>().empty());
+  EXPECT_TRUE(world->collect_entities_with<UnitComponent>().empty());
 
-  auto transforms = world->get_entities_with<TransformComponent>();
+  auto transforms = world->collect_entities_with<TransformComponent>();
   ASSERT_EQ(transforms.size(), 1U);
   EXPECT_EQ(transforms.front()->get_id(), 42U);
   EXPECT_NE(transforms.front()->get_component<TransformComponent>(), nullptr);

--- a/tests/core/system_schedule_test.cpp
+++ b/tests/core/system_schedule_test.cpp
@@ -1,0 +1,212 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "game/core/component.h"
+#include "game/core/deferred_mutations.h"
+#include "game/core/entity.h"
+#include "game/core/system.h"
+#include "game/core/system_schedule.h"
+#include "game/core/world.h"
+
+namespace {
+
+using Engine::Core::AttackComponent;
+using Engine::Core::component_type_id;
+using Engine::Core::DeferredMutations;
+using Engine::Core::EntityID;
+using Engine::Core::MovementComponent;
+using Engine::Core::plan_phase_batches;
+using Engine::Core::SystemAccess;
+using Engine::Core::SystemPhase;
+using Engine::Core::TransformComponent;
+using Engine::Core::UnitComponent;
+using Engine::Core::World;
+
+auto access(std::vector<Engine::Core::ComponentTypeId> reads,
+            std::vector<Engine::Core::ComponentTypeId> writes) -> SystemAccess {
+  return SystemAccess{
+      .reads = std::move(reads), .writes = std::move(writes), .exclusive = false};
+}
+
+TEST(SystemAccessTest, TwoReadersOfTheSameComponentDoNotCollide) {
+  const auto reader_a = access({component_type_id<TransformComponent>()}, {});
+  const auto reader_b = access({component_type_id<TransformComponent>()}, {});
+  EXPECT_FALSE(reader_a.conflicts_with(reader_b));
+}
+
+TEST(SystemAccessTest, AWriterCollidesWithAnyoneTouchingWhatItWrites) {
+  const auto writer = access({}, {component_type_id<TransformComponent>()});
+  const auto reader = access({component_type_id<TransformComponent>()}, {});
+  const auto other_writer = access({}, {component_type_id<TransformComponent>()});
+  const auto unrelated = access({component_type_id<UnitComponent>()},
+                                {component_type_id<AttackComponent>()});
+
+  EXPECT_TRUE(writer.conflicts_with(reader));
+  EXPECT_TRUE(reader.conflicts_with(writer));
+  EXPECT_TRUE(writer.conflicts_with(other_writer));
+  EXPECT_FALSE(writer.conflicts_with(unrelated));
+}
+
+TEST(SystemAccessTest, AnUndeclaredSystemCollidesWithEverything) {
+  const SystemAccess undeclared = SystemAccess::everything();
+  const auto declared = access({component_type_id<UnitComponent>()}, {});
+
+  EXPECT_TRUE(undeclared.conflicts_with(declared));
+  EXPECT_TRUE(declared.conflicts_with(undeclared));
+  EXPECT_TRUE(undeclared.conflicts_with(SystemAccess::everything()));
+}
+
+TEST(SystemScheduleTest, GroupsIndependentSystemsAndSplitsCollidingOnes) {
+  const std::vector<SystemAccess> systems{
+      access({component_type_id<TransformComponent>()}, {}),
+      access({component_type_id<UnitComponent>()}, {}),
+      access({}, {component_type_id<TransformComponent>()}),
+      access({component_type_id<AttackComponent>()}, {}),
+  };
+
+  const auto batches = plan_phase_batches(systems);
+
+  ASSERT_EQ(batches.size(), 2U);
+  EXPECT_EQ(batches[0], (std::vector<std::size_t>{0, 1}));
+  EXPECT_EQ(batches[1], (std::vector<std::size_t>{2, 3}));
+}
+
+TEST(SystemScheduleTest, UndeclaredSystemsEachGetTheirOwnBatch) {
+  const std::vector<SystemAccess> systems{SystemAccess::everything(),
+                                          SystemAccess::everything(),
+                                          SystemAccess::everything()};
+
+  const auto batches = plan_phase_batches(systems);
+
+  ASSERT_EQ(batches.size(), 3U);
+  for (const auto& batch : batches) {
+    EXPECT_EQ(batch.size(), 1U);
+  }
+}
+
+TEST(SystemScheduleTest, BatchesRunInRegistrationOrder) {
+  const std::vector<SystemAccess> systems{
+      access({component_type_id<TransformComponent>()}, {}),
+      access({}, {component_type_id<TransformComponent>()}),
+      access({component_type_id<TransformComponent>()}, {}),
+  };
+
+  const auto batches = plan_phase_batches(systems);
+
+  std::vector<std::size_t> flattened;
+  for (const auto& batch : batches) {
+    flattened.insert(flattened.end(), batch.begin(), batch.end());
+  }
+  EXPECT_EQ(flattened, (std::vector<std::size_t>{0, 1, 2}));
+}
+
+TEST(SystemPhaseTest, EveryPhaseHasAName) {
+  for (std::uint8_t raw = 0; raw < static_cast<std::uint8_t>(SystemPhase::_Count);
+       ++raw) {
+    const auto phase = static_cast<SystemPhase>(raw);
+    EXPECT_STRNE(Engine::Core::phase_name(phase), "?");
+  }
+}
+
+auto spawn_unit(World& world) -> EntityID {
+  auto* entity = world.create_entity();
+  entity->add_component<TransformComponent>();
+  entity->add_component<UnitComponent>();
+  return entity->get_id();
+}
+
+TEST(DeferredMutationsTest, NothingHappensUntilTheBarrier) {
+  World world;
+  const EntityID id = spawn_unit(world);
+
+  DeferredMutations pending;
+  pending.add_component<MovementComponent>(id);
+  pending.destroy_entity(id);
+
+  EXPECT_EQ(pending.pending(), 2U);
+  EXPECT_TRUE(world.is_alive(id));
+  EXPECT_FALSE(world.get_entity(id)->has_component<MovementComponent>());
+
+  pending.apply(world);
+
+  EXPECT_TRUE(pending.empty());
+  EXPECT_FALSE(world.is_alive(id));
+}
+
+TEST(DeferredMutationsTest, AppliesInTheOrderRecorded) {
+  World world;
+  const EntityID id = spawn_unit(world);
+
+  DeferredMutations pending;
+  pending.add_component<MovementComponent>(id);
+  pending.remove_component<MovementComponent>(id);
+  pending.add_component<AttackComponent>(id);
+  pending.apply(world);
+
+  auto* entity = world.get_entity(id);
+  ASSERT_NE(entity, nullptr);
+  EXPECT_FALSE(entity->has_component<MovementComponent>());
+  EXPECT_TRUE(entity->has_component<AttackComponent>());
+}
+
+TEST(DeferredMutationsTest, ForwardsConstructorArguments) {
+  World world;
+  const EntityID id = spawn_unit(world);
+
+  DeferredMutations pending;
+  pending.add_component<AttackComponent>(id, 7.5F, 3.0F, 0.5F);
+  pending.apply(world);
+
+  const auto* attack = world.get_entity(id)->get_component<AttackComponent>();
+  ASSERT_NE(attack, nullptr);
+  EXPECT_FLOAT_EQ(attack->range, 7.5F);
+}
+
+TEST(DeferredMutationsTest, SurvivesAnEntityThatDiedBeforeTheBarrier) {
+  World world;
+  const EntityID id = spawn_unit(world);
+
+  DeferredMutations pending;
+  pending.add_component<MovementComponent>(id);
+  world.destroy_entity(id);
+
+  pending.apply(world);
+  EXPECT_FALSE(world.is_alive(id));
+}
+
+TEST(DeferredMutationsTest, AChangeRecordedByAChangeWaitsForTheNextBarrier) {
+  World world;
+  const EntityID id = spawn_unit(world);
+
+  DeferredMutations pending;
+  pending.run([&pending, id](World&) { pending.destroy_entity(id); });
+
+  pending.apply(world);
+  EXPECT_TRUE(world.is_alive(id));
+  EXPECT_EQ(pending.pending(), 1U);
+
+  pending.apply(world);
+  EXPECT_FALSE(world.is_alive(id));
+}
+
+TEST(DeferredMutationsTest, LetsASystemRestructureTheWorldWhileWalkingAView) {
+  World world;
+  std::vector<EntityID> ids;
+  for (int i = 0; i < 8; ++i) {
+    ids.push_back(spawn_unit(world));
+  }
+
+  DeferredMutations pending;
+  for (auto [id, transform, unit] : world.view<TransformComponent, UnitComponent>()) {
+    (void)transform;
+    (void)unit;
+    pending.destroy_entity(id);
+  }
+  pending.apply(world);
+
+  for (const EntityID id : ids) {
+    EXPECT_FALSE(world.is_alive(id));
+  }
+}
+
+} // namespace

--- a/tests/core/tutorial_mission_test.cpp
+++ b/tests/core/tutorial_mission_test.cpp
@@ -92,7 +92,7 @@ protected:
 
   auto living_units_of(int owner) -> std::vector<Engine::Core::Entity*> {
     std::vector<Engine::Core::Entity*> units;
-    for (auto* entity : m_world.get_entities_with<UnitComponent>()) {
+    for (auto* entity : m_world.collect_entities_with<UnitComponent>()) {
       const auto* unit = entity->get_component<UnitComponent>();
       if (unit != nullptr && unit->health > 0 && unit->owner_id == owner) {
         units.push_back(entity);
@@ -122,7 +122,8 @@ protected:
 
 TEST_F(TutorialMissionTest, EveryForceFieldsExactlyOneCommander) {
   std::map<int, int> commanders;
-  for (auto* entity : m_world.get_entities_with<Engine::Core::CommanderComponent>()) {
+  for (auto* entity :
+       m_world.collect_entities_with<Engine::Core::CommanderComponent>()) {
     const auto* unit = entity->get_component<UnitComponent>();
     if (unit != nullptr && unit->health > 0) {
       ++commanders[unit->owner_id];

--- a/tests/core/world_spatial_index_test.cpp
+++ b/tests/core/world_spatial_index_test.cpp
@@ -1,0 +1,187 @@
+#include <algorithm>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "game/core/component.h"
+#include "game/core/entity.h"
+#include "game/core/world.h"
+#include "game/core/world_spatial_index.h"
+
+namespace {
+
+using Engine::Core::BuildingComponent;
+using Engine::Core::EntityID;
+using Engine::Core::TransformComponent;
+using Engine::Core::UnitComponent;
+using Engine::Core::World;
+using Engine::Core::WorldSpatialIndex;
+
+auto spawn(World& world, float x, float z, int owner_id, int health = 100) -> EntityID {
+  auto* entity = world.create_entity();
+  auto* transform = entity->add_component<TransformComponent>();
+  transform->position.x = x;
+  transform->position.z = z;
+  auto* unit = entity->add_component<UnitComponent>();
+  unit->owner_id = owner_id;
+  unit->health = health;
+  return entity->get_id();
+}
+
+auto ids_in_radius(const WorldSpatialIndex& index,
+                   float x,
+                   float z,
+                   float radius) -> std::vector<EntityID> {
+  std::vector<EntityID> found;
+  index.for_each_in_radius(
+      x, z, radius, [&found](const WorldSpatialIndex::Entry& entry) {
+        found.push_back(entry.id);
+      });
+  std::sort(found.begin(), found.end());
+  return found;
+}
+
+TEST(WorldSpatialIndexTest, FindsOnlyEntitiesInsideTheRadius) {
+  World world;
+  const EntityID close = spawn(world, 1.0F, 1.0F, 1);
+  const EntityID edge = spawn(world, 4.0F, 0.0F, 1);
+  spawn(world, 40.0F, 40.0F, 1);
+
+  auto& index = world.spatial_index();
+  index.rebuild(world);
+
+  const auto found = ids_in_radius(index, 0.0F, 0.0F, 5.0F);
+  std::vector<EntityID> expected{close, edge};
+  std::sort(expected.begin(), expected.end());
+  EXPECT_EQ(found, expected);
+}
+
+TEST(WorldSpatialIndexTest, AgreesWithTheBruteForceScanAtEveryRadius) {
+  World world;
+  std::vector<EntityID> ids;
+  for (int i = 0; i < 40; ++i) {
+    const auto fi = static_cast<float>(i);
+    ids.push_back(spawn(world,
+                        std::fmod(fi * 7.0F, 60.0F) - 30.0F,
+                        std::fmod(fi * 13.0F, 60.0F) - 30.0F,
+                        1));
+  }
+
+  auto& index = world.spatial_index();
+  index.rebuild(world);
+
+  for (float radius : {0.5F, 3.0F, 9.0F, 25.0F}) {
+    std::vector<EntityID> brute;
+    for (const EntityID id : ids) {
+      auto* entity = world.get_entity(id);
+      const auto& position = entity->get_component<TransformComponent>()->position;
+      const float dx = position.x - 2.0F;
+      const float dz = position.z + 4.0F;
+      if (dx * dx + dz * dz <= radius * radius) {
+        brute.push_back(id);
+      }
+    }
+    std::sort(brute.begin(), brute.end());
+    EXPECT_EQ(ids_in_radius(index, 2.0F, -4.0F, radius), brute) << "radius " << radius;
+  }
+}
+
+TEST(WorldSpatialIndexTest, CarriesTheFlagsProximityQueriesFilterOn) {
+  World world;
+  const EntityID soldier = spawn(world, 0.0F, 0.0F, 1);
+  const EntityID corpse = spawn(world, 1.0F, 0.0F, 1, 0);
+
+  auto* fort = world.get_entity(spawn(world, 2.0F, 0.0F, 2));
+  fort->add_component<BuildingComponent>();
+
+  auto& index = world.spatial_index();
+  index.rebuild(world);
+
+  const auto* soldier_entry = index.find(soldier);
+  ASSERT_NE(soldier_entry, nullptr);
+  EXPECT_TRUE(soldier_entry->is(WorldSpatialIndex::k_alive));
+  EXPECT_FALSE(soldier_entry->is(WorldSpatialIndex::k_building));
+  EXPECT_EQ(soldier_entry->owner_id, 1);
+
+  const auto* corpse_entry = index.find(corpse);
+  ASSERT_NE(corpse_entry, nullptr);
+  EXPECT_FALSE(corpse_entry->is(WorldSpatialIndex::k_alive));
+
+  const auto* fort_entry = index.find(fort->get_id());
+  ASSERT_NE(fort_entry, nullptr);
+  EXPECT_TRUE(fort_entry->is(WorldSpatialIndex::k_building));
+  EXPECT_EQ(fort_entry->owner_id, 2);
+}
+
+TEST(WorldSpatialIndexTest, ForgetsEntitiesThatLeftTheWorld) {
+  World world;
+  const EntityID doomed = spawn(world, 0.0F, 0.0F, 1);
+  const EntityID survivor = spawn(world, 1.0F, 0.0F, 1);
+
+  auto& index = world.spatial_index();
+  index.rebuild(world);
+  ASSERT_NE(index.find(doomed), nullptr);
+
+  world.destroy_entity(doomed);
+  index.rebuild(world);
+
+  EXPECT_EQ(index.find(doomed), nullptr);
+  EXPECT_NE(index.find(survivor), nullptr);
+  EXPECT_EQ(index.entry_count(), 1U);
+}
+
+TEST(WorldSpatialIndexTest, RefreshRebuildsOncePerTickAndNotMore) {
+  World world;
+  spawn(world, 0.0F, 0.0F, 1);
+
+  auto& index = world.spatial_index();
+  world.update(0.016F);
+  index.refresh(world);
+  const std::uint64_t after_first_tick = index.stats().rebuilds;
+
+  index.refresh(world);
+  index.refresh(world);
+  index.refresh(world);
+  EXPECT_EQ(index.stats().rebuilds, after_first_tick);
+
+  world.update(0.016F);
+  index.refresh(world);
+  EXPECT_EQ(index.stats().rebuilds, after_first_tick + 1);
+}
+
+TEST(WorldSpatialIndexTest, RefreshNeverServesStaleDataToAnUntickedWorld) {
+  World world;
+  const EntityID mover = spawn(world, 0.0F, 0.0F, 1);
+
+  auto& index = world.spatial_index();
+  index.refresh(world);
+  ASSERT_EQ(ids_in_radius(index, 0.0F, 0.0F, 1.0F).size(), 1U);
+
+  world.get_entity(mover)->get_component<TransformComponent>()->position.x = 50.0F;
+  index.refresh(world);
+
+  EXPECT_TRUE(ids_in_radius(index, 0.0F, 0.0F, 1.0F).empty());
+  EXPECT_EQ(ids_in_radius(index, 50.0F, 0.0F, 1.0F).size(), 1U);
+}
+
+TEST(WorldSpatialIndexTest, ExaminesFarFewerCandidatesThanAFullScan) {
+  World world;
+  for (int x = 0; x < 30; ++x) {
+    for (int z = 0; z < 30; ++z) {
+      spawn(world, static_cast<float>(x) * 3.0F, static_cast<float>(z) * 3.0F, 1);
+    }
+  }
+
+  auto& index = world.spatial_index();
+  index.rebuild(world);
+  index.reset_stats();
+
+  std::vector<const WorldSpatialIndex::Entry*> out;
+  index.query_radius(45.0F, 45.0F, 5.0F, out);
+
+  EXPECT_FALSE(out.empty());
+
+  EXPECT_LT(index.stats().candidates_examined, 100U);
+}
+
+} // namespace

--- a/tests/core/world_view_test.cpp
+++ b/tests/core/world_view_test.cpp
@@ -1,0 +1,136 @@
+#include <algorithm>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "game/core/component.h"
+#include "game/core/entity.h"
+#include "game/core/world.h"
+
+namespace {
+
+using Engine::Core::AttackComponent;
+using Engine::Core::EntityID;
+using Engine::Core::MovementComponent;
+using Engine::Core::TransformComponent;
+using Engine::Core::UnitComponent;
+using Engine::Core::World;
+
+auto spawn_unit(World& world, float x, float z) -> EntityID {
+  auto* entity = world.create_entity();
+  auto* transform = entity->add_component<TransformComponent>();
+  transform->position.x = x;
+  transform->position.z = z;
+  entity->add_component<UnitComponent>();
+  return entity->get_id();
+}
+
+TEST(WorldViewTest, VisitsOnlyEntitiesCarryingEveryComponent) {
+  World world;
+  const EntityID both = spawn_unit(world, 1.0F, 2.0F);
+
+  auto* transform_only = world.create_entity();
+  transform_only->add_component<TransformComponent>();
+
+  auto* unit_only = world.create_entity();
+  unit_only->add_component<UnitComponent>();
+
+  std::vector<EntityID> visited;
+  for (auto [id, transform, unit] : world.view<TransformComponent, UnitComponent>()) {
+    visited.push_back(id);
+    EXPECT_FLOAT_EQ(transform.position.x, 1.0F);
+    EXPECT_FLOAT_EQ(transform.position.z, 2.0F);
+    EXPECT_EQ(unit.health, unit.health);
+  }
+
+  ASSERT_EQ(visited.size(), 1U);
+  EXPECT_EQ(visited.front(), both);
+}
+
+TEST(WorldViewTest, ComponentReferencesAreLiveAndWritable) {
+  World world;
+  const EntityID id = spawn_unit(world, 0.0F, 0.0F);
+
+  for (auto [entity_id, transform, unit] :
+       world.view<TransformComponent, UnitComponent>()) {
+    (void)entity_id;
+    (void)unit;
+    transform.position.x = 42.0F;
+  }
+
+  auto* entity = world.get_entity(id);
+  ASSERT_NE(entity, nullptr);
+  EXPECT_FLOAT_EQ(entity->get_component<TransformComponent>()->position.x, 42.0F);
+}
+
+TEST(WorldViewTest, IteratesTheSmallestComponentSet) {
+  World world;
+  for (int i = 0; i < 32; ++i) {
+    spawn_unit(world, static_cast<float>(i), 0.0F);
+  }
+
+  auto* attacker = world.create_entity();
+  attacker->add_component<TransformComponent>();
+  attacker->add_component<UnitComponent>();
+  attacker->add_component<AttackComponent>();
+
+  auto view = world.view<UnitComponent, AttackComponent>();
+
+  EXPECT_EQ(view.candidate_count(), 1U);
+
+  std::size_t visited = 0;
+  for (auto entry : view) {
+    (void)entry;
+    ++visited;
+  }
+  EXPECT_EQ(visited, 1U);
+}
+
+TEST(WorldViewTest, EmptyForAComponentNobodyCarries) {
+  World world;
+  spawn_unit(world, 0.0F, 0.0F);
+
+  EXPECT_TRUE(world.view<MovementComponent>().empty());
+  EXPECT_FALSE(world.view<UnitComponent>().empty());
+}
+
+TEST(WorldViewTest, SkipsEntitiesDestroyedBeforeTheWalkReachesThem) {
+  World world;
+  const EntityID first = spawn_unit(world, 0.0F, 0.0F);
+  const EntityID second = spawn_unit(world, 1.0F, 0.0F);
+  world.destroy_entity(first);
+
+  std::vector<EntityID> visited;
+  for (auto [id, transform, unit] : world.view<TransformComponent, UnitComponent>()) {
+    (void)transform;
+    (void)unit;
+    visited.push_back(id);
+  }
+
+  ASSERT_EQ(visited.size(), 1U);
+  EXPECT_EQ(visited.front(), second);
+}
+
+TEST(WorldViewTest, MatchesTheMaterialisingQuery) {
+  World world;
+  for (int i = 0; i < 8; ++i) {
+    spawn_unit(world, static_cast<float>(i), 0.0F);
+  }
+
+  std::vector<EntityID> collected;
+  for (auto* entity : world.collect_entities_with<UnitComponent>()) {
+    collected.push_back(entity->get_id());
+  }
+
+  std::vector<EntityID> viewed;
+  for (auto [id, unit] : world.view<UnitComponent>()) {
+    (void)unit;
+    viewed.push_back(id);
+  }
+
+  std::sort(collected.begin(), collected.end());
+  std::sort(viewed.begin(), viewed.end());
+  EXPECT_EQ(collected, viewed);
+}
+
+} // namespace

--- a/tests/headless/mission_wave_assault_test.cpp
+++ b/tests/headless/mission_wave_assault_test.cpp
@@ -246,7 +246,7 @@ TEST_F(MissionWaveAssaultTest, WaveUnitsAttackTheRampartInTheirWay) {
   int damage_dealt = 0;
   std::unordered_set<EntityID> barriers;
   for (auto* entity :
-       session.world().get_entities_with<Engine::Core::WallSegmentComponent>()) {
+       session.world().collect_entities_with<Engine::Core::WallSegmentComponent>()) {
     const auto* unit = entity->get_component<UnitComponent>();
     if (unit == nullptr) {
       continue;
@@ -374,7 +374,7 @@ TEST_F(MissionWaveAssaultTest, WaveCannotWalkThroughAnIntactRampart) {
 
   std::unordered_set<EntityID> rampart;
   for (auto* entity :
-       session.world().get_entities_with<Engine::Core::WallSegmentComponent>()) {
+       session.world().collect_entities_with<Engine::Core::WallSegmentComponent>()) {
     rampart.insert(entity->get_id());
   }
   ASSERT_FALSE(rampart.empty());

--- a/tests/map/iron_sepulcher_skirmish_test.cpp
+++ b/tests/map/iron_sepulcher_skirmish_test.cpp
@@ -65,7 +65,7 @@ auto find_zone(const Game::Map::MapDefinition& map_definition,
 auto living_guardians_of_owner(Engine::Core::World& world, int owner_id)
     -> std::vector<Engine::Core::UnitComponent*> {
   std::vector<Engine::Core::UnitComponent*> units;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity != nullptr
                      ? entity->get_component<Engine::Core::UnitComponent>()
                      : nullptr;
@@ -78,7 +78,7 @@ auto living_guardians_of_owner(Engine::Core::World& world, int owner_id)
 }
 
 auto find_local_commander(Engine::Core::World& world) -> Engine::Core::Entity* {
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == nullptr ||
         entity->get_component<Engine::Core::CommanderComponent>() == nullptr) {
       continue;

--- a/tests/map/map_transformer_test.cpp
+++ b/tests/map/map_transformer_test.cpp
@@ -82,7 +82,7 @@ TEST_F(MapTransformerStructureTest, SpawnsAuthoredBuildingsAndRegistersOwners) {
 
   int tower_count = 0;
   int home_count = 0;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     ASSERT_NE(entity, nullptr);
     const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
@@ -155,7 +155,8 @@ TEST_F(MapTransformerStructureTest,
   };
 
   std::vector<WallSnapshot> walls;
-  for (auto* entity : world.get_entities_with<Engine::Core::WallSegmentComponent>()) {
+  for (auto* entity :
+       world.collect_entities_with<Engine::Core::WallSegmentComponent>()) {
     ASSERT_NE(entity, nullptr);
     const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
@@ -230,7 +231,7 @@ TEST_F(MapTransformerStructureTest, AuthoredGuardSpawnIsScenarioControlled) {
 
   Engine::Core::Entity* guard_entity = nullptr;
   Engine::Core::Entity* strategic_entity = nullptr;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     ASSERT_NE(entity, nullptr);
     const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     ASSERT_NE(unit, nullptr);
@@ -268,7 +269,7 @@ TEST_F(MapTransformerStructureTest, DoesNotAcceptBuildingsThroughTroopSpawns) {
   });
 
   Game::Map::MapTransformer::apply_to_world(def, world);
-  EXPECT_TRUE(world.get_entities_with<Engine::Core::UnitComponent>().empty());
+  EXPECT_TRUE(world.collect_entities_with<Engine::Core::UnitComponent>().empty());
 }
 
 } // namespace

--- a/tests/render/battle_render_optimizer_test.cpp
+++ b/tests/render/battle_render_optimizer_test.cpp
@@ -4,12 +4,13 @@
 
 using namespace Render;
 
+namespace {
+
 class BattleRenderOptimizerTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    auto& optimizer = BattleRenderOptimizer::instance();
     BattleRenderConfig config;
-    config.temporal_culling_threshold = 15;
+    config.battle_mode_unit_threshold = 15;
     config.animation_throttle_threshold = 30;
     config.animation_throttle_distance = 40.0F;
     config.combat_render_priority_distance = 50.0F;
@@ -17,6 +18,15 @@ protected:
     config.animation_skip_frames = 2;
     config.enabled = true;
     optimizer.set_config(config);
+  }
+
+  BattleRenderOptimizer optimizer;
+  BattleRenderOptimizer::FrameStats stats;
+
+  auto open_frame(int visible_units) -> const BattleRenderOptimizer::FrameSnapshot& {
+    optimizer.begin_frame();
+    optimizer.set_visible_unit_count(visible_units);
+    return optimizer.frame();
   }
 
   static auto moving_motion() -> Engine::Core::MotionPresentationComponent {
@@ -27,208 +37,96 @@ protected:
   }
 };
 
-TEST_F(BattleRenderOptimizerTest, DisabledOptimizerAlwaysRendersUnits) {
-  auto& optimizer = BattleRenderOptimizer::instance();
+TEST_F(BattleRenderOptimizerTest, EachOptimizerCountsItsOwnFrames) {
+  BattleRenderOptimizer other;
+
+  optimizer.begin_frame();
+  optimizer.begin_frame();
+  other.begin_frame();
+
+  EXPECT_EQ(optimizer.frame_counter(), 2U);
+  EXPECT_EQ(other.frame_counter(), 1U);
+}
+
+TEST_F(BattleRenderOptimizerTest, FrameCounterIncrements) {
+  const std::uint32_t before = optimizer.frame_counter();
+  optimizer.begin_frame();
+  EXPECT_EQ(optimizer.frame_counter(), before + 1U);
+}
+
+TEST_F(BattleRenderOptimizerTest, TheFrameSnapshotIsTakenOnceAndDoesNotShift) {
+  const auto& frame = open_frame(100);
+  ASSERT_TRUE(frame.config.enabled);
+
+  BattleRenderConfig disabled = optimizer.config();
+  disabled.enabled = false;
+  optimizer.set_config(disabled);
+
+  EXPECT_TRUE(optimizer.frame().config.enabled);
+  optimizer.begin_frame();
+  EXPECT_FALSE(optimizer.frame().config.enabled);
+}
+
+TEST_F(BattleRenderOptimizerTest, TheVisibleCountSurvivesTheFrameBoundary) {
+  open_frame(120);
+  optimizer.begin_frame();
+
+  EXPECT_EQ(optimizer.visible_unit_count(), 120);
+}
+
+TEST_F(BattleRenderOptimizerTest, DisabledOptimizerAlwaysUpdatesAnimations) {
   BattleRenderConfig config = optimizer.config();
   config.enabled = false;
   optimizer.set_config(config);
-  optimizer.set_visible_unit_count(100);
-  optimizer.begin_frame();
+  const auto& frame = open_frame(100);
 
-  EXPECT_TRUE(optimizer.should_render_unit(1, nullptr, false, false));
-  EXPECT_TRUE(optimizer.should_render_unit(2, nullptr, false, false));
-  EXPECT_TRUE(optimizer.should_render_unit(3, nullptr, false, false));
-}
-
-TEST_F(BattleRenderOptimizerTest, SelectedUnitsAlwaysRender) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  optimizer.begin_frame();
-
-  EXPECT_TRUE(optimizer.should_render_unit(1, nullptr, true, false));
-  EXPECT_TRUE(optimizer.should_render_unit(2, nullptr, true, false));
-}
-
-TEST_F(BattleRenderOptimizerTest, HoveredUnitsAlwaysRender) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  optimizer.begin_frame();
-
-  EXPECT_TRUE(optimizer.should_render_unit(1, nullptr, false, true));
-  EXPECT_TRUE(optimizer.should_render_unit(2, nullptr, false, true));
-}
-
-TEST_F(BattleRenderOptimizerTest, MovingUnitsWithStaleSnapshotAlwaysRender) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  optimizer.begin_frame();
-
-  Engine::Core::MotionPresentationComponent motion;
-  motion.snapshot_valid = false;
-  motion.set_state(Engine::Core::MotionPresentationState::Walk);
-
-  uint32_t const frame = optimizer.frame_counter();
-  uint32_t const id_would_skip = (frame % 2 == 0) ? 1 : 2;
-
-  EXPECT_TRUE(optimizer.should_render_unit(id_would_skip, &motion, false, false));
-}
-
-TEST_F(BattleRenderOptimizerTest,
-       AnimationThrottlingMovingUnitsAlwaysUpdatesWithStaleSnapshot) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-
-  optimizer.begin_frame();
-  uint32_t const frame = optimizer.frame_counter();
-
-  uint32_t throttled_id = 0;
-  for (uint32_t id = 1; id <= 3; ++id) {
-    if ((id + frame) % 3 != 0) {
-      throttled_id = id;
-      break;
-    }
-  }
-  ASSERT_NE(throttled_id, 0U);
-
-  Engine::Core::MotionPresentationComponent motion;
-  motion.snapshot_valid = false;
-  motion.set_state(Engine::Core::MotionPresentationState::Walk);
-
-  float const far_distance_sq = 100.0F * 100.0F;
-  EXPECT_TRUE(optimizer.should_update_animation(
-      throttled_id, far_distance_sq, false, false, &motion));
-}
-
-TEST_F(BattleRenderOptimizerTest, MovingUnitsAlwaysRender) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  optimizer.begin_frame();
-  auto motion = moving_motion();
-
-  EXPECT_TRUE(optimizer.should_render_unit(1, &motion, false, false));
-  EXPECT_TRUE(optimizer.should_render_unit(2, &motion, false, false));
-}
-
-TEST_F(BattleRenderOptimizerTest, BelowThresholdAlwaysRenders) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(10);
-  optimizer.begin_frame();
-
-  EXPECT_TRUE(optimizer.should_render_unit(1, nullptr, false, false));
-  EXPECT_TRUE(optimizer.should_render_unit(2, nullptr, false, false));
-  EXPECT_TRUE(optimizer.should_render_unit(3, nullptr, false, false));
-}
-
-TEST_F(BattleRenderOptimizerTest, AboveThresholdStillRendersIdleUnitsEveryFrame) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  optimizer.begin_frame();
-
-  bool const unit1_render = optimizer.should_render_unit(1, nullptr, false, false);
-  bool const unit2_render = optimizer.should_render_unit(2, nullptr, false, false);
-
-  EXPECT_TRUE(unit1_render);
-  EXPECT_TRUE(unit2_render);
-  EXPECT_EQ(optimizer.units_skipped_temporal(), 0);
-}
-
-TEST_F(BattleRenderOptimizerTest, TemporalCullingDoesNotDropDrawSubmission) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-
-  optimizer.begin_frame();
-  bool const frame1_result = optimizer.should_render_unit(1, nullptr, false, false);
-
-  optimizer.begin_frame();
-  bool const frame2_result = optimizer.should_render_unit(1, nullptr, false, false);
-
-  EXPECT_TRUE(frame1_result);
-  EXPECT_TRUE(frame2_result);
-  EXPECT_EQ(optimizer.units_skipped_temporal(), 0);
-}
-
-TEST_F(BattleRenderOptimizerTest, ActiveCombatUnitsAlwaysRender) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-
-  optimizer.begin_frame();
-  EXPECT_TRUE(optimizer.should_render_unit(1, nullptr, false, false, true));
-
-  optimizer.begin_frame();
-  EXPECT_TRUE(optimizer.should_render_unit(1, nullptr, false, false, true));
-}
-
-TEST_F(BattleRenderOptimizerTest, DistantCombatUnitsAlwaysRender) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  float const far_distance_sq = 100.0F * 100.0F;
-
-  optimizer.begin_frame();
-  bool const frame1 =
-      optimizer.should_render_unit(1, nullptr, false, false, true, far_distance_sq);
-
-  optimizer.begin_frame();
-  bool const frame2 =
-      optimizer.should_render_unit(1, nullptr, false, false, true, far_distance_sq);
-
-  EXPECT_TRUE(frame1);
-  EXPECT_TRUE(frame2);
-}
-
-TEST_F(BattleRenderOptimizerTest, AnimationThrottlingBelowThresholdAlwaysUpdates) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(20);
-  optimizer.begin_frame();
-
-  EXPECT_TRUE(
-      optimizer.should_update_animation(1, 100.0F * 100.0F, false, false, nullptr));
-  EXPECT_TRUE(
-      optimizer.should_update_animation(2, 100.0F * 100.0F, false, false, nullptr));
-}
-
-TEST_F(BattleRenderOptimizerTest, AnimationThrottlingSelectedAlwaysUpdates) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  optimizer.begin_frame();
-
-  EXPECT_TRUE(
-      optimizer.should_update_animation(1, 100.0F * 100.0F, true, false, nullptr));
-  EXPECT_TRUE(
-      optimizer.should_update_animation(2, 100.0F * 100.0F, true, false, nullptr));
-}
-
-TEST_F(BattleRenderOptimizerTest, AnimationThrottlingMovingUnitsAlwaysUpdates) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  auto motion = moving_motion();
-
-  for (int frame = 0; frame < 6; ++frame) {
-    optimizer.begin_frame();
-    EXPECT_TRUE(
-        optimizer.should_update_animation(1, 100.0F * 100.0F, false, false, &motion));
+  for (std::uint32_t id = 1; id <= 6; ++id) {
+    EXPECT_TRUE(frame.should_update_animation(
+        id, 100.0F * 100.0F, false, false, nullptr, stats));
   }
 }
 
-TEST_F(BattleRenderOptimizerTest, AnimationThrottlingCloseUnitsAlwaysUpdate) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-  optimizer.begin_frame();
-
+TEST_F(BattleRenderOptimizerTest, SelectedUnitsAlwaysUpdate) {
+  const auto& frame = open_frame(100);
   EXPECT_TRUE(
-      optimizer.should_update_animation(1, 10.0F * 10.0F, false, false, nullptr));
+      frame.should_update_animation(1, 100.0F * 100.0F, true, false, nullptr, stats));
   EXPECT_TRUE(
-      optimizer.should_update_animation(2, 30.0F * 30.0F, false, false, nullptr));
+      frame.should_update_animation(2, 100.0F * 100.0F, true, false, nullptr, stats));
 }
 
-TEST_F(BattleRenderOptimizerTest, AnimationThrottlingDistantUnitsThrottled) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
+TEST_F(BattleRenderOptimizerTest, MovingUnitsAlwaysUpdate) {
+  auto motion = moving_motion();
+  for (int i = 0; i < 6; ++i) {
+    const auto& frame = open_frame(100);
+    EXPECT_TRUE(frame.should_update_animation(
+        1, 100.0F * 100.0F, false, false, &motion, stats));
+  }
+}
 
+TEST_F(BattleRenderOptimizerTest, BelowTheThresholdNothingIsThrottled) {
+  const auto& frame = open_frame(20);
+  EXPECT_TRUE(
+      frame.should_update_animation(1, 100.0F * 100.0F, false, false, nullptr, stats));
+  EXPECT_TRUE(
+      frame.should_update_animation(2, 100.0F * 100.0F, false, false, nullptr, stats));
+  EXPECT_EQ(stats.animations_throttled, 0);
+}
+
+TEST_F(BattleRenderOptimizerTest, CloseUnitsAlwaysUpdate) {
+  const auto& frame = open_frame(100);
+  EXPECT_TRUE(
+      frame.should_update_animation(1, 10.0F * 10.0F, false, false, nullptr, stats));
+  EXPECT_TRUE(
+      frame.should_update_animation(2, 30.0F * 30.0F, false, false, nullptr, stats));
+}
+
+TEST_F(BattleRenderOptimizerTest, DistantIdleUnitsTakeTurns) {
   int updated = 0;
   int throttled = 0;
-  for (int frame = 0; frame < 6; ++frame) {
-    optimizer.begin_frame();
-    if (optimizer.should_update_animation(1, 100.0F * 100.0F, false, false, nullptr)) {
+  for (int i = 0; i < 6; ++i) {
+    const auto& frame = open_frame(100);
+    if (frame.should_update_animation(
+            1, 100.0F * 100.0F, false, false, nullptr, stats)) {
       ++updated;
     } else {
       ++throttled;
@@ -237,73 +135,57 @@ TEST_F(BattleRenderOptimizerTest, AnimationThrottlingDistantUnitsThrottled) {
 
   EXPECT_GT(throttled, 0);
   EXPECT_GT(updated, 0);
+  EXPECT_EQ(updated + throttled, 6);
 }
 
-TEST_F(BattleRenderOptimizerTest, NearbyCombatAnimationsAreNeverThrottled) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-
-  for (int frame = 0; frame < 6; ++frame) {
-    optimizer.begin_frame();
+TEST_F(BattleRenderOptimizerTest, UnitsInCombatAreNeverThrottled) {
+  for (int i = 0; i < 6; ++i) {
+    const auto& frame = open_frame(100);
     EXPECT_TRUE(
-        optimizer.should_update_animation(1, 10.0F * 10.0F, false, true, nullptr));
-  }
-}
-
-TEST_F(BattleRenderOptimizerTest, DistantCombatAnimationsAlwaysUpdate) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
-
-  for (int frame = 0; frame < 6; ++frame) {
-    optimizer.begin_frame();
+        frame.should_update_animation(1, 10.0F * 10.0F, false, true, nullptr, stats));
     EXPECT_TRUE(
-        optimizer.should_update_animation(1, 100.0F * 100.0F, false, true, nullptr));
+        frame.should_update_animation(2, 100.0F * 100.0F, false, true, nullptr, stats));
   }
+  EXPECT_EQ(stats.animations_throttled, 0);
 }
 
-TEST_F(BattleRenderOptimizerTest, BatchingBoostIncreasesWithUnitCount) {
-  auto& optimizer = BattleRenderOptimizer::instance();
+TEST_F(BattleRenderOptimizerTest, StatsAreCallerLocalUntilCommitted) {
+  const auto& frame = open_frame(100);
+  for (std::uint32_t id = 1; id <= 12; ++id) {
+    (void)frame.should_update_animation(
+        id, 100.0F * 100.0F, false, false, nullptr, stats);
+  }
 
-  optimizer.set_visible_unit_count(10);
-  float const boost_low = optimizer.get_batching_boost();
+  EXPECT_GT(stats.animations_updated + stats.animations_throttled, 0);
+  EXPECT_EQ(optimizer.animations_updated(), 0);
+  EXPECT_EQ(optimizer.animations_throttled(), 0);
 
-  optimizer.set_visible_unit_count(30);
-  float const boost_high = optimizer.get_batching_boost();
-
-  EXPECT_FLOAT_EQ(boost_low, 1.0F);
-  EXPECT_GT(boost_high, 1.0F);
+  optimizer.commit_frame_stats(stats);
+  EXPECT_EQ(optimizer.animations_updated(), stats.animations_updated);
+  EXPECT_EQ(optimizer.animations_throttled(), stats.animations_throttled);
 }
 
-TEST_F(BattleRenderOptimizerTest, IsBattleModeDetectsBattles) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-
-  optimizer.set_visible_unit_count(10);
-  EXPECT_FALSE(optimizer.is_battle_mode());
-
-  optimizer.set_visible_unit_count(20);
-  EXPECT_TRUE(optimizer.is_battle_mode());
-}
-
-TEST_F(BattleRenderOptimizerTest, FrameCounterIncrements) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-
-  uint32_t const frame1 = optimizer.frame_counter();
-  optimizer.begin_frame();
-  uint32_t const frame2 = optimizer.frame_counter();
-
-  EXPECT_EQ(frame2, frame1 + 1);
-}
-
-TEST_F(BattleRenderOptimizerTest, StatsResetOnBeginFrame) {
-  auto& optimizer = BattleRenderOptimizer::instance();
-  optimizer.set_visible_unit_count(100);
+TEST_F(BattleRenderOptimizerTest, CommittedStatsResetOnTheNextFrame) {
+  const auto& frame = open_frame(100);
+  (void)frame.should_update_animation(1, 100.0F * 100.0F, false, false, nullptr, stats);
+  optimizer.commit_frame_stats(stats);
 
   optimizer.begin_frame();
-  (void)optimizer.should_render_unit(1, nullptr, false, false);
-  (void)optimizer.should_render_unit(2, nullptr, false, false);
-
-  optimizer.begin_frame();
-  EXPECT_EQ(optimizer.units_rendered_this_frame(), 0);
-  EXPECT_EQ(optimizer.units_skipped_temporal(), 0);
+  EXPECT_EQ(optimizer.animations_updated(), 0);
   EXPECT_EQ(optimizer.animations_throttled(), 0);
 }
+
+TEST_F(BattleRenderOptimizerTest, BatchingBoostRisesWithTheUnitCount) {
+  const float low = open_frame(10).batching_boost();
+  const float high = open_frame(30).batching_boost();
+
+  EXPECT_FLOAT_EQ(low, 1.0F);
+  EXPECT_GT(high, 1.0F);
+}
+
+TEST_F(BattleRenderOptimizerTest, BattleModeIsABatchingThresholdNotACullingOne) {
+  EXPECT_FALSE(open_frame(10).battle_mode());
+  EXPECT_TRUE(open_frame(20).battle_mode());
+}
+
+} // namespace

--- a/tests/render/draw_queue_sort_cost_test.cpp
+++ b/tests/render/draw_queue_sort_cost_test.cpp
@@ -1,0 +1,136 @@
+
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "render/draw_queue.h"
+#include "render/frame_budget.h"
+
+namespace {
+
+using Render::GL::DrawQueue;
+using Render::GL::GroundMarkerCmd;
+using Render::GL::Mesh;
+using Render::GL::MeshCmd;
+using Render::GL::Shader;
+using Render::GL::TerrainSurfaceCmd;
+using Render::GL::Texture;
+
+auto fake_mesh(std::uintptr_t index) -> Mesh* {
+  return reinterpret_cast<Mesh*>(0x1000U + index * 0x40U);
+}
+auto fake_shader(std::uintptr_t index) -> Shader* {
+  return reinterpret_cast<Shader*>(0x9000U + index * 0x40U);
+}
+auto fake_texture(std::uintptr_t index) -> Texture* {
+  return reinterpret_cast<Texture*>(0xE000U + index * 0x40U);
+}
+
+void fill_frame(DrawQueue& queue, std::size_t mesh_commands) {
+  queue.clear();
+
+  for (int chunk = 0; chunk < 16; ++chunk) {
+    TerrainSurfaceCmd terrain;
+    terrain.mesh = fake_mesh(static_cast<std::uintptr_t>(chunk));
+    terrain.sort_key = static_cast<std::uint32_t>(chunk);
+    queue.submit(terrain);
+  }
+
+  constexpr std::size_t k_archetypes = 12;
+  for (std::size_t i = 0; i < mesh_commands; ++i) {
+    const std::uintptr_t archetype = i % k_archetypes;
+    MeshCmd mesh;
+    mesh.mesh = fake_mesh(64U + archetype);
+    mesh.shader = fake_shader(archetype % 3U);
+    mesh.texture = fake_texture(archetype);
+    mesh.material_id = static_cast<int>(archetype);
+    queue.submit(mesh);
+  }
+
+  for (int marker = 0; marker < 64; ++marker) {
+    queue.submit(GroundMarkerCmd{});
+  }
+}
+
+auto time_sort_ms(DrawQueue& queue, std::size_t mesh_commands, int repeats) -> double {
+
+  fill_frame(queue, mesh_commands);
+  queue.sort_for_batching();
+
+  std::vector<double> samples;
+  samples.reserve(static_cast<std::size_t>(repeats));
+  for (int i = 0; i < repeats; ++i) {
+    fill_frame(queue, mesh_commands);
+    const auto started = std::chrono::steady_clock::now();
+    queue.sort_for_batching();
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    samples.push_back(std::chrono::duration<double, std::milli>(elapsed).count());
+  }
+
+  std::sort(samples.begin(), samples.end());
+  return samples[samples.size() / 2U];
+}
+
+TEST(DrawQueueSortCost, ARealisticFrameNeverSortsTheWholeQueue) {
+  DrawQueue queue;
+  fill_frame(queue, 2000);
+  queue.sort_for_batching();
+
+  ASSERT_EQ(queue.size(), 2000U + 16U + 64U);
+
+  std::size_t terrain_end = 0;
+  while (terrain_end < queue.size() &&
+         queue.get_sorted(terrain_end).index() == Render::GL::TerrainSurfaceCmdIndex) {
+    ++terrain_end;
+  }
+  EXPECT_EQ(terrain_end, 16U);
+
+  std::size_t mesh_end = terrain_end;
+  while (mesh_end < queue.size() &&
+         queue.get_sorted(mesh_end).index() == Render::GL::MeshCmdIndex) {
+    ++mesh_end;
+  }
+  EXPECT_EQ(mesh_end - terrain_end, 2000U);
+  EXPECT_EQ(queue.size() - mesh_end, 64U);
+}
+
+TEST(DrawQueueSortCost, BatchingSurvivesTheSort) {
+  DrawQueue queue;
+  fill_frame(queue, 2400);
+  queue.sort_for_batching();
+
+  std::size_t instanced = 0;
+  for (const auto& batch : queue.prepared_batches()) {
+    if (batch.is_instanced()) {
+      instanced += batch.count;
+    }
+  }
+  EXPECT_GT(instanced, 2000U)
+      << "sorting is supposed to earn its keep by producing instanceable runs";
+}
+
+TEST(DrawQueueSortCost, ReportsSortCostAcrossQueueSizes) {
+  DrawQueue queue;
+
+  const double at_2k = time_sort_ms(queue, 2000, 20);
+  const double at_20k = time_sort_ms(queue, 20000, 20);
+  const double at_100k = time_sort_ms(queue, 100000, 10);
+
+  std::printf("draw queue sort (median of repeated frames):\n"
+              "  2,080 commands  %.3f ms\n"
+              " 20,080 commands  %.3f ms\n"
+              "100,080 commands  %.3f ms\n",
+              at_2k,
+              at_20k,
+              at_100k);
+
+  EXPECT_GT(at_2k, 0.0);
+  EXPECT_GT(at_20k, 0.0);
+  EXPECT_GT(at_100k, 0.0);
+}
+
+} // namespace

--- a/tests/session/session_context_test.cpp
+++ b/tests/session/session_context_test.cpp
@@ -56,10 +56,11 @@ TEST(SessionContextTest, WorldsAreSessionScoped) {
   ASSERT_NE(entity, nullptr);
   entity->add_component<Engine::Core::TransformComponent>();
 
-  EXPECT_EQ(first.world().get_entities_with<Engine::Core::TransformComponent>().size(),
-            1U);
+  EXPECT_EQ(
+      first.world().collect_entities_with<Engine::Core::TransformComponent>().size(),
+      1U);
   EXPECT_TRUE(
-      second.world().get_entities_with<Engine::Core::TransformComponent>().empty());
+      second.world().collect_entities_with<Engine::Core::TransformComponent>().empty());
 }
 
 TEST(SessionContextTest, WorldResolvesBackToItsOwningSession) {

--- a/tests/systems/combat_mode_test.cpp
+++ b/tests/systems/combat_mode_test.cpp
@@ -2311,7 +2311,7 @@ TEST_F(CombatModeTest, LethalDamageStartsDeathSequenceBeforeCleanup) {
   EXPECT_FALSE(target->has_component<PendingRemovalComponent>());
   EXPECT_FALSE(movement->get_has_target());
 
-  auto blood_stains = world->get_entities_with<BloodStainComponent>();
+  auto blood_stains = world->collect_entities_with<BloodStainComponent>();
   ASSERT_EQ(blood_stains.size(), 1U);
   auto* blood_transform = blood_stains.front()->get_component<TransformComponent>();
   auto* blood_stain = blood_stains.front()->get_component<BloodStainComponent>();
@@ -2384,7 +2384,7 @@ TEST_F(CombatModeTest, NonLethalDamageQueuesPerSoldierCasualtyAnimations) {
   EXPECT_EQ(casualties->entries.front().state, DeathSequenceState::Dying);
   EXPECT_FALSE(target->has_component<DeathAnimationComponent>());
 
-  auto blood_stains = world->get_entities_with<BloodStainComponent>();
+  auto blood_stains = world->collect_entities_with<BloodStainComponent>();
   ASSERT_EQ(blood_stains.size(), 1U);
   auto* blood_transform = blood_stains.front()->get_component<TransformComponent>();
   ASSERT_NE(blood_transform, nullptr);
@@ -2859,7 +2859,7 @@ TEST_F(CombatModeTest,
   EXPECT_LT(primary_enemy_unit->health, 40);
   EXPECT_LT(splash_enemy_unit->health, 100);
   EXPECT_EQ(allied_undead_unit->health, 100);
-  EXPECT_EQ(world->get_entities_with<FirePatchComponent>().size(), 1U);
+  EXPECT_EQ(world->collect_entities_with<FirePatchComponent>().size(), 1U);
   EXPECT_NE(primary_enemy->get_component<BurningStatusComponent>(), nullptr);
   EXPECT_NE(splash_enemy->get_component<BurningStatusComponent>(), nullptr);
   EXPECT_EQ(allied_undead->get_component<BurningStatusComponent>(), nullptr);
@@ -3138,7 +3138,7 @@ TEST_F(CombatModeTest, BuildingDeathsDoNotCreateBloodStains) {
 
   Game::Systems::Combat::deal_damage(world.get(), building, 40, attacker->get_id());
 
-  EXPECT_TRUE(world->get_entities_with<BloodStainComponent>().empty());
+  EXPECT_TRUE(world->collect_entities_with<BloodStainComponent>().empty());
 }
 
 TEST_F(CombatModeTest, BloodStainsAreCappedAtTenActiveEntries) {
@@ -3158,13 +3158,13 @@ TEST_F(CombatModeTest, BloodStainsAreCappedAtTenActiveEntries) {
     Game::Systems::Combat::deal_damage(world.get(), target, 10, attacker->get_id());
 
     if (index == 0) {
-      auto blood_stains = world->get_entities_with<BloodStainComponent>();
+      auto blood_stains = world->collect_entities_with<BloodStainComponent>();
       ASSERT_EQ(blood_stains.size(), 1U);
       first_stain_id = blood_stains.front()->get_id();
     }
   }
 
-  auto blood_stains = world->get_entities_with<BloodStainComponent>();
+  auto blood_stains = world->collect_entities_with<BloodStainComponent>();
   ASSERT_EQ(blood_stains.size(), 10U);
   EXPECT_EQ(world->get_entity(first_stain_id), nullptr);
 }
@@ -5166,7 +5166,7 @@ TEST_F(CombatModeTest, CombatHitResolverFireballAreaImpactSpawnsFirePatch) {
   EXPECT_NE(splash->get_component<BurningStatusComponent>(), nullptr);
   EXPECT_EQ(ally->get_component<BurningStatusComponent>(), nullptr);
 
-  auto fire_patches = world->get_entities_with<FirePatchComponent>();
+  auto fire_patches = world->collect_entities_with<FirePatchComponent>();
   ASSERT_EQ(fire_patches.size(), 1U);
   auto* fire_patch = fire_patches.front()->get_component<FirePatchComponent>();
   auto* fire_patch_transform =

--- a/tests/systems/gate_system_test.cpp
+++ b/tests/systems/gate_system_test.cpp
@@ -183,8 +183,9 @@ TEST_F(GateSystemTest, OpensForOwnerTroopInRange) {
 
   tick(world, 2.0F);
 
-  const auto* gate =
-      world.get_entities_with<GateComponent>().front()->get_component<GateComponent>();
+  const auto* gate = world.collect_entities_with<GateComponent>()
+                         .front()
+                         ->get_component<GateComponent>();
   EXPECT_TRUE(gate->is_passable());
   EXPECT_EQ(gate->state, GateComponent::State::Open);
 }

--- a/tests/systems/production_system_test.cpp
+++ b/tests/systems/production_system_test.cpp
@@ -405,7 +405,7 @@ TEST_F(ProductionSystemTest, BuilderCompletesMarketplaceConstruction) {
   system.update(&world, 0.1F);
 
   Engine::Core::Entity* marketplace = nullptr;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == builder) {
       continue;
     }
@@ -558,7 +558,7 @@ TEST_F(ProductionSystemTest, ABuiltTempleCanRecruitHealersAndFillsFromDelivery) 
   system.update(&world, 0.1F);
 
   Engine::Core::Entity* temple = nullptr;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     if (entity == builder) {
       continue;
     }

--- a/tests/systems/runtime_phase_order_test.cpp
+++ b/tests/systems/runtime_phase_order_test.cpp
@@ -1,0 +1,76 @@
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+#include "game/core/system_schedule.h"
+#include "game/core/world.h"
+#include "game/session/session_context.h"
+#include "game/systems/runtime_system_registry.h"
+
+namespace {
+
+using Engine::Core::SystemPhase;
+using Game::Session::ScopedSession;
+using Game::Session::SessionContext;
+
+TEST(RuntimeSystemPhaseOrderTest, PhasesNeverGoBackwardsThroughTheRegistry) {
+  SessionContext session;
+  const ScopedSession scope(session);
+  Game::Systems::register_runtime_systems(session.world());
+
+  const auto phases = session.world().system_phases();
+  ASSERT_FALSE(phases.empty());
+  ASSERT_EQ(phases.size(), session.world().systems().size());
+
+  for (std::size_t i = 1; i < phases.size(); ++i) {
+    EXPECT_LE(static_cast<int>(phases[i - 1]), static_cast<int>(phases[i]))
+        << "system " << i << " runs in phase " << Engine::Core::phase_name(phases[i])
+        << " after phase " << Engine::Core::phase_name(phases[i - 1]);
+  }
+}
+
+TEST(RuntimeSystemPhaseOrderTest, TheMatchUsesEveryPhase) {
+  SessionContext session;
+  const ScopedSession scope(session);
+  Game::Systems::register_runtime_systems(session.world());
+
+  std::vector<bool> seen(static_cast<std::size_t>(SystemPhase::_Count), false);
+  for (const SystemPhase phase : session.world().system_phases()) {
+    seen[static_cast<std::size_t>(phase)] = true;
+  }
+
+  for (std::size_t raw = 0; raw < seen.size(); ++raw) {
+    EXPECT_TRUE(seen[raw]) << "no system runs in phase "
+                           << Engine::Core::phase_name(static_cast<SystemPhase>(raw));
+  }
+}
+
+TEST(RuntimeSystemPhaseOrderTest, NoSystemHasDeclaredWhatItTouchesYet) {
+  SessionContext session;
+  const ScopedSession scope(session);
+  Game::Systems::register_runtime_systems(session.world());
+
+  std::size_t systems_in_phases = 0;
+  std::size_t batches = 0;
+  for (std::uint8_t raw = 0; raw < static_cast<std::uint8_t>(SystemPhase::_Count);
+       ++raw) {
+    const auto plan =
+        session.world().plan_phase_schedule(static_cast<SystemPhase>(raw));
+    batches += plan.size();
+    for (const auto& batch : plan) {
+      systems_in_phases += batch.size();
+    }
+  }
+
+  EXPECT_EQ(systems_in_phases, session.world().systems().size());
+  EXPECT_EQ(batches, systems_in_phases);
+}
+
+TEST(RuntimeSystemPhaseOrderTest, AnEmptyWorldTicksWithoutSystems) {
+  Engine::Core::World world;
+  world.update(0.016F);
+  EXPECT_EQ(world.tick_id(), 1U);
+}
+
+} // namespace

--- a/tests/systems/undead_awakening_system_test.cpp
+++ b/tests/systems/undead_awakening_system_test.cpp
@@ -135,7 +135,7 @@ auto add_intruder(Engine::Core::World& world,
 
 auto count_owner_units(Engine::Core::World& world, int owner_id) -> int {
   int count = 0;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit != nullptr && unit->owner_id == owner_id && unit->health > 0 &&
         Game::Units::is_troop_spawn(unit->spawn_type)) {
@@ -199,7 +199,7 @@ TEST_F(UndeadAwakeningSystemTest, SpawnsOnlyAfterEnemyUnitEntersZone) {
   system.update(&world, 0.1F);
   EXPECT_EQ(count_owner_units(world, 99), 2);
 
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* spawned = entity->get_component<Engine::Core::UnitComponent>();
     if (spawned == nullptr || spawned->owner_id != 99) {
       continue;
@@ -253,7 +253,7 @@ TEST_F(UndeadAwakeningSystemTest, ZoneWithoutAuthoredWavesRaisesTheDefaultGarris
   system.update(&world, 0.1F);
 
   std::map<Game::Units::SpawnType, int> roster;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit != nullptr && unit->owner_id == 99 && unit->health > 0 &&
         Game::Units::is_troop_spawn(unit->spawn_type)) {
@@ -277,7 +277,7 @@ TEST_F(UndeadAwakeningSystemTest, MapAuthoredWavesOverrideTheDefaultGarrison) {
   add_intruder(world, {0.5F, 0.0F, 0.5F});
   system.update(&world, 0.1F);
 
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit != nullptr && unit->owner_id == 99 &&
         Game::Units::is_troop_spawn(unit->spawn_type)) {
@@ -301,7 +301,7 @@ TEST_F(UndeadAwakeningSystemTest, WaveRisesTogetherAtDistinctSpreadPositions) {
   system.update(&world, 0.1F);
 
   std::vector<QVector3D> positions;
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     auto* transform = entity->get_component<Engine::Core::TransformComponent>();
     if (unit != nullptr && transform != nullptr && unit->owner_id == 99 &&
@@ -671,7 +671,7 @@ TEST_F(UndeadAwakeningSystemTest, EveryWaveAnnouncesItsNumberOutOfTheTotal) {
   EXPECT_TRUE(announcements.front().contains(QStringLiteral("Wave 1/2")))
       << announcements.front().toStdString();
 
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit != nullptr && unit->owner_id == 99 &&
         Game::Units::is_troop_spawn(unit->spawn_type)) {
@@ -747,7 +747,7 @@ TEST_F(UndeadAwakeningSystemTest, ShrineCaptureIsLockedWhileAnyGuardianStands) {
   system.update(&world, 0.1F);
   EXPECT_TRUE(capture->capture_blocked);
 
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit != nullptr && unit->owner_id == 99 &&
         Game::Units::is_troop_spawn(unit->spawn_type)) {

--- a/tests/systems/victory_service_test.cpp
+++ b/tests/systems/victory_service_test.cpp
@@ -291,7 +291,7 @@ TEST_F(VictoryServiceTest, CommanderAloneWithoutBarracksTriggersDefeat) {
   advance_past_startup_delay(world);
   ASSERT_FALSE(m_service->is_game_over());
 
-  for (auto* entity : world.get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (unit == nullptr ||
         entity->get_component<Engine::Core::CommanderComponent>() != nullptr) {

--- a/tests/systems/wall_system_test.cpp
+++ b/tests/systems/wall_system_test.cpp
@@ -198,7 +198,7 @@ TEST_F(WallMechanicsTest, BuilderConstructionSpawnsWallSegment) {
   system.update(&world, 0.1F);
 
   Entity* spawned_wall = nullptr;
-  for (auto* entity : world.get_entities_with<UnitComponent>()) {
+  for (auto* entity : world.collect_entities_with<UnitComponent>()) {
     if (entity == builder) {
       continue;
     }

--- a/tests/wildlife/wildlife_system_test.cpp
+++ b/tests/wildlife/wildlife_system_test.cpp
@@ -90,7 +90,7 @@ auto beside(Entity* entity, float offset_x) -> QVector3D {
 
 auto count_species(World& world, Species species) -> int {
   int count = 0;
-  for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
     const auto* wildlife = entity->get_component<Engine::Core::WildlifeComponent>();
     const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
     if (wildlife != nullptr && unit != nullptr && wildlife->species == species &&
@@ -103,7 +103,7 @@ auto count_species(World& world, Species species) -> int {
 
 auto collect_species(World& world, Species species) -> std::vector<Entity*> {
   std::vector<Entity*> result;
-  for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
     const auto* wildlife = entity->get_component<Engine::Core::WildlifeComponent>();
     if (wildlife != nullptr && wildlife->species == species) {
       result.push_back(entity);
@@ -806,7 +806,7 @@ TEST_F(WildlifeSystemTest, AMapThatNeverAuthoredWildlifeStillGetsAPopulation) {
   EXPECT_GT(count_species(world, Species::Wolf), 0);
 
   const auto& terrain = Game::Map::TerrainService::instance();
-  for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
     const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
     ASSERT_NE(transform, nullptr);
     EXPECT_FALSE(
@@ -842,7 +842,7 @@ TEST_F(WildlifeSystemTest, ShippedForestMapPopulatesEverySpeciesItEnables) {
   EXPECT_TRUE(birds_seen) << "no flyover crossed the map in two minutes";
 
   const auto& terrain = Game::Map::TerrainService::instance();
-  for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
+  for (auto* entity : world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
     const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
     ASSERT_NE(transform, nullptr);
     EXPECT_FALSE(

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -49,6 +49,18 @@ if(BUILD_TESTING)
     )
 endif()
 
+# ---- sim_benchmark: the repeatable large-battle workload --------------------
+#
+# The fixed scenario optimisation work is measured against: 1k, 5k and 10k units
+# ticked a fixed number of times, reporting simulation ms, peak RSS, the
+# per-system timing table and the query counters. It links the same simulation
+# kernel the game does and nothing else, so a number it produces is a statement
+# about the simulation and not about the renderer.
+add_executable(sim_benchmark sim_benchmark/main.cpp)
+target_link_libraries(sim_benchmark PRIVATE Qt${QT_VERSION_MAJOR}::Core soi_runtime soi_ai game_sim)
+target_include_directories(sim_benchmark PRIVATE ${CMAKE_SOURCE_DIR})
+set_target_properties(sim_benchmark PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
 # ---- soi_headless: the simulation with no window ---------------------------
 #
 # A session, the runtime system registry, the AI and a fixed-step loop, linked

--- a/tools/arena/arena_scenario.cpp
+++ b/tools/arena/arena_scenario.cpp
@@ -1511,7 +1511,8 @@ struct ArenaScenarioRunner::Impl {
   }
 
   void record_animals(TraceFrame& frame) {
-    for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
+    for (auto* entity :
+         world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
       if (entity == nullptr) {
         continue;
       }
@@ -1526,7 +1527,8 @@ struct ArenaScenarioRunner::Impl {
 
   void observe_wildlife() {
     int population = 0;
-    for (auto* entity : world.get_entities_with<Engine::Core::WildlifeComponent>()) {
+    for (auto* entity :
+         world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
       if (entity == nullptr) {
         continue;
       }
@@ -1574,7 +1576,7 @@ struct ArenaScenarioRunner::Impl {
     if (scenario.undead_zones.empty()) {
       return;
     }
-    auto const entities = world.get_entities_with<Engine::Core::UnitComponent>();
+    auto const entities = world.collect_entities_with<Engine::Core::UnitComponent>();
     for (auto const& zone : scenario.undead_zones) {
       auto& state = undead_zone_states[zone.id];
       auto& seen = undead_zone_entities[zone.id];
@@ -4050,7 +4052,7 @@ auto ArenaScenarioRunner::start() -> bool {
         rpg->rpg_hp;
   }
   for (auto* entity :
-       m_impl->world.get_entities_with<Engine::Core::BuildingComponent>()) {
+       m_impl->world.collect_entities_with<Engine::Core::BuildingComponent>()) {
     if (entity != nullptr) {
       m_impl->initial_building_ids.insert(entity->get_id());
     }
@@ -4116,7 +4118,7 @@ void ArenaScenarioRunner::observe_rendered_frame(
   frame.timings = timings;
   m_impl->record_animals(frame);
   for (auto* entity :
-       m_impl->world.get_entities_with<Engine::Core::BuildingComponent>()) {
+       m_impl->world.collect_entities_with<Engine::Core::BuildingComponent>()) {
     if (entity == nullptr || m_impl->initial_building_ids.contains(entity->get_id()) ||
         m_impl->observed_constructed_building_ids.contains(entity->get_id())) {
       continue;

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -2515,7 +2515,8 @@ void ArenaViewport::clear_wildlife() {
     wildlife->configure(disabled, 1U);
   }
   std::vector<Engine::Core::EntityID> doomed;
-  for (auto* entity : m_world->get_entities_with<Engine::Core::WildlifeComponent>()) {
+  for (auto* entity :
+       m_world->collect_entities_with<Engine::Core::WildlifeComponent>()) {
     if (entity != nullptr) {
       doomed.push_back(entity->get_id());
     }
@@ -2650,7 +2651,7 @@ void ArenaViewport::clear_undead_zones() {
   }
 
   std::vector<Engine::Core::EntityID> doomed;
-  for (auto* entity : m_world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* entity : m_world->collect_entities_with<Engine::Core::UnitComponent>()) {
     auto* unit = entity != nullptr
                      ? entity->get_component<Engine::Core::UnitComponent>()
                      : nullptr;
@@ -4113,7 +4114,8 @@ void ArenaViewport::configure_rpg_scenario_commander(Engine::Core::EntityID enti
   }
 
   m_rpg_initial_enemy_units = 0;
-  for (auto* candidate : m_world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate :
+       m_world->collect_entities_with<Engine::Core::UnitComponent>()) {
     auto const* candidate_unit =
         candidate != nullptr ? candidate->get_component<Engine::Core::UnitComponent>()
                              : nullptr;
@@ -4174,7 +4176,8 @@ auto ArenaViewport::rpg_bow_hud_state() const -> ArenaViewport::RpgBowHudState {
   }
 
   int alive_enemies = 0;
-  for (auto* candidate : m_world->get_entities_with<Engine::Core::UnitComponent>()) {
+  for (auto* candidate :
+       m_world->collect_entities_with<Engine::Core::UnitComponent>()) {
     auto const* candidate_unit =
         candidate != nullptr ? candidate->get_component<Engine::Core::UnitComponent>()
                              : nullptr;
@@ -4251,7 +4254,7 @@ auto ArenaViewport::enter_rpg_interactive_control(Engine::Core::EntityID entity_
   }
   if (target_id == 0) {
     for (auto* candidate :
-         m_world->get_entities_with<Engine::Core::CommanderComponent>()) {
+         m_world->collect_entities_with<Engine::Core::CommanderComponent>()) {
       auto const* unit = candidate != nullptr
                              ? candidate->get_component<Engine::Core::UnitComponent>()
                              : nullptr;
@@ -4997,7 +5000,7 @@ void ArenaViewport::draw_stats_overlay(QPainter& painter) {
   int player_count = 0;
   int enemy_count = 0;
   if (m_world != nullptr) {
-    for (auto* entity : m_world->get_entities_with<Engine::Core::UnitComponent>()) {
+    for (auto* entity : m_world->collect_entities_with<Engine::Core::UnitComponent>()) {
       auto* uc = entity != nullptr
                      ? entity->get_component<Engine::Core::UnitComponent>()
                      : nullptr;

--- a/tools/sim_benchmark/main.cpp
+++ b/tools/sim_benchmark/main.cpp
@@ -1,0 +1,268 @@
+
+
+#include <QCoreApplication>
+
+#include <algorithm>
+#include <chrono>
+#include <cinttypes>
+#include <clocale>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "game/core/component.h"
+#include "game/core/system_profiler.h"
+#include "game/core/world.h"
+#include "game/core/world_spatial_index.h"
+#include "game/map/map_definition.h"
+#include "game/map/terrain_service.h"
+#include "game/session/session_context.h"
+#include "game/session/simulation_clock.h"
+#include "game/session/world_digest.h"
+#include "game/systems/default_content.h"
+#include "game/systems/nav_grid.h"
+#include "game/systems/owner_registry.h"
+#include "game/systems/runtime_system_registry.h"
+#include "game/units/factory.h"
+#include "game/units/spawn_type.h"
+
+namespace {
+
+using Engine::Core::AttackComponent;
+using Engine::Core::MovementComponent;
+using Engine::Core::TransformComponent;
+using Engine::Core::UnitComponent;
+using Game::Session::ScopedSession;
+using Game::Session::SessionContext;
+
+constexpr int k_left_owner = 1;
+constexpr int k_right_owner = 2;
+
+constexpr float k_file_spacing = 4.0F;
+constexpr float k_rank_spacing = 5.0F;
+constexpr int k_default_ticks = 240;
+
+constexpr int k_ranks_per_army = 8;
+
+struct Options {
+  std::vector<int> unit_counts{1000, 5000, 10000};
+  int ticks{k_default_ticks};
+  bool per_system{true};
+};
+
+auto files_per_army(int units_per_side) -> int {
+  return std::max(1, (units_per_side + k_ranks_per_army - 1) / k_ranks_per_army);
+}
+
+auto map_size_for(int units_per_side) -> int {
+  const int width = static_cast<int>(
+      static_cast<float>(files_per_army(units_per_side)) * k_file_spacing);
+  return std::clamp(width + 64, 96, 4096);
+}
+
+auto peak_rss_kb() -> std::uint64_t {
+#if defined(__linux__)
+  std::FILE* status = std::fopen("/proc/self/status", "r");
+  if (status == nullptr) {
+    return 0;
+  }
+  char line[256];
+  std::uint64_t value = 0;
+  while (std::fgets(line, sizeof(line), status) != nullptr) {
+    if (std::strncmp(line, "VmHWM:", 6) == 0) {
+      value = std::strtoull(line + 6, nullptr, 10);
+      break;
+    }
+  }
+  std::fclose(status);
+  return value;
+#else
+  return 0;
+#endif
+}
+
+void muster(SessionContext& session,
+            int owner_id,
+            int count,
+            float origin_x,
+            float origin_z,
+            float facing_z) {
+  const int files = files_per_army(count);
+  for (int index = 0; index < count; ++index) {
+    const int rank = index / files;
+    const int file = index % files;
+
+    auto* entity = session.world().create_entity();
+    auto* transform = entity->add_component<TransformComponent>();
+    transform->position.x = origin_x + static_cast<float>(file) * k_file_spacing;
+    transform->position.z =
+        origin_z + static_cast<float>(rank) * k_rank_spacing * facing_z;
+
+    auto* unit = entity->add_component<UnitComponent>(120, 120, 2.4F, 14.0F);
+    unit->owner_id = owner_id;
+    unit->spawn_type = (index % 4 == 0) ? Game::Units::SpawnType::Archer
+                                        : Game::Units::SpawnType::Spearman;
+
+    entity->add_component<MovementComponent>();
+    entity->add_component<AttackComponent>(12.0F, 8.0F, 1.0F);
+  }
+}
+
+struct Result {
+  int units{0};
+  int ticks{0};
+  double total_ms{0.0};
+  double mean_ms{0.0};
+  double min_ms{0.0};
+  double p95_ms{0.0};
+  double max_ms{0.0};
+  std::uint64_t digest{0};
+  std::uint64_t peak_rss_kb{0};
+  std::size_t entities{0};
+  Engine::Core::SystemProfiler::TickSummary last_tick;
+  std::string system_report;
+};
+
+auto run_scenario(int units_per_side, int ticks, bool per_system) -> Result {
+  const int map_size = map_size_for(units_per_side);
+  Game::Systems::NavGrid::initialize(map_size, map_size);
+
+  auto factory = std::make_shared<Game::Units::UnitFactoryRegistry>();
+  Game::Units::register_built_in_units(*factory);
+
+  auto session = std::make_unique<SessionContext>();
+  const ScopedSession scope(*session);
+
+  auto& owners = session->owners();
+  owners.register_owner_with_id(k_left_owner, Game::Systems::OwnerType::Player, "left");
+  owners.register_owner_with_id(k_right_owner, Game::Systems::OwnerType::AI, "right");
+  owners.set_owner_team(k_left_owner, 1);
+  owners.set_owner_team(k_right_owner, 2);
+  Game::Systems::initialize_default_content(session->nations());
+  Game::Systems::register_runtime_systems(session->world());
+
+  Game::Map::MapDefinition map_definition;
+  map_definition.grid.width = map_size;
+  map_definition.grid.height = map_size;
+  map_definition.grid.tile_size = 1.0F;
+  session->terrain().initialize(map_definition);
+
+  const auto centre = static_cast<float>(map_size) * 0.5F;
+  const float line_width =
+      static_cast<float>(files_per_army(units_per_side)) * k_file_spacing;
+  const float line_left = centre - line_width * 0.5F;
+
+  muster(*session, k_left_owner, units_per_side, line_left, centre - 8.0F, -1.0F);
+  muster(*session, k_right_owner, units_per_side, line_left, centre + 8.0F, 1.0F);
+
+  auto& world = session->world();
+  auto& profiler = world.system_profiler();
+  profiler.set_enabled(per_system);
+
+  Result result;
+  result.units = units_per_side * 2;
+  result.ticks = ticks;
+  result.entities = world.entity_count();
+
+  const auto step = static_cast<float>(session->clock().tick_seconds());
+
+  world.update(step);
+
+  std::vector<double> samples;
+  samples.reserve(static_cast<std::size_t>(ticks));
+  for (int tick = 0; tick < ticks; ++tick) {
+    const auto started = std::chrono::steady_clock::now();
+    world.update(step);
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    samples.push_back(std::chrono::duration<double, std::milli>(elapsed).count());
+  }
+
+  for (const double sample : samples) {
+    result.total_ms += sample;
+    result.max_ms = std::max(result.max_ms, sample);
+  }
+  result.mean_ms = result.total_ms / static_cast<double>(samples.size());
+
+  std::vector<double> sorted = samples;
+  std::sort(sorted.begin(), sorted.end());
+  result.min_ms = sorted.front();
+  result.p95_ms = sorted[std::min(sorted.size() - 1U, sorted.size() * 95U / 100U)];
+
+  result.digest = Game::Session::session_digest(*session);
+  result.peak_rss_kb = peak_rss_kb();
+  result.last_tick = profiler.last_tick();
+  if (per_system) {
+    result.system_report = profiler.format_report();
+  }
+  return result;
+}
+
+void print_result(const Result& result) {
+  std::printf("\n=== %d units (%zu entities), %d ticks "
+              "=======================================\n",
+              result.units,
+              result.entities,
+              result.ticks);
+  std::printf("simulation   min %7.3f ms   mean %7.3f ms   p95 %7.3f ms   "
+              "max %7.3f ms\n",
+              result.min_ms,
+              result.mean_ms,
+              result.p95_ms,
+              result.max_ms);
+  std::printf("headroom     %6.1f%% of a 16.67 ms frame at the mean, %.1f%% at the "
+              "fastest tick\n",
+              result.mean_ms / 16.67 * 100.0,
+              result.min_ms / 16.67 * 100.0);
+  std::printf("memory       peak RSS %" PRIu64 " MB\n", result.peak_rss_kb / 1024U);
+  std::printf("digest       %016" PRIx64 "\n", result.digest);
+
+  if (!result.system_report.empty()) {
+    std::printf("\n%s", result.system_report.c_str());
+  }
+}
+
+auto parse_options(int argc, char** argv, Options& options) -> bool {
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--units" && i + 1 < argc) {
+      options.unit_counts = {std::atoi(argv[++i])};
+    } else if (arg == "--ticks" && i + 1 < argc) {
+      options.ticks = std::atoi(argv[++i]);
+    } else if (arg == "--no-systems") {
+      options.per_system = false;
+    } else if (arg == "--help" || arg == "-h") {
+      std::printf("usage: sim_benchmark [--units N] [--ticks N] [--no-systems]\n");
+      return false;
+    } else {
+      std::fprintf(stderr, "sim_benchmark: unknown argument '%s'\n", arg.c_str());
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+auto main(int argc, char** argv) -> int {
+  QCoreApplication app(argc, argv);
+
+  std::setlocale(LC_NUMERIC, "C");
+
+  Options options;
+  if (!parse_options(argc, argv, options)) {
+    return 1;
+  }
+
+  std::printf("Standard of Iron -- simulation benchmark\n");
+  std::printf("%d ticks per scenario, fixed 1/60 s step\n", options.ticks);
+
+  for (const int units : options.unit_counts) {
+    const Result result = run_scenario(units / 2, options.ticks, options.per_system);
+    print_result(result);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
…re the tick

A thousand-unit battle line spent about half a second of CPU per simulation tick. Nearly all of it came from one line: the combat mode processor decided "is an enemy in melee reach?" by walking every unit in the world, once per attacking unit, computing formation contact geometry for each candidate. That is roughly 620 full-world scans and 620,000 entity handles resolved per tick. Bounding the search by the attacker's own reach takes the same battle line to about a fifth of the time, with the world digest unchanged.

Finding it needed instrumentation that did not exist, and keeping it needs an engine rule, so most of this change is the scaffolding rather than the fix.

Queries
  World::view<A, B>() and entity_view<A, B>() walk the smallest matching
  component set and resolve components directly, allocating nothing.
  get_entities_with is now collect_entities_with at all 223 call sites: it
  allocates a vector and resolves every handle in it, and the old name made
  that look free, which is why it spread.

  Engine::Core::WorldSpatialIndex is a counting-sorted uniform grid rebuilt at
  most once per tick. It belongs to the world it indexes rather than to a
  process-wide singleton, so two worlds in one process never see each other's
  entities, and each entry carries the fields proximity queries filter on so a
  caller can reject a candidate without touching the entity. Patrol, healing,
  ally alerting and combat mode targeting now go through it; patrol and healing
  were O(units^2) per tick before.

  scripts/check-world-scans.py ratchets the number of full-world scans per
  directory downward, wired into the build like the ambient-lookup budget.

Measurement
  Engine::Core::SystemProfiler records per-system tick times and the queries
  each system opened -- views, materialising scans, spatial queries and the
  candidates each examined -- and attributes scans to the source line that made
  them, which is how the line above was found. Off by default.

  tools/sim_benchmark is the repeatable workload: two armies as battle lines at
  1k, 5k and 10k units, reporting simulation ms, peak RSS, the per-system table
  and a world digest that says whether the workload itself moved.

Structure
  Engine::Core::SystemPhase names the stages the tick already ran in, and
  Engine::Core::DeferredMutations lets a system record a structural change that
  the world applies at the next phase boundary, so the instants at which the
  world's shape can change are few and named. SystemAccess lets a system
  declare what it reads and writes; plan_phase_batches groups the
  non-conflicting ones. Nothing runs in parallel yet and nothing reordered -- a
  test asserts the phases only ever advance down the registry.

  World::EntityLock skips the entity mutex for the thread that already holds
  it. The tick holds it start to finish, so every lookup inside was a recursive
  re-acquire: two atomic read-modify-writes per get_entity, per unit, per
  system. The guarantee is unchanged; only the cost of restating it is gone.

Renderer
  BattleRenderOptimizer stopped pretending to cull. should_render_unit had been
  reduced to `return true` behind a counter and three atomics, while the real
  culling happens in collect_unit_entries well before it, so it is gone. What
  remains -- animation throttling and the batching ratio -- reads one immutable
  per-frame snapshot instead of taking a lock per unit, accumulates statistics
  caller-local, and belongs to the Renderer rather than to the process.

  Draw-queue sorting was profiled rather than changed: 0.06 ms at 2k commands,
  1.1 ms at 20k, 18 ms at 100k. The queue already buckets by pass, pipeline and
  transparency and skips sorting append-ordered kinds entirely, and the game
  submits low thousands, so it needs no restructuring. The new test prints the
  numbers and asserts only what does not depend on machine load.