### PR TITLE
feat(combat): make melee swings continuous and embodied

### DIFF
--- a/animation/CMakeLists.txt
+++ b/animation/CMakeLists.txt
@@ -18,9 +18,11 @@ add_library(
     guard_manifest.cpp
     hold_pose_manifest.cpp
     horse_gait_manifest.cpp
+    individuality_manifest.cpp
     intent_manifest.cpp
     layout_manifest.cpp
     locomotion_manifest.cpp
+    melee_swing_manifest.cpp
     micro_variation_manifest.cpp
     mounted_pose_manifest.cpp
     playback_manifest.cpp

--- a/animation/individuality_manifest.cpp
+++ b/animation/individuality_manifest.cpp
@@ -1,0 +1,63 @@
+#include "individuality_manifest.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "layout_manifest.h"
+
+namespace Animation {
+
+namespace {
+
+[[nodiscard]] auto cohort_of(std::uint32_t soldier_seed) noexcept -> float {
+  return static_cast<float>(static_cast<int>((soldier_seed >> 9U) % 3U) - 1);
+}
+
+[[nodiscard]] auto centered(int index, int count) noexcept -> float {
+  if (count <= 1) {
+    return 0.0F;
+  }
+  return ((static_cast<float>(index) / static_cast<float>(count - 1)) * 2.0F) - 1.0F;
+}
+
+} // namespace
+
+auto resolve_soldier_individuality(const SoldierIndividualityInputs& inputs) noexcept
+    -> SoldierIndividuality {
+  SoldierIndividuality individuality{};
+  if (inputs.single_soldier) {
+    return individuality;
+  }
+
+  float const cohort = cohort_of(inputs.soldier_seed);
+  float const rank = centered(inputs.row, inputs.rows);
+  float const file = centered(inputs.col, inputs.cols);
+  float const checker = (((inputs.row + inputs.col) & 1) == 0) ? -1.0F : 1.0F;
+
+  std::uint32_t rng_state = inputs.soldier_seed ^ 0xA511E9B3U;
+  auto noise = [&rng_state]() {
+    return layout_random(rng_state) - 0.5F;
+  };
+
+  individuality.gait_phase_offset =
+      std::clamp(0.125F + (rank * 0.040F) + (file * 0.018F) + (checker * 0.012F) +
+                     (cohort * 0.026F) + (noise() * 0.014F),
+                 0.0F,
+                 0.25F);
+
+  individuality.cadence_scale =
+      1.0F + (((cohort * 0.60F) + (noise() * 0.80F)) * k_individuality_cadence_spread);
+
+  individuality.swing_phase_offset =
+      (0.5F + (cohort * 0.22F) + (noise() * 0.9F)) * 0.14F;
+  individuality.swing_tempo_scale = 1.0F + ((cohort * 0.05F) + (noise() * 0.10F));
+  individuality.swing_plane_offset =
+      ((cohort * 0.45F) + (checker * 0.25F) + (noise() * 0.9F)) *
+      k_individuality_swing_spread;
+
+  individuality.idle_phase_offset = layout_random(rng_state);
+
+  return individuality;
+}
+
+} // namespace Animation

--- a/animation/individuality_manifest.h
+++ b/animation/individuality_manifest.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Animation {
+
+struct SoldierIndividualityInputs {
+
+  std::uint32_t soldier_seed{0U};
+
+  int row{0};
+  int col{0};
+  int rows{1};
+  int cols{1};
+
+  bool single_soldier{false};
+};
+
+struct SoldierIndividuality {
+
+  float gait_phase_offset{0.0F};
+
+  float cadence_scale{1.0F};
+
+  float swing_phase_offset{0.0F};
+
+  float swing_tempo_scale{1.0F};
+
+  float swing_plane_offset{0.0F};
+
+  float idle_phase_offset{0.0F};
+};
+
+inline constexpr float k_individuality_cadence_spread = 0.035F;
+
+inline constexpr float k_individuality_swing_spread = 0.22F;
+
+[[nodiscard]] auto resolve_soldier_individuality(
+    const SoldierIndividualityInputs& inputs) noexcept -> SoldierIndividuality;
+
+} // namespace Animation

--- a/animation/layout_manifest.cpp
+++ b/animation/layout_manifest.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cmath>
 
+#include "individuality_manifest.h"
+
 namespace Animation {
 
 namespace {
@@ -15,32 +17,11 @@ namespace {
   return normalized * 2.0F - 1.0F;
 }
 
-[[nodiscard]] auto phase_cohort_offset(std::uint32_t inst_seed) noexcept -> float {
-  int const cohort = static_cast<int>((inst_seed >> 9U) % 3U) - 1;
-  return static_cast<float>(cohort);
-}
-
 } // namespace
 
 auto layout_random(std::uint32_t& state) noexcept -> float {
   state = state * 1664525U + 1013904223U;
   return static_cast<float>(state & 0x7FFFFFU) / static_cast<float>(0x7FFFFFU);
-}
-
-auto structured_layout_phase_offset(
-    int row, int col, int rows, int cols, std::uint32_t inst_seed) noexcept -> float {
-  float const row_bias = centered_grid_coordinate(row, rows) * 0.040F;
-  float const col_bias = centered_grid_coordinate(col, cols) * 0.018F;
-  float const checker_bias = (((row + col) & 1) == 0 ? -1.0F : 1.0F) * 0.012F;
-  float const cohort_bias = phase_cohort_offset(inst_seed) * 0.026F;
-
-  std::uint32_t rng_state = inst_seed ^ 0xA511E9B3U;
-  float const micro_bias = (layout_random(rng_state) - 0.5F) * 0.014F;
-
-  return std::clamp(0.125F + row_bias + col_bias + checker_bias + cohort_bias +
-                        micro_bias,
-                    0.0F,
-                    0.25F);
 }
 
 auto resolve_soldier_layout_policy(const SoldierLayoutPolicyInputs& inputs) noexcept
@@ -58,8 +39,14 @@ auto resolve_soldier_layout_policy(const SoldierLayoutPolicyInputs& inputs) noex
   if (!inputs.force_single_soldier) {
     policy.vertical_jitter = (layout_random(rng_state) - 0.5F) * 0.03F;
     policy.yaw_delta = (layout_random(rng_state) - 0.5F) * 5.0F;
-    policy.phase_offset = structured_layout_phase_offset(
-        inputs.row, inputs.col, inputs.rows, inputs.cols, policy.inst_seed);
+    policy.individuality = resolve_soldier_individuality({
+        .soldier_seed = policy.inst_seed,
+        .row = inputs.row,
+        .col = inputs.col,
+        .rows = inputs.rows,
+        .cols = inputs.cols,
+        .single_soldier = false,
+    });
   }
 
   return policy;

--- a/animation/layout_manifest.h
+++ b/animation/layout_manifest.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include "individuality_manifest.h"
+
 namespace Animation {
 
 struct SoldierLayoutPolicyInputs {
@@ -28,7 +30,8 @@ struct SoldierLayoutPolicy {
   float offset_z_delta{0.0F};
   float vertical_jitter{0.0F};
   float yaw_delta{0.0F};
-  float phase_offset{0.0F};
+
+  SoldierIndividuality individuality{};
   std::uint8_t rank_band{0U};
   std::uint8_t row_index{0U};
   std::uint8_t col_index{0U};
@@ -36,9 +39,6 @@ struct SoldierLayoutPolicy {
 };
 
 [[nodiscard]] auto layout_random(std::uint32_t& state) noexcept -> float;
-
-[[nodiscard]] auto structured_layout_phase_offset(
-    int row, int col, int rows, int cols, std::uint32_t inst_seed) noexcept -> float;
 
 [[nodiscard]] auto resolve_soldier_layout_policy(
     const SoldierLayoutPolicyInputs& inputs) noexcept -> SoldierLayoutPolicy;

--- a/animation/locomotion_manifest.cpp
+++ b/animation/locomotion_manifest.cpp
@@ -432,6 +432,8 @@ build_targets(const HumanoidLocomotionInputs& inputs) noexcept -> LocomotionTarg
   } else {
     targets.cycle_time = inputs.tuning.idle_cycle_time;
   }
+
+  targets.cycle_time /= std::clamp(inputs.cadence_scale, 0.80F, 1.25F);
   targets.base_phase =
       wrap_locomotion_phase((inputs.sample_time + inputs.phase_offset) /
                             std::max(0.001F, targets.cycle_time));

--- a/animation/locomotion_manifest.h
+++ b/animation/locomotion_manifest.h
@@ -56,6 +56,8 @@ struct HumanoidLocomotionInputs {
   float locomotion_direction_z{1.0F};
   float sample_time{0.0F};
   float phase_offset{0.0F};
+
+  float cadence_scale{1.0F};
   HumanoidLocomotionTuning tuning{};
   bool has_persistent_state{false};
   HumanoidLocomotionPersistentState previous{};

--- a/animation/melee_swing_manifest.cpp
+++ b/animation/melee_swing_manifest.cpp
@@ -1,0 +1,444 @@
+#include "melee_swing_manifest.h"
+
+#include <array>
+#include <limits>
+
+namespace Animation {
+
+namespace {
+
+[[nodiscard]] auto add(const PoseVec3& a, const PoseVec3& b) noexcept -> PoseVec3 {
+  return {a.x + b.x, a.y + b.y, a.z + b.z};
+}
+
+[[nodiscard]] auto scale(const PoseVec3& v, float s) noexcept -> PoseVec3 {
+  return {v.x * s, v.y * s, v.z * s};
+}
+
+[[nodiscard]] auto length(const PoseVec3& v) noexcept -> float {
+  return std::sqrt((v.x * v.x) + (v.y * v.y) + (v.z * v.z));
+}
+
+[[nodiscard]] auto normalize(const PoseVec3& v,
+                             const PoseVec3& fallback) noexcept -> PoseVec3 {
+  float const len = length(v);
+  if (len < k_melee_intent_min_axis) {
+    return fallback;
+  }
+  return scale(v, 1.0F / len);
+}
+
+[[nodiscard]] auto
+nlerp(const PoseVec3& from, const PoseVec3& to, float t) noexcept -> PoseVec3 {
+  PoseVec3 const mixed{std::lerp(from.x, to.x, t),
+                       std::lerp(from.y, to.y, t),
+                       std::lerp(from.z, to.z, t)};
+  return normalize(mixed, to);
+}
+
+[[nodiscard]] auto smoothstep(float t) noexcept -> float {
+  float const clamped = std::clamp(t, 0.0F, 1.0F);
+  return clamped * clamped * (3.0F - (2.0F * clamped));
+}
+
+constexpr float k_nominal_swing_seconds = 1.40F;
+
+constexpr float k_weapon_shoulder_x = 0.19F;
+
+struct SwingKey {
+  float time{0.0F};
+  PoseVec3 grip{};
+  PoseVec3 blade{};
+};
+
+using SwingKeys = std::array<SwingKey, 6>;
+
+[[nodiscard]] auto build_swing_keys(const MeleeSwingInputs& inputs,
+                                    const MeleeIntent& intent) noexcept -> SwingKeys {
+  PoseVec3 const shoulder{k_weapon_shoulder_x, inputs.shoulder_y, 0.0F};
+  float const reach = std::max(inputs.arm_reach, 0.15F);
+  float const thrust = intent.thrust_amount;
+
+  MeleeRestDirection const rest =
+      inputs.has_rest ? inputs.rest
+                      : MeleeRestDirection{intent.windup_dir_x, intent.windup_dir_y};
+
+  auto from_shoulder = [&](PoseVec3 direction, float extension) {
+    return add(shoulder,
+               scale(normalize(direction, {0.0F, 0.0F, 1.0F}), reach * extension));
+  };
+
+  PoseVec3 const guard_grip =
+      from_shoulder({rest.x * 0.60F, rest.y * 0.45F, 0.75F}, 0.55F);
+  PoseVec3 const guard_blade =
+      normalize({rest.x * 0.25F, 0.86F, 0.45F}, {0.12F, 0.86F, 0.50F});
+
+  PoseVec3 const chamber_grip = from_shoulder(
+      {intent.windup_dir_x, intent.windup_dir_y, -0.35F + (0.20F * thrust)},
+      0.80F - (0.25F * thrust));
+  PoseVec3 const chamber_blade = normalize(
+      {intent.windup_dir_x * 0.50F, intent.windup_dir_y * 0.80F, -0.40F}, guard_blade);
+
+  PoseVec3 const apex_grip = from_shoulder({intent.windup_dir_x * 0.85F,
+                                            intent.windup_dir_y * 0.95F,
+                                            -0.10F + (0.35F * thrust)},
+                                           0.92F - (0.18F * thrust));
+  PoseVec3 const apex_blade =
+      normalize({intent.windup_dir_x * 0.40F, intent.windup_dir_y * 0.90F, -0.20F},
+                chamber_blade);
+
+  PoseVec3 const contact_grip{intent.weapon_target_x,
+                              inputs.shoulder_y + intent.weapon_target_y,
+                              intent.weapon_target_z};
+  PoseVec3 const contact_blade{
+      intent.blade_dir_x, intent.blade_dir_y, intent.blade_dir_z};
+
+  PoseVec3 const follow_grip =
+      add(contact_grip,
+          scale(normalize({intent.strike_dir_x * (1.0F - thrust),
+                           intent.strike_dir_y * (1.0F - thrust),
+                           0.30F + (0.70F * thrust)},
+                          {0.0F, 0.0F, 1.0F}),
+                reach * (0.30F + (0.42F * intent.follow_through))));
+  PoseVec3 const follow_blade = normalize(
+      {intent.strike_dir_x * 0.80F, intent.strike_dir_y * 0.70F, 0.20F}, contact_blade);
+
+  return SwingKeys{SwingKey{0.0F, guard_grip, guard_blade},
+                   SwingKey{k_melee_chamber_time, chamber_grip, chamber_blade},
+                   SwingKey{k_melee_apex_time, apex_grip, apex_blade},
+                   SwingKey{k_melee_contact_time, contact_grip, contact_blade},
+                   SwingKey{k_melee_follow_time, follow_grip, follow_blade},
+                   SwingKey{1.0F, guard_grip, guard_blade}};
+}
+
+[[nodiscard]] auto catmull_rom(const PoseVec3& p0,
+                               const PoseVec3& p1,
+                               const PoseVec3& p2,
+                               const PoseVec3& p3,
+                               float u) noexcept -> PoseVec3 {
+  float const u2 = u * u;
+  float const u3 = u2 * u;
+  auto axis = [&](float a0, float a1, float a2, float a3) {
+    return 0.5F * (((2.0F * a1)) + ((-a0 + a2) * u) +
+                   (((2.0F * a0) - (5.0F * a1) + (4.0F * a2) - a3) * u2) +
+                   ((-a0 + (3.0F * a1) - (3.0F * a2) + a3) * u3));
+  };
+  return {axis(p0.x, p1.x, p2.x, p3.x),
+          axis(p0.y, p1.y, p2.y, p3.y),
+          axis(p0.z, p1.z, p2.z, p3.z)};
+}
+
+[[nodiscard]] auto catmull_rom_tangent(const PoseVec3& p0,
+                                       const PoseVec3& p1,
+                                       const PoseVec3& p2,
+                                       const PoseVec3& p3,
+                                       float u) noexcept -> PoseVec3 {
+  float const u2 = u * u;
+  auto axis = [&](float a0, float a1, float a2, float a3) {
+    return 0.5F *
+           ((-a0 + a2) + ((2.0F * ((2.0F * a0) - (5.0F * a1) + (4.0F * a2) - a3)) * u) +
+            ((3.0F * (-a0 + (3.0F * a1) - (3.0F * a2) + a3)) * u2));
+  };
+  return {axis(p0.x, p1.x, p2.x, p3.x),
+          axis(p0.y, p1.y, p2.y, p3.y),
+          axis(p0.z, p1.z, p2.z, p3.z)};
+}
+
+} // namespace
+
+void normalize_melee_intent(MeleeIntent& intent) noexcept {
+  auto normalize_pair = [](float& x, float& y, float fallback_x, float fallback_y) {
+    float const len = std::sqrt((x * x) + (y * y));
+    if (len < k_melee_intent_min_axis) {
+      x = fallback_x;
+      y = fallback_y;
+      return;
+    }
+    x /= len;
+    y /= len;
+  };
+  normalize_pair(intent.windup_dir_x, intent.windup_dir_y, 0.80F, 0.60F);
+  normalize_pair(intent.strike_dir_x,
+                 intent.strike_dir_y,
+                 -intent.windup_dir_x,
+                 -intent.windup_dir_y);
+
+  PoseVec3 const blade =
+      normalize({intent.blade_dir_x, intent.blade_dir_y, intent.blade_dir_z},
+                {0.12F, 0.86F, 0.50F});
+  intent.blade_dir_x = blade.x;
+  intent.blade_dir_y = blade.y;
+  intent.blade_dir_z = blade.z;
+
+  intent.thrust_amount = std::clamp(intent.thrust_amount, 0.0F, 1.0F);
+  intent.charge = std::clamp(intent.charge, 0.0F, 1.0F);
+  intent.swing_speed = std::clamp(intent.swing_speed, 0.35F, 2.20F);
+  intent.follow_through = std::clamp(intent.follow_through, 0.0F, 1.0F);
+  intent.elevation = std::clamp(intent.elevation, -1.20F, 1.20F);
+}
+
+auto normalized_melee_intent(MeleeIntent intent) noexcept -> MeleeIntent {
+  normalize_melee_intent(intent);
+  return intent;
+}
+
+void complete_melee_intent(MeleeIntent& intent, float reach) noexcept {
+  normalize_melee_intent(intent);
+
+  if (intent.thrust_amount > 0.0F) {
+    constexpr float k_hip_guard_x = 0.55F;
+    constexpr float k_hip_guard_y = -0.84F;
+    intent.windup_dir_x =
+        std::lerp(intent.windup_dir_x, k_hip_guard_x, intent.thrust_amount);
+    intent.windup_dir_y =
+        std::lerp(intent.windup_dir_y, k_hip_guard_y, intent.thrust_amount);
+    normalize_melee_intent(intent);
+  }
+
+  float const usable_reach = std::max(reach, 0.20F);
+  float const lateral = usable_reach * 0.55F * (1.0F - intent.thrust_amount);
+  intent.weapon_target_x = intent.strike_dir_x * lateral;
+  intent.weapon_target_y = intent.elevation;
+  intent.weapon_target_z = usable_reach * (0.72F + (0.38F * intent.thrust_amount));
+
+  float const cut_weight = 0.75F * (1.0F - intent.thrust_amount);
+  intent.blade_dir_x = intent.strike_dir_x * cut_weight;
+  intent.blade_dir_y = intent.strike_dir_y * cut_weight;
+  intent.blade_dir_z = 0.55F + (0.45F * intent.thrust_amount);
+
+  normalize_melee_intent(intent);
+}
+
+auto melee_intent_from_strike_angle(float strike_angle,
+                                    float thrust_amount,
+                                    float reach) noexcept -> MeleeIntent {
+  MeleeIntent intent{};
+  intent.strike_dir_x = std::cos(strike_angle);
+  intent.strike_dir_y = std::sin(strike_angle);
+  intent.windup_dir_x = -intent.strike_dir_x;
+  intent.windup_dir_y = -intent.strike_dir_y;
+  intent.thrust_amount = thrust_amount;
+  complete_melee_intent(intent, reach);
+  return intent;
+}
+
+auto melee_intent_for_attack_variant(std::uint8_t variant,
+                                     float reach) noexcept -> MeleeIntent {
+  switch (variant % 3U) {
+  case 1U:
+    return melee_intent_from_strike_angle(k_melee_right_cut_angle, 0.0F, reach);
+  case 2U:
+    return melee_intent_from_strike_angle(k_melee_overhead_angle, 0.0F, reach);
+  default:
+    break;
+  }
+  return melee_intent_from_strike_angle(k_melee_left_cut_angle, 0.0F, reach);
+}
+
+auto melee_intent_rotated(const MeleeIntent& intent,
+                          float radians,
+                          float reach) noexcept -> MeleeIntent {
+  MeleeIntent rotated = intent;
+  float const angle = intent.strike_angle() + radians;
+  rotated.strike_dir_x = std::cos(angle);
+  rotated.strike_dir_y = std::sin(angle);
+  rotated.windup_dir_x = -rotated.strike_dir_x;
+  rotated.windup_dir_y = -rotated.strike_dir_y;
+  complete_melee_intent(rotated, reach);
+  return rotated;
+}
+
+auto nearest_attack_variant(const MeleeIntent& intent) noexcept -> std::uint8_t {
+  std::uint8_t best = 0U;
+  float best_delta = std::numeric_limits<float>::infinity();
+  for (std::uint8_t variant = 0U; variant < 3U; ++variant) {
+    float const delta =
+        melee_intent_strike_delta(melee_intent_for_attack_variant(variant), intent);
+    if (delta < best_delta) {
+      best_delta = delta;
+      best = variant;
+    }
+  }
+  return best;
+}
+
+auto melee_intent_about_anchor(const MeleeIntent& live,
+                               const MeleeIntent& anchor,
+                               float reach) noexcept -> MeleeIntent {
+
+  if (live.thrust_amount >= 0.55F) {
+    return live;
+  }
+
+  MeleeIntent const own = melee_intent_for_attack_variant(nearest_attack_variant(live));
+  constexpr float k_two_pi = 6.283185307F;
+  float offset = live.strike_angle() - own.strike_angle();
+  while (offset > k_two_pi * 0.5F) {
+    offset -= k_two_pi;
+  }
+  while (offset < -k_two_pi * 0.5F) {
+    offset += k_two_pi;
+  }
+
+  MeleeIntent carried = live;
+  float const angle = anchor.strike_angle() + offset;
+  carried.strike_dir_x = std::cos(angle);
+  carried.strike_dir_y = std::sin(angle);
+  carried.windup_dir_x = -carried.strike_dir_x;
+  carried.windup_dir_y = -carried.strike_dir_y;
+  complete_melee_intent(carried, reach);
+  return carried;
+}
+
+auto melee_intent_strike_delta(const MeleeIntent& from,
+                               const MeleeIntent& to) noexcept -> float {
+  float const dot = std::clamp((from.strike_dir_x * to.strike_dir_x) +
+                                   (from.strike_dir_y * to.strike_dir_y),
+                               -1.0F,
+                               1.0F);
+  return std::acos(dot);
+}
+
+auto melee_intent_resting_direction(const MeleeIntent& intent) noexcept
+    -> MeleeRestDirection {
+  float const carry = 0.55F + (0.35F * intent.follow_through);
+  MeleeRestDirection rest{intent.strike_dir_x * carry, intent.strike_dir_y * carry};
+  float const len = std::sqrt((rest.x * rest.x) + (rest.y * rest.y));
+  if (len < k_melee_intent_min_axis) {
+    return {};
+  }
+  rest.x /= len;
+  rest.y /= len;
+  return rest;
+}
+
+auto blend_melee_intent(const MeleeIntent& from,
+                        const MeleeIntent& to,
+                        float t,
+                        float reach) noexcept -> MeleeIntent {
+  float const weight = std::clamp(t, 0.0F, 1.0F);
+  MeleeIntent result = from;
+
+  constexpr float k_two_pi = 6.283185307F;
+  float delta = to.strike_angle() - from.strike_angle();
+  while (delta > k_two_pi * 0.5F) {
+    delta -= k_two_pi;
+  }
+  while (delta < -k_two_pi * 0.5F) {
+    delta += k_two_pi;
+  }
+  float const angle = from.strike_angle() + (delta * weight);
+  result.strike_dir_x = std::cos(angle);
+  result.strike_dir_y = std::sin(angle);
+  result.windup_dir_x = -result.strike_dir_x;
+  result.windup_dir_y = -result.strike_dir_y;
+
+  result.thrust_amount = std::lerp(from.thrust_amount, to.thrust_amount, weight);
+  result.elevation = std::lerp(from.elevation, to.elevation, weight);
+  result.charge = std::lerp(from.charge, to.charge, weight);
+  result.swing_speed = std::lerp(from.swing_speed, to.swing_speed, weight);
+  result.follow_through = std::lerp(from.follow_through, to.follow_through, weight);
+  complete_melee_intent(result, reach);
+  return result;
+}
+
+auto resolve_melee_swing(const MeleeSwingInputs& inputs) noexcept -> MeleeSwingSample {
+  MeleeIntent const intent = normalized_melee_intent(inputs.intent);
+  SwingKeys const keys = build_swing_keys(inputs, intent);
+  float const phase = std::clamp(inputs.phase, 0.0F, 1.0F);
+
+  std::size_t segment = 0;
+  while (segment + 2 < keys.size() && phase > keys[segment + 1].time) {
+    ++segment;
+  }
+  float const span = std::max(keys[segment + 1].time - keys[segment].time, 1.0e-4F);
+  float const u = std::clamp((phase - keys[segment].time) / span, 0.0F, 1.0F);
+
+  auto key_at = [&keys](std::size_t index) -> const SwingKey& {
+    return keys[std::clamp<std::size_t>(index, 0, keys.size() - 1)];
+  };
+  const SwingKey& k0 = key_at(segment == 0 ? 0 : segment - 1);
+  const SwingKey& k1 = keys[segment];
+  const SwingKey& k2 = keys[segment + 1];
+  const SwingKey& k3 = key_at(segment + 2);
+
+  MeleeSwingSample sample{};
+  sample.grip = catmull_rom(k0.grip, k1.grip, k2.grip, k3.grip, u);
+  sample.blade_direction = nlerp(k1.blade, k2.blade, smoothstep(u));
+
+  PoseVec3 const tangent = catmull_rom_tangent(k0.grip, k1.grip, k2.grip, k3.grip, u);
+  float const phase_rate = intent.swing_speed / (k_nominal_swing_seconds * span);
+  sample.speed = length(scale(tangent, phase_rate));
+
+  if (phase <= k_melee_contact_time) {
+    sample.commitment = smoothstep(phase / k_melee_contact_time);
+  } else {
+    sample.commitment = 1.0F - smoothstep((phase - k_melee_contact_time) /
+                                          (1.0F - k_melee_contact_time));
+  }
+
+  return sample;
+}
+
+auto resolve_melee_body_solve(const MeleeBodySolveInputs& inputs) noexcept
+    -> MeleeBodySolveSample {
+  MeleeSwingSample const swing = resolve_melee_swing(inputs.swing);
+  MeleeIntent const intent = normalized_melee_intent(inputs.swing.intent);
+
+  MeleeBodySolveSample solved{};
+  solved.grip = swing.grip;
+  solved.blade_direction = swing.blade_direction;
+
+  PoseVec3 const shoulder{k_weapon_shoulder_x, inputs.swing.shoulder_y, 0.0F};
+  float const reach = std::max(inputs.swing.arm_reach, 0.15F);
+
+  constexpr float k_twist_per_metre = 1.05F;
+  constexpr float k_max_twist = 0.62F;
+  float const lateral_offset = swing.grip.x - shoulder.x;
+  solved.spine_twist =
+      std::clamp(-lateral_offset * k_twist_per_metre, -k_max_twist, k_max_twist);
+
+  solved.pelvis_twist = solved.spine_twist * (-0.30F + (0.75F * swing.commitment));
+
+  float const commitment_signed = (swing.commitment * 2.0F) - 1.0F;
+  solved.weight_shift = commitment_signed * (0.60F + (0.40F * intent.thrust_amount)) *
+                        (0.70F + (0.30F * intent.charge));
+
+  constexpr float k_nominal_grip_speed = 3.0F;
+  float const drive = std::clamp(swing.speed / k_nominal_grip_speed, 0.60F, 1.60F);
+
+  constexpr float k_lean_metres = 0.085F;
+  solved.forward_lean = k_lean_metres * commitment_signed * drive *
+                        (0.75F + (0.55F * intent.thrust_amount));
+  solved.lateral_lean = 0.055F * intent.strike_dir_x * swing.commitment * drive;
+
+  float const grip_distance = length({swing.grip.x - shoulder.x,
+                                      swing.grip.y - shoulder.y,
+                                      swing.grip.z - shoulder.z});
+  constexpr float k_comfortable_fraction = 0.82F;
+  float const overreach = grip_distance - (reach * k_comfortable_fraction);
+  solved.shoulder_drive =
+      std::clamp(overreach / std::max(reach * 0.30F, 0.01F), 0.0F, 1.0F) * 0.12F;
+
+  solved.front_foot_advance =
+      std::max(0.0F, solved.weight_shift) * (0.075F + (0.075F * intent.thrust_amount));
+  solved.back_foot_brace = std::max(0.0F, -solved.weight_shift) * 0.055F;
+
+  PoseVec3 const off_shoulder{-k_weapon_shoulder_x, inputs.swing.shoulder_y, 0.0F};
+  if (std::abs(inputs.offhand_along_weapon) > 1.0e-4F) {
+
+    solved.offhand =
+        add(swing.grip, scale(swing.blade_direction, inputs.offhand_along_weapon));
+  } else {
+
+    PoseVec3 const counter = normalize({-intent.strike_dir_x * 0.85F,
+                                        (-intent.strike_dir_y * 0.45F) + 0.15F,
+                                        0.40F - (0.25F * swing.commitment)},
+                                       {-1.0F, 0.0F, 0.35F});
+    solved.offhand = add(off_shoulder, scale(counter, reach * 0.58F));
+  }
+
+  return solved;
+}
+
+} // namespace Animation

--- a/animation/melee_swing_manifest.h
+++ b/animation/melee_swing_manifest.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+#include "pose_manifest.h"
+
+namespace Animation {
+
+struct MeleeIntent {
+
+  float windup_dir_x{0.80F};
+  float windup_dir_y{0.60F};
+
+  float strike_dir_x{-0.80F};
+  float strike_dir_y{-0.60F};
+
+  float thrust_amount{0.0F};
+
+  float elevation{0.0F};
+
+  float charge{0.0F};
+
+  float swing_speed{1.0F};
+
+  float follow_through{0.5F};
+
+  float weapon_target_x{0.0F};
+  float weapon_target_y{0.0F};
+  float weapon_target_z{1.10F};
+
+  float blade_dir_x{0.12F};
+  float blade_dir_y{0.86F};
+  float blade_dir_z{0.50F};
+
+  [[nodiscard]] auto strike_angle() const noexcept -> float {
+    return std::atan2(strike_dir_y, strike_dir_x);
+  }
+};
+
+inline constexpr float k_melee_intent_min_axis = 1.0e-4F;
+
+inline constexpr float k_melee_left_cut_angle = -2.378F;
+inline constexpr float k_melee_right_cut_angle = -0.764F;
+inline constexpr float k_melee_overhead_angle = -1.731F;
+inline constexpr float k_melee_thrust_angle = -0.200F;
+
+inline constexpr float k_melee_default_reach = 1.5F;
+
+void normalize_melee_intent(MeleeIntent& intent) noexcept;
+
+[[nodiscard]] auto normalized_melee_intent(MeleeIntent intent) noexcept -> MeleeIntent;
+
+void complete_melee_intent(MeleeIntent& intent,
+                           float reach = k_melee_default_reach) noexcept;
+
+[[nodiscard]] auto melee_intent_from_strike_angle(
+    float strike_angle,
+    float thrust_amount = 0.0F,
+    float reach = k_melee_default_reach) noexcept -> MeleeIntent;
+
+[[nodiscard]] auto melee_intent_for_attack_variant(
+    std::uint8_t variant, float reach = k_melee_default_reach) noexcept -> MeleeIntent;
+
+[[nodiscard]] auto
+nearest_attack_variant(const MeleeIntent& intent) noexcept -> std::uint8_t;
+
+[[nodiscard]] auto
+melee_intent_about_anchor(const MeleeIntent& live,
+                          const MeleeIntent& anchor,
+                          float reach = k_melee_default_reach) noexcept -> MeleeIntent;
+
+[[nodiscard]] auto
+melee_intent_rotated(const MeleeIntent& intent,
+                     float radians,
+                     float reach = k_melee_default_reach) noexcept -> MeleeIntent;
+
+[[nodiscard]] auto melee_intent_strike_delta(const MeleeIntent& from,
+                                             const MeleeIntent& to) noexcept -> float;
+
+struct MeleeRestDirection {
+  float x{0.80F};
+  float y{0.60F};
+};
+
+[[nodiscard]] auto melee_intent_resting_direction(const MeleeIntent& intent) noexcept
+    -> MeleeRestDirection;
+
+[[nodiscard]] auto
+blend_melee_intent(const MeleeIntent& from,
+                   const MeleeIntent& to,
+                   float t,
+                   float reach = k_melee_default_reach) noexcept -> MeleeIntent;
+
+inline constexpr float k_melee_chamber_time = 0.18F;
+inline constexpr float k_melee_apex_time = 0.32F;
+inline constexpr float k_melee_contact_time = 0.58F;
+inline constexpr float k_melee_follow_time = 0.76F;
+
+struct MeleeSwingInputs {
+  MeleeIntent intent{};
+
+  float phase{0.0F};
+
+  float shoulder_y{1.40F};
+
+  float arm_reach{0.62F};
+
+  MeleeRestDirection rest{};
+  bool has_rest{false};
+};
+
+struct MeleeSwingSample {
+  PoseVec3 grip{};
+  PoseVec3 blade_direction{0.12F, 0.86F, 0.50F};
+
+  float speed{0.0F};
+
+  float commitment{0.0F};
+};
+
+[[nodiscard]] auto
+resolve_melee_swing(const MeleeSwingInputs& inputs) noexcept -> MeleeSwingSample;
+
+struct MeleeBodySolveInputs {
+  MeleeSwingInputs swing{};
+
+  float offhand_along_weapon{0.0F};
+};
+
+struct MeleeBodySolveSample {
+
+  PoseVec3 grip{};
+  PoseVec3 offhand{};
+  PoseVec3 blade_direction{0.12F, 0.86F, 0.50F};
+
+  float spine_twist{0.0F};
+  float pelvis_twist{0.0F};
+
+  float forward_lean{0.0F};
+  float lateral_lean{0.0F};
+
+  float shoulder_drive{0.0F};
+
+  float weight_shift{0.0F};
+  float front_foot_advance{0.0F};
+  float back_foot_brace{0.0F};
+};
+
+[[nodiscard]] auto resolve_melee_body_solve(const MeleeBodySolveInputs& inputs) noexcept
+    -> MeleeBodySolveSample;
+
+} // namespace Animation

--- a/app/commander/commander_control_controller.cpp
+++ b/app/commander/commander_control_controller.cpp
@@ -19,6 +19,7 @@
 #include "game/systems/building_line_of_sight.h"
 #include "game/systems/combat_actions/combat_action_definition.h"
 #include "game/systems/combat_actions/combat_action_service.h"
+#include "game/systems/combat_actions/melee_intent_solver.h"
 #include "game/systems/combat_system/damage_processor.h"
 #include "game/systems/combat_system/mounted_charge_processor.h"
 #include "game/systems/nav_grid.h"
@@ -1976,6 +1977,19 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
     }
     m_input.primary_action_scan_cooldown = 0.08F;
   }
+
+  Game::Systems::CombatActions::advance_melee_control(
+      *commander,
+      {.aim_delta_x = signed_angle_delta(m_view_yaw, m_previous_view_yaw),
+       .aim_delta_y = m_view_pitch - m_previous_view_pitch,
+       .view_pitch_degrees = m_view_pitch,
+       .move_right_axis = m_move_right_axis,
+       .move_forward_axis = m_move_forward_axis,
+       .held_duration = m_primary_held_duration,
+       .primary_held = m_input.primary_action,
+       .delta_time = dt});
+  m_previous_view_yaw = m_view_yaw;
+  m_previous_view_pitch = m_view_pitch;
 
   if (auto const* struck =
           commander->get_component<Engine::Core::RpgCommanderActionComponent>()) {

--- a/app/commander/commander_control_controller.h
+++ b/app/commander/commander_control_controller.h
@@ -158,6 +158,9 @@ private:
   InputState m_input;
   float m_view_yaw = 0.0F;
   float m_view_pitch = 0.0F;
+
+  float m_previous_view_yaw = 0.0F;
+  float m_previous_view_pitch = 0.0F;
   QPoint m_mouse_center;
   bool m_mouse_center_valid = false;
   QPoint m_last_mouse_global;

--- a/app/commander/commander_status_builder.cpp
+++ b/app/commander/commander_status_builder.cpp
@@ -229,7 +229,7 @@ auto build_controlled_commander_status(const CommanderStatusInput& input)
               ? commander_entity->get_component<Engine::Core::CombatStateComponent>()
               : nullptr) {
     result["combat_phase"] = static_cast<int>(combat_state->animation_state);
-    result["attack_direction"] = static_cast<int>(combat_state->attack_direction);
+    result["attack_direction"] = static_cast<int>(combat_state->attack_direction());
     result["is_attacking"] =
         combat_state->animation_state != Engine::Core::CombatAnimationState::Idle;
   }

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -275,6 +275,7 @@ add_library(
     systems/combat_actions/combat_action_definition.cpp
     systems/combat_actions/combat_action_events.cpp
     systems/combat_actions/combat_action_service.cpp
+    systems/combat_actions/melee_intent_solver.cpp
     systems/combat_actions/projectile_release.cpp
     systems/combat_actions/weapon_trace.cpp
     systems/rpg_combat_system/rpg_bow_aim.cpp

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "../../animation/combat_manifest.h"
 #include "../systems/nation_id.h"
 #include "../systems/projectile_kind.h"
 #include "../systems/resource_types.h"
@@ -18,6 +19,7 @@
 #include "../units/troop_type.h"
 #include "../wildlife/wildlife_species.h"
 #include "entity.h"
+#include "melee_intent.h"
 
 namespace Game::Systems {
 class MovementSystem;
@@ -643,15 +645,7 @@ enum class CombatAttackFamily : std::uint8_t {
   }
 }
 
-enum class CombatAnimationState : std::uint8_t {
-  Idle,
-  Advance,
-  WindUp,
-  Strike,
-  Impact,
-  Recover,
-  Reposition
-};
+using CombatAnimationState = Animation::CombatPhase;
 
 enum class AttackDirection : std::uint8_t {
   LeftSlash = 0,
@@ -661,13 +655,65 @@ enum class AttackDirection : std::uint8_t {
   HeavyOverhead = 4
 };
 
+[[nodiscard]] inline auto
+classify_attack_direction(const MeleeIntent& raw,
+                          bool heavy = false) noexcept -> AttackDirection {
+  MeleeIntent const intent = normalized_melee_intent(raw);
+
+  if (intent.thrust_amount >= 0.55F) {
+    return AttackDirection::Thrust;
+  }
+
+  bool const descending = intent.strike_dir_y < -0.10F;
+  bool const vertical = std::abs(intent.strike_dir_y) > std::abs(intent.strike_dir_x);
+  if (descending && vertical) {
+    return (heavy || intent.charge >= 0.60F) ? AttackDirection::HeavyOverhead
+                                             : AttackDirection::Overhead;
+  }
+
+  return intent.strike_dir_x < 0.0F ? AttackDirection::LeftSlash
+                                    : AttackDirection::RightSlash;
+}
+
+[[nodiscard]] inline auto melee_intent_from_attack_direction(
+    AttackDirection direction,
+    float reach = k_melee_default_reach) noexcept -> MeleeIntent {
+  switch (direction) {
+  case AttackDirection::RightSlash:
+    return melee_intent_from_strike_angle(
+        Animation::k_melee_right_cut_angle, 0.0F, reach);
+  case AttackDirection::Overhead:
+    return melee_intent_from_strike_angle(
+        Animation::k_melee_overhead_angle, 0.0F, reach);
+  case AttackDirection::HeavyOverhead: {
+    MeleeIntent intent =
+        melee_intent_from_strike_angle(Animation::k_melee_overhead_angle, 0.0F, reach);
+    intent.charge = 1.0F;
+    intent.follow_through = 0.85F;
+    complete_melee_intent(intent, reach);
+    return intent;
+  }
+  case AttackDirection::Thrust:
+    return melee_intent_from_strike_angle(Animation::k_melee_thrust_angle, 1.0F, reach);
+  case AttackDirection::LeftSlash:
+    break;
+  }
+  return melee_intent_from_strike_angle(Animation::k_melee_left_cut_angle, 0.0F, reach);
+}
+
 class CombatStateComponent {
 public:
   CombatStateComponent() = default;
 
   CombatAnimationState animation_state{CombatAnimationState::Idle};
   CombatAttackFamily attack_family{CombatAttackFamily::None};
-  AttackDirection attack_direction{AttackDirection::LeftSlash};
+
+  MeleeIntent intent{};
+
+  [[nodiscard]] auto attack_direction() const noexcept -> AttackDirection {
+    return classify_attack_direction(intent, finisher_attack);
+  }
+
   float state_time{0.0F};
   float state_duration{0.0F};
   float attack_offset{0.0F};
@@ -1022,6 +1068,31 @@ public:
   float flag_rally_flag_z{0.0F};
   bool flag_rally_flag_active{false};
   bool flag_rally_issue_commands{false};
+};
+
+class CommanderBodyControlComponent {
+public:
+  CommanderBodyControlComponent() = default;
+
+  static constexpr float k_windup_steer_authority = 1.0F;
+  static constexpr float k_strike_steer_authority = 0.35F;
+  static constexpr float k_recover_steer_authority = 0.0F;
+
+  static constexpr float k_max_steer_rate = 7.5F;
+
+  static constexpr float k_sweep_degrees = 45.0F;
+
+  MeleeIntent steered_intent{};
+
+  float steer_x{0.0F};
+  float steer_y{0.0F};
+  float steer_rate{0.0F};
+
+  bool swing_in_flight{false};
+
+  float rest_dir_x{0.80F};
+  float rest_dir_y{0.60F};
+  bool rest_valid{false};
 };
 
 class CommanderGuardComponent {
@@ -2095,6 +2166,13 @@ public:
   bool is_in_melee_lock{false};
   CombatAnimationState combat_phase{CombatAnimationState::Idle};
   float combat_phase_progress{0.0F};
+
+  MeleeIntent melee_intent{};
+  bool melee_intent_valid{false};
+  float melee_rest_x{0.80F};
+  float melee_rest_y{0.60F};
+  bool melee_rest_valid{false};
+
   CombatAttackFamily attack_family{CombatAttackFamily::None};
   std::uint8_t attack_variant{0};
   bool finisher_attack{false};

--- a/game/core/melee_intent.h
+++ b/game/core/melee_intent.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../../animation/melee_swing_manifest.h"
+
+namespace Engine::Core {
+
+using MeleeIntent = Animation::MeleeIntent;
+using MeleeRestDirection = Animation::MeleeRestDirection;
+
+using Animation::blend_melee_intent;
+using Animation::complete_melee_intent;
+using Animation::k_melee_default_reach;
+using Animation::k_melee_intent_min_axis;
+using Animation::melee_intent_from_strike_angle;
+using Animation::melee_intent_resting_direction;
+using Animation::melee_intent_strike_delta;
+using Animation::normalize_melee_intent;
+using Animation::normalized_melee_intent;
+
+} // namespace Engine::Core

--- a/game/core/world.cpp
+++ b/game/core/world.cpp
@@ -493,6 +493,15 @@ void publish_creature_presentation_entity(Entity* entity, World* world) {
   next.combat_phase =
       combat != nullptr ? combat->animation_state : CombatAnimationState::Idle;
   next.combat_phase_progress = action.combat_phase_progress;
+  if (combat != nullptr) {
+    next.melee_intent = combat->intent;
+    next.melee_intent_valid = true;
+  }
+  if (auto const* body = entity->get_component<CommanderBodyControlComponent>()) {
+    next.melee_rest_x = body->rest_dir_x;
+    next.melee_rest_y = body->rest_dir_y;
+    next.melee_rest_valid = body->rest_valid;
+  }
   next.attack_family =
       combat != nullptr ? combat->attack_family : CombatAttackFamily::None;
   if (action.attack_family != Animation::CombatAttackFamily::None &&

--- a/game/save/serialization.cpp
+++ b/game/save/serialization.cpp
@@ -580,6 +580,20 @@ auto Serialization::serialize_entity(const Entity* entity) -> QJsonObject {
     combat_state_obj["attack_offset"] =
         static_cast<double>(combat_state->attack_offset);
     combat_state_obj["attack_variant"] = static_cast<int>(combat_state->attack_variant);
+
+    combat_state_obj["swing_strike_x"] =
+        static_cast<double>(combat_state->intent.strike_dir_x);
+    combat_state_obj["swing_strike_y"] =
+        static_cast<double>(combat_state->intent.strike_dir_y);
+    combat_state_obj["swing_thrust"] =
+        static_cast<double>(combat_state->intent.thrust_amount);
+    combat_state_obj["swing_elevation"] =
+        static_cast<double>(combat_state->intent.elevation);
+    combat_state_obj["swing_charge"] = static_cast<double>(combat_state->intent.charge);
+    combat_state_obj["swing_speed"] =
+        static_cast<double>(combat_state->intent.swing_speed);
+    combat_state_obj["swing_follow_through"] =
+        static_cast<double>(combat_state->intent.follow_through);
     combat_state_obj["finisher_attack"] = combat_state->finisher_attack;
     combat_state_obj["is_hit_paused"] = combat_state->is_hit_paused;
     combat_state_obj["hit_pause_remaining"] =
@@ -1482,6 +1496,24 @@ void Serialization::deserialize_entity(Entity* entity, const QJsonObject& json) 
         static_cast<float>(combat_state_obj["attack_offset"].toDouble(0.0));
     combat_state->attack_variant =
         static_cast<std::uint8_t>(combat_state_obj["attack_variant"].toInt(0));
+
+    auto& swing = combat_state->intent;
+    swing.strike_dir_x = static_cast<float>(
+        combat_state_obj["swing_strike_x"].toDouble(swing.strike_dir_x));
+    swing.strike_dir_y = static_cast<float>(
+        combat_state_obj["swing_strike_y"].toDouble(swing.strike_dir_y));
+    swing.windup_dir_x = -swing.strike_dir_x;
+    swing.windup_dir_y = -swing.strike_dir_y;
+    swing.thrust_amount =
+        static_cast<float>(combat_state_obj["swing_thrust"].toDouble(0.0));
+    swing.elevation =
+        static_cast<float>(combat_state_obj["swing_elevation"].toDouble(0.0));
+    swing.charge = static_cast<float>(combat_state_obj["swing_charge"].toDouble(0.0));
+    swing.swing_speed =
+        static_cast<float>(combat_state_obj["swing_speed"].toDouble(1.0));
+    swing.follow_through =
+        static_cast<float>(combat_state_obj["swing_follow_through"].toDouble(0.5));
+    Engine::Core::complete_melee_intent(swing);
     combat_state->finisher_attack = combat_state_obj["finisher_attack"].toBool(false);
     combat_state->is_hit_paused = combat_state_obj["is_hit_paused"].toBool(false);
     combat_state->hit_pause_remaining =

--- a/game/save/snapshot_contract.cpp
+++ b/game/save/snapshot_contract.cpp
@@ -86,7 +86,14 @@ constexpr std::array k_fields = std::to_array<FieldSpec>({
     {"AttackTargetComponent",
      AuthoritativeSerialized,
      "Current target and chase flag."},
-    {"CombatStateComponent", AuthoritativeSerialized, "Combat phase and timers."},
+    {"CombatStateComponent",
+     AuthoritativeSerialized,
+     "Combat phase, timers and the swing being executed."},
+    {"CommanderBodyControlComponent",
+     DerivedRebuilt,
+     "Live melee steering: the aim travel going into the swing and where the "
+     "last one left the blade. Rebuilt from the first tick of direct control, "
+     "and a save cannot be taken mid-input anyway."},
     {"HitFeedbackComponent",
      AuthoritativeSerialized,
      "Trauma drives both camera shake and stagger, so it is simulation state."},

--- a/game/systems/combat_actions/combat_action_service.cpp
+++ b/game/systems/combat_actions/combat_action_service.cpp
@@ -6,59 +6,11 @@
 #include "../../core/world.h"
 #include "../../units/spawn_type.h"
 #include "combat_action_events.h"
+#include "melee_intent_solver.h"
 
 namespace Game::Systems::CombatActions {
 
 namespace {
-
-[[nodiscard]] auto
-select_rpg_sword_action_id(const Engine::Core::CommanderComponent* commander,
-                           std::uint8_t attack_sequence,
-                           int move_right_axis,
-                           int move_forward_axis,
-                           bool finisher_attack) -> CombatActionId {
-  if (finisher_attack) {
-    return CombatActionId::RpgSwordFinisher;
-  }
-
-  if (move_forward_axis > 0) {
-    return CombatActionId::RpgSwordThrust;
-  }
-
-  if (move_forward_axis < 0 || (move_right_axis == 0 && commander != nullptr &&
-                                commander->power_strike_active)) {
-    return CombatActionId::RpgSwordOverhead;
-  }
-
-  switch (attack_sequence % 5U) {
-  case 0:
-    return CombatActionId::RpgSwordSlashLeft;
-  case 1:
-    return CombatActionId::RpgSwordSlashRight;
-  case 2:
-    return (move_right_axis > 0) ? CombatActionId::RpgSwordSlashRight
-                                 : CombatActionId::RpgSwordSlashLeft;
-  case 3:
-    return (move_right_axis < 0) ? CombatActionId::RpgSwordSlashLeft
-                                 : CombatActionId::RpgSwordSlashRight;
-  case 4:
-    return CombatActionId::RpgSwordOverhead;
-  default:
-    return CombatActionId::RpgSwordSlashLeft;
-  }
-}
-
-[[nodiscard]] auto select_rpg_spear_action_id(int move_right_axis,
-                                              int move_forward_axis,
-                                              bool finisher_attack) -> CombatActionId {
-  if (finisher_attack) {
-    return CombatActionId::RpgSpearFinisher;
-  }
-  if (move_forward_axis < 0 || move_right_axis != 0) {
-    return CombatActionId::RpgSpearSweep;
-  }
-  return CombatActionId::RpgSpearThrust;
-}
 
 [[nodiscard]] auto should_request_ranged_action(
     const Engine::Core::AttackComponent* attack,
@@ -143,28 +95,29 @@ auto CombatActionService::request_attack(
 
   CombatActionId action_id = CombatActionId::None;
   const CombatActionDefinition* definition = nullptr;
-  if (commander != nullptr &&
-      attack_family == Engine::Core::CombatAttackFamily::Sword) {
-    if (is_mounted_unit(unit)) {
-      action_id = CombatActionId::MountedSwordSlash;
-    } else {
-      auto* action =
-          attacker->get_component<Engine::Core::RpgCommanderActionComponent>();
-      action_id = select_rpg_sword_action_id(
-          commander,
-          action != nullptr ? action->melee_attack_sequence : 0U,
-          request.move_right_axis,
-          request.move_forward_axis,
-          finisher_attack);
-    }
-    definition = find_combat_action_definition(action_id);
-  } else if (commander != nullptr &&
-             attack_family == Engine::Core::CombatAttackFamily::Spear) {
-    action_id = is_mounted_unit(unit)
-                    ? CombatActionId::MountedSpearThrust
-                    : select_rpg_spear_action_id(request.move_right_axis,
-                                                 request.move_forward_axis,
-                                                 finisher_attack);
+  Engine::Core::MeleeIntent swing{};
+  bool swing_resolved = false;
+
+  if (commander != nullptr && attack_family != Engine::Core::CombatAttackFamily::None &&
+      attack_family != Engine::Core::CombatAttackFamily::Bow) {
+
+    auto const* body =
+        attacker->get_component<Engine::Core::CommanderBodyControlComponent>();
+    swing = body != nullptr
+                ? body->steered_intent
+                : resolve_melee_intent({
+                      .move_right_axis = request.move_right_axis,
+                      .move_forward_axis = request.move_forward_axis,
+                      .held_duration = request.primary_held_duration,
+                      .reach = attack != nullptr ? attack->melee_range
+                                                 : Engine::Core::k_melee_default_reach,
+                      .prefer_thrust =
+                          attack_family == Engine::Core::CombatAttackFamily::Spear,
+                  });
+    swing_resolved = true;
+
+    action_id = select_melee_action(
+        swing, attack_family, is_mounted_unit(unit), finisher_attack);
     definition = find_combat_action_definition(action_id);
   } else if (commander != nullptr &&
              attack_family == Engine::Core::CombatAttackFamily::Bow) {
@@ -190,6 +143,9 @@ auto CombatActionService::request_attack(
                   (finisher_attack ? 1.70F : 1.35F);
     combat_state->attack_family = attack_family;
     combat_state->finisher_attack = finisher_attack;
+    if (swing_resolved) {
+      combat_state->intent = swing;
+    }
 
     static std::uint8_t s_fpv_attack_seed = 0;
     combat_state->attack_offset = static_cast<float>(s_fpv_attack_seed % 7) * 0.022F;
@@ -212,7 +168,6 @@ auto CombatActionService::request_attack(
 
       if (combat_state != nullptr && definition != nullptr) {
         combat_state->attack_variant = 0U;
-        combat_state->attack_direction = definition->attack_direction;
         action->melee_attack_sequence =
             static_cast<std::uint8_t>((action->melee_attack_sequence + 1U) % 5U);
       }

--- a/game/systems/combat_actions/melee_intent_solver.cpp
+++ b/game/systems/combat_actions/melee_intent_solver.cpp
@@ -1,0 +1,287 @@
+#include "melee_intent_solver.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "../../core/component.h"
+
+namespace Game::Systems::CombatActions {
+
+namespace {
+
+[[nodiscard]] auto smoothstep(float value) noexcept -> float {
+  float const t = std::clamp(value, 0.0F, 1.0F);
+  return t * t * (3.0F - (2.0F * t));
+}
+
+[[nodiscard]] auto resolve_chamber(const MeleeIntentInputs& inputs) noexcept
+    -> Engine::Core::MeleeRestDirection {
+  Engine::Core::MeleeRestDirection const guard{0.80F, 0.60F};
+  if (!inputs.has_rest) {
+    return guard;
+  }
+
+  constexpr float k_guard_recovery = 0.34F;
+  Engine::Core::MeleeRestDirection chamber{
+      std::lerp(inputs.rest_dir_x, guard.x, k_guard_recovery),
+      std::lerp(inputs.rest_dir_y, guard.y, k_guard_recovery)};
+  float const length = std::sqrt((chamber.x * chamber.x) + (chamber.y * chamber.y));
+  if (length < Engine::Core::k_melee_intent_min_axis) {
+    return guard;
+  }
+  chamber.x /= length;
+  chamber.y /= length;
+  return chamber;
+}
+
+[[nodiscard]] auto
+steer_authority_for(Engine::Core::CombatAnimationState phase) noexcept -> float {
+  using Body = Engine::Core::CommanderBodyControlComponent;
+  using CS = Engine::Core::CombatAnimationState;
+  switch (phase) {
+  case CS::Idle:
+  case CS::Advance:
+  case CS::WindUp:
+    return Body::k_windup_steer_authority;
+  case CS::Strike:
+  case CS::Impact:
+    return Body::k_strike_steer_authority;
+  case CS::Recover:
+  case CS::Reposition:
+    break;
+  }
+  return Body::k_recover_steer_authority;
+}
+
+[[nodiscard]] auto melee_family_of(const Engine::Core::Entity& fighter) noexcept
+    -> Engine::Core::CombatAttackFamily {
+  auto const* unit = fighter.get_component<Engine::Core::UnitComponent>();
+  auto const* attack = fighter.get_component<Engine::Core::AttackComponent>();
+  if (unit == nullptr || attack == nullptr) {
+    return Engine::Core::CombatAttackFamily::None;
+  }
+  return Engine::Core::resolve_combat_attack_family(unit->spawn_type,
+                                                    attack->current_mode);
+}
+
+[[nodiscard]] auto
+melee_reach_of(const Engine::Core::Entity& fighter) noexcept -> float {
+  auto const* attack = fighter.get_component<Engine::Core::AttackComponent>();
+  return attack != nullptr ? attack->melee_range : Engine::Core::k_melee_default_reach;
+}
+
+} // namespace
+
+auto resolve_melee_intent(const MeleeIntentInputs& inputs) noexcept
+    -> Engine::Core::MeleeIntent {
+  Engine::Core::MeleeIntent intent{};
+
+  auto const chamber = resolve_chamber(inputs);
+  intent.windup_dir_x = chamber.x;
+  intent.windup_dir_y = chamber.y;
+
+  float const drag_length = std::sqrt((inputs.aim_delta_x * inputs.aim_delta_x) +
+                                      (inputs.aim_delta_y * inputs.aim_delta_y));
+  float const sweep = smoothstep(drag_length / k_melee_full_sweep_drag);
+
+  if (drag_length > Engine::Core::k_melee_intent_min_axis) {
+
+    intent.strike_dir_x = inputs.aim_delta_x / drag_length;
+    intent.strike_dir_y = inputs.aim_delta_y / drag_length;
+  } else {
+
+    intent.strike_dir_x =
+        -chamber.x + (static_cast<float>(inputs.move_right_axis) * 0.45F);
+    intent.strike_dir_y = -chamber.y;
+  }
+
+  float thrust = 0.0F;
+  if (inputs.move_forward_axis > 0) {
+    thrust += 0.60F;
+  }
+  if (inputs.move_forward_axis < 0) {
+    thrust -= 0.35F;
+  }
+  if (inputs.prefer_thrust) {
+    thrust += 0.75F;
+  }
+
+  intent.thrust_amount = std::clamp(thrust * (1.0F - (0.85F * sweep)), 0.0F, 1.0F);
+
+  intent.charge =
+      std::clamp(inputs.held_duration / k_melee_full_charge_seconds, 0.0F, 1.0F);
+
+  constexpr float k_rate_gain = 0.55F;
+  intent.swing_speed =
+      std::clamp(0.80F + (inputs.aim_rate * k_rate_gain), 0.45F, 2.10F);
+
+  intent.follow_through =
+      std::clamp(0.32F + (0.46F * sweep) + (0.22F * intent.charge), 0.0F, 1.0F);
+
+  constexpr float k_pitch_to_metres = 1.0F / 55.0F;
+  float const strike_rise =
+      intent.strike_dir_y /
+      std::max(std::sqrt((intent.strike_dir_x * intent.strike_dir_x) +
+                         (intent.strike_dir_y * intent.strike_dir_y)),
+               Engine::Core::k_melee_intent_min_axis);
+  intent.elevation =
+      (inputs.view_pitch_degrees * k_pitch_to_metres) + (strike_rise * 0.38F * sweep);
+
+  Engine::Core::complete_melee_intent(intent, inputs.reach);
+  return intent;
+}
+
+auto steer_melee_intent(const Engine::Core::MeleeIntent& current,
+                        const Engine::Core::MeleeIntent& desired,
+                        float authority,
+                        float max_delta) noexcept -> Engine::Core::MeleeIntent {
+  float weight = std::clamp(authority, 0.0F, 1.0F);
+  if (weight <= 0.0F) {
+    return current;
+  }
+
+  float const angular_gap = Engine::Core::melee_intent_strike_delta(current, desired);
+  if (angular_gap * weight > max_delta && angular_gap > 0.0F) {
+    weight = std::min(weight, max_delta / angular_gap);
+  }
+
+  Engine::Core::MeleeIntent result =
+      Engine::Core::blend_melee_intent(current, desired, weight);
+
+  result.charge = std::max(current.charge, desired.charge);
+  return result;
+}
+
+auto select_melee_action(const Engine::Core::MeleeIntent& intent,
+                         Engine::Core::CombatAttackFamily family,
+                         bool mounted,
+                         bool finisher) noexcept -> CombatActionId {
+  auto const direction = Engine::Core::classify_attack_direction(intent);
+
+  switch (family) {
+  case Engine::Core::CombatAttackFamily::Sword:
+    if (mounted) {
+      return CombatActionId::MountedSwordSlash;
+    }
+    if (finisher) {
+      return CombatActionId::RpgSwordFinisher;
+    }
+    switch (direction) {
+    case Engine::Core::AttackDirection::Thrust:
+      return CombatActionId::RpgSwordThrust;
+    case Engine::Core::AttackDirection::Overhead:
+    case Engine::Core::AttackDirection::HeavyOverhead:
+      return CombatActionId::RpgSwordOverhead;
+    case Engine::Core::AttackDirection::RightSlash:
+      return CombatActionId::RpgSwordSlashRight;
+    case Engine::Core::AttackDirection::LeftSlash:
+      break;
+    }
+    return CombatActionId::RpgSwordSlashLeft;
+
+  case Engine::Core::CombatAttackFamily::Spear:
+    if (mounted) {
+      return CombatActionId::MountedSpearThrust;
+    }
+    if (finisher) {
+      return CombatActionId::RpgSpearFinisher;
+    }
+    return direction == Engine::Core::AttackDirection::Thrust
+               ? CombatActionId::RpgSpearThrust
+               : CombatActionId::RpgSpearSweep;
+
+  case Engine::Core::CombatAttackFamily::Bow:
+    return CombatActionId::RpgBowShot;
+
+  case Engine::Core::CombatAttackFamily::None:
+    break;
+  }
+  return CombatActionId::None;
+}
+
+namespace {
+
+void latch_melee_rest(Engine::Core::Entity& fighter) noexcept {
+  auto const* combat = fighter.get_component<Engine::Core::CombatStateComponent>();
+  auto* body = fighter.get_component<Engine::Core::CommanderBodyControlComponent>();
+  if (combat == nullptr || body == nullptr) {
+    return;
+  }
+  auto const rest = Engine::Core::melee_intent_resting_direction(combat->intent);
+  body->rest_dir_x = rest.x;
+  body->rest_dir_y = rest.y;
+  body->rest_valid = true;
+  body->steer_x = 0.0F;
+  body->steer_y = 0.0F;
+}
+
+} // namespace
+
+void advance_melee_control(Engine::Core::Entity& fighter,
+                           const MeleeControlTick& tick) noexcept {
+  using Body = Engine::Core::CommanderBodyControlComponent;
+  auto* body = Engine::Core::get_or_add_component<Body>(&fighter);
+  if (body == nullptr) {
+    return;
+  }
+
+  auto* combat = fighter.get_component<Engine::Core::CombatStateComponent>();
+  auto const phase = combat != nullptr ? combat->animation_state
+                                       : Engine::Core::CombatAnimationState::Idle;
+  bool const idle = phase == Engine::Core::CombatAnimationState::Idle;
+  float const dt = std::max(tick.delta_time, 0.0F);
+
+  constexpr float k_filter_hz = 12.0F;
+  float const smoothing = dt > 0.0F ? 1.0F - std::exp(-dt * k_filter_hz) : 1.0F;
+
+  if (idle && body->swing_in_flight) {
+    latch_melee_rest(fighter);
+  }
+  body->swing_in_flight = !idle;
+
+  constexpr float k_sweep_scale = 1.0F / Body::k_sweep_degrees;
+  if (tick.primary_held) {
+    body->steer_x += tick.aim_delta_x * k_sweep_scale;
+    body->steer_y += tick.aim_delta_y * k_sweep_scale;
+  } else if (idle) {
+    body->steer_x = 0.0F;
+    body->steer_y = 0.0F;
+  }
+
+  float const tick_motion = std::sqrt((tick.aim_delta_x * tick.aim_delta_x) +
+                                      (tick.aim_delta_y * tick.aim_delta_y)) *
+                            k_sweep_scale;
+  float const instantaneous_rate = dt > 0.0F ? tick_motion / dt : 0.0F;
+  body->steer_rate = std::lerp(body->steer_rate, instantaneous_rate, smoothing);
+
+  body->steered_intent = resolve_melee_intent({
+      .aim_delta_x = body->steer_x,
+      .aim_delta_y = body->steer_y,
+      .aim_rate = body->steer_rate,
+      .move_right_axis = tick.move_right_axis,
+      .move_forward_axis = tick.move_forward_axis,
+      .held_duration = tick.held_duration,
+      .view_pitch_degrees = tick.view_pitch_degrees,
+      .reach = melee_reach_of(fighter),
+      .has_rest = body->rest_valid,
+      .rest_dir_x = body->rest_dir_x,
+      .rest_dir_y = body->rest_dir_y,
+      .prefer_thrust =
+          melee_family_of(fighter) == Engine::Core::CombatAttackFamily::Spear,
+  });
+
+  float const authority = steer_authority_for(phase);
+  if (combat != nullptr) {
+    if (idle) {
+
+      combat->intent = body->steered_intent;
+    } else if (authority > 0.0F) {
+      combat->intent = steer_melee_intent(combat->intent,
+                                          body->steered_intent,
+                                          authority * smoothing,
+                                          Body::k_max_steer_rate * dt);
+    }
+  }
+}
+
+} // namespace Game::Systems::CombatActions

--- a/game/systems/combat_actions/melee_intent_solver.h
+++ b/game/systems/combat_actions/melee_intent_solver.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "../../core/entity.h"
+#include "../../core/melee_intent.h"
+#include "combat_action_definition.h"
+
+namespace Game::Systems::CombatActions {
+
+struct MeleeIntentInputs {
+
+  float aim_delta_x{0.0F};
+  float aim_delta_y{0.0F};
+
+  float aim_rate{0.0F};
+
+  int move_right_axis{0};
+  int move_forward_axis{0};
+
+  float held_duration{0.0F};
+
+  float view_pitch_degrees{0.0F};
+
+  float reach{1.5F};
+
+  bool has_rest{false};
+  float rest_dir_x{0.80F};
+  float rest_dir_y{0.60F};
+
+  bool prefer_thrust{false};
+};
+
+inline constexpr float k_melee_full_sweep_drag = 0.85F;
+
+inline constexpr float k_melee_full_charge_seconds = 0.45F;
+
+[[nodiscard]] auto resolve_melee_intent(const MeleeIntentInputs& inputs) noexcept
+    -> Engine::Core::MeleeIntent;
+
+[[nodiscard]] auto
+steer_melee_intent(const Engine::Core::MeleeIntent& current,
+                   const Engine::Core::MeleeIntent& desired,
+                   float authority,
+                   float max_delta) noexcept -> Engine::Core::MeleeIntent;
+
+[[nodiscard]] auto select_melee_action(const Engine::Core::MeleeIntent& intent,
+                                       Engine::Core::CombatAttackFamily family,
+                                       bool mounted,
+                                       bool finisher) noexcept -> CombatActionId;
+
+struct MeleeControlTick {
+
+  float aim_delta_x{0.0F};
+  float aim_delta_y{0.0F};
+
+  float view_pitch_degrees{0.0F};
+
+  int move_right_axis{0};
+  int move_forward_axis{0};
+
+  float held_duration{0.0F};
+  bool primary_held{false};
+
+  float delta_time{0.0F};
+};
+
+void advance_melee_control(Engine::Core::Entity& fighter,
+                           const MeleeControlTick& tick) noexcept;
+
+} // namespace Game::Systems::CombatActions

--- a/game/systems/combat_actions/weapon_trace.cpp
+++ b/game/systems/combat_actions/weapon_trace.cpp
@@ -13,6 +13,7 @@
 
 #include "../../../animation/attack_pose_manifest.h"
 #include "../../../animation/clip_manifest.h"
+#include "../../../animation/melee_swing_manifest.h"
 #include "../../core/component.h"
 #include "../../core/world.h"
 #include "../combat_system/combat_utils.h"
@@ -272,24 +273,6 @@ mounted_seat_relative(Animation::MountedSeatOffset offset) -> QVector3D {
 
 [[nodiscard]] auto normalized_or_forward(QVector3D value) -> QVector3D {
   return normalized_or(value, QVector3D(0.0F, 0.0F, 1.0F));
-}
-
-[[nodiscard]] auto
-local_sword_blade_direction(const CombatActionDefinition& definition,
-                            const QVector3D& previous_grip,
-                            const QVector3D& current_grip) -> QVector3D {
-  if (definition.attack_direction == Engine::Core::AttackDirection::Thrust) {
-    return QVector3D(0.0F, -0.08F, 1.0F).normalized();
-  }
-
-  QVector3D const sweep = current_grip - previous_grip;
-  if (definition.attack_direction == Engine::Core::AttackDirection::LeftSlash ||
-      definition.attack_direction == Engine::Core::AttackDirection::RightSlash) {
-    QVector3D const direction = QVector3D(sweep.x() * 0.35F, -0.08F, 1.0F);
-    return normalized_or_forward(direction);
-  }
-
-  return QVector3D(0.0F, -0.20F, 1.0F).normalized();
 }
 
 [[nodiscard]] auto sample_weapon_attack_pose(const CombatActionDefinition& definition,
@@ -693,9 +676,31 @@ sample_mounted_spear_trace_segment(const AttackerFrame& frame,
   return sample;
 }
 
+struct WeaponContactShape {
+  float lateral_limit{0.0F};
+  float min_forward{0.0F};
+};
+
+[[nodiscard]] auto contact_shape(const CombatActionDefinition& definition,
+                                 const Engine::Core::MeleeIntent& intent,
+                                 float target_radius) -> WeaponContactShape {
+  float const vertical = std::clamp(std::abs(intent.strike_dir_y), 0.0F, 1.0F);
+  float const thrust = intent.thrust_amount;
+
+  float const cut_lateral = definition.hit_shape.reach * 0.70F;
+  float const overhead_lateral = std::max(0.55F, definition.hit_shape.radius);
+  float const sweep_lateral = std::lerp(cut_lateral, overhead_lateral, vertical);
+
+  return {.lateral_limit =
+              std::lerp(sweep_lateral, definition.hit_shape.radius, thrust) +
+              target_radius,
+          .min_forward = std::lerp(std::lerp(0.05F, 0.10F, vertical), 0.25F, thrust)};
+}
+
 [[nodiscard]] auto
 weapon_contact_score(const LocalTargetSample& sample,
-                     const CombatActionDefinition& definition) -> float {
+                     const CombatActionDefinition& definition,
+                     const Engine::Core::MeleeIntent& intent) -> float {
   if (sample.entity == nullptr || !std::isfinite(sample.forward) ||
       !std::isfinite(sample.right) || !std::isfinite(sample.distance) ||
       sample.forward <= 0.0F) {
@@ -707,31 +712,9 @@ weapon_contact_score(const LocalTargetSample& sample,
     return std::numeric_limits<float>::infinity();
   }
 
-  float lateral_limit = definition.hit_shape.reach * 0.70F + sample.radius;
-  float min_forward = 0.0F;
-  switch (definition.attack_direction) {
-  case Engine::Core::AttackDirection::Thrust:
-    lateral_limit = definition.hit_shape.radius + sample.radius;
-    min_forward = 0.20F;
-    break;
-  case Engine::Core::AttackDirection::Overhead:
-  case Engine::Core::AttackDirection::HeavyOverhead:
-    lateral_limit = std::max(0.55F, definition.hit_shape.radius) + sample.radius;
-    min_forward = 0.10F;
-    break;
-  case Engine::Core::AttackDirection::LeftSlash:
-  case Engine::Core::AttackDirection::RightSlash:
-  default:
-    min_forward = 0.05F;
-    break;
-  }
-  if (definition.weapon_family == WeaponFamily::Spear &&
-      definition.attack_direction == Engine::Core::AttackDirection::Thrust) {
-    lateral_limit = definition.hit_shape.radius + sample.radius;
-    min_forward = std::max(min_forward, 0.25F);
-  }
-
-  if (sample.forward < min_forward || std::abs(sample.right) > lateral_limit) {
+  auto const shape = contact_shape(definition, intent, sample.radius);
+  if (sample.forward < shape.min_forward ||
+      std::abs(sample.right) > shape.lateral_limit) {
     return std::numeric_limits<float>::infinity();
   }
 
@@ -742,8 +725,77 @@ weapon_contact_score(const LocalTargetSample& sample,
 
 namespace {
 
+[[nodiscard]] auto anchor_intent_for(const CombatActionDefinition& definition)
+    -> Engine::Core::MeleeIntent {
+  return Engine::Core::melee_intent_from_attack_direction(definition.attack_direction,
+                                                          definition.hit_shape.reach);
+}
+
+inline constexpr float k_steered_trace_threshold = 0.15F;
+
+[[nodiscard]] auto steer_amount(const CombatActionDefinition& definition,
+                                const Engine::Core::MeleeIntent& intent) -> float {
+  return Engine::Core::melee_intent_strike_delta(anchor_intent_for(definition), intent);
+}
+
+[[nodiscard]] auto sample_solved_swing_segment(const AttackerFrame& frame,
+                                               const CombatActionDefinition& definition,
+                                               const Engine::Core::MeleeIntent& intent,
+                                               float window_start,
+                                               float window_end,
+                                               float previous,
+                                               float current) -> WeaponTraceSegment {
+  using HP = Render::GL::HumanProportions;
+  WeaponTraceSegment segment;
+
+  float const window = std::max(window_end - window_start, 1.0e-4F);
+  auto swing_phase = [&](float action_time) {
+    float const t = std::clamp((action_time - window_start) / window, 0.0F, 1.0F);
+    return std::lerp(Animation::k_melee_apex_time, Animation::k_melee_follow_time, t);
+  };
+
+  Animation::MeleeSwingInputs swing{};
+  swing.intent = intent;
+  swing.shoulder_y = HP::SHOULDER_Y;
+  swing.arm_reach = HP::UPPER_ARM_LEN + HP::FORE_ARM_LEN;
+
+  swing.phase = swing_phase(previous);
+  auto const previous_sample = Animation::resolve_melee_swing(swing);
+  swing.phase = swing_phase(current);
+  auto const current_sample = Animation::resolve_melee_swing(swing);
+
+  auto grip_of = [](const Animation::MeleeSwingSample& sample) {
+    return QVector3D(sample.grip.x, sample.grip.y, sample.grip.z);
+  };
+  auto blade_of = [](const Animation::MeleeSwingSample& sample) {
+    return QVector3D(
+        sample.blade_direction.x, sample.blade_direction.y, sample.blade_direction.z);
+  };
+
+  float const blade_length = definition.weapon_family == WeaponFamily::Spear
+                                 ? definition.hit_shape.reach
+                                 : std::max(0.45F, definition.hit_shape.reach * 0.46F);
+  float const base_offset =
+      definition.weapon_family == WeaponFamily::Spear ? 0.15F : 0.08F;
+
+  QVector3D const previous_grip = grip_of(previous_sample);
+  QVector3D const current_grip = grip_of(current_sample);
+  QVector3D const previous_dir = blade_of(previous_sample);
+  QVector3D const current_dir = blade_of(current_sample);
+
+  segment.previous_base = to_world(frame, previous_grip + previous_dir * base_offset);
+  segment.current_base = to_world(frame, current_grip + current_dir * base_offset);
+  segment.previous_tip = to_world(frame, previous_grip + previous_dir * blade_length);
+  segment.current_tip = to_world(frame, current_grip + current_dir * blade_length);
+  segment.radius = std::max(0.04F, definition.hit_shape.radius);
+  segment.source = WeaponTraceSegmentSource::AuthoredPose;
+  segment.valid = true;
+  return segment;
+}
+
 auto sample_authored_weapon_trace_segment(const AttackerFrame& frame,
                                           const CombatActionDefinition& definition,
+                                          const Engine::Core::MeleeIntent& intent,
                                           WeaponTraceTimeSpan time_span)
     -> WeaponTraceSegment {
   WeaponTraceSegment segment;
@@ -767,6 +819,12 @@ auto sample_authored_weapon_trace_segment(const AttackerFrame& frame,
   float const current = std::clamp(raw_current, window_start, window_end);
   if (previous > current) {
     previous = current;
+  }
+
+  if (steer_amount(definition, intent) > k_steered_trace_threshold &&
+      !is_mounted_weapon_action(definition.id)) {
+    return sample_solved_swing_segment(
+        frame, definition, intent, window_start, window_end, previous, current);
   }
 
   if (definition.weapon_family == WeaponFamily::Sword) {
@@ -812,10 +870,9 @@ auto sample_authored_weapon_trace_segment(const AttackerFrame& frame,
     segment.current_base = to_world(frame, current_grip + current_dir * 0.15F);
   } else {
     float const blade_length = std::max(0.45F, definition.hit_shape.reach * 0.46F);
-    QVector3D const previous_dir =
-        local_sword_blade_direction(definition, previous_grip, current_grip);
-    QVector3D const current_dir =
-        local_sword_blade_direction(definition, previous_grip, current_grip);
+    QVector3D const previous_dir = normalized_or_forward(
+        QVector3D(intent.blade_dir_x, intent.blade_dir_y, intent.blade_dir_z));
+    QVector3D const current_dir = previous_dir;
     previous_tip = previous_grip + previous_dir * blade_length;
     current_tip = current_grip + current_dir * blade_length;
     segment.previous_base = to_world(frame, previous_grip + previous_dir * 0.08F);
@@ -830,14 +887,26 @@ auto sample_authored_weapon_trace_segment(const AttackerFrame& frame,
   return segment;
 }
 
+[[nodiscard]] auto
+live_intent_of(const Engine::Core::Entity& attacker,
+               const CombatActionDefinition& definition) -> Engine::Core::MeleeIntent {
+  if (auto const* combat =
+          attacker.get_component<Engine::Core::CombatStateComponent>()) {
+    return combat->intent;
+  }
+  return anchor_intent_for(definition);
+}
+
 } // namespace
 
 auto sample_authored_weapon_trace_segment(Engine::Core::Entity& attacker,
                                           const CombatActionDefinition& definition,
                                           WeaponTraceTimeSpan time_span)
     -> WeaponTraceSegment {
-  return sample_authored_weapon_trace_segment(
-      attacker_frame(attacker), definition, time_span);
+  return sample_authored_weapon_trace_segment(attacker_frame(attacker),
+                                              definition,
+                                              live_intent_of(attacker, definition),
+                                              time_span);
 }
 
 auto find_weapon_trace_contact(
@@ -876,8 +945,11 @@ auto find_weapon_trace_contact(
   }
 
   auto const presented_attacker = presented_attacker_frame(attacker, target_hint_id);
-  auto const segment = sample_authored_weapon_trace_segment(
-      presented_attacker.frame, definition, time_span);
+  auto const segment =
+      sample_authored_weapon_trace_segment(presented_attacker.frame,
+                                           definition,
+                                           live_intent_of(attacker, definition),
+                                           time_span);
   if (!segment.valid) {
     return find_weapon_trace_contact(
         world, attacker, definition, target_hint_id, ignored_target_ids);
@@ -967,6 +1039,7 @@ auto find_weapon_trace_contact(
   }
   auto const presented_attacker = presented_attacker_frame(attacker, target_hint_id);
   contact.attacker_soldier_slot = presented_attacker.soldier_slot;
+  auto const intent = live_intent_of(attacker, definition);
 
   auto consider = [&](Engine::Core::Entity* candidate,
                       float& best_score,
@@ -989,13 +1062,7 @@ auto find_weapon_trace_contact(
           sample.forward <= 0.0F) {
         continue;
       }
-      if (definition.weapon_family == WeaponFamily::Spear &&
-          definition.attack_direction == Engine::Core::AttackDirection::Thrust &&
-          std::abs(sample.right) > definition.hit_shape.radius + sample.radius) {
-        continue;
-      }
-
-      float const score = weapon_contact_score(sample, definition);
+      float const score = weapon_contact_score(sample, definition, intent);
       if (!std::isfinite(score) || score >= best_score) {
         continue;
       }

--- a/game/systems/combat_system/attack_processor.cpp
+++ b/game/systems/combat_system/attack_processor.cpp
@@ -171,6 +171,18 @@ void begin_attack_animation(Engine::Core::Entity* attacker,
           std::min(k_variant_slots - 1,
                    static_cast<int>(deterministic_unit_roll(seed, 2U) *
                                     static_cast<float>(k_variant_slots))));
+
+      constexpr float k_swing_arc_radians = 1.25F;
+      float const arc =
+          (deterministic_unit_roll(seed, 3U) - 0.5F) * k_swing_arc_radians;
+      bool const thrusting =
+          combat_state->attack_family == Engine::Core::CombatAttackFamily::Spear;
+      float const centre = thrusting ? Animation::k_melee_thrust_angle
+                                     : Animation::k_melee_left_cut_angle;
+      float const reach =
+          attack != nullptr ? attack->melee_range : Engine::Core::k_melee_default_reach;
+      combat_state->intent = Engine::Core::melee_intent_from_strike_angle(
+          centre + arc, thrusting ? 1.0F : 0.0F, reach);
     }
   }
 }

--- a/game/systems/combat_system/combat_state_processor.cpp
+++ b/game/systems/combat_system/combat_state_processor.cpp
@@ -185,21 +185,15 @@ auto commander_phase_scale(const Engine::Core::Entity& unit,
     return 1.0F;
   }
 
-  float direction_scale = 1.0F;
-  switch (combat_state.attack_direction) {
-  case Engine::Core::AttackDirection::Thrust:
-    direction_scale = 0.80F;
-    break;
-  case Engine::Core::AttackDirection::Overhead:
-    direction_scale = 1.15F;
-    break;
-  case Engine::Core::AttackDirection::HeavyOverhead:
-    direction_scale = 1.30F;
-    break;
-  default:
-    direction_scale = 1.0F;
-    break;
-  }
+  auto const& intent = combat_state.intent;
+  float const commitment =
+      1.0F + (0.20F * intent.charge) + (0.15F * (intent.follow_through - 0.50F));
+  float const thrust_relief = 1.0F - (0.22F * intent.thrust_amount);
+
+  float const arc_scale = std::clamp(
+      1.0F + (0.45F * (std::abs(intent.strike_dir_y) - 0.60F)), 0.80F, 1.35F);
+  float const direction_scale =
+      commitment * thrust_relief * arc_scale / intent.swing_speed;
 
   switch (state) {
   case CS::Advance:
@@ -227,7 +221,9 @@ auto phase_duration_for_state(const Engine::Core::Entity& unit,
   if (commander != nullptr && commander->fpv_controlled) {
 
     if (auto const* definition = running_authored_action(unit); definition != nullptr) {
-      return Game::Systems::CombatActions::authored_phase_duration(*definition, state);
+
+      return Game::Systems::CombatActions::authored_phase_duration(*definition, state) /
+             std::clamp(combat_state.intent.swing_speed, 0.55F, 1.85F);
     }
     return base_phase_duration(state) *
            commander_phase_scale(unit, combat_state, state);

--- a/game/systems/combat_system/mounted_charge_processor.cpp
+++ b/game/systems/combat_system/mounted_charge_processor.cpp
@@ -116,7 +116,9 @@ void clear_charge_action(Engine::Core::Entity& entity) {
 
   combat->animation_state = Engine::Core::CombatAnimationState::Strike;
   combat->attack_family = Engine::Core::CombatAttackFamily::None;
-  combat->attack_direction = Engine::Core::AttackDirection::Thrust;
+
+  combat->intent = Engine::Core::melee_intent_from_attack_direction(
+      Engine::Core::AttackDirection::Thrust);
   combat->state_time = 0.0F;
   combat->state_duration = Engine::Core::CombatStateComponent::k_strike_duration;
   combat->damage_dealt_this_swing = false;

--- a/render/creature/animation_core_bridge.h
+++ b/render/creature/animation_core_bridge.h
@@ -35,46 +35,4 @@ namespace Render::Creature {
   return Engine::Core::CombatAttackFamily::None;
 }
 
-[[nodiscard]] constexpr auto animation_combat_phase(
-    Engine::Core::CombatAnimationState phase) noexcept -> Animation::CombatPhase {
-  switch (phase) {
-  case Engine::Core::CombatAnimationState::Advance:
-    return Animation::CombatPhase::Advance;
-  case Engine::Core::CombatAnimationState::WindUp:
-    return Animation::CombatPhase::WindUp;
-  case Engine::Core::CombatAnimationState::Strike:
-    return Animation::CombatPhase::Strike;
-  case Engine::Core::CombatAnimationState::Impact:
-    return Animation::CombatPhase::Impact;
-  case Engine::Core::CombatAnimationState::Recover:
-    return Animation::CombatPhase::Recover;
-  case Engine::Core::CombatAnimationState::Reposition:
-    return Animation::CombatPhase::Reposition;
-  case Engine::Core::CombatAnimationState::Idle:
-    break;
-  }
-  return Animation::CombatPhase::Idle;
-}
-
-[[nodiscard]] constexpr auto engine_combat_phase(Animation::CombatPhase phase) noexcept
-    -> Engine::Core::CombatAnimationState {
-  switch (phase) {
-  case Animation::CombatPhase::Advance:
-    return Engine::Core::CombatAnimationState::Advance;
-  case Animation::CombatPhase::WindUp:
-    return Engine::Core::CombatAnimationState::WindUp;
-  case Animation::CombatPhase::Strike:
-    return Engine::Core::CombatAnimationState::Strike;
-  case Animation::CombatPhase::Impact:
-    return Engine::Core::CombatAnimationState::Impact;
-  case Animation::CombatPhase::Recover:
-    return Engine::Core::CombatAnimationState::Recover;
-  case Animation::CombatPhase::Reposition:
-    return Engine::Core::CombatAnimationState::Reposition;
-  case Animation::CombatPhase::Idle:
-    break;
-  }
-  return Engine::Core::CombatAnimationState::Idle;
-}
-
 } // namespace Render::Creature

--- a/render/creature/combat_visual_state.cpp
+++ b/render/creature/combat_visual_state.cpp
@@ -42,7 +42,7 @@ auto animation_raw_inputs(const CombatVisualRawInputs& raw) noexcept
       .is_dying = raw.is_dying,
       .is_dead = raw.is_dead,
       .locomotion = raw.locomotion,
-      .combat_phase = animation_combat_phase(raw.combat_phase),
+      .combat_phase = raw.combat_phase,
       .combat_phase_progress = raw.combat_phase_progress,
       .attack_variant = raw.attack_variant,
       .attack_target_id = raw.attack_target_id,

--- a/render/creature/pose_intent.cpp
+++ b/render/creature/pose_intent.cpp
@@ -42,7 +42,7 @@ auto intent_inputs(const Render::GL::AnimationInputs& inputs) noexcept
       .is_melee = inputs.is_melee,
       .is_in_melee_lock = inputs.is_in_melee_lock,
       .is_casting = inputs.is_casting,
-      .combat_phase = animation_combat_phase(inputs.combat_phase),
+      .combat_phase = inputs.combat_phase,
       .attack_family = animation_attack_family(inputs.attack_family),
       .has_authoritative_combat = combat != nullptr,
       .combat_active = combat != nullptr ? combat->active : false,
@@ -60,7 +60,7 @@ auto intent_inputs(const Render::GL::AnimationInputs& inputs) noexcept
 
 auto is_stationary_melee_combat_phase(Render::GL::CombatAnimPhase phase) noexcept
     -> bool {
-  return Animation::is_stationary_melee_combat_phase(animation_combat_phase(phase));
+  return Animation::is_stationary_melee_combat_phase(phase);
 }
 
 auto should_prioritize_attack_pose_over_locomotion(

--- a/render/elephant/elephant_motion.cpp
+++ b/render/elephant/elephant_motion.cpp
@@ -155,7 +155,8 @@ auto evaluate_elephant_motion(
     const ElephantProfile& profile,
     const AnimationInputs& anim,
     Render::Creature::ElephantAnimationStateComponent* io_state,
-    float model_scale) -> ElephantMotionSample {
+    float model_scale,
+    const Animation::SoldierIndividuality& individuality) -> ElephantMotionSample {
   Render::Creature::ElephantAnimationStateComponent fallback_state{};
   Render::Creature::ElephantAnimationStateComponent& state =
       io_state != nullptr ? *io_state : fallback_state;
@@ -178,6 +179,8 @@ auto evaluate_elephant_motion(
     });
     g.cycle_time = cadence.cycle_time;
   }
+
+  g.cycle_time /= std::clamp(individuality.cadence_scale, 0.80F, 1.25F);
   sample.gait = g;
 
   Render::Creature::MovementAnimationState const movement_animation =
@@ -194,7 +197,8 @@ auto evaluate_elephant_motion(
       state.locomotion_phase =
           Quadruped::wrap_phase(state.locomotion_phase + elapsed / cycle_time);
     } else {
-      state.locomotion_phase = Quadruped::wrap_phase(anim.time / cycle_time);
+      state.locomotion_phase = Quadruped::wrap_phase((anim.time / cycle_time) +
+                                                     individuality.gait_phase_offset);
     }
     state.locomotion_phase_time = anim.time;
     state.locomotion_phase_valid = true;

--- a/render/elephant/elephant_motion.h
+++ b/render/elephant/elephant_motion.h
@@ -2,6 +2,7 @@
 
 #include <QVector3D>
 
+#include "animation/individuality_manifest.h"
 #include "attachment_frames.h"
 
 namespace Render::Creature {
@@ -56,7 +57,9 @@ auto evaluate_elephant_motion(
     const ElephantProfile& profile,
     const AnimationInputs& anim,
     Render::Creature::ElephantAnimationStateComponent* io_state = nullptr,
-    float model_scale = 1.0F) -> ElephantMotionSample;
+    float model_scale = 1.0F,
+
+    const Animation::SoldierIndividuality& individuality = {}) -> ElephantMotionSample;
 
 auto build_elephant_pose_motion(const ElephantMotionSample& motion,
                                 const AnimationInputs& anim)

--- a/render/elephant/prepare.cpp
+++ b/render/elephant/prepare.cpp
@@ -20,6 +20,7 @@
 #include "render/creature/quadruped/render_stats.h"
 #include "render/gl/humanoid/animation/animation_inputs.h"
 #include "render/horse/horse_motion.h"
+#include "render/math/creature_math_utils.h"
 #include "render/submitter.h"
 #include "scene/camera.h"
 
@@ -146,7 +147,13 @@ void prepare_elephant_render(const Render::GL::ElephantRendererBase& owner,
                 anim,
                 Engine::Core::get_or_add_component<
                     Render::Creature::ElephantAnimationStateComponent>(ctx.entity),
-                Render::GL::mount_model_scale(ctx.entity));
+                Render::GL::mount_model_scale(ctx.entity),
+                Animation::resolve_soldier_individuality({
+                    .soldier_seed =
+                        ctx.entity != nullptr
+                            ? Render::Creature::stable_entity_seed(ctx.entity->get_id())
+                            : 0U,
+                }));
 
   HowdahAttachmentFrame const howdah =
       (shared_howdah != nullptr) ? *shared_howdah : motion.howdah;

--- a/render/gl/humanoid/animation/animation_inputs.cpp
+++ b/render/gl/humanoid/animation/animation_inputs.cpp
@@ -60,27 +60,6 @@ void reset_humanoid_animation_state(
   return Render::Creature::MovementAnimationState::Idle;
 }
 
-[[nodiscard]] constexpr auto to_animation_combat_phase(
-    Engine::Core::CombatAnimationState phase) noexcept -> Animation::CombatPhase {
-  switch (phase) {
-  case Engine::Core::CombatAnimationState::Idle:
-    return Animation::CombatPhase::Idle;
-  case Engine::Core::CombatAnimationState::Advance:
-    return Animation::CombatPhase::Advance;
-  case Engine::Core::CombatAnimationState::WindUp:
-    return Animation::CombatPhase::WindUp;
-  case Engine::Core::CombatAnimationState::Strike:
-    return Animation::CombatPhase::Strike;
-  case Engine::Core::CombatAnimationState::Impact:
-    return Animation::CombatPhase::Impact;
-  case Engine::Core::CombatAnimationState::Recover:
-    return Animation::CombatPhase::Recover;
-  case Engine::Core::CombatAnimationState::Reposition:
-    return Animation::CombatPhase::Reposition;
-  }
-  return Animation::CombatPhase::Idle;
-}
-
 [[nodiscard]] auto synthesize_visual_movement_from_inputs(
     const DrawContext&, const AnimationInputs& anim) -> VisualMovementState {
   VisualMovementState state{};
@@ -212,6 +191,10 @@ void apply_presentation_sample(
   anim.is_in_melee_lock = presentation.is_in_melee_lock;
   anim.combat_phase = presentation.combat_phase;
   anim.combat_phase_progress = presentation.combat_phase_progress;
+  anim.melee_intent = presentation.melee_intent;
+  anim.melee_intent_valid = presentation.melee_intent_valid;
+  anim.melee_rest = {presentation.melee_rest_x, presentation.melee_rest_y};
+  anim.melee_rest_valid = presentation.melee_rest_valid;
   anim.attack_family = presentation.attack_family;
   anim.attack_variant = presentation.attack_variant;
   anim.finisher_attack = presentation.finisher_attack;
@@ -441,7 +424,7 @@ auto visual_movement_for_animation_inputs(
 auto approximate_attack_phase(const AnimationInputs& anim) noexcept -> float {
   return Animation::approximate_humanoid_attack_phase({
       .is_attacking = anim.is_attacking,
-      .combat_phase = to_animation_combat_phase(anim.combat_phase),
+      .combat_phase = anim.combat_phase,
       .combat_phase_progress = anim.combat_phase_progress,
       .finisher_attack = anim.finisher_attack,
       .sample_time = anim.time,

--- a/render/gl/humanoid/humanoid_types.h
+++ b/render/gl/humanoid/humanoid_types.h
@@ -8,6 +8,7 @@
 #include "animation/action_manifest.h"
 #include "animation/clip_manifest.h"
 #include "animation/guard_manifest.h"
+#include "animation/individuality_manifest.h"
 #include "animation/locomotion_manifest.h"
 #include "animation/playback_manifest.h"
 #include "animation/rig/side.h"
@@ -64,6 +65,11 @@ struct AnimationInputs {
   float hold_entry_progress;
   CombatAnimPhase combat_phase{CombatAnimPhase::Idle};
   float combat_phase_progress{0.0F};
+
+  Animation::MeleeIntent melee_intent{};
+  bool melee_intent_valid{false};
+  Animation::MeleeRestDirection melee_rest{};
+  bool melee_rest_valid{false};
   Engine::Core::CombatAttackFamily attack_family{
       Engine::Core::CombatAttackFamily::None};
   std::uint8_t attack_variant{0};
@@ -319,6 +325,8 @@ struct HumanoidAnimationContext {
   AnimationInputs inputs;
   VariationParams variation;
   FormationParams formation;
+
+  Animation::SoldierIndividuality individuality{};
   HumanoidGaitDescriptor gait{};
   float locomotion_cycle_time{0.0F};
   float locomotion_phase{0.0F};

--- a/render/horse/horse_motion.cpp
+++ b/render/horse/horse_motion.cpp
@@ -433,6 +433,11 @@ auto evaluate_horse_motion(const HorseProfile& profile,
   state.idle_bob_intensity = transition.idle_bob_intensity;
 
   HorseGait resolved = resolve_persistent_gait(state, profile);
+
+  auto const& individuality = rider_ctx.individuality;
+  resolved.phase_offset =
+      Quadruped::wrap_phase(resolved.phase_offset + individuality.gait_phase_offset);
+
   sample.is_moving =
       state.current_gait != GaitType::IDLE || state.target_gait != GaitType::IDLE;
   if (sample.is_moving) {
@@ -452,6 +457,9 @@ auto evaluate_horse_motion(const HorseProfile& profile,
     resolved.cycle_time = cadence.cycle_time;
     resolved.stride_swing = cadence.stride_swing;
   }
+
+  resolved.cycle_time /= std::clamp(individuality.cadence_scale, 0.80F, 1.25F);
+
   evaluate_phase_and_bob(state,
                          profile,
                          anim,

--- a/render/humanoid/pose_controller.cpp
+++ b/render/humanoid/pose_controller.cpp
@@ -3,10 +3,12 @@
 #include <QVector3D>
 
 #include <algorithm>
+#include <cmath>
 
 #include "animation/ambient_pose_manifest.h"
 #include "animation/attack_pose_manifest.h"
 #include "animation/hold_pose_manifest.h"
+#include "animation/melee_swing_manifest.h"
 #include "animation/posture_pose_manifest.h"
 #include "animation/showcase_pose_manifest.h"
 #include "grip_axis.h"
@@ -668,6 +670,10 @@ void HumanoidPoseController::combat_sword_slash_variant(float attack_phase,
                                 variant,
                                 reach_scale));
   apply_weapon_attack_sample(*this, m_pose, sample);
+  steer_melee_swing(attack_phase,
+                    Animation::melee_intent_for_attack_variant(variant),
+                    0.0F,
+                    baked_sword_direction());
 }
 
 void HumanoidPoseController::mount_on_horse(float saddle_height) {
@@ -801,6 +807,121 @@ void HumanoidPoseController::sword_slash_variant(float attack_phase,
                                 variant,
                                 reach_scale));
   apply_weapon_attack_sample(*this, m_pose, sample);
+  steer_melee_swing(attack_phase,
+                    Animation::melee_intent_for_attack_variant(variant),
+                    0.0F,
+                    baked_sword_direction());
+}
+
+namespace {
+
+[[nodiscard]] auto rotate_about_spine(const QVector3D& point,
+                                      const QVector3D& spine,
+                                      float angle) -> QVector3D {
+  float const dx = point.x() - spine.x();
+  float const dz = point.z() - spine.z();
+  float const cos_a = std::cos(angle);
+  float const sin_a = std::sin(angle);
+  return {spine.x() + (dx * cos_a) - (dz * sin_a),
+          point.y(),
+          spine.z() + (dx * sin_a) + (dz * cos_a)};
+}
+
+void apply_melee_body_solve(HumanoidPoseController& controller,
+                            HumanoidPose& pose,
+                            const Animation::MeleeBodySolveSample& solved,
+                            float weight,
+                            const QVector3D& baked_weapon_axis) {
+  QVector3D const spine(pose.pelvis_pos.x(), 0.0F, pose.pelvis_pos.z());
+  float const chest_twist = solved.spine_twist * weight;
+  float const hip_twist = solved.pelvis_twist * weight;
+
+  for (QVector3D* joint :
+       {&pose.shoulder_l, &pose.shoulder_r, &pose.neck_base, &pose.head_pos}) {
+    *joint = rotate_about_spine(*joint, spine, chest_twist);
+  }
+  for (QVector3D* joint : {&pose.knee_l, &pose.knee_r, &pose.foot_l, &pose.foot_r}) {
+    *joint = rotate_about_spine(*joint, spine, hip_twist);
+  }
+
+  QVector3D const chest_travel(
+      solved.lateral_lean * weight, 0.0F, solved.forward_lean * weight);
+  pose.shoulder_l += chest_travel;
+  pose.shoulder_r += chest_travel;
+  pose.neck_base += chest_travel * 0.85F;
+  pose.head_pos += chest_travel * 0.70F;
+  pose.pelvis_pos += chest_travel * 0.35F;
+
+  QVector3D const grip(solved.grip.x, solved.grip.y, solved.grip.z);
+  QVector3D const towards_grip = (grip - pose.shoulder_r).normalized();
+  pose.shoulder_r += towards_grip * (solved.shoulder_drive * weight);
+
+  pose.foot_r.setZ(pose.foot_r.z() - (solved.back_foot_brace * weight));
+  pose.knee_r.setZ(pose.knee_r.z() - (solved.back_foot_brace * weight * 0.6F));
+  pose.foot_l.setZ(pose.foot_l.z() + (solved.front_foot_advance * weight));
+  pose.knee_l.setZ(pose.knee_l.z() + (solved.front_foot_advance * weight * 0.6F));
+
+  auto reach_limited = [](const QVector3D& shoulder, const QVector3D& target) {
+    return Render::Humanoid::PosePrimitives::clamp_to_reach(
+        shoulder,
+        target,
+        Render::Humanoid::PosePrimitives::humanoid_arm_reach_limit(
+            1.0F, Render::Humanoid::PosePrimitives::k_committed_arm_reach_fraction));
+  };
+
+  QVector3D const offhand(solved.offhand.x, solved.offhand.y, solved.offhand.z);
+  controller.place_hand_at(
+      Side::Right,
+      reach_limited(pose.shoulder_r, pose.hand_r + ((grip - pose.hand_r) * weight)));
+  controller.place_hand_at(
+      Side::Left,
+      reach_limited(pose.shoulder_l, pose.hand_l + ((offhand - pose.hand_l) * weight)));
+
+  QVector3D const blade(
+      solved.blade_direction.x, solved.blade_direction.y, solved.blade_direction.z);
+  aim_held_weapon(pose, blade, baked_weapon_axis);
+}
+
+} // namespace
+
+void HumanoidPoseController::steer_melee_swing(float attack_phase,
+                                               const Animation::MeleeIntent& anchor,
+                                               float offhand_along_weapon,
+                                               const QVector3D& baked_weapon_axis) {
+
+  if (!m_anim_ctx.inputs.melee_intent_valid) {
+    return;
+  }
+
+  using HP = HumanProportions;
+  float const arm_reach = Render::Humanoid::PosePrimitives::humanoid_arm_reach_limit(
+      1.0F, Render::Humanoid::PosePrimitives::k_committed_arm_reach_fraction);
+
+  auto const live =
+      Animation::melee_intent_about_anchor(m_anim_ctx.inputs.melee_intent, anchor);
+
+  constexpr float k_full_authority_radians = 0.785F;
+  float const weight = std::clamp(Animation::melee_intent_strike_delta(anchor, live) /
+                                      k_full_authority_radians,
+                                  0.0F,
+                                  1.0F);
+  if (weight <= 0.001F) {
+    return;
+  }
+
+  auto const solved = Animation::resolve_melee_body_solve({
+      .swing =
+          {
+              .intent = live,
+              .phase = attack_phase,
+              .shoulder_y = HP::SHOULDER_Y,
+              .arm_reach = arm_reach,
+              .rest = m_anim_ctx.inputs.melee_rest,
+              .has_rest = m_anim_ctx.inputs.melee_rest_valid,
+          },
+      .offhand_along_weapon = offhand_along_weapon,
+  });
+  apply_melee_body_solve(*this, m_pose, solved, weight, baked_weapon_axis);
 }
 
 void HumanoidPoseController::spear_thrust_variant(float attack_phase,
@@ -815,6 +936,13 @@ void HumanoidPoseController::spear_thrust_variant(float attack_phase,
   aim_held_weapon(m_pose,
                   spear_qvec_from_pose(sample.offhand_spear_direction),
                   baked_spear_direction());
+
+  constexpr float k_spear_leading_hand_reach = 0.34F;
+  steer_melee_swing(
+      attack_phase,
+      Animation::melee_intent_from_strike_angle(Animation::k_melee_thrust_angle, 1.0F),
+      k_spear_leading_hand_reach,
+      baked_spear_direction());
 }
 
 void HumanoidPoseController::crouch(float depth) {

--- a/render/humanoid/pose_controller.h
+++ b/render/humanoid/pose_controller.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "animation/death_pose_manifest.h"
+#include "animation/melee_swing_manifest.h"
 #include "animation/reaction_pose_manifest.h"
 #include "animation/rig/humanoid_proportions.h"
 #include "animation/showcase_pose_manifest.h"
@@ -56,6 +57,11 @@ public:
                            std::uint8_t variant,
                            float reach_scale = 1.0F);
   void spear_thrust_variant(float attack_phase, std::uint8_t variant);
+
+  void steer_melee_swing(float attack_phase,
+                         const Animation::MeleeIntent& anchor,
+                         float offhand_along_weapon,
+                         const QVector3D& baked_weapon_axis);
   void mount_on_horse(float saddle_height);
   void hold_spear_idle();
   void channel_spell_idle();

--- a/render/humanoid/prepare.h
+++ b/render/humanoid/prepare.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <vector>
 
+#include "animation/individuality_manifest.h"
 #include "game/formation/unit_layout.h"
 #include "render/creature/pipeline/creature_render_graph.h"
 #include "render/creature/pipeline/creature_render_state.h"
@@ -33,7 +34,8 @@ struct SoldierLayout {
   float offset_z{0.0F};
   float vertical_jitter{0.0F};
   float yaw_offset{0.0F};
-  float phase_offset{0.0F};
+
+  Animation::SoldierIndividuality individuality{};
   std::uint8_t rank_band{0U};
   std::uint8_t row_index{0U};
   std::uint8_t col_index{0U};
@@ -70,7 +72,7 @@ struct HumanoidLocomotionInputs {
   QVector3D movement_target{0.0F, 0.0F, 0.0F};
   bool has_movement_target{false};
   float animation_time{0.0F};
-  float phase_offset{0.0F};
+  Animation::SoldierIndividuality individuality{};
   Render::Creature::HumanoidAnimationStateComponent* persistent_state{nullptr};
   bool allow_persistent_update{false};
 };

--- a/render/humanoid/prepare_animation.cpp
+++ b/render/humanoid/prepare_animation.cpp
@@ -60,7 +60,7 @@ void sync_combat_visual_inputs(
 
   auto const scrubbed = Animation::scrubbed_combat_phase_from_attack_phase(
       visual.attack_phase, visual.amplified_attack, visual.finisher_attack);
-  inputs.combat_phase = Render::Creature::engine_combat_phase(scrubbed.phase);
+  inputs.combat_phase = scrubbed.phase;
   inputs.combat_phase_progress = scrubbed.progress;
 }
 
@@ -74,8 +74,7 @@ void apply_combat_micro_variation(const HumanoidAnimationContext& anim_ctx,
       .is_dying = anim_ctx.inputs.is_dying,
       .is_dead = anim_ctx.inputs.is_dead,
       .lane = anim_ctx.inputs.combat_visual.lane,
-      .combat_phase =
-          Render::Creature::animation_combat_phase(anim_ctx.inputs.combat_phase),
+      .combat_phase = anim_ctx.inputs.combat_phase,
       .is_attacking = anim_ctx.inputs.is_attacking,
       .attack_phase = anim_ctx.attack_phase,
       .sample_time = anim_ctx.inputs.time,
@@ -152,7 +151,7 @@ auto build_soldier_layout(const SoldierLayoutInputs& inputs) -> SoldierLayout {
   layout.rank_band = policy.rank_band;
   layout.inst_seed = policy.inst_seed;
   layout.vertical_jitter = policy.vertical_jitter;
-  layout.phase_offset = policy.phase_offset;
+  layout.individuality = policy.individuality;
 
   if (!inputs.force_single_soldier) {
     Game::Formation::UnitLayoutQuery query;
@@ -259,7 +258,8 @@ auto build_humanoid_locomotion_state(const HumanoidLocomotionInputs& inputs)
       .locomotion_direction_x = inputs.locomotion_direction.x(),
       .locomotion_direction_z = inputs.locomotion_direction.z(),
       .sample_time = inputs.animation_time,
-      .phase_offset = inputs.phase_offset,
+      .phase_offset = inputs.individuality.gait_phase_offset,
+      .cadence_scale = inputs.individuality.cadence_scale,
       .tuning = humanoid_locomotion_tuning(inputs.variation),
       .has_persistent_state = inputs.persistent_state != nullptr,
       .previous = persistent,

--- a/render/humanoid/prepare_submission.cpp
+++ b/render/humanoid/prepare_submission.cpp
@@ -656,7 +656,7 @@ void prepare_humanoid_instances(const HumanoidRendererBase& owner,
     float const offset_x = layout.offset_x;
     float const offset_z = layout.offset_z;
     uint32_t const inst_seed = layout.inst_seed;
-    float const phase_offset = layout.phase_offset;
+    auto const& individuality = layout.individuality;
     float const applied_yaw_offset = layout.yaw_offset + casualty_yaw;
 
     SoldierTurnSmoothingResult turn_smoothing{};
@@ -958,11 +958,15 @@ void prepare_humanoid_instances(const HumanoidRendererBase& owner,
       soldier_render_anim.is_hit_reacting = false;
     }
     Render::Creature::CombatVisualRawInputs raw_combat{};
+
     raw_combat.sample_time =
         soldier_render_anim.time *
-        (soldier_directive != nullptr ? soldier_directive->combat_speed_scale : 1.0F);
-    raw_combat.attack_offset = soldier_render_anim.attack_offset;
-    raw_combat.has_attack_offset = soldier_render_anim.has_attack_offset;
+        (soldier_directive != nullptr ? soldier_directive->combat_speed_scale : 1.0F) *
+        individuality.swing_tempo_scale;
+
+    raw_combat.attack_offset =
+        soldier_render_anim.attack_offset + individuality.swing_phase_offset;
+    raw_combat.has_attack_offset = true;
 
     bool visual_attack_requested =
         soldier_render_anim.is_attacking || soldier_in_formation_fight;
@@ -1028,6 +1032,9 @@ void prepare_humanoid_instances(const HumanoidRendererBase& owner,
       locomotion_persistent_state->combat_visual = combat_resolution.persistent;
     }
     sync_combat_visual_inputs(soldier_render_anim, combat_resolution.resolved);
+
+    soldier_render_anim.melee_intent = Animation::melee_intent_rotated(
+        soldier_render_anim.melee_intent, individuality.swing_plane_offset);
     bool const render_has_locomotion =
         Render::Creature::is_moving_animation(soldier_render_anim.movement_state);
 
@@ -1040,7 +1047,7 @@ void prepare_humanoid_instances(const HumanoidRendererBase& owner,
     locomotion_inputs.movement_target = visual_locomotion.movement_target;
     locomotion_inputs.has_movement_target = visual_locomotion.has_movement_target;
     locomotion_inputs.animation_time = anim.time;
-    locomotion_inputs.phase_offset = phase_offset;
+    locomotion_inputs.individuality = individuality;
     locomotion_inputs.persistent_state = locomotion_persistent_state;
     locomotion_inputs.allow_persistent_update = allow_animation_persistence;
     if (soldier_turn_smoothed && turn_smoothing.relocating) {
@@ -1089,7 +1096,8 @@ void prepare_humanoid_instances(const HumanoidRendererBase& owner,
     anim_ctx.inputs.is_mounted = is_mounted_spawn;
     anim_ctx.variation = variation;
     anim_ctx.formation = formation;
-    anim_ctx.jitter_seed = phase_offset;
+    anim_ctx.individuality = individuality;
+    anim_ctx.jitter_seed = individuality.idle_phase_offset;
 
     anim_ctx.entity_forward = forward;
     anim_ctx.entity_right = right;

--- a/render/profiling/combat_animation_diagnostics.cpp
+++ b/render/profiling/combat_animation_diagnostics.cpp
@@ -50,9 +50,7 @@ auto attack_phase_window(Render::GL::CombatAnimPhase phase,
                          bool amplified_attack,
                          bool finisher_attack) noexcept -> CombatPhaseWindow {
   auto const window =
-      Animation::attack_phase_window(Render::Creature::animation_combat_phase(phase),
-                                     amplified_attack,
-                                     finisher_attack);
+      Animation::attack_phase_window(phase, amplified_attack, finisher_attack);
   return {window.start, window.end, window.offset_weight};
 }
 
@@ -62,7 +60,7 @@ auto scrubbed_combat_phase_from_attack_phase(float attack_phase,
     -> ScrubbedCombatPhase {
   auto const scrubbed = Animation::scrubbed_combat_phase_from_attack_phase(
       attack_phase, amplified_attack, finisher_attack);
-  return {Render::Creature::engine_combat_phase(scrubbed.phase), scrubbed.progress};
+  return {scrubbed.phase, scrubbed.progress};
 }
 
 auto combat_phase_name(Render::GL::CombatAnimPhase phase) noexcept -> const char* {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,6 +183,7 @@ add_executable(
     systems/commander_duel_test.cpp
     systems/melee_engagement_test.cpp
     systems/melee_exchange_test.cpp
+    systems/melee_intent_test.cpp
     systems/archer_bonus_test.cpp
     systems/arrow_system_test.cpp
     systems/spent_projectile_test.cpp

--- a/tests/core/commander_control_controller_test.cpp
+++ b/tests/core/commander_control_controller_test.cpp
@@ -475,7 +475,8 @@ TEST_F(CommanderControlControllerTest,
   EXPECT_EQ(targets, nullptr);
 }
 
-TEST_F(CommanderControlControllerTest, PrimaryActionAlternatesSwordSwaysAcrossClicks) {
+TEST_F(CommanderControlControllerTest,
+       PrimaryActionGrowsTheNextSwingOutOfWhereTheLastOneFinished) {
   Engine::Core::World world;
   auto* commander = create_commander(world, 0.0F, 0.0F);
   ASSERT_NE(commander, nullptr);
@@ -491,6 +492,7 @@ TEST_F(CommanderControlControllerTest, PrimaryActionAlternatesSwordSwaysAcrossCl
   attack->current_mode = Engine::Core::AttackComponent::CombatMode::Melee;
 
   CommanderControlController controller;
+  Render::GL::Camera camera;
   ASSERT_TRUE(controller.primary_action(world, commander->get_id(), 1));
 
   auto* combat_state = commander->get_component<Engine::Core::CombatStateComponent>();
@@ -505,15 +507,23 @@ TEST_F(CommanderControlControllerTest, PrimaryActionAlternatesSwordSwaysAcrossCl
                 Game::Systems::CombatActions::CombatActionId::RpgSwordSlashLeft));
   EXPECT_EQ(action->melee_attack_sequence, 1U);
 
+  auto const first_swing = combat_state->intent;
+  EXPECT_LT(first_swing.strike_dir_x, 0.0F);
+  EXPECT_LT(first_swing.strike_dir_y, 0.0F);
+
+  ASSERT_TRUE(controller.update(world, commander->get_id(), 1, camera, 0.016F));
   combat_state->animation_state = Engine::Core::CombatAnimationState::Idle;
   combat_state->state_time = 0.0F;
   combat_state->state_duration = 0.0F;
   action->action_running = false;
   action->action_completed = true;
+  ASSERT_TRUE(controller.update(world, commander->get_id(), 1, camera, 0.016F));
 
   ASSERT_TRUE(controller.primary_action(world, commander->get_id(), 1));
 
   EXPECT_EQ(combat_state->attack_variant, 0U);
+  EXPECT_GT(combat_state->intent.strike_dir_x, 0.0F);
+  EXPECT_GT(combat_state->intent.strike_dir_y, 0.0F);
   EXPECT_EQ(action->combat_action_id,
             static_cast<std::uint8_t>(
                 Game::Systems::CombatActions::CombatActionId::RpgSwordSlashRight));
@@ -650,7 +660,7 @@ TEST_F(CommanderControlControllerTest, PrimaryActionUsesSpearActionForSpearComma
   ASSERT_NE(action, nullptr);
 
   EXPECT_EQ(combat_state->attack_family, Engine::Core::CombatAttackFamily::Spear);
-  EXPECT_EQ(combat_state->attack_direction, Engine::Core::AttackDirection::Thrust);
+  EXPECT_EQ(combat_state->attack_direction(), Engine::Core::AttackDirection::Thrust);
   EXPECT_EQ(action->combat_action_id,
             static_cast<std::uint8_t>(
                 Game::Systems::CombatActions::CombatActionId::RpgSpearThrust));
@@ -685,7 +695,8 @@ TEST_F(CommanderControlControllerTest,
   ASSERT_NE(action, nullptr);
 
   EXPECT_EQ(combat_state->attack_family, Engine::Core::CombatAttackFamily::Sword);
-  EXPECT_EQ(combat_state->attack_direction, Engine::Core::AttackDirection::RightSlash);
+
+  EXPECT_EQ(combat_state->attack_direction(), Engine::Core::AttackDirection::LeftSlash);
   EXPECT_EQ(action->combat_action_id,
             static_cast<std::uint8_t>(
                 Game::Systems::CombatActions::CombatActionId::MountedSwordSlash));
@@ -720,7 +731,7 @@ TEST_F(CommanderControlControllerTest,
   ASSERT_NE(action, nullptr);
 
   EXPECT_EQ(combat_state->attack_family, Engine::Core::CombatAttackFamily::Spear);
-  EXPECT_EQ(combat_state->attack_direction, Engine::Core::AttackDirection::Thrust);
+  EXPECT_EQ(combat_state->attack_direction(), Engine::Core::AttackDirection::Thrust);
   EXPECT_EQ(action->combat_action_id,
             static_cast<std::uint8_t>(
                 Game::Systems::CombatActions::CombatActionId::MountedSpearThrust));

--- a/tests/render/creature/humanoid_prepare_test.cpp
+++ b/tests/render/creature/humanoid_prepare_test.cpp
@@ -4664,14 +4664,46 @@ TEST(AnimationCoreIntentManifest, LifecycleActionsOverrideCombatIntent) {
   EXPECT_EQ(hit.semantic.action, Animation::ActionIntent::HitReaction);
 }
 
-TEST(AnimationCoreLayoutManifest, StructuredPhaseOffsetIsDeterministicAndBounded) {
-  auto const first = Animation::structured_layout_phase_offset(1, 2, 3, 4, 0x12345678U);
-  auto const second =
-      Animation::structured_layout_phase_offset(1, 2, 3, 4, 0x12345678U);
+TEST(AnimationCoreIndividuality, GaitOffsetIsDeterministicAndBounded) {
+  Animation::SoldierIndividualityInputs const inputs{
+      .soldier_seed = 0x12345678U, .row = 1, .col = 2, .rows = 3, .cols = 4};
+  auto const first = Animation::resolve_soldier_individuality(inputs);
+  auto const second = Animation::resolve_soldier_individuality(inputs);
 
-  EXPECT_FLOAT_EQ(first, second);
-  EXPECT_GE(first, 0.0F);
-  EXPECT_LE(first, 0.25F);
+  EXPECT_FLOAT_EQ(first.gait_phase_offset, second.gait_phase_offset);
+  EXPECT_GE(first.gait_phase_offset, 0.0F);
+  EXPECT_LE(first.gait_phase_offset, 0.25F);
+}
+
+TEST(AnimationCoreIndividuality, ALoneFigureIsNotDesynchronizedFromAnything) {
+  auto const alone = Animation::resolve_soldier_individuality({
+      .soldier_seed = 0x12345678U,
+      .single_soldier = true,
+  });
+
+  EXPECT_FLOAT_EQ(alone.gait_phase_offset, 0.0F);
+  EXPECT_FLOAT_EQ(alone.cadence_scale, 1.0F);
+  EXPECT_FLOAT_EQ(alone.swing_phase_offset, 0.0F);
+  EXPECT_FLOAT_EQ(alone.swing_tempo_scale, 1.0F);
+  EXPECT_FLOAT_EQ(alone.swing_plane_offset, 0.0F);
+}
+
+TEST(AnimationCoreIndividuality, NeighboursGetGenuinelyDifferentStrideAndSwing) {
+
+  auto const left = Animation::resolve_soldier_individuality(
+      {.soldier_seed = 0x11111111U, .row = 0, .col = 0, .rows = 2, .cols = 4});
+  auto const right = Animation::resolve_soldier_individuality(
+      {.soldier_seed = 0x22222222U, .row = 0, .col = 1, .rows = 2, .cols = 4});
+
+  EXPECT_NE(left.gait_phase_offset, right.gait_phase_offset);
+  EXPECT_NE(left.cadence_scale, right.cadence_scale);
+  EXPECT_NE(left.swing_phase_offset, right.swing_phase_offset);
+  EXPECT_NE(left.swing_plane_offset, right.swing_plane_offset);
+
+  EXPECT_LT(std::abs(left.cadence_scale - right.cadence_scale),
+            2.0F * Animation::k_individuality_cadence_spread);
+  EXPECT_LT(std::abs(left.swing_plane_offset - right.swing_plane_offset),
+            2.0F * Animation::k_individuality_swing_spread);
 }
 
 TEST(AnimationCoreLayoutManifest, SingleSoldierPolicyHasNoJitter) {
@@ -4696,7 +4728,7 @@ TEST(AnimationCoreLayoutManifest, SingleSoldierPolicyHasNoJitter) {
   EXPECT_FLOAT_EQ(policy.offset_z_delta, 0.0F);
   EXPECT_FLOAT_EQ(policy.vertical_jitter, 0.0F);
   EXPECT_FLOAT_EQ(policy.yaw_delta, 0.0F);
-  EXPECT_FLOAT_EQ(policy.phase_offset, 0.0F);
+  EXPECT_FLOAT_EQ(policy.individuality.gait_phase_offset, 0.0F);
 }
 
 TEST(AnimationCoreLayoutManifest, MultiSoldierPolicyOwnsRankSeedAndJitter) {
@@ -4719,8 +4751,8 @@ TEST(AnimationCoreLayoutManifest, MultiSoldierPolicyOwnsRankSeedAndJitter) {
   EXPECT_EQ(policy.inst_seed, 0x12345678U ^ std::uint32_t(3 * 9176U));
   EXPECT_NE(policy.vertical_jitter, 0.0F);
   EXPECT_NE(policy.yaw_delta, 0.0F);
-  EXPECT_GE(policy.phase_offset, 0.0F);
-  EXPECT_LE(policy.phase_offset, 0.25F);
+  EXPECT_GE(policy.individuality.gait_phase_offset, 0.0F);
+  EXPECT_LE(policy.individuality.gait_phase_offset, 0.25F);
 }
 
 TEST(AnimationCoreLayoutManifest, MeleeAttackKeepsFormationRootStable) {
@@ -4740,7 +4772,8 @@ TEST(AnimationCoreLayoutManifest, MeleeAttackKeepsFormationRootStable) {
   auto const melee = Animation::resolve_soldier_layout_policy(inputs);
 
   EXPECT_FLOAT_EQ(idle.vertical_jitter, melee.vertical_jitter);
-  EXPECT_FLOAT_EQ(idle.phase_offset, melee.phase_offset);
+  EXPECT_FLOAT_EQ(idle.individuality.gait_phase_offset,
+                  melee.individuality.gait_phase_offset);
   EXPECT_FLOAT_EQ(idle.offset_x_delta, melee.offset_x_delta);
   EXPECT_FLOAT_EQ(idle.offset_z_delta, melee.offset_z_delta);
   EXPECT_FLOAT_EQ(idle.yaw_delta, melee.yaw_delta);
@@ -9149,7 +9182,8 @@ TEST(HumanoidPrepare, BuildSoldierLayoutIsDeterministic) {
   EXPECT_FLOAT_EQ(first.offset_z, second.offset_z);
   EXPECT_FLOAT_EQ(first.vertical_jitter, second.vertical_jitter);
   EXPECT_FLOAT_EQ(first.yaw_offset, second.yaw_offset);
-  EXPECT_FLOAT_EQ(first.phase_offset, second.phase_offset);
+  EXPECT_FLOAT_EQ(first.individuality.gait_phase_offset,
+                  second.individuality.gait_phase_offset);
   EXPECT_EQ(first.inst_seed, second.inst_seed);
 }
 
@@ -9174,7 +9208,7 @@ TEST(HumanoidPrepare, BuildSoldierLayoutLeavesSingleSoldierUnjittered) {
   EXPECT_FLOAT_EQ(layout.offset_z, 0.0F);
   EXPECT_FLOAT_EQ(layout.vertical_jitter, 0.0F);
   EXPECT_FLOAT_EQ(layout.yaw_offset, 0.0F);
-  EXPECT_FLOAT_EQ(layout.phase_offset, 0.0F);
+  EXPECT_FLOAT_EQ(layout.individuality.gait_phase_offset, 0.0F);
   EXPECT_EQ(layout.inst_seed, inputs.seed);
 }
 
@@ -9219,7 +9253,7 @@ TEST(HumanoidPrepare, BuildLocomotionStateIsDeterministicForRun) {
   inputs.movement_target = QVector3D(3.0F, 0.0F, 8.0F);
   inputs.has_movement_target = true;
   inputs.animation_time = 1.5F;
-  inputs.phase_offset = 0.125F;
+  inputs.individuality.gait_phase_offset = 0.125F;
 
   auto const first = Render::Humanoid::build_humanoid_locomotion_state(inputs);
   auto const second = Render::Humanoid::build_humanoid_locomotion_state(inputs);
@@ -9242,7 +9276,7 @@ TEST(HumanoidPrepare, BuildLocomotionStateUsesAuthoritativeMovementState) {
   inputs.entity_forward = QVector3D(0.0F, 0.0F, 1.0F);
   inputs.locomotion_direction = QVector3D(0.0F, 0.0F, 1.0F);
   inputs.animation_time = 1.0F;
-  inputs.phase_offset = 0.0F;
+  inputs.individuality.gait_phase_offset = 0.0F;
 
   inputs.move_speed = 2.30F;
   auto const walking = Render::Humanoid::build_humanoid_locomotion_state(inputs);
@@ -9265,7 +9299,7 @@ TEST(HumanoidPrepare, BuildLocomotionStateWalkCadenceTightensAsSpeedRises) {
   inputs.entity_forward = QVector3D(0.0F, 0.0F, 1.0F);
   inputs.locomotion_direction = QVector3D(0.0F, 0.0F, 1.0F);
   inputs.animation_time = 1.0F;
-  inputs.phase_offset = 0.0F;
+  inputs.individuality.gait_phase_offset = 0.0F;
 
   inputs.move_speed = 1.25F;
   auto const slow_walk = Render::Humanoid::build_humanoid_locomotion_state(inputs);
@@ -9282,7 +9316,7 @@ TEST(HumanoidPrepare, BuildLocomotionStateAnimatesIdlePhaseOverTime) {
   inputs.anim.movement_state = Render::Creature::MovementAnimationState::Idle;
   inputs.variation.walk_speed_mult = 1.0F;
   inputs.animation_time = 0.10F;
-  inputs.phase_offset = 0.125F;
+  inputs.individuality.gait_phase_offset = 0.125F;
 
   auto const first = Render::Humanoid::build_humanoid_locomotion_state(inputs);
 
@@ -9312,7 +9346,7 @@ TEST(HumanoidPrepare, BuildLocomotionStateKeepsAdvancingPhaseDuringCadenceChange
   inputs.variation.walk_speed_mult = 1.0F;
   inputs.entity_forward = QVector3D(0.0F, 0.0F, 1.0F);
   inputs.locomotion_direction = QVector3D(0.0F, 0.0F, 1.0F);
-  inputs.phase_offset = 0.125F;
+  inputs.individuality.gait_phase_offset = 0.125F;
   inputs.persistent_state = &persistent;
   inputs.allow_persistent_update = true;
   inputs.animation_time = 1.00F;
@@ -9340,7 +9374,7 @@ TEST(HumanoidPrepare, BuildLocomotionStatePreservesPhaseAcrossWalkRunTransition)
   inputs.variation.walk_speed_mult = 1.0F;
   inputs.entity_forward = QVector3D(0.0F, 0.0F, 1.0F);
   inputs.locomotion_direction = QVector3D(0.0F, 0.0F, 1.0F);
-  inputs.phase_offset = 0.125F;
+  inputs.individuality.gait_phase_offset = 0.125F;
   inputs.persistent_state = &persistent;
   inputs.allow_persistent_update = true;
 
@@ -9367,7 +9401,7 @@ TEST(HumanoidPrepare, BuildLocomotionStateSkipsPersistentWritesWhenUpdatesDisabl
   inputs.variation.walk_speed_mult = 1.0F;
   inputs.entity_forward = QVector3D(0.0F, 0.0F, 1.0F);
   inputs.locomotion_direction = QVector3D(0.0F, 0.0F, 1.0F);
-  inputs.phase_offset = 0.125F;
+  inputs.individuality.gait_phase_offset = 0.125F;
   inputs.persistent_state = &persistent;
   inputs.allow_persistent_update = true;
   inputs.anim.movement_state = Render::Creature::MovementAnimationState::Walk;
@@ -9657,7 +9691,7 @@ TEST(HumanoidPrepare, WalkRunTransitionKeepsPlaybackGroundingCoherent) {
   inputs.variation = Render::GL::VariationParams::from_seed(2222U);
   inputs.entity_forward = QVector3D(0.0F, 0.0F, 1.0F);
   inputs.locomotion_direction = QVector3D(0.0F, 0.0F, 1.0F);
-  inputs.phase_offset = 0.125F;
+  inputs.individuality.gait_phase_offset = 0.125F;
   inputs.persistent_state = &persistent;
   inputs.allow_persistent_update = true;
   inputs.anim.movement_state = Render::Creature::MovementAnimationState::Walk;

--- a/tests/systems/melee_intent_test.cpp
+++ b/tests/systems/melee_intent_test.cpp
@@ -1,0 +1,261 @@
+#include <cmath>
+#include <gtest/gtest.h>
+#include <numbers>
+
+#include "animation/melee_swing_manifest.h"
+#include "game/core/component.h"
+#include "game/systems/combat_actions/melee_intent_solver.h"
+
+namespace {
+
+using Engine::Core::AttackDirection;
+using Engine::Core::classify_attack_direction;
+using Engine::Core::melee_intent_from_attack_direction;
+using Engine::Core::MeleeIntent;
+using Game::Systems::CombatActions::MeleeIntentInputs;
+using Game::Systems::CombatActions::resolve_melee_intent;
+using Game::Systems::CombatActions::select_melee_action;
+using Game::Systems::CombatActions::steer_melee_intent;
+
+constexpr float k_full_sweep = 1.0F;
+
+TEST(MeleeIntentTest, ClassificationRoundTripsTheCanonicalSwings) {
+  for (auto direction : {AttackDirection::LeftSlash,
+                         AttackDirection::RightSlash,
+                         AttackDirection::Overhead,
+                         AttackDirection::Thrust}) {
+    EXPECT_EQ(classify_attack_direction(melee_intent_from_attack_direction(direction)),
+              direction);
+  }
+
+  auto const heavy = melee_intent_from_attack_direction(AttackDirection::HeavyOverhead);
+  EXPECT_EQ(classify_attack_direction(heavy), AttackDirection::HeavyOverhead);
+}
+
+TEST(MeleeIntentTest, TheSwingFollowsTheLineThePlayerDraws) {
+  auto const drag = [](float x, float y) {
+    return resolve_melee_intent({.aim_delta_x = x, .aim_delta_y = y});
+  };
+
+  EXPECT_EQ(classify_attack_direction(drag(-0.7F * k_full_sweep, -0.7F * k_full_sweep)),
+            AttackDirection::LeftSlash);
+  EXPECT_EQ(classify_attack_direction(drag(0.7F * k_full_sweep, -0.7F * k_full_sweep)),
+            AttackDirection::RightSlash);
+  EXPECT_EQ(classify_attack_direction(drag(0.0F, -k_full_sweep)),
+            AttackDirection::Overhead);
+}
+
+TEST(MeleeIntentTest, SwingsAreContinuousNotSnappedToFiveDirections) {
+
+  auto const shallow =
+      resolve_melee_intent({.aim_delta_x = -0.90F, .aim_delta_y = -0.20F});
+  auto const steeper =
+      resolve_melee_intent({.aim_delta_x = -0.80F, .aim_delta_y = -0.45F});
+
+  EXPECT_EQ(classify_attack_direction(shallow), classify_attack_direction(steeper));
+  EXPECT_GT(Engine::Core::melee_intent_strike_delta(shallow, steeper), 0.05F);
+  EXPECT_NE(shallow.weapon_target_y, steeper.weapon_target_y);
+}
+
+TEST(MeleeIntentTest, AFlickAsksForAFasterSwingThanADrag) {
+  auto const drag =
+      resolve_melee_intent({.aim_delta_x = -k_full_sweep, .aim_rate = 0.4F});
+  auto const flick =
+      resolve_melee_intent({.aim_delta_x = -k_full_sweep, .aim_rate = 2.0F});
+  EXPECT_GT(flick.swing_speed, drag.swing_speed);
+}
+
+TEST(MeleeIntentTest, HoldingTheStrikeChargesItAndCarriesItFurther) {
+  auto const quick = resolve_melee_intent({.held_duration = 0.0F});
+  auto const held = resolve_melee_intent({.held_duration = 0.6F});
+  EXPECT_LT(quick.charge, held.charge);
+  EXPECT_LT(quick.follow_through, held.follow_through);
+}
+
+TEST(MeleeIntentTest, AForwardStepThrustsAndASweepOverridesIt) {
+  auto const stepping = resolve_melee_intent({.move_forward_axis = 1});
+  EXPECT_EQ(classify_attack_direction(stepping), AttackDirection::Thrust);
+
+  auto const cutting = resolve_melee_intent(
+      {.aim_delta_x = -k_full_sweep, .aim_delta_y = -0.4F, .move_forward_axis = 1});
+  EXPECT_NE(classify_attack_direction(cutting), AttackDirection::Thrust);
+}
+
+TEST(MeleeIntentTest, TheNextSwingGrowsOutOfWhereTheLastOneFinished) {
+  auto const first = resolve_melee_intent({});
+  auto const rest = Engine::Core::melee_intent_resting_direction(first);
+
+  auto const second = resolve_melee_intent(
+      {.has_rest = true, .rest_dir_x = rest.x, .rest_dir_y = rest.y});
+
+  EXPECT_LT(first.strike_dir_y, 0.0F);
+  EXPECT_GT(second.strike_dir_y, 0.0F);
+  EXPECT_GT(Engine::Core::melee_intent_strike_delta(first, second), 1.0F);
+}
+
+TEST(MeleeIntentTest, SteeringIsRateLimitedSoAFlickBendsTheBladeNotTeleportsIt) {
+  auto const current = melee_intent_from_attack_direction(AttackDirection::LeftSlash);
+  auto const desired = melee_intent_from_attack_direction(AttackDirection::RightSlash);
+
+  constexpr float k_small_step = 0.10F;
+  auto const stepped = steer_melee_intent(current, desired, 1.0F, k_small_step);
+  float const moved = Engine::Core::melee_intent_strike_delta(current, stepped);
+  EXPECT_GT(moved, 0.0F);
+  EXPECT_LE(moved, k_small_step + 1.0e-3F);
+
+  auto const locked = steer_melee_intent(current, desired, 0.0F, 1.0F);
+  EXPECT_NEAR(Engine::Core::melee_intent_strike_delta(current, locked), 0.0F, 1.0e-4F);
+}
+
+TEST(MeleeIntentTest, ActionSelectionFollowsTheSwingRatherThanACounter) {
+  using Game::Systems::CombatActions::CombatActionId;
+  auto const left = resolve_melee_intent({.aim_delta_x = -0.7F, .aim_delta_y = -0.7F});
+  auto const right = resolve_melee_intent({.aim_delta_x = 0.7F, .aim_delta_y = -0.7F});
+
+  EXPECT_EQ(
+      select_melee_action(left, Engine::Core::CombatAttackFamily::Sword, false, false),
+      CombatActionId::RpgSwordSlashLeft);
+  EXPECT_EQ(
+      select_melee_action(right, Engine::Core::CombatAttackFamily::Sword, false, false),
+      CombatActionId::RpgSwordSlashRight);
+
+  EXPECT_EQ(
+      select_melee_action(left, Engine::Core::CombatAttackFamily::Sword, false, false),
+      select_melee_action(left, Engine::Core::CombatAttackFamily::Sword, false, false));
+}
+
+TEST(MeleeIntentTest, OneSwingCarriedOntoDifferentAnchorsKeepsItsDeviation) {
+
+  auto const shared =
+      resolve_melee_intent({.aim_delta_x = -0.55F, .aim_delta_y = -0.83F});
+  auto const own = Animation::melee_intent_for_attack_variant(
+      Animation::nearest_attack_variant(shared));
+  float const deviation = Engine::Core::melee_intent_strike_delta(own, shared);
+  EXPECT_GT(deviation, 0.02F);
+
+  for (std::uint8_t variant = 0U; variant < 3U; ++variant) {
+    auto const anchor = Animation::melee_intent_for_attack_variant(variant);
+    auto const carried = Animation::melee_intent_about_anchor(shared, anchor);
+    EXPECT_NEAR(
+        Engine::Core::melee_intent_strike_delta(anchor, carried), deviation, 1.0e-3F);
+    EXPECT_FLOAT_EQ(carried.charge, shared.charge);
+    EXPECT_FLOAT_EQ(carried.swing_speed, shared.swing_speed);
+  }
+
+  auto const left = Animation::melee_intent_about_anchor(
+      shared, Animation::melee_intent_for_attack_variant(0U));
+  auto const right = Animation::melee_intent_about_anchor(
+      shared, Animation::melee_intent_for_attack_variant(1U));
+  EXPECT_GT(Engine::Core::melee_intent_strike_delta(left, right), 1.0F);
+}
+
+TEST(MeleeSwingTest, TheArcPassesThroughTheWeaponObjectiveAndKeepsMoving) {
+  Animation::MeleeSwingInputs inputs{};
+  inputs.intent = melee_intent_from_attack_direction(AttackDirection::LeftSlash);
+  inputs.phase = Animation::k_melee_contact_time;
+
+  auto const contact = Animation::resolve_melee_swing(inputs);
+  EXPECT_NEAR(contact.grip.x, inputs.intent.weapon_target_x, 1.0e-3F);
+  EXPECT_NEAR(contact.grip.z, inputs.intent.weapon_target_z, 1.0e-3F);
+  EXPECT_NEAR(
+      contact.grip.y, inputs.shoulder_y + inputs.intent.weapon_target_y, 1.0e-3F);
+
+  EXPECT_GT(contact.speed, 0.0F);
+  EXPECT_NEAR(contact.commitment, 1.0F, 1.0e-3F);
+}
+
+TEST(MeleeSwingTest, TheChamberIsBehindTheFrontalPlaneAndTheStrikeIsInFrontOfIt) {
+  Animation::MeleeSwingInputs inputs{};
+  inputs.intent = melee_intent_from_attack_direction(AttackDirection::LeftSlash);
+
+  inputs.phase = Animation::k_melee_chamber_time;
+  auto const chamber = Animation::resolve_melee_swing(inputs);
+  inputs.phase = Animation::k_melee_contact_time;
+  auto const contact = Animation::resolve_melee_swing(inputs);
+
+  EXPECT_LT(chamber.grip.z, 0.0F);
+  EXPECT_GT(contact.grip.z, chamber.grip.z);
+
+  EXPECT_GT(chamber.grip.x, contact.grip.x);
+}
+
+TEST(MeleeSwingTest, AFasterSwingCoversTheSameArcMoreQuickly) {
+  Animation::MeleeSwingInputs inputs{};
+  inputs.intent = melee_intent_from_attack_direction(AttackDirection::LeftSlash);
+  inputs.phase = 0.5F;
+
+  auto const nominal = Animation::resolve_melee_swing(inputs);
+  inputs.intent.swing_speed = 2.0F;
+  auto const quick = Animation::resolve_melee_swing(inputs);
+
+  EXPECT_NEAR(nominal.grip.x, quick.grip.x, 1.0e-4F);
+  EXPECT_GT(quick.speed, nominal.speed * 1.5F);
+}
+
+TEST(MeleeBodySolveTest, TheTorsoWindsUpAgainstTheChamberAndUnwindsThroughContact) {
+  Animation::MeleeBodySolveInputs inputs{};
+  inputs.swing.intent = melee_intent_from_attack_direction(AttackDirection::LeftSlash);
+
+  inputs.swing.phase = Animation::k_melee_chamber_time;
+  auto const loaded = Animation::resolve_melee_body_solve(inputs);
+  inputs.swing.phase = Animation::k_melee_contact_time;
+  auto const landed = Animation::resolve_melee_body_solve(inputs);
+
+  EXPECT_LT(loaded.spine_twist, 0.0F);
+  EXPECT_GT(landed.spine_twist, 0.0F);
+
+  EXPECT_LT(loaded.pelvis_twist * loaded.spine_twist, 0.0F);
+  EXPECT_GT(landed.pelvis_twist * landed.spine_twist, 0.0F);
+}
+
+TEST(MeleeBodySolveTest, WeightTravelsFromTheBackFootToTheFrontOne) {
+  Animation::MeleeBodySolveInputs inputs{};
+  inputs.swing.intent = melee_intent_from_attack_direction(AttackDirection::Overhead);
+
+  inputs.swing.phase = Animation::k_melee_chamber_time;
+  auto const loading = Animation::resolve_melee_body_solve(inputs);
+  inputs.swing.phase = Animation::k_melee_contact_time;
+  auto const landing = Animation::resolve_melee_body_solve(inputs);
+
+  EXPECT_LT(loading.weight_shift, 0.0F);
+  EXPECT_GT(landing.weight_shift, 0.0F);
+  EXPECT_GT(loading.back_foot_brace, 0.0F);
+  EXPECT_GT(landing.front_foot_advance, 0.0F);
+  EXPECT_LT(loading.forward_lean, landing.forward_lean);
+}
+
+TEST(MeleeBodySolveTest, ATwoHandedGripPinsTheOffHandToTheWeapon) {
+  Animation::MeleeBodySolveInputs inputs{};
+  inputs.swing.intent = melee_intent_from_attack_direction(AttackDirection::Thrust);
+  inputs.swing.phase = Animation::k_melee_contact_time;
+
+  inputs.offhand_along_weapon = 0.20F;
+  auto const paired = Animation::resolve_melee_body_solve(inputs);
+  inputs.offhand_along_weapon = 0.0F;
+  auto const free_hand = Animation::resolve_melee_body_solve(inputs);
+
+  auto const gap = [](const Animation::PoseVec3& a, const Animation::PoseVec3& b) {
+    return std::sqrt(((a.x - b.x) * (a.x - b.x)) + ((a.y - b.y) * (a.y - b.y)) +
+                     ((a.z - b.z) * (a.z - b.z)));
+  };
+  EXPECT_NEAR(gap(paired.offhand, paired.grip), 0.20F, 1.0e-3F);
+  EXPECT_GT(gap(free_hand.offhand, free_hand.grip), 0.4F);
+}
+
+TEST(MeleeBodySolveTest, OnlyAnObjectiveBeyondTheArmDrivesTheShoulderAfterIt) {
+  Animation::MeleeBodySolveInputs inputs{};
+  inputs.swing.arm_reach = 0.60F;
+  inputs.swing.phase = Animation::k_melee_contact_time;
+
+  inputs.swing.intent = Engine::Core::melee_intent_from_strike_angle(
+      Animation::k_melee_thrust_angle, 1.0F, 0.40F);
+  auto const within_reach = Animation::resolve_melee_body_solve(inputs);
+  EXPECT_NEAR(within_reach.shoulder_drive, 0.0F, 1.0e-4F);
+
+  inputs.swing.intent = Engine::Core::melee_intent_from_strike_angle(
+      Animation::k_melee_thrust_angle, 1.0F, 2.40F);
+  auto const beyond_reach = Animation::resolve_melee_body_solve(inputs);
+  EXPECT_GT(beyond_reach.shoulder_drive, within_reach.shoulder_drive);
+}
+
+} // namespace


### PR DESCRIPTION
Replace categorical, sequence-driven melee selection with a continuous melee intent that carries strike direction, chamber, thrust, elevation, charge, speed, follow-through, and weapon targets through simulation and rendering.

Drive commander attacks from accumulated aim and movement input, retain the finishing guard between exchanges, limit mid-swing steering by combat phase, and derive authored action anchors from the resulting intent. Use that same authoritative intent for weapon tracing, hit geometry, combat-state progression, mounted attacks, and save restoration.

Add procedural swing and full-body pose solving so the grip, off hand, torso, pelvis, weight transfer, feet, and weapon arc respond coherently to each attack. Propagate the data through humanoid, horse, and elephant preparation while removing the duplicated combat-phase bridge.

Introduce deterministic per-entity individuality for gait, posture, handedness, and timing, and apply it consistently across creature animation paths. Register the new manifests and solver sources in the build definitions and expand focused coverage for commander input, melee intent classification and steering, procedural swing geometry, and humanoid pose preparation.

Spell out the C standard I/O dependency in the sacred mountain slope coverage added on main so the repository portability gate remains valid with lean standard-library implementations.