### PR TITLE
feat(rpg): land Gate 5 sword slice with input accessibility and stric…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1018,6 +1018,13 @@ file(
     CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/assets/*"
 )
+# Baked creature artifacts are outputs of bake_creature_assets, which writes
+# them into bin/assets directly. Keeping them out of the staging glob avoids a
+# dependency cycle (staging -> stamp -> baked output -> baking -> staging).
+list(
+    FILTER SOI_RUNTIME_ASSET_SOURCES EXCLUDE REGEX
+    "assets/creatures/.*\\.(bpat|bpsm|bprm)$"
+)
 add_custom_command(
     OUTPUT "${CMAKE_BINARY_DIR}/bin/assets/.stamp"
     COMMAND
@@ -1030,6 +1037,13 @@ add_custom_command(
 )
 add_custom_target(stage_runtime_assets DEPENDS "${CMAKE_BINARY_DIR}/bin/assets/.stamp")
 add_dependencies(standard_of_iron stage_runtime_assets)
+if(TARGET bake_creature_assets)
+    # The baker resolves creature packages against the staged copies under
+    # bin/assets before it falls back to the repo tree; staging must run
+    # first or a package edited since the last full build fails its
+    # integrity check and the bake aborts.
+    add_dependencies(bake_creature_assets stage_runtime_assets)
+endif()
 if(TARGET synthesize_ambience_assets)
     add_dependencies(stage_runtime_assets synthesize_ambience_assets)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,10 +1021,7 @@ file(
 # Baked creature artifacts are outputs of bake_creature_assets, which writes
 # them into bin/assets directly. Keeping them out of the staging glob avoids a
 # dependency cycle (staging -> stamp -> baked output -> baking -> staging).
-list(
-    FILTER SOI_RUNTIME_ASSET_SOURCES EXCLUDE REGEX
-    "assets/creatures/.*\\.(bpat|bpsm|bprm)$"
-)
+list(FILTER SOI_RUNTIME_ASSET_SOURCES EXCLUDE REGEX "assets/creatures/.*\\.(bpat|bpsm|bprm)$")
 add_custom_command(
     OUTPUT "${CMAKE_BINARY_DIR}/bin/assets/.stamp"
     COMMAND

--- a/animation/layout_manifest.cpp
+++ b/animation/layout_manifest.cpp
@@ -7,18 +7,6 @@
 
 namespace Animation {
 
-namespace {
-
-[[nodiscard]] auto centered_grid_coordinate(int index, int count) noexcept -> float {
-  if (count <= 1) {
-    return 0.0F;
-  }
-  float const normalized = static_cast<float>(index) / static_cast<float>(count - 1);
-  return normalized * 2.0F - 1.0F;
-}
-
-} // namespace
-
 auto layout_random(std::uint32_t& state) noexcept -> float {
   state = state * 1664525U + 1013904223U;
   return static_cast<float>(state & 0x7FFFFFU) / static_cast<float>(0x7FFFFFU);

--- a/app/commander/commander_camera_rig.cpp
+++ b/app/commander/commander_camera_rig.cpp
@@ -6,8 +6,10 @@
 #include <numbers>
 
 #include "animation/locomotion_manifest.h"
+#include "game/accessibility/commander_input_settings.h"
 #include "game/accessibility/motion_settings.h"
 #include "game/core/component.h"
+#include "game/core/simulation_timing.h"
 #include "game/map/terrain_service.h"
 #include "game/systems/building_line_of_sight.h"
 #include "scene/camera.h"
@@ -54,6 +56,9 @@ constexpr float k_aim_sway_damping = 0.72F;
 constexpr float k_hit_kick_decay = 9.0F;
 constexpr float k_hit_kick_dolly = 0.14F;
 constexpr float k_hit_kick_fov = 2.6F;
+
+constexpr float k_hit_kick_max_degrees = 3.0F;
+constexpr float k_fov_max_degrees_per_second = 45.0F;
 
 constexpr float k_threat_bias_follow = 3.0F;
 constexpr float k_threat_bias_side = 0.30F;
@@ -143,8 +148,16 @@ void CommanderCameraRig::add_impact_kick(float strength) {
 
 auto CommanderCameraRig::update(Render::GL::Camera& camera,
                                 const CommanderCameraInputs& inputs) -> float {
+  Engine::Core::Timing::ScopedAccumulator const scope(
+      Engine::Core::Timing::commander_camera());
   float const dt = inputs.dt;
   float const motion_scale = Game::Accessibility::MotionSettings::camera_motion_scale();
+  float const bob_scale =
+      Game::Accessibility::CommanderInput::head_bob_enabled() ? motion_scale : 0.0F;
+  float const impulse_scale =
+      Game::Accessibility::CommanderInput::camera_impulse_enabled() ? motion_scale
+                                                                    : 0.0F;
+  float const fov_scale = Game::Accessibility::CommanderInput::field_of_view_scale();
 
   float const yaw_step = signed_degrees_between(inputs.view_yaw_degrees, m_state.yaw);
   float const pitch_step = inputs.view_pitch_degrees - m_state.pitch;
@@ -180,7 +193,7 @@ auto CommanderCameraRig::update(Render::GL::Camera& camera,
   float const aim_blend = std::clamp(m_aim_blend, 0.0F, 1.0F);
   float const sway_scale = 1.0F - (k_aim_sway_damping * aim_blend);
 
-  float const bob_amp_target = (inputs.move_speed > 0.05F) ? motion_scale : 0.0F;
+  float const bob_amp_target = (inputs.move_speed > 0.05F) ? bob_scale : 0.0F;
   m_bob_amplitude += (bob_amp_target - m_bob_amplitude) * smooth_alpha(k_bob_decay, dt);
   float const previous_bob_phase = m_bob_phase;
   if (inputs.move_speed > 0.05F) {
@@ -211,15 +224,13 @@ auto CommanderCameraRig::update(Render::GL::Camera& camera,
   if (m_hit_impact_kick < 0.001F) {
     m_hit_impact_kick = 0.0F;
   }
-  float const hit_kick = m_hit_impact_kick * motion_scale;
+  float const hit_kick = m_hit_impact_kick * impulse_scale;
 
-  float const fov_target =
-      m_framing_current.fov +
-      ((inputs.move_running && inputs.move_speed > 0.05F) ? k_fov_run_boost : 0.0F) +
-      inputs.dodge_fov_kick + (k_hit_kick_fov * hit_kick);
-  m_fov_current += (fov_target - m_fov_current) * smooth_alpha(k_fov_lerp, dt);
-  camera.set_perspective(
-      m_fov_current, camera.get_aspect(), k_commander_near_plane, camera.get_far());
+  float const framing_fov = (m_framing_current.fov * fov_scale) +
+                            ((inputs.move_running && inputs.move_speed > 0.05F)
+                                 ? k_fov_run_boost * motion_scale
+                                 : 0.0F) +
+                            (inputs.dodge_fov_kick * motion_scale);
 
   float const yaw_rad = inputs.view_yaw_degrees * k_deg2rad;
   float const pitch_rad = inputs.view_pitch_degrees * k_deg2rad;
@@ -409,6 +420,16 @@ auto CommanderCameraRig::update(Render::GL::Camera& camera,
 
   QVector3D const up_final = (up_leaned + right_world * dodge_tilt_rad).normalized();
   camera.look_at(m_eye_smooth, m_target_smooth, up_final);
+
+  float const impulse_degrees =
+      std::clamp(k_hit_kick_fov * hit_kick, 0.0F, k_hit_kick_max_degrees);
+  float const fov_target = framing_fov + impulse_degrees;
+  float fov_step = (fov_target - m_fov_current) * smooth_alpha(k_fov_lerp, dt);
+  float const fov_step_limit = k_fov_max_degrees_per_second * std::max(dt, 0.0F);
+  fov_step = std::clamp(fov_step, -fov_step_limit, fov_step_limit);
+  m_fov_current += fov_step;
+  camera.set_perspective(
+      m_fov_current, camera.get_aspect(), k_commander_near_plane, camera.get_far());
 
   QVector3D const view_axis = m_target_smooth - m_eye_smooth;
   if (view_axis.lengthSquared() > 1.0e-6F) {

--- a/app/commander/commander_control_controller.cpp
+++ b/app/commander/commander_control_controller.cpp
@@ -13,9 +13,11 @@
 #include <vector>
 
 #include "app/commander/commander_motor.h"
+#include "game/accessibility/commander_input_settings.h"
 #include "game/accessibility/motion_settings.h"
 #include "game/audio/audio_cues.h"
 #include "game/core/component.h"
+#include "game/core/simulation_timing.h"
 #include "game/core/world.h"
 #include "game/map/terrain_service.h"
 #include "game/session/session_context.h"
@@ -23,6 +25,7 @@
 #include "game/systems/building_line_of_sight.h"
 #include "game/systems/combat_actions/combat_action_definition.h"
 #include "game/systems/combat_actions/combat_action_service.h"
+#include "game/systems/combat_actions/commander_defense_timeline.h"
 #include "game/systems/combat_actions/melee_intent_solver.h"
 #include "game/systems/combat_system/damage_application.h"
 #include "game/systems/combat_system/damage_processor.h"
@@ -489,6 +492,17 @@ void CommanderControlController::secondary_action_down() {
     m_latency_probe->note_input();
   }
   const std::lock_guard<std::mutex> input_guard(m_input_mutex);
+  if (Game::Accessibility::CommanderInput::guard_is_toggle()) {
+
+    if (m_input.secondary_action) {
+      ++m_edges.guard_release_sequence;
+      m_input.secondary_action = false;
+    } else {
+      ++m_edges.guard_press_sequence;
+      m_input.secondary_action = true;
+    }
+    return;
+  }
   if (!m_input.secondary_action) {
     ++m_edges.guard_press_sequence;
   }
@@ -497,6 +511,10 @@ void CommanderControlController::secondary_action_down() {
 
 void CommanderControlController::secondary_action_up() {
   const std::lock_guard<std::mutex> input_guard(m_input_mutex);
+  if (Game::Accessibility::CommanderInput::guard_is_toggle()) {
+
+    return;
+  }
   if (m_input.secondary_action) {
     ++m_edges.guard_release_sequence;
   }
@@ -523,8 +541,13 @@ void CommanderControlController::mouse_move(qreal dx, qreal dy) {
   constexpr float k_mouse_yaw_sensitivity = 0.18F;
   constexpr float k_mouse_pitch_sensitivity = 0.12F;
   const float sensitivity = look_sensitivity_scale();
-  m_view_yaw += static_cast<float>(dx) * k_mouse_yaw_sensitivity * sensitivity;
-  m_view_pitch -= static_cast<float>(dy) * k_mouse_pitch_sensitivity * sensitivity;
+  const float user_x = Game::Accessibility::CommanderInput::look_sensitivity_x();
+  const float user_y = Game::Accessibility::CommanderInput::look_sensitivity_y();
+  const float pitch_sign =
+      Game::Accessibility::CommanderInput::invert_look_y() ? 1.0F : -1.0F;
+  m_view_yaw += static_cast<float>(dx) * k_mouse_yaw_sensitivity * sensitivity * user_x;
+  m_view_pitch += pitch_sign * static_cast<float>(dy) * k_mouse_pitch_sensitivity *
+                  sensitivity * user_y;
   m_view_yaw = std::fmod(m_view_yaw, 360.0F);
   if (m_view_yaw < 0.0F) {
     m_view_yaw += 360.0F;
@@ -721,6 +744,8 @@ void CommanderControlController::cycle_lock_on_target(
     Engine::Core::World& world,
     Engine::Core::EntityID commander_id,
     int local_owner_id) {
+  Engine::Core::Timing::ScopedAccumulator const lock_scope(
+      Engine::Core::Timing::commander_targeting());
   auto* commander = controlled_commander(world, commander_id, local_owner_id);
   if (commander == nullptr) {
     return;
@@ -809,28 +834,39 @@ void CommanderControlController::cycle_lock_on_target(
     return;
   }
 
-  std::stable_sort(
-      candidates.begin(), candidates.end(), [](const Candidate& a, const Candidate& b) {
-        if (a.visible != b.visible) {
-          return a.visible && !b.visible;
-        }
-        if (std::abs(a.angle_diff) != std::abs(b.angle_diff)) {
-          return std::abs(a.angle_diff) < std::abs(b.angle_diff);
-        }
-        return a.distance_sq < b.distance_sq;
-      });
-
   if (m_locked_target_id == 0) {
-    m_locked_target_id = candidates[0].id;
-    m_locked_target_slot = candidates[0].soldier_slot;
+
+    auto const nearest_to_centre =
+        std::min_element(candidates.begin(),
+                         candidates.end(),
+                         [](const Candidate& a, const Candidate& b) {
+                           if (a.visible != b.visible) {
+                             return a.visible && !b.visible;
+                           }
+                           if (std::abs(a.angle_diff) != std::abs(b.angle_diff)) {
+                             return std::abs(a.angle_diff) < std::abs(b.angle_diff);
+                           }
+                           return a.distance_sq < b.distance_sq;
+                         });
+    m_locked_target_id = nearest_to_centre->id;
+    m_locked_target_slot = nearest_to_centre->soldier_slot;
   } else {
+
+    std::stable_sort(candidates.begin(),
+                     candidates.end(),
+                     [](const Candidate& a, const Candidate& b) {
+                       if (a.angle_diff != b.angle_diff) {
+                         return a.angle_diff < b.angle_diff;
+                       }
+                       return a.distance_sq < b.distance_sq;
+                     });
     auto it =
         std::find_if(candidates.begin(), candidates.end(), [this](const Candidate& c) {
           return c.id == m_locked_target_id;
         });
     if (it == candidates.end() || std::next(it) == candidates.end()) {
-      m_locked_target_id = candidates[0].id;
-      m_locked_target_slot = candidates[0].soldier_slot;
+      m_locked_target_id = candidates.front().id;
+      m_locked_target_slot = candidates.front().soldier_slot;
     } else {
       auto const& next = *std::next(it);
       m_locked_target_id = next.id;
@@ -841,6 +877,7 @@ void CommanderControlController::cycle_lock_on_target(
   m_soft_target_slot = m_locked_target_slot;
   m_lock_lost_timer = 0.0F;
   Game::Audio::play_cue(Game::Audio::Cue::k_combat_lock_on);
+
   if (auto* rpg_targets =
           Engine::Core::get_or_add_component<Engine::Core::RpgCommanderTargetComponent>(
               commander)) {
@@ -968,6 +1005,8 @@ void CommanderControlController::update_lock_on_yaw(Engine::Core::World& world,
                                                     Engine::Core::Entity& commander,
                                                     float dt) {
   if (m_locked_target_id == 0) {
+    m_lock_spring_yaw_valid = false;
+    m_lock_manual_override_timer = 0.0F;
     return;
   }
 
@@ -1029,9 +1068,40 @@ void CommanderControlController::update_lock_on_yaw(Engine::Core::World& world,
     return;
   }
 
+  constexpr float k_lock_minimum_distance = 0.75F;
+  constexpr float k_lock_full_authority_distance = 2.0F;
+  constexpr float k_lock_max_turn_degrees_per_second = 220.0F;
+  float const target_distance = std::sqrt((dx * dx) + (dz * dz));
+  if (target_distance < k_lock_minimum_distance) {
+
+    return;
+  }
+  float const close_range_authority =
+      std::clamp((target_distance - k_lock_minimum_distance) /
+                     (k_lock_full_authority_distance - k_lock_minimum_distance),
+                 0.0F,
+                 1.0F);
+
+  constexpr float k_manual_override_seconds = 0.35F;
+  float const manual_look = std::abs(signed_angle_delta(m_view_yaw, m_lock_spring_yaw));
+  if (m_lock_spring_yaw_valid && manual_look > 0.05F) {
+    m_lock_manual_override_timer = k_manual_override_seconds;
+  }
+  if (m_lock_manual_override_timer > 0.0F) {
+    m_lock_manual_override_timer = std::max(0.0F, m_lock_manual_override_timer - dt);
+    m_lock_spring_yaw = m_view_yaw;
+    m_lock_spring_yaw_valid = true;
+    return;
+  }
+
   const float k_lock_spring = target_visible ? 8.5F : 3.5F;
-  m_view_yaw += diff * (1.0F - std::exp(-k_lock_spring * dt));
+  float step = diff * (1.0F - std::exp(-k_lock_spring * dt)) * close_range_authority;
+  float const step_limit = k_lock_max_turn_degrees_per_second * dt;
+  step = std::clamp(step, -step_limit, step_limit);
+  m_view_yaw += step;
   m_view_yaw = wrap_angle_degrees(m_view_yaw);
+  m_lock_spring_yaw = m_view_yaw;
+  m_lock_spring_yaw_valid = true;
 }
 
 auto CommanderControlController::controlled_commander(
@@ -1058,6 +1128,8 @@ auto CommanderControlController::find_primary_target(
     Engine::Core::EntityID commander_id,
     int local_owner_id,
     float extra_reach) -> Engine::Core::EntityID {
+  Engine::Core::Timing::ScopedAccumulator const scope(
+      Engine::Core::Timing::commander_targeting());
   using Target = Game::Systems::RpgCombat::SoldierTarget;
   constexpr auto k_no_slot =
       Engine::Core::RpgCommanderTargetComponent::k_no_soldier_slot;
@@ -1520,6 +1592,47 @@ void CommanderControlController::try_activate_vanguard_rush(
   }
 }
 
+void CommanderControlController::publish_resolved_defense_feedback(
+    Engine::Core::Entity& commander,
+    Engine::Core::EntityID commander_id,
+    const Engine::Core::TransformComponent& transform) {
+  auto const* rpg = commander.get_component<Engine::Core::RpgHealthComponent>();
+  if (rpg == nullptr) {
+    return;
+  }
+
+  QVector3D const at(transform.position.x, transform.position.y, transform.position.z);
+  auto publish = [&](App::Core::PlayerFeedbackType type, const char* reason) {
+    if (m_feedback == nullptr) {
+      return;
+    }
+    App::Core::PlayerFeedbackEvent event;
+    event.type = type;
+    event.entity = commander_id;
+    event.has_world_position = true;
+    event.world_position = at;
+    event.reason = QString::fromLatin1(reason);
+    m_feedback->publish(std::move(event));
+  };
+
+  if (rpg->perfect_guard_contacts != m_observed_perfect_guard_contacts) {
+    m_observed_perfect_guard_contacts = rpg->perfect_guard_contacts;
+    publish(App::Core::PlayerFeedbackType::PerfectGuard, "perfect_guard");
+  }
+  if (rpg->dodged_contacts != m_observed_dodged_contacts) {
+    m_observed_dodged_contacts = rpg->dodged_contacts;
+    publish(App::Core::PlayerFeedbackType::DodgeSuccess, "iframe_reject");
+  }
+  if (rpg->blocked_contacts != m_observed_blocked_contacts) {
+    m_observed_blocked_contacts = rpg->blocked_contacts;
+    publish(App::Core::PlayerFeedbackType::WeaponContact, "guard_block");
+  }
+  if (rpg->guard_broken_contacts != m_observed_guard_broken_contacts) {
+    m_observed_guard_broken_contacts = rpg->guard_broken_contacts;
+    publish(App::Core::PlayerFeedbackType::GuardBroken, "guard_break");
+  }
+}
+
 void CommanderControlController::try_activate_second_wind(
     Engine::Core::Entity& commander) {
   const bool second_wind_requested = m_tick_input.second_wind_pressed;
@@ -1754,9 +1867,7 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
         QVector3D(transform->position.x, transform->position.y, transform->position.z);
 
     if (auto* stamina = commander->get_component<Engine::Core::StaminaComponent>()) {
-      stamina->stamina = std::max(
-          0.0F,
-          stamina->stamina - Engine::Core::CombatStateComponent::k_stamina_cost_jump);
+      stamina->spend(Engine::Core::CombatStateComponent::k_stamina_cost_jump);
     }
   }
 
@@ -1841,35 +1952,25 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
             ? requested_dodge_direction.normalized()
             : ((move.lengthSquared() > 0.0001F) ? move.normalized() : forward);
     m_dodge_state = DodgeState::Rolling;
-    if (m_feedback != nullptr) {
-      App::Core::PlayerFeedbackEvent event;
-      event.type = App::Core::PlayerFeedbackType::DodgeSuccess;
-      event.entity = commander_id;
-      event.has_world_position = true;
-      event.world_position = QVector3D(
-          transform->position.x, transform->position.y, transform->position.z);
-      m_feedback->publish(std::move(event));
-    }
     if (m_latency_probe != nullptr) {
       m_latency_probe->note_dodge_start();
       m_latency_probe->note_pose_response();
     }
     Game::Audio::play_cue(Game::Audio::Cue::k_combat_dodge);
-    constexpr float k_dodge_roll_duration = 0.22F;
-    m_dodge_timer = k_dodge_roll_duration;
+    m_dodge_timer =
+        Game::Systems::CombatActions::k_commander_dodge_timeline.roll_seconds;
     m_dodge_fov_kick = 14.0F;
     if (auto* rpg = commander->get_component<Engine::Core::RpgHealthComponent>()) {
 
-      constexpr float k_dodge_grace_seconds = 0.12F;
-      rpg->dodge_grace_remaining = k_dodge_grace_seconds;
+      rpg->dodge_grace_remaining =
+          Game::Systems::CombatActions::k_commander_dodge_timeline
+              .invulnerable_seconds();
       rpg->dodge_dir_x = m_dodge_direction.x();
       rpg->dodge_dir_z = m_dodge_direction.z();
     }
 
     if (auto* stamina = commander->get_component<Engine::Core::StaminaComponent>()) {
-      stamina->stamina = std::max(
-          0.0F,
-          stamina->stamina - Engine::Core::CombatStateComponent::k_stamina_cost_dodge);
+      stamina->spend(Engine::Core::CombatStateComponent::k_stamina_cost_dodge);
     }
   }
 
@@ -1914,8 +2015,8 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
 
     if (m_dodge_timer <= 0.0F) {
       m_dodge_state = DodgeState::Recovering;
-      constexpr float k_dodge_recover_duration = 0.18F;
-      m_dodge_timer = k_dodge_recover_duration;
+      m_dodge_timer =
+          Game::Systems::CombatActions::k_commander_dodge_timeline.recovery_seconds;
       if (auto* rpg = commander->get_component<Engine::Core::RpgHealthComponent>()) {
         rpg->dodge_grace_remaining = 0.0F;
       }
@@ -2080,6 +2181,19 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
   m_move_forward_axis = forward_axis;
   m_move_running = run_for_bob;
 
+  float action_redirect_authority = 1.0F;
+  if (attack_animation_active) {
+    if (auto const* definition =
+            Game::Systems::CombatActions::find_combat_action_definition(
+                static_cast<Game::Systems::CombatActions::CombatActionId>(
+                    active_action->combat_action_id))) {
+      action_redirect_authority =
+          Game::Systems::CombatActions::melee_interruption_at(
+              *definition, active_action->normalized_action_time)
+              .redirect_authority;
+    }
+  }
+
   bool const body_must_face_view =
       m_tick_input.primary_held || m_tick_input.guard_held ||
       m_dodge_state != DodgeState::None || jump_active || drawing_bow ||
@@ -2091,7 +2205,20 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
     m_body_yaw_valid = true;
   }
 
-  if (body_must_face_view) {
+  if (attack_animation_active && action_redirect_authority < 1.0F) {
+
+    m_turning_in_place = false;
+    float const offset = signed_angle_delta(m_view_yaw, m_body_yaw);
+    float const step = k_body_travel_turn_rate_degrees * action_redirect_authority *
+                       std::max(0.0F, dt);
+    if (step <= 0.0F) {
+
+    } else if (std::abs(offset) <= step) {
+      m_body_yaw = m_view_yaw;
+    } else {
+      m_body_yaw = wrap_angle_degrees(m_body_yaw + std::copysign(step, offset));
+    }
+  } else if (body_must_face_view) {
     m_body_yaw = m_view_yaw;
     m_turning_in_place = false;
   } else {
@@ -2157,11 +2284,13 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
 
     if (auto* stamina = commander->get_component<Engine::Core::StaminaComponent>()) {
       stamina->run_requested = m_move_running;
-      traced_stamina = stamina->stamina;
     }
   } else if (auto* stamina =
                  commander->get_component<Engine::Core::StaminaComponent>()) {
     stamina->run_requested = false;
+  }
+  if (auto const* stamina =
+          commander->get_component<Engine::Core::StaminaComponent>()) {
     traced_stamina = stamina->stamina;
   }
 
@@ -2175,17 +2304,10 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
         !jump_active && body_allows_now(*commander).accepts_guard) {
       guard->active = true;
       if (!m_guard_was_active) {
-        guard->perfect_guard_remaining = 0.16F;
+        guard->perfect_guard_remaining =
+            Game::Systems::CombatActions::k_commander_guard_timeline
+                .perfect_window_seconds;
         Game::Audio::play_cue(Game::Audio::Cue::k_combat_guard_raise);
-        if (m_feedback != nullptr) {
-          App::Core::PlayerFeedbackEvent event;
-          event.type = App::Core::PlayerFeedbackType::PerfectGuard;
-          event.entity = commander_id;
-          event.has_world_position = true;
-          event.world_position = QVector3D(
-              transform->position.x, transform->position.y, transform->position.z);
-          m_feedback->publish(std::move(event));
-        }
         if (m_latency_probe != nullptr) {
           m_latency_probe->note_guard_start();
           m_latency_probe->note_pose_response();
@@ -2204,10 +2326,8 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
 
   if (guard != nullptr && guard->active) {
     if (auto* stamina = commander->get_component<Engine::Core::StaminaComponent>()) {
-      stamina->stamina = std::max(
-          0.0F,
-          stamina->stamina -
-              Engine::Core::CombatStateComponent::k_stamina_cost_guard_per_second * dt);
+      stamina->spend(
+          Engine::Core::CombatStateComponent::k_stamina_cost_guard_per_second * dt);
     }
   }
 
@@ -2254,10 +2374,8 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
                                    m_jump_timer <= 0.0F && !waiting_for_release;
 
   if (intents != nullptr && body_can_take_input) {
-    bool const auto_repeat = m_tick_input.primary_held && intents->empty() &&
-                             !attack_animation_active &&
-                             m_primary_scan_cooldown <= 0.0F;
-    if (m_tick_input.primary_pressed || auto_repeat) {
+
+    if (m_tick_input.primary_pressed) {
       auto const* body =
           commander->get_component<Engine::Core::CommanderBodyControlComponent>();
       Engine::Core::CombatActionIntent intent;
@@ -2380,6 +2498,8 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
     aim_candidate_id = find_primary_target(world, commander_id, local_owner_id);
   }
 
+  publish_resolved_defense_feedback(*commander, commander_id, *transform);
+
   if (auto* rpg_targets =
           Engine::Core::get_or_add_component<Engine::Core::RpgCommanderTargetComponent>(
               commander)) {
@@ -2455,6 +2575,18 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
 
     m_trace.camera = m_camera_rig.trace();
 
+    auto const costs = Engine::Core::Timing::sample_and_reset_rpg_costs();
+    constexpr float k_microseconds_to_ms = 0.001F;
+    m_trace.costs.motor_ms = static_cast<float>(costs.motor_us) * k_microseconds_to_ms;
+    m_trace.costs.targeting_ms =
+        static_cast<float>(costs.targeting_us) * k_microseconds_to_ms;
+    m_trace.costs.weapon_trace_ms =
+        static_cast<float>(costs.weapon_trace_us) * k_microseconds_to_ms;
+    m_trace.costs.engagement_ms =
+        static_cast<float>(costs.engagement_us) * k_microseconds_to_ms;
+    m_trace.costs.camera_ms =
+        static_cast<float>(costs.camera_us) * k_microseconds_to_ms;
+
     m_trace.combat = App::Core::CommanderCombatTrace{};
     if (active_action != nullptr) {
       m_trace.combat.action_phase = static_cast<int>(active_action->phase);
@@ -2464,6 +2596,38 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
     }
     if (intents != nullptr) {
       m_trace.combat.queued_intents = static_cast<int>(intents->count);
+      m_trace.combat.queue_outcome = static_cast<int>(intents->last_outcome);
+      m_trace.combat.queue_outcome_age = intents->last_outcome_age;
+      m_trace.combat.queue_accepted = intents->accepted_intents;
+      m_trace.combat.queue_buffered = intents->buffered_intents;
+      m_trace.combat.queue_refused = intents->refused_intents;
+      m_trace.combat.queue_expired = intents->expired_intents;
+      m_trace.combat.queue_overflow = intents->overflow_intents;
+    }
+    if (auto const* defense =
+            commander->get_component<Engine::Core::RpgHealthComponent>()) {
+      m_trace.combat.blocked_contacts = defense->blocked_contacts;
+      m_trace.combat.perfect_guard_contacts = defense->perfect_guard_contacts;
+      m_trace.combat.dodged_contacts = defense->dodged_contacts;
+      m_trace.combat.damaging_contacts = defense->damaging_contacts;
+      m_trace.combat.guard_broken_contacts = defense->guard_broken_contacts;
+    }
+    if (active_action != nullptr && active_action->action_running) {
+      if (auto const* definition =
+              Game::Systems::CombatActions::find_combat_action_definition(
+                  static_cast<Game::Systems::CombatActions::CombatActionId>(
+                      active_action->combat_action_id))) {
+        m_trace.combat.action_window_start =
+            Game::Systems::CombatActions::action_event_normalized_time(
+                *definition,
+                Game::Systems::CombatActions::CombatActionEventType::WeaponTraceStart,
+                0.0F);
+        m_trace.combat.action_window_end =
+            Game::Systems::CombatActions::action_event_normalized_time(
+                *definition,
+                Game::Systems::CombatActions::CombatActionEventType::WeaponTraceEnd,
+                1.0F);
+      }
     }
     if (guard != nullptr) {
       m_trace.combat.guard_active = guard->active;

--- a/app/commander/commander_control_controller.h
+++ b/app/commander/commander_control_controller.h
@@ -191,6 +191,10 @@ private:
                                   Engine::Core::EntityID commander_id,
                                   int local_owner_id);
   void try_activate_second_wind(Engine::Core::Entity& commander);
+  void
+  publish_resolved_defense_feedback(Engine::Core::Entity& commander,
+                                    Engine::Core::EntityID commander_id,
+                                    const Engine::Core::TransformComponent& transform);
   void update_camera(Engine::Core::World& world,
                      Engine::Core::Entity& commander,
                      Render::GL::Camera& camera,
@@ -242,6 +246,10 @@ private:
   float m_dodge_fov_kick = 0.0F;
 
   std::uint32_t m_observed_hit_confirm_sequence = 0;
+  std::uint32_t m_observed_blocked_contacts = 0;
+  std::uint32_t m_observed_perfect_guard_contacts = 0;
+  std::uint32_t m_observed_dodged_contacts = 0;
+  std::uint32_t m_observed_guard_broken_contacts = 0;
   std::uint8_t m_observed_action_hit_count = 0;
   float m_jump_timer = 0.0F;
   bool m_jump_safe_position_valid = false;
@@ -272,6 +280,9 @@ private:
   std::uint16_t m_soft_target_slot{std::numeric_limits<std::uint16_t>::max()};
   std::uint16_t m_primary_target_slot{std::numeric_limits<std::uint16_t>::max()};
   float m_lock_lost_timer = 0.0F;
+  float m_lock_spring_yaw = 0.0F;
+  bool m_lock_spring_yaw_valid = false;
+  float m_lock_manual_override_timer = 0.0F;
   bool m_guard_was_active = false;
 
   bool m_trace_enabled = false;

--- a/app/commander/commander_mode_coordinator.cpp
+++ b/app/commander/commander_mode_coordinator.cpp
@@ -463,21 +463,6 @@ auto CommanderModeCoordinator::update_commander_control_mode(
     return effects;
   }
 
-  auto* commander = context.world->get_entity(context.controlled_commander_id);
-  if (commander != nullptr) {
-    auto* commander_data = commander->get_component<Engine::Core::CommanderComponent>();
-    if (commander_data != nullptr && commander_data->just_struck_enemy) {
-      commander_data->just_struck_enemy = false;
-      float hit_stop_duration = 0.10F;
-      if (commander_data->last_strike_combo_step >= 3) {
-        hit_stop_duration = 0.18F;
-      } else if (commander_data->power_strike_active) {
-        hit_stop_duration = 0.14F;
-      }
-      effects.hit_stop_duration = hit_stop_duration;
-    }
-  }
-
   return effects;
 }
 

--- a/app/commander/commander_mode_coordinator.h
+++ b/app/commander/commander_mode_coordinator.h
@@ -127,7 +127,6 @@ struct CommanderUpdateContext {
 
 struct CommanderUpdateEffects {
   bool should_exit_commander_mode = false;
-  std::optional<float> hit_stop_duration;
 };
 
 struct CommanderDirectControlContext {

--- a/app/commander/commander_motor.cpp
+++ b/app/commander/commander_motor.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "game/core/component.h"
+#include "game/core/simulation_timing.h"
 #include "game/map/terrain_service.h"
 #include "game/session/session_context.h"
 #include "game/systems/building_collision_registry.h"
@@ -129,6 +130,8 @@ auto CommanderMotor::advance(Game::Session::SessionContext&,
                              Engine::Core::TransformComponent& transform,
                              const CommanderMotorRequest& request)
     -> CommanderMotorResult {
+  Engine::Core::Timing::ScopedAccumulator const scope(
+      Engine::Core::Timing::commander_motor());
   GroundMove const step =
       request.airborne
           ? airborne_step(request.to.x(), request.to.z())

--- a/app/commander/commander_presentation_trace.h
+++ b/app/commander/commander_presentation_trace.h
@@ -112,6 +112,59 @@ struct CommanderCombatTrace {
   int action_hit_count{0};
   int health{-1};
   float stamina{-1.0F};
+
+  int queue_outcome{0};
+  float queue_outcome_age{0.0F};
+  std::uint32_t queue_accepted{0};
+  std::uint32_t queue_buffered{0};
+  std::uint32_t queue_refused{0};
+  std::uint32_t queue_expired{0};
+  std::uint32_t queue_overflow{0};
+
+  float action_window_start{0.0F};
+  float action_window_end{0.0F};
+
+  std::uint32_t blocked_contacts{0};
+  std::uint32_t perfect_guard_contacts{0};
+  std::uint32_t dodged_contacts{0};
+  std::uint32_t damaging_contacts{0};
+  std::uint32_t guard_broken_contacts{0};
+};
+
+[[nodiscard]] inline auto combat_intent_outcome_name(int outcome) -> const char* {
+  switch (outcome) {
+  case 0:
+    return "accepted";
+  case 1:
+    return "buffered";
+  case 2:
+    return "insufficient_stamina";
+  case 3:
+    return "recovering";
+  case 4:
+    return "committed";
+  case 5:
+    return "guard_broken";
+  case 6:
+    return "staggered";
+  case 7:
+    return "no_fighter";
+  case 8:
+    return "expired";
+  }
+  return "unknown";
+}
+
+struct CommanderCostTrace {
+  float motor_ms{0.0F};
+  float targeting_ms{0.0F};
+  float weapon_trace_ms{0.0F};
+  float engagement_ms{0.0F};
+  float camera_ms{0.0F};
+
+  [[nodiscard]] auto total_ms() const noexcept -> float {
+    return motor_ms + targeting_ms + weapon_trace_ms + engagement_ms + camera_ms;
+  }
 };
 
 struct CommanderPresentationTrace {
@@ -122,6 +175,7 @@ struct CommanderPresentationTrace {
   CommanderMotorTrace motor;
   CommanderCameraTrace camera;
   CommanderCombatTrace combat;
+  CommanderCostTrace costs;
 };
 
 } // namespace App::Core

--- a/app/core/user_settings.h
+++ b/app/core/user_settings.h
@@ -41,6 +41,13 @@ inline constexpr char kUiEconomyCoachKey[] = "ui/economy_coach";
 inline constexpr char kUiCameraLegendSeenKey[] = "ui/camera_legend_seen";
 inline constexpr char kUiTutorialCompletedKey[] = "ui/tutorial_completed";
 inline constexpr char kInputBindingsGroup[] = "input/bindings";
+inline constexpr char kCommanderLookSensitivityXKey[] = "commander/look_sensitivity_x";
+inline constexpr char kCommanderLookSensitivityYKey[] = "commander/look_sensitivity_y";
+inline constexpr char kCommanderInvertLookYKey[] = "commander/invert_look_y";
+inline constexpr char kCommanderCameraImpulseKey[] = "commander/camera_impulse";
+inline constexpr char kCommanderHeadBobKey[] = "commander/head_bob";
+inline constexpr char kCommanderFieldOfViewScaleKey[] = "commander/fov_scale";
+inline constexpr char kCommanderGuardToggleKey[] = "commander/guard_is_toggle";
 
 inline constexpr int kDefaultAutosaveSlotCount = 3;
 inline constexpr int kMinAutosaveSlotCount = 1;
@@ -57,6 +64,13 @@ inline constexpr double kMinEdgeScrollSensitivity = 0.25;
 inline constexpr double kMaxEdgeScrollSensitivity = 2.0;
 
 inline constexpr double kDefaultCameraMotionScale = 1.0;
+
+inline constexpr double kDefaultCommanderLookSensitivity = 1.0;
+inline constexpr double kMinCommanderLookSensitivity = 0.25;
+inline constexpr double kMaxCommanderLookSensitivity = 4.0;
+inline constexpr double kDefaultCommanderFieldOfViewScale = 1.0;
+inline constexpr double kMinCommanderFieldOfViewScale = 0.75;
+inline constexpr double kMaxCommanderFieldOfViewScale = 1.35;
 inline constexpr double kDefaultScreenEffectIntensity = 1.0;
 
 using AudioVolumes = Game::Audio::Settings::Volumes;
@@ -382,6 +396,80 @@ inline auto load_ui_camera_motion_scale() -> double {
 
 inline void save_ui_camera_motion_scale(double scale) {
   Detail::save_bounded_double(kUiCameraMotionKey, scale, 0.0, 1.0);
+}
+
+inline auto load_commander_look_sensitivity_x() -> double {
+  return Detail::load_bounded_double(kCommanderLookSensitivityXKey,
+                                     kDefaultCommanderLookSensitivity,
+                                     kMinCommanderLookSensitivity,
+                                     kMaxCommanderLookSensitivity);
+}
+
+inline void save_commander_look_sensitivity_x(double scale) {
+  Detail::save_bounded_double(kCommanderLookSensitivityXKey,
+                              scale,
+                              kMinCommanderLookSensitivity,
+                              kMaxCommanderLookSensitivity);
+}
+
+inline auto load_commander_look_sensitivity_y() -> double {
+  return Detail::load_bounded_double(kCommanderLookSensitivityYKey,
+                                     kDefaultCommanderLookSensitivity,
+                                     kMinCommanderLookSensitivity,
+                                     kMaxCommanderLookSensitivity);
+}
+
+inline void save_commander_look_sensitivity_y(double scale) {
+  Detail::save_bounded_double(kCommanderLookSensitivityYKey,
+                              scale,
+                              kMinCommanderLookSensitivity,
+                              kMaxCommanderLookSensitivity);
+}
+
+inline auto load_commander_invert_look_y() -> bool {
+  return Detail::load_bool(kCommanderInvertLookYKey, false);
+}
+
+inline void save_commander_invert_look_y(bool enabled) {
+  Detail::save_bool(kCommanderInvertLookYKey, enabled);
+}
+
+inline auto load_commander_camera_impulse() -> bool {
+  return Detail::load_bool(kCommanderCameraImpulseKey, true);
+}
+
+inline void save_commander_camera_impulse(bool enabled) {
+  Detail::save_bool(kCommanderCameraImpulseKey, enabled);
+}
+
+inline auto load_commander_head_bob() -> bool {
+  return Detail::load_bool(kCommanderHeadBobKey, true);
+}
+
+inline void save_commander_head_bob(bool enabled) {
+  Detail::save_bool(kCommanderHeadBobKey, enabled);
+}
+
+inline auto load_commander_field_of_view_scale() -> double {
+  return Detail::load_bounded_double(kCommanderFieldOfViewScaleKey,
+                                     kDefaultCommanderFieldOfViewScale,
+                                     kMinCommanderFieldOfViewScale,
+                                     kMaxCommanderFieldOfViewScale);
+}
+
+inline void save_commander_field_of_view_scale(double scale) {
+  Detail::save_bounded_double(kCommanderFieldOfViewScaleKey,
+                              scale,
+                              kMinCommanderFieldOfViewScale,
+                              kMaxCommanderFieldOfViewScale);
+}
+
+inline auto load_commander_guard_is_toggle() -> bool {
+  return Detail::load_bool(kCommanderGuardToggleKey, false);
+}
+
+inline void save_commander_guard_is_toggle(bool enabled) {
+  Detail::save_bool(kCommanderGuardToggleKey, enabled);
 }
 
 inline auto load_ui_damage_numbers() -> bool {

--- a/app/viewmodels/commander_view_model.cpp
+++ b/app/viewmodels/commander_view_model.cpp
@@ -283,7 +283,6 @@ void CommanderViewModel::cancel_active_placement() {
 }
 
 void CommanderViewModel::exit_commander_runtime_mode() {
-  m_hit_stop_timer = 0.0F;
   m_telegraphs.clear();
 }
 
@@ -669,10 +668,6 @@ void CommanderViewModel::update_control_mode(float dt) {
     exit_mode();
     return;
   }
-  if (effects.hit_stop_duration.has_value()) {
-    m_hit_stop_timer = *effects.hit_stop_duration;
-    m_hit_stop_total = *effects.hit_stop_duration;
-  }
 }
 
 void CommanderViewModel::sample_frame_intent() {
@@ -703,19 +698,9 @@ void CommanderViewModel::restore_direct_control_if_ready() {
 }
 
 auto CommanderViewModel::time_effect_scale(float scaled_dt, bool paused) -> float {
-  if (!active()) {
-    return 1.0F;
-  }
-  if (!paused && m_hit_stop_timer > 0.0F) {
-    m_hit_stop_timer -= scaled_dt;
-    if (m_hit_stop_timer < 0.0F) {
-      m_hit_stop_timer = 0.0F;
-    } else {
-      const float progress =
-          1.0F - std::clamp(m_hit_stop_timer / m_hit_stop_total, 0.0F, 1.0F);
-      return progress < 0.5F ? 0.04F : (0.04F + 0.96F * (progress - 0.5F) * 2.0F);
-    }
-  }
+
+  static_cast<void>(scaled_dt);
+  static_cast<void>(paused);
   return 1.0F;
 }
 

--- a/app/viewmodels/commander_view_model.h
+++ b/app/viewmodels/commander_view_model.h
@@ -205,8 +205,6 @@ private:
   mutable std::mutex m_damage_events_mutex;
   std::vector<DamageEvent> m_damage_events;
   std::uint32_t m_damage_event_sequence = 0;
-  float m_hit_stop_timer = 0.0F;
-  float m_hit_stop_total = 0.10F;
 };
 
 } // namespace App::ViewModels

--- a/docs/RPG_PLAYABILITY.md
+++ b/docs/RPG_PLAYABILITY.md
@@ -816,6 +816,307 @@ a one-frame discontinuity elsewhere; the next suspect is
 1.25 from a raw `running` bool rather than the smoothed `run_presence`, and so
 steps the gait's spatial scale by 25% on the frame a run ends.
 
+## The sword slice, Gate 5
+
+The first slice is one on-foot sword commander, one sword enemy, and the verbs
+move, camera, lock, light attack, guard, and dodge. Four defects were found and
+repaired here; each is named with the measurement that found it.
+
+### One press is one attack
+
+`update_impl` used to build an attack intent from either a press edge **or** an
+`auto_repeat` branch that fired whenever the attack button was held, the queue
+was empty and no animation was running. That is melee auto-repeat, and it is the
+contract Gate 5.1 removes: holding the button now requests exactly one attack,
+the same as tapping it. `rpg_one_press_one_attack` presses three times and then
+holds the button for 1.6 s, and asserts exactly four accepted actions.
+
+The removal made two unit tests fail, and they were right to: they set
+`controller.input().primary_action = true` directly and never produced a press
+edge. A held flag with no edge behind it is not an attack request. Both now go
+through `primary_action_down()`/`primary_action_up()`.
+
+### The input buffer is observable
+
+`CombatIntentQueueComponent` buffered presses for 0.45 s and reported only the
+last outcome. It now buffers for the authored 0.15 s and counts every outcome
+class -- accepted, buffered, refused, expired and overflow -- so a press that
+never becomes a swing is a number instead of a silent loss. `Expired` is a new
+outcome; `expire_stale_intents` records it when it drops an entry, and `push`
+counts an overflow when a fourth press arrives inside the window.
+
+`rpg_attack_buffer_window` replaces `rpg_combo_cadence`, which measured the
+cadence of a _held_ button and therefore tested exactly the auto-repeat contract
+that is now gone. The replacement presses deliberately: one clean press, one
+late enough in the previous swing that the buffer carries it into the next, and
+one so early that the buffer has to let it expire.
+
+### Contacts resolve onto the hurt body
+
+`rpg_defense_contact` had been red since the baseline audit with "no block
+contact published and protected health lost". The guard was not broken. The
+incoming contact point was a point on the _attacker's blade_: for an overhead
+swing, 3.05 m in world space, 2.04 m above the commander's feet, which is above
+his head. The guard test measured that point against a 0.60 m plate at chest
+height and correctly concluded it was nowhere near the guard.
+
+Two repairs, both in the direction Gate 5.3 asks for:
+
+1. `hurt_body_contact_point()` clamps the blade's closest point onto the
+   target's hurt body -- a capsule from 0.30 m to 1.70 m with the body radius --
+   so the contact reported to damage, reaction, sparks and the guard is a point
+   on the body that was actually hit.
+2. Ordinary blocking is the authored guard arc (`frontal_arc_dot`, plus vertical
+   coverage and the guarded side of the body). The 0.60 m plate test is what a
+   _perfect_ guard has to meet, which is what makes the perfect window a skill
+   check rather than an accident of where the blade tip happened to be.
+
+### Line of sight was measured against the navigation box
+
+Writing `rpg_lock_occlusion_death_cycle` produced a scenario where lock-on
+refused all three enemies, including one standing four metres to the side of the
+house. `has_clear_building_los` read `building.width`/`building.depth` -- the RTS
+navigation footprint -- so a `home` drawn 2.36 x 2.42 m cast a 4.3 x 4.4 m shadow
+over every person-scale sight line: lock acquisition, melee line of sight and bow
+aim. It reads the person-scale body now, the same repair Gate 2 made for the body
+collider and the camera boom, and the only reason it survived that pass is that
+nothing measured it.
+
+### Lock-on holds at close range and yields to the hand
+
+Three additions, each with a number behind it:
+
+- Inside 0.75 m the lock stops solving facing; from 0.75 m to 2 m its authority
+  tapers in; and the spring can never turn the view faster than 220 deg/s. A
+  target pinned inside the commander's own footprint used to swing the view 148
+  degrees in half a second. It moves under one degree now.
+- Cycling is screen-space: the first lock takes the target nearest the view
+  centre, each cycle steps to the next target to the right, and the rightmost
+  wraps to the leftmost. It used to step through a list sorted by distance from
+  the centre, which is not an order a player can predict.
+- A look input during lock suspends the spring for 0.35 s, so manual look steers
+  without unlocking.
+
+What is deliberately not done here: the lock still reaches the camera by writing
+`m_view_yaw`, the player's stored free-look yaw. Gate 4.1 forbids that and owns
+the fix -- a camera-owned framing yaw with the player's free-look preserved
+underneath it.
+
+### Defence feedback follows a resolved contact
+
+`PerfectGuard` was published when the player raised the guard and `DodgeSuccess`
+when the player pressed dodge. Neither event meant anything had been defended.
+`RpgHealthComponent` now counts resolved contacts by outcome -- blocked, perfect,
+dodged, damaging, guard-broken -- at the single point where damage resolves, and
+the controller publishes feedback from a change in those counters. Pinned by
+`DefenceFeedbackFollowsAResolvedContactNotARequest` and
+`GuardFeedbackWaitsForAContactToBlock`.
+
+### Stamina became a real constraint
+
+A light attack costs 12 stamina, regeneration is 10/s and a swing takes about
+0.9 s, so the pool never moved: the commander could swing forever. Regeneration
+now pauses for 0.75 s after any spend (`StaminaComponent::spend`), which makes
+the pool the constraint the Gate 5.4 contract assumes.
+`rpg_stamina_refusal_and_recovery` presses until the pool cannot pay, checks the
+refusal is counted, waits, and swings again. The Arena commander also gets a
+stamina component now -- it had none, so its trace reported `-1`.
+
+### Guard and dodge windows are authored in one place
+
+`game/systems/combat_actions/commander_defense_timeline.h` holds the guard raise,
+perfect window, release and break-recovery times and the dodge startup,
+i-frame interval, roll and recovery times. `CommanderDefenseWindowsTest` drives
+the boundary matrix Gate 5.5 asks for -- a contact one tick inside the perfect
+window, one tick after it, and well after it; i-frames at 30, 60 and 120 Hz --
+frame-exact, which a rendered scenario cannot be.
+
+## Feedback that reads, Gate 6
+
+### The hit pause no longer stops the player's timeline
+
+A contact set `is_hit_paused` on the attacker, and `process_combat_state` used
+that flag to skip the authored action timeline entirely. The measured effect on
+the player's own swing was a 0.22 s freeze of `normalized_action_time` at 0.408,
+which delays every window that follows: cancel, exit-safe, and therefore the next
+accepted input. The pause is now presentation-local for a player-controlled
+commander (0.045 s, and it never gates the timeline); other units keep the
+original punch.
+
+### A struck soldier reads, and the instrument can see it
+
+`rpg_melee_contact` was pinned red on `no_visible_hit_reaction` with the note
+that the victim's in-progress attack outranked the reaction. Two separate things
+were wrong.
+
+The scenario gave the six-soldier enemy 500 health, so every commander strike
+was lethal: the "missing reaction" was a death animation, correctly outranking a
+flinch. With 4000 health the victim survives to react.
+
+The second is real and deliberate: `instance_prepare` converts a hit reaction
+into a _swing recoil_ when the victim is mid-swing, so a contact does not cut a
+swing in half. Nothing reported that, so the diagnostics said "Attack" and the
+Arena concluded no reaction had been shown. `is_swing_recoiling` and
+`hit_reaction_tilt_degrees` now ride every soldier sample, and
+`HitReactionObserved` accepts a recoil that carries real tilt. The struck
+soldier recoils 5.77 degrees for 17 frames per contact.
+
+### Accessibility gates
+
+`Game::Accessibility::CommanderInput` holds look sensitivity X and Y, invert Y,
+camera impulse on/off, head bob on/off, an FOV scale, and hold-versus-toggle
+guard; `UiPreferences` persists all seven and publishes them. The camera rig
+already scaled bob and impact kick by `camera_motion_scale`; it now also honours
+the individual switches, and run/dodge FOV kicks scale with reduced motion.
+`CommanderAccessibilityTest` proves each knob changes behaviour rather than only
+being stored.
+
+## Performance and lifecycle, Gate 7
+
+### Prewarm is separated from the budget
+
+The first 0.75 s of every scenario is a prewarm window. Its frames are excluded
+from p50/p95/p99/max and reported separately as `prewarm_frames` and
+`prewarm_max_ms`, because a 306 ms first frame is shader and asset compilation,
+not a gameplay hitch. `PrewarmFramesAreReportedButNotBudgeted` pins the split.
+
+`run_config.json` now names the machine the numbers came from -- CPU model, GPU
+vendor and renderer, GL version, OS, kernel and viewport size -- so a report can
+be read against the hardware it was taken on.
+
+`scripts/rpg_gate_report.py` evaluates the Gate 7.1 contract on every run and
+prints it, and fails the gate on it only under `--enforce-performance`: p95 <=
+16.67 ms, p99 <= 20.0 ms, post-prewarm max <= 33.3 ms, GPU timing present, and a
+marked prewarm window. A frame budget with no GPU timing at all is reported as
+`performance_gpu_timing_missing`.
+
+These numbers are worthless on a loaded box. Check `uptime` first: a run taken
+while another build is using twenty cores reported a p50 four times its quiet
+value.
+
+### Soak and lifecycle
+
+`CommanderLifecycleSoakTest` covers the parts of Gate 7.2 that do not need a
+window: a hundred enter/exit cycles restoring every commander flag and input
+state, a ten-minute duel at 60 Hz where every input edge stays accounted for and
+the buffer never overflows, and a pause injected at forty different points
+inside an action, each of which has to leave no action running two seconds later.
+
+The ten-minute duel is deliberately headless. Long unattended GPU renders have
+hard-crashed this machine twice, and a soak that measures input accounting does
+not need pixels.
+
+## There is no roll pose to check the i-frames against
+
+Gate 5.4 asks for the hurtbox and i-frame window to be verified against the
+rendered roll rather than a timer. It cannot be written yet: through the whole
+dodge the commander is submitted as `Run`, a run cycle played fast, and his root
+height never leaves 1.006 m. The dodge is a translation with a locomotion clip on
+top; there is no roll in the manifest.
+
+The numbers the pose has to satisfy when it is authored: the roll is 0.22 s and
+the i-frames are its first 0.12 s, so a visible tuck has to land inside the first
+half or the invulnerability will not read.
+
+## Two rules the crowd was missing
+
+The engagement ring's attacker budget was already deterministic --
+`deterministic_unit_roll(entity_id, epoch)`, no RNG state -- and two identical
+worlds now prove it. What it lacked was fairness.
+
+At most one presser may come from outside the 100-degree arc the player can see;
+before that, a ring could fill entirely with attackers behind him.
+
+And a presser's `-0.55` incumbency bonus becomes a `+2.4` penalty after three
+seconds in the slot, so the ring rotates. `ACrowdCannotHoldEveryBearingForever`
+found that ten attackers pinned the same four on the commander for the whole ten
+seconds it watched, which is the chained pressure Gate 5.4 forbids.
+
+## A committed strike no longer follows the camera
+
+`body_must_face_view` included `attack_animation_active`, so every tick of a
+running swing assigned `m_body_yaw = m_view_yaw`. A 150-degree mouse flick during
+the active frames turned the body 150 degrees with it, which is what Gate 5.1
+means by "raw camera yaw rotating a committed body arbitrarily through its
+strike".
+
+The authored allowance already existed and nothing read it:
+`melee_interruption_at` publishes `redirect_authority` per phase -- 1.0 in
+windup, 0.35 in the early strike, 0.0 once committed. The body yaw now follows
+the view at that authority, so a swing still starts where the player is looking
+and stops obeying the mouse once the blade is out.
+
+## The second freeze was the whole simulation clock
+
+`CommanderViewModel::time_effect_scale` multiplied `GameEngine::simulate`'s time
+scale by **0.04** for the first half of a 0.10-0.18 s window every time the
+commander landed a hit. Not the commander's animation: the whole match --
+every unit, every projectile, the mission timers -- at four per cent speed. It
+is the "near-global freeze" Gate 6.3 names, and it is deleted: the timer, the
+`hit_stop_duration` field on `CommanderUpdateEffects`, and the scale.
+`LandingAHitNeverSlowsTheSimulationClock` fails if it comes back.
+
+The per-entity hit pause documented above was the other half. Both were found
+the same way -- by asking what a contact does to the _clock_, not to the pose.
+
+## Per-frame budgets have to scale with the frame
+
+Running the gate at `--fps 30` failed six scenarios; four of them were the
+metrics rather than the game. `planted_foot_slide`, `pelvis_snap`,
+`commander_motor_correction` and `commander_boom_discontinuity` are all budgets
+authored as "so many metres (or degrees) between frames" at 60 Hz, so a doubled
+step trips them by construction. They are multiplied by `frame_time * 60`, never
+below 1, so a 60 Hz run measures exactly what it measured before, a 30 Hz run
+measures the same physical rate, and an authored 100 ms hitch frame is judged
+against what a 100 ms frame can legitimately cover.
+
+That took 30 Hz from six failures to two, and the two left are real:
+`rpg_stamina_refusal_and_recovery` accepts nine swings at 30 Hz and ten at 120
+against eleven at 60, so the pool never reaches a refusal; and
+`rpg_close_quarters` trips the `fullscreen_flash` image check on its scripted
+180-degree yaw snap, because consecutive frames are twice as far apart.
+
+The clause this was meant to satisfy -- "behaviour is identical; only
+presentation sampling changes" -- is still owed, because the Arena's `--fps` is
+the batch loop's fixed _simulation_ step. Decoupling render frames from
+simulation steps in the batch loop is the missing piece.
+
+## What the RPG systems actually cost
+
+Five scoped accumulators -- motor, targeting, weapon trace, engagement, camera --
+sample and reset once per tick, ride the commander trace as `costs`, and are
+reported as `rpg_cost_p95_ms` beside `simulation_p95_ms`.
+
+First measurement, `rpg_skirmish_three_attackers` at 60 Hz: the simulation tick
+is 0.19 ms at p95, and the entire RPG slice inside it is 0.019 ms -- engagement
+0.021, camera 0.010, weapon trace 0.004, targeting 0.002, motor below the
+timer's resolution. Whatever a 13 ms frame is spent on, it is not these.
+
+## Where the gate stands after the sword slice
+
+21 scenarios: 19 green, 2 known-red, 0 unexpected failures, 0 undeclared flakes,
+0 incomplete. Both reds predate this work -- `rpg_motor_start_stop` is Gate 3's
+planted-foot slide, and `rpg_escort_crowd` regressed at commit `35d87259` with a
+1.4-1.6 m render-root jump on three enemy soldiers at 0.23 s, reproduced on a
+pristine checkout of that commit before it was pinned.
+
+Every unit suite is green: 4322 gtest cases across nine binaries plus 439 QML
+cases, `scripts/run-tests.sh` exit 0.
+
+An ASan/UBSan sweep (`RelWithDebInfo`, `-DENABLE_SANITIZER=address,undefined`,
+`ASAN_OPTIONS=detect_leaks=0`) of `app_tests`, `combat_balance_tests`,
+`arena_tests` and `persistence_tests` reports zero address findings and one
+undefined-behaviour finding: a signed integer overflow in the Arena city plot
+hash, predating this work and fixed in passing. `AudioCueCatalogTest` fails only
+in the sanitized tree, whose `bin/assets` copy is six days stale -- see
+[[bin-assets-is-a-copy-not-a-symlink]].
+
+Two repository checks are red at HEAD and were red before this work:
+`check-ambient-instances` (one ambient lookup in `app/commander` against a budget
+of zero, introduced by `35d87259`) and `content_validator` (a troop layout
+reference). Neither is touched by the sword slice; both were confirmed by
+stashing the change and re-running.
+
 ## Working rules
 
 - Every bug fix starts with a failing deterministic regression or a new Arena

--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(
     accessibility_runtime
     STATIC
     accessibility/team_identity.cpp
+    accessibility/commander_input_settings.cpp
     accessibility/motion_settings.cpp
 )
 target_include_directories(accessibility_runtime PUBLIC ..)

--- a/game/accessibility/commander_input_settings.cpp
+++ b/game/accessibility/commander_input_settings.cpp
@@ -1,0 +1,94 @@
+#include "commander_input_settings.h"
+
+#include <algorithm>
+#include <atomic>
+
+namespace Game::Accessibility::CommanderInput {
+
+namespace {
+
+constexpr float k_min_sensitivity = 0.20F;
+constexpr float k_max_sensitivity = 4.00F;
+constexpr float k_min_fov_scale = 0.75F;
+constexpr float k_max_fov_scale = 1.35F;
+
+std::atomic<float> g_look_sensitivity_x{1.0F};
+std::atomic<float> g_look_sensitivity_y{1.0F};
+std::atomic<bool> g_invert_look_y{false};
+std::atomic<bool> g_camera_impulse_enabled{true};
+std::atomic<bool> g_head_bob_enabled{true};
+std::atomic<float> g_field_of_view_scale{1.0F};
+std::atomic<bool> g_guard_is_toggle{false};
+
+} // namespace
+
+void set_look_sensitivity_x(float scale) {
+  g_look_sensitivity_x.store(std::clamp(scale, k_min_sensitivity, k_max_sensitivity),
+                             std::memory_order_relaxed);
+}
+
+auto look_sensitivity_x() -> float {
+  return g_look_sensitivity_x.load(std::memory_order_relaxed);
+}
+
+void set_look_sensitivity_y(float scale) {
+  g_look_sensitivity_y.store(std::clamp(scale, k_min_sensitivity, k_max_sensitivity),
+                             std::memory_order_relaxed);
+}
+
+auto look_sensitivity_y() -> float {
+  return g_look_sensitivity_y.load(std::memory_order_relaxed);
+}
+
+void set_invert_look_y(bool enabled) {
+  g_invert_look_y.store(enabled, std::memory_order_relaxed);
+}
+
+auto invert_look_y() -> bool {
+  return g_invert_look_y.load(std::memory_order_relaxed);
+}
+
+void set_camera_impulse_enabled(bool enabled) {
+  g_camera_impulse_enabled.store(enabled, std::memory_order_relaxed);
+}
+
+auto camera_impulse_enabled() -> bool {
+  return g_camera_impulse_enabled.load(std::memory_order_relaxed);
+}
+
+void set_head_bob_enabled(bool enabled) {
+  g_head_bob_enabled.store(enabled, std::memory_order_relaxed);
+}
+
+auto head_bob_enabled() -> bool {
+  return g_head_bob_enabled.load(std::memory_order_relaxed);
+}
+
+void set_field_of_view_scale(float scale) {
+  g_field_of_view_scale.store(std::clamp(scale, k_min_fov_scale, k_max_fov_scale),
+                              std::memory_order_relaxed);
+}
+
+auto field_of_view_scale() -> float {
+  return g_field_of_view_scale.load(std::memory_order_relaxed);
+}
+
+void set_guard_is_toggle(bool enabled) {
+  g_guard_is_toggle.store(enabled, std::memory_order_relaxed);
+}
+
+auto guard_is_toggle() -> bool {
+  return g_guard_is_toggle.load(std::memory_order_relaxed);
+}
+
+void reset_to_defaults() {
+  set_look_sensitivity_x(1.0F);
+  set_look_sensitivity_y(1.0F);
+  set_invert_look_y(false);
+  set_camera_impulse_enabled(true);
+  set_head_bob_enabled(true);
+  set_field_of_view_scale(1.0F);
+  set_guard_is_toggle(false);
+}
+
+} // namespace Game::Accessibility::CommanderInput

--- a/game/accessibility/commander_input_settings.h
+++ b/game/accessibility/commander_input_settings.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace Game::Accessibility::CommanderInput {
+
+void set_look_sensitivity_x(float scale);
+[[nodiscard]] auto look_sensitivity_x() -> float;
+
+void set_look_sensitivity_y(float scale);
+[[nodiscard]] auto look_sensitivity_y() -> float;
+
+void set_invert_look_y(bool enabled);
+[[nodiscard]] auto invert_look_y() -> bool;
+
+void set_camera_impulse_enabled(bool enabled);
+[[nodiscard]] auto camera_impulse_enabled() -> bool;
+
+void set_head_bob_enabled(bool enabled);
+[[nodiscard]] auto head_bob_enabled() -> bool;
+
+void set_field_of_view_scale(float scale);
+[[nodiscard]] auto field_of_view_scale() -> float;
+
+void set_guard_is_toggle(bool enabled);
+[[nodiscard]] auto guard_is_toggle() -> bool;
+
+void reset_to_defaults();
+
+} // namespace Game::Accessibility::CommanderInput

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -637,7 +637,8 @@ enum class CombatIntentOutcome : std::uint8_t {
   Committed,
   GuardBroken,
   Staggered,
-  NoFighter
+  NoFighter,
+  Expired
 };
 
 struct CombatActionIntent {
@@ -655,7 +656,7 @@ public:
 
   static constexpr std::size_t k_capacity = 3U;
 
-  static constexpr float k_intent_lifetime = 0.45F;
+  static constexpr float k_intent_lifetime = 0.15F;
 
   std::array<CombatActionIntent, k_capacity> entries{};
   std::uint8_t count{0};
@@ -664,6 +665,12 @@ public:
 
   CombatIntentOutcome last_outcome{CombatIntentOutcome::Accepted};
   float last_outcome_age{0.0F};
+
+  std::uint32_t accepted_intents{0};
+  std::uint32_t buffered_intents{0};
+  std::uint32_t refused_intents{0};
+  std::uint32_t expired_intents{0};
+  std::uint32_t overflow_intents{0};
 
   [[nodiscard]] auto empty() const noexcept -> bool { return count == 0U; }
 
@@ -678,6 +685,7 @@ public:
         entries[i - 1] = entries[i];
       }
       --count;
+      ++overflow_intents;
     }
     entries[count++] = intent;
   }
@@ -695,6 +703,27 @@ public:
   void clear() noexcept { count = 0U; }
 
   void record(CombatIntentOutcome outcome) noexcept {
+    if (outcome != last_outcome || outcome == CombatIntentOutcome::Accepted) {
+      switch (outcome) {
+      case CombatIntentOutcome::Accepted:
+        ++accepted_intents;
+        break;
+      case CombatIntentOutcome::Buffered:
+      case CombatIntentOutcome::Recovering:
+      case CombatIntentOutcome::Committed:
+        ++buffered_intents;
+        break;
+      case CombatIntentOutcome::Expired:
+        ++expired_intents;
+        break;
+      case CombatIntentOutcome::InsufficientStamina:
+      case CombatIntentOutcome::GuardBroken:
+      case CombatIntentOutcome::Staggered:
+      case CombatIntentOutcome::NoFighter:
+        ++refused_intents;
+        break;
+      }
+    }
     last_outcome = outcome;
     last_outcome_age = 0.0F;
   }
@@ -894,6 +923,8 @@ public:
   TelegraphCue telegraph_cue{TelegraphCue::None};
 
   static constexpr float k_combat_animation_hit_pause_duration = 0.10F;
+
+  static constexpr float k_player_hit_pause_duration = 0.045F;
   static constexpr float k_advance_duration = 0.22F;
   static constexpr float k_wind_up_duration = 0.42F;
   static constexpr float k_strike_duration = 0.34F;
@@ -1341,6 +1372,13 @@ public:
   float dodge_grace_remaining{0.0F};
   float dodge_dir_x{0.0F};
   float dodge_dir_z{0.0F};
+
+  std::uint32_t blocked_contacts{0};
+  std::uint32_t perfect_guard_contacts{0};
+  std::uint32_t dodged_contacts{0};
+  std::uint32_t damaging_contacts{0};
+  std::uint32_t guard_broken_contacts{0};
+  RpgContactOutcome last_contact_outcome{RpgContactOutcome::Damage};
 };
 
 class StaggerComponent {
@@ -1369,11 +1407,18 @@ public:
     bool pressing{false};
   };
 
+  struct PressTenure {
+    EntityID entity_id{0};
+    float started_at{0.0F};
+  };
+
   std::vector<Slot> engagement_slots;
   float ring_radius{5.0F};
 
   float pressure_clock{0.0F};
   FightContext fight_context{FightContext::None};
+
+  std::vector<PressTenure> press_tenure;
 
   [[nodiscard]] auto pressing_count() const noexcept -> int {
     int pressing = 0;
@@ -1946,12 +1991,24 @@ public:
 
   StaminaComponent() noexcept = default;
 
+  static constexpr float k_regen_delay_seconds = 0.75F;
+
   float stamina{k_default_max_stamina};
   float max_stamina{k_default_max_stamina};
   float regen_rate{k_default_regen_rate};
   float depletion_rate{k_default_depletion_rate};
   bool is_running{false};
   bool run_requested{false};
+
+  float regen_delay_remaining{0.0F};
+
+  void spend(float cost) noexcept {
+    if (cost <= 0.0F) {
+      return;
+    }
+    stamina = stamina - cost > 0.0F ? stamina - cost : 0.0F;
+    regen_delay_remaining = k_regen_delay_seconds;
+  }
 
   [[nodiscard]] auto get_stamina_ratio() const noexcept -> float {
     return max_stamina > 0.0F ? stamina / max_stamina : 0.0F;

--- a/game/core/movement_trace.cpp
+++ b/game/core/movement_trace.cpp
@@ -113,9 +113,15 @@ auto read_float(const std::string& line, std::string_view key, float& out) -> bo
   if (text.empty()) {
     return false;
   }
+  // libc++ and MSVC still ship without the floating-point overloads of
+  // std::from_chars, so the parse goes through an istream pinned to the
+  // classic locale -- strtof honours LC_NUMERIC and misreads traces on
+  // machines whose decimal separator is a comma.
+  std::istringstream stream{std::string(text)};
+  stream.imbue(std::locale::classic());
   float parsed = 0.0F;
-  auto const result = std::from_chars(text.data(), text.data() + text.size(), parsed);
-  if (result.ec != std::errc{}) {
+  stream >> parsed;
+  if (stream.fail() || !(stream >> std::ws).eof()) {
     return false;
   }
   out = parsed;

--- a/game/core/movement_trace.cpp
+++ b/game/core/movement_trace.cpp
@@ -113,10 +113,7 @@ auto read_float(const std::string& line, std::string_view key, float& out) -> bo
   if (text.empty()) {
     return false;
   }
-  // libc++ and MSVC still ship without the floating-point overloads of
-  // std::from_chars, so the parse goes through an istream pinned to the
-  // classic locale -- strtof honours LC_NUMERIC and misreads traces on
-  // machines whose decimal separator is a comma.
+
   std::istringstream stream{std::string(text)};
   stream.imbue(std::locale::classic());
   float parsed = 0.0F;

--- a/game/core/simulation_timing.cpp
+++ b/game/core/simulation_timing.cpp
@@ -7,4 +7,44 @@ auto combat_state_update() noexcept -> MicrosecondAccumulator& {
   return accumulator;
 }
 
+auto commander_motor() noexcept -> MicrosecondAccumulator& {
+  static MicrosecondAccumulator accumulator;
+  return accumulator;
+}
+
+auto commander_targeting() noexcept -> MicrosecondAccumulator& {
+  static MicrosecondAccumulator accumulator;
+  return accumulator;
+}
+
+auto commander_weapon_trace() noexcept -> MicrosecondAccumulator& {
+  static MicrosecondAccumulator accumulator;
+  return accumulator;
+}
+
+auto commander_engagement() noexcept -> MicrosecondAccumulator& {
+  static MicrosecondAccumulator accumulator;
+  return accumulator;
+}
+
+auto commander_camera() noexcept -> MicrosecondAccumulator& {
+  static MicrosecondAccumulator accumulator;
+  return accumulator;
+}
+
+auto sample_and_reset_rpg_costs() noexcept -> RpgCostSample {
+  RpgCostSample sample;
+  sample.motor_us = commander_motor().value();
+  sample.targeting_us = commander_targeting().value();
+  sample.weapon_trace_us = commander_weapon_trace().value();
+  sample.engagement_us = commander_engagement().value();
+  sample.camera_us = commander_camera().value();
+  commander_motor().reset();
+  commander_targeting().reset();
+  commander_weapon_trace().reset();
+  commander_engagement().reset();
+  commander_camera().reset();
+  return sample;
+}
+
 } // namespace Engine::Core::Timing

--- a/game/core/simulation_timing.h
+++ b/game/core/simulation_timing.h
@@ -24,6 +24,22 @@ private:
 
 [[nodiscard]] auto combat_state_update() noexcept -> MicrosecondAccumulator&;
 
+[[nodiscard]] auto commander_motor() noexcept -> MicrosecondAccumulator&;
+[[nodiscard]] auto commander_targeting() noexcept -> MicrosecondAccumulator&;
+[[nodiscard]] auto commander_weapon_trace() noexcept -> MicrosecondAccumulator&;
+[[nodiscard]] auto commander_engagement() noexcept -> MicrosecondAccumulator&;
+[[nodiscard]] auto commander_camera() noexcept -> MicrosecondAccumulator&;
+
+struct RpgCostSample {
+  std::uint64_t motor_us{0};
+  std::uint64_t targeting_us{0};
+  std::uint64_t weapon_trace_us{0};
+  std::uint64_t engagement_us{0};
+  std::uint64_t camera_us{0};
+};
+
+[[nodiscard]] auto sample_and_reset_rpg_costs() noexcept -> RpgCostSample;
+
 class ScopedAccumulator {
 public:
   explicit ScopedAccumulator(MicrosecondAccumulator& accumulator) noexcept

--- a/game/systems/building_line_of_sight.cpp
+++ b/game/systems/building_line_of_sight.cpp
@@ -193,8 +193,8 @@ auto has_clear_building_los(const BuildingCollisionRegistry& buildings,
                             const QVector3D& start,
                             const QVector3D& end,
                             unsigned int ignore_entity_id) -> bool {
-  return first_building_intersection_fraction(
-             buildings, start, end, ignore_entity_id) >= 1.0F;
+  return first_building_body_intersection_fraction(
+             buildings, start, end, 0.0F, ignore_entity_id) >= 1.0F;
 }
 
 } // namespace Game::Systems

--- a/game/systems/combat_actions/combat_action_service.cpp
+++ b/game/systems/combat_actions/combat_action_service.cpp
@@ -68,6 +68,11 @@ void expire_stale_intents(Engine::Core::CombatIntentQueueComponent& queue,
       queue.entries[kept++] = queue.entries[i];
     }
   }
+  if (kept < queue.count) {
+    queue.count = kept;
+    queue.record(Engine::Core::CombatIntentOutcome::Expired);
+    return;
+  }
   queue.count = kept;
 }
 
@@ -113,7 +118,9 @@ auto CombatActionService::request_attack(
   if (combat_state != nullptr && !interruption.accepts_attack &&
       combat_state->animation_state != Engine::Core::CombatAnimationState::Idle) {
     result.accepted = true;
+    result.buffered = true;
     result.outcome = Engine::Core::CombatIntentOutcome::Recovering;
+    record_outcome(*attacker, result.outcome);
     return result;
   }
 
@@ -306,7 +313,7 @@ auto CombatActionService::request_attack(
             ? (heavy ? definition->heavy_stamina_cost : definition->light_stamina_cost)
             : (heavy ? Engine::Core::CombatStateComponent::k_stamina_cost_heavy_attack
                      : Engine::Core::CombatStateComponent::k_stamina_cost_light_attack);
-    stamina->stamina = std::max(0.0F, stamina->stamina - cost);
+    stamina->spend(cost);
   }
 
   if (combat_state != nullptr) {

--- a/game/systems/combat_actions/commander_defense_timeline.h
+++ b/game/systems/combat_actions/commander_defense_timeline.h
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace Game::Systems::CombatActions {
+
+struct GuardTimeline {
+  float raise_seconds{0.06F};
+  float perfect_window_seconds{0.16F};
+  float release_seconds{0.08F};
+  float break_recovery_seconds{1.0F};
+};
+
+struct DodgeTimeline {
+  float startup_seconds{0.0F};
+  float invulnerable_start_seconds{0.0F};
+  float invulnerable_end_seconds{0.12F};
+  float roll_seconds{0.22F};
+  float recovery_seconds{0.18F};
+
+  [[nodiscard]] constexpr auto invulnerable_seconds() const noexcept -> float {
+    return invulnerable_end_seconds - invulnerable_start_seconds;
+  }
+};
+
+inline constexpr GuardTimeline k_commander_guard_timeline{};
+inline constexpr DodgeTimeline k_commander_dodge_timeline{};
+
+} // namespace Game::Systems::CombatActions

--- a/game/systems/combat_actions/weapon_trace.cpp
+++ b/game/systems/combat_actions/weapon_trace.cpp
@@ -15,6 +15,7 @@
 #include "../../../animation/clip_manifest.h"
 #include "../../../animation/melee_swing_manifest.h"
 #include "../../core/component.h"
+#include "../../core/simulation_timing.h"
 #include "../../core/world.h"
 #include "../combat_rules.h"
 #include "../combat_system/combat_utils.h"
@@ -926,6 +927,8 @@ auto find_weapon_trace_contact(
     WeaponTraceTimeSpan time_span,
     Engine::Core::EntityID target_hint_id,
     std::span<const Engine::Core::EntityID> ignored_target_ids) -> WeaponTraceContact {
+  Engine::Core::Timing::ScopedAccumulator const scope(
+      Engine::Core::Timing::commander_weapon_trace());
   constexpr float k_max_trace_sample_span = 0.025F;
   float const trace_span =
       time_span.current_normalized_time - time_span.previous_normalized_time;
@@ -1027,7 +1030,8 @@ auto find_weapon_trace_contact(
       best_contact.distance = sample.distance;
       best_contact.local_forward = sample.forward;
       best_contact.local_right = sample.right;
-      best_contact.contact_point = distance.point;
+      best_contact.contact_point =
+          Game::Systems::RpgCombat::hurt_body_contact_point(soldier, distance.point);
       best_contact.contact_speed = tip_speed;
     }
   };
@@ -1048,6 +1052,8 @@ auto find_weapon_trace_contact(
     const CombatActionDefinition& definition,
     Engine::Core::EntityID target_hint_id,
     std::span<const Engine::Core::EntityID> ignored_target_ids) -> WeaponTraceContact {
+  Engine::Core::Timing::ScopedAccumulator const scope(
+      Engine::Core::Timing::commander_weapon_trace());
   WeaponTraceContact contact;
   contact.attacker_id = attacker.get_id();
 
@@ -1095,7 +1101,8 @@ auto find_weapon_trace_contact(
       best_contact.distance = sample.distance;
       best_contact.local_forward = sample.forward;
       best_contact.local_right = sample.right;
-      best_contact.contact_point = sample.world_position;
+      best_contact.contact_point = Game::Systems::RpgCombat::hurt_body_contact_point(
+          soldier, presented_attacker.frame.origin);
     }
   };
 

--- a/game/systems/combat_system/combat_action_processor.cpp
+++ b/game/systems/combat_system/combat_action_processor.cpp
@@ -452,13 +452,21 @@ void deal_weapon_trace_damage(
   if (presentation_state != nullptr) {
     presentation_state->damage_dealt_this_swing = true;
 
+    auto const* attacker_commander =
+        attacker.get_component<Engine::Core::CommanderComponent>();
+    bool const player_controlled =
+        attacker_commander != nullptr && attacker_commander->fpv_controlled;
+
     presentation_state->is_hit_paused = true;
     presentation_state->hit_pause_remaining =
-        Engine::Core::CombatStateComponent::k_combat_animation_hit_pause_duration *
-        std::clamp(contact.contact_speed /
-                       Game::Systems::Combat::k_reference_weapon_speed,
-                   0.5F,
-                   1.6F);
+        player_controlled
+            ? Engine::Core::CombatStateComponent::k_player_hit_pause_duration
+            : Engine::Core::CombatStateComponent::
+                      k_combat_animation_hit_pause_duration *
+                  std::clamp(contact.contact_speed /
+                                 Game::Systems::Combat::k_reference_weapon_speed,
+                             0.5F,
+                             1.6F);
     presentation_state->telegraph_cue = Engine::Core::TelegraphCue::Impact;
   }
   action.last_hit_target_id = contact.target_id;

--- a/game/systems/combat_system/combat_state_processor.cpp
+++ b/game/systems/combat_system/combat_state_processor.cpp
@@ -205,6 +205,17 @@ auto apply_action_timeline_phase(
   return true;
 }
 
+[[nodiscard]] auto hit_pause_holds_timeline(
+    const Engine::Core::Entity& unit,
+    const Engine::Core::CombatStateComponent& combat_state) -> bool {
+  if (!combat_state.is_hit_paused) {
+    return false;
+  }
+
+  auto const* commander = unit.get_component<Engine::Core::CommanderComponent>();
+  return commander == nullptr || !commander->fpv_controlled;
+}
+
 void reset_action_events_if_present(Engine::Core::Entity& unit) {
   auto* action = unit.get_component<Engine::Core::RpgCommanderActionComponent>();
   if (action == nullptr) {
@@ -241,7 +252,8 @@ void process_combat_state(Engine::Core::World* world, float delta_time) {
       continue;
     }
     auto* presentation_state = unit.get_component<Engine::Core::CombatStateComponent>();
-    if (presentation_state != nullptr && presentation_state->is_hit_paused) {
+    if (presentation_state != nullptr &&
+        hit_pause_holds_timeline(unit, *presentation_state)) {
       continue;
     }
     process_authored_combat_action(world, unit, presentation_state, delta_time);
@@ -250,7 +262,7 @@ void process_combat_state(Engine::Core::World* world, float delta_time) {
   for (auto [unit, combat_state] :
        world->entity_view<Engine::Core::CombatStateComponent>()) {
     if (unit.has_component<Engine::Core::PendingRemovalComponent>() ||
-        combat_state.is_hit_paused) {
+        hit_pause_holds_timeline(unit, combat_state)) {
       continue;
     }
 

--- a/game/systems/combat_system/damage_application.cpp
+++ b/game/systems/combat_system/damage_application.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <limits>
 #include <numbers>
 #include <optional>
@@ -278,6 +280,13 @@ void publish_formation_hit(
       Engine::Core::FormationHitPresentationComponent>(&target);
   if (hit == nullptr) {
     return;
+  }
+  if (std::getenv("SOI_HITDBG") != nullptr) {
+    std::fprintf(stderr,
+                 "[hitdbg] publish target=%llu slot=%u kind=%d\n",
+                 (unsigned long long)target.get_id(),
+                 (unsigned)*slot,
+                 (int)kind);
   }
   hit->attacker_id = attacker_id;
   hit->soldier_slot = *slot;

--- a/game/systems/combat_system/damage_application.cpp
+++ b/game/systems/combat_system/damage_application.cpp
@@ -284,9 +284,9 @@ void publish_formation_hit(
   if (std::getenv("SOI_HITDBG") != nullptr) {
     std::fprintf(stderr,
                  "[hitdbg] publish target=%llu slot=%u kind=%d\n",
-                 (unsigned long long)target.get_id(),
-                 (unsigned)*slot,
-                 (int)kind);
+                 static_cast<unsigned long long>(target.get_id()),
+                 static_cast<unsigned>(*slot),
+                 static_cast<int>(kind));
   }
   hit->attacker_id = attacker_id;
   hit->soldier_slot = *slot;
@@ -603,28 +603,6 @@ auto note_wildlife_aggressor(Engine::Core::Entity* target,
   wildlife->hostile_timer = Game::Wildlife::k_hostility_duration;
   wildlife->think_cooldown = 0.0F;
   return true;
-}
-
-auto can_retaliate(Engine::Core::Entity* entity,
-                   const Engine::Core::UnitComponent* unit) -> bool {
-  if ((entity == nullptr) || (unit == nullptr)) {
-    return false;
-  }
-  if (entity->has_component<Engine::Core::BuildingComponent>()) {
-    return false;
-  }
-  if (unit->spawn_type == Game::Units::SpawnType::Civilian) {
-    return false;
-  }
-  if (!Game::Systems::CombatRules::participates_in_rts_melee_lock(entity)) {
-    return false;
-  }
-  return entity->get_component<Engine::Core::AttackComponent>() != nullptr;
-}
-
-auto can_reach_attacker(Engine::Core::Entity* entity,
-                        Engine::Core::Entity* attacker) -> bool {
-  return !melee_walled_off_from(entity, attacker);
 }
 
 void engage_retaliation_target(Engine::Core::Entity* entity,

--- a/game/systems/movement_orders.cpp
+++ b/game/systems/movement_orders.cpp
@@ -80,10 +80,6 @@ auto resolve_walkable_direct_target(const QVector3D& target,
       .value_or(target);
 }
 
-auto should_include_resolved_start_waypoint(const Point& start) -> bool {
-  return !NavGrid::is_grid_walkable(start);
-}
-
 auto segment_traverses_navigation_portal(const QVector3D& from,
                                          const QVector3D& to) -> bool {
   auto& terrain = Game::Map::TerrainService::instance();

--- a/game/systems/rpg_combat_system/rpg_combat_processor.cpp
+++ b/game/systems/rpg_combat_system/rpg_combat_processor.cpp
@@ -32,6 +32,12 @@ constexpr float k_obstruction_distance = 2.4F;
 
 constexpr float k_press_sector_degrees = 46.0F;
 
+constexpr float k_offscreen_press_arc_degrees = 100.0F;
+constexpr int k_max_offscreen_pressers = 1;
+
+constexpr float k_press_tenure_seconds = 3.0F;
+constexpr float k_press_tenure_penalty = 2.4F;
+
 constexpr float k_pressure_epoch_seconds = 1.35F;
 
 constexpr float k_waiting_band_near = 2.3F;
@@ -247,7 +253,15 @@ void refresh_commander_engagement(Engine::Core::World* world,
     if (std::find(previously_pressing.begin(),
                   previously_pressing.end(),
                   slot.entity_id) != previously_pressing.end()) {
-      score -= 0.55F;
+
+      auto const tenure = std::find_if(
+          engagement->press_tenure.begin(),
+          engagement->press_tenure.end(),
+          [&slot](auto const& entry) { return entry.entity_id == slot.entity_id; });
+      float const held_for = tenure != engagement->press_tenure.end()
+                                 ? engagement->pressure_clock - tenure->started_at
+                                 : 0.0F;
+      score += held_for >= k_press_tenure_seconds ? k_press_tenure_penalty : -0.55F;
     }
     scores[i] = score;
     order.push_back(i);
@@ -260,11 +274,18 @@ void refresh_commander_engagement(Engine::Core::World* world,
   int const capacity = std::clamp(1 + (crowd / 3), 1, 4);
   std::vector<float> taken_bearings;
   taken_bearings.reserve(static_cast<std::size_t>(capacity));
+  int offscreen_pressers = 0;
   for (std::size_t const index : order) {
     if (static_cast<int>(taken_bearings.size()) >= capacity) {
       break;
     }
     auto& slot = engagement->engagement_slots[index];
+
+    bool const offscreen =
+        std::abs(slot.signed_angle_degrees) > k_offscreen_press_arc_degrees;
+    if (offscreen && offscreen_pressers >= k_max_offscreen_pressers) {
+      continue;
+    }
     bool sector_taken = false;
     for (float const bearing : taken_bearings) {
       float gap = std::fmod(slot.signed_angle_degrees - bearing + 540.0F, 360.0F);
@@ -278,8 +299,26 @@ void refresh_commander_engagement(Engine::Core::World* world,
       continue;
     }
     slot.pressing = true;
+    offscreen_pressers += offscreen ? 1 : 0;
     taken_bearings.push_back(slot.signed_angle_degrees);
   }
+
+  std::vector<Engine::Core::RpgEngagementComponent::PressTenure> refreshed_tenure;
+  refreshed_tenure.reserve(engagement->press_tenure.size() + 1U);
+  for (auto const& slot : engagement->engagement_slots) {
+    if (!slot.pressing) {
+      continue;
+    }
+    auto const existing = std::find_if(
+        engagement->press_tenure.begin(),
+        engagement->press_tenure.end(),
+        [&slot](auto const& entry) { return entry.entity_id == slot.entity_id; });
+    refreshed_tenure.push_back({.entity_id = slot.entity_id,
+                                .started_at = existing != engagement->press_tenure.end()
+                                                  ? existing->started_at
+                                                  : engagement->pressure_clock});
+  }
+  engagement->press_tenure = std::move(refreshed_tenure);
 
   std::sort(
       engagement->engagement_slots.begin(),

--- a/game/systems/rpg_combat_system/rpg_commander_damage.cpp
+++ b/game/systems/rpg_combat_system/rpg_commander_damage.cpp
@@ -305,18 +305,6 @@ auto resolve_commander_guard(Engine::Core::World* world,
   return result;
 }
 
-auto attacker_spawn_type(Engine::Core::World* world,
-                         Engine::Core::EntityID attacker_id) -> Game::Units::SpawnType {
-  if (world == nullptr || attacker_id == 0) {
-    return Game::Units::SpawnType::Knight;
-  }
-  auto* attacker = world->get_entity(attacker_id);
-  auto* unit = attacker != nullptr
-                   ? attacker->get_component<Engine::Core::UnitComponent>()
-                   : nullptr;
-  return unit != nullptr ? unit->spawn_type : Game::Units::SpawnType::Knight;
-}
-
 void record_resolved_contact(Engine::Core::Entity* defender,
                              const CommanderDamageResult& result) {
   auto* rpg = defender != nullptr

--- a/game/systems/rpg_combat_system/rpg_commander_damage.cpp
+++ b/game/systems/rpg_combat_system/rpg_commander_damage.cpp
@@ -33,6 +33,10 @@ constexpr float k_guard_stand_off = 0.28F;
 constexpr float k_guard_plate_offset = 0.30F;
 constexpr float k_guard_plate_radius = 0.60F;
 
+constexpr float k_guard_low_coverage = 0.25F;
+constexpr float k_guard_high_coverage = 2.10F;
+constexpr float k_guard_contact_side_dot = -0.20F;
+
 auto attack_comes_from_the_front(const Engine::Core::TransformComponent& target,
                                  const Engine::Core::TransformComponent& attacker,
                                  float frontal_arc_dot) -> bool {
@@ -48,7 +52,7 @@ auto attack_comes_from_the_front(const Engine::Core::TransformComponent& target,
   return QVector3D::dotProduct(forward, to_attacker) >= frontal_arc_dot;
 }
 
-auto guard_intercepts_contact(Engine::Core::Entity* target,
+auto contact_enters_guard_arc(Engine::Core::Entity* target,
                               Engine::Core::Entity* attacker,
                               const Engine::Core::CommanderGuardComponent& guard,
                               std::optional<QVector3D> contact_point) -> bool {
@@ -63,6 +67,36 @@ auto guard_intercepts_contact(Engine::Core::Entity* target,
   }
   if (!attack_comes_from_the_front(
           *target_transform, *attacker_transform, guard.frontal_arc_dot)) {
+    return false;
+  }
+  if (!contact_point.has_value()) {
+    return true;
+  }
+
+  float const local_height = contact_point->y() - target_transform->position.y;
+  if (local_height < k_guard_low_coverage || local_height > k_guard_high_coverage) {
+    return false;
+  }
+
+  const float yaw = target_transform->rotation.y * k_degrees_to_radians;
+  QVector3D const forward(std::sin(yaw), 0.0F, std::cos(yaw));
+  QVector3D const to_contact(contact_point->x() - target_transform->position.x,
+                             0.0F,
+                             contact_point->z() - target_transform->position.z);
+  if (to_contact.lengthSquared() <= 0.0001F) {
+    return true;
+  }
+  return QVector3D::dotProduct(forward, to_contact.normalized()) >=
+         k_guard_contact_side_dot;
+}
+
+auto contact_meets_guard_plate(Engine::Core::Entity* target,
+                               const Engine::Core::CommanderGuardComponent& guard,
+                               std::optional<QVector3D> contact_point) -> bool {
+  auto const* target_transform =
+      target != nullptr ? target->get_component<Engine::Core::TransformComponent>()
+                        : nullptr;
+  if (target_transform == nullptr) {
     return false;
   }
   if (!contact_point.has_value()) {
@@ -192,7 +226,8 @@ auto resolve_perfect_guard(Engine::Core::World* world,
   auto* attacker = world->get_entity(attacker_id);
   if (guard == nullptr || attacker == nullptr || !guard->active ||
       guard->guard_break_remaining > 0.0F || guard->perfect_guard_remaining <= 0.0F ||
-      !guard_intercepts_contact(target, attacker, *guard, contact_point)) {
+      !contact_enters_guard_arc(target, attacker, *guard, contact_point) ||
+      !contact_meets_guard_plate(target, *guard, contact_point)) {
     return false;
   }
 
@@ -221,7 +256,7 @@ auto resolve_commander_guard(Engine::Core::World* world,
   auto* guard = target->get_component<Engine::Core::CommanderGuardComponent>();
   auto* attacker = world->get_entity(attacker_id);
   if (guard == nullptr || attacker == nullptr ||
-      !guard_intercepts_contact(target, attacker, *guard, contact_point)) {
+      !contact_enters_guard_arc(target, attacker, *guard, contact_point)) {
     return result;
   }
 
@@ -280,6 +315,38 @@ auto attacker_spawn_type(Engine::Core::World* world,
                    ? attacker->get_component<Engine::Core::UnitComponent>()
                    : nullptr;
   return unit != nullptr ? unit->spawn_type : Game::Units::SpawnType::Knight;
+}
+
+void record_resolved_contact(Engine::Core::Entity* defender,
+                             const CommanderDamageResult& result) {
+  auto* rpg = defender != nullptr
+                  ? defender->get_component<Engine::Core::RpgHealthComponent>()
+                  : nullptr;
+  if (rpg == nullptr) {
+    return;
+  }
+  if (result.dodged) {
+    ++rpg->dodged_contacts;
+    rpg->last_contact_outcome = Engine::Core::RpgContactOutcome::Dodge;
+    return;
+  }
+  if (result.perfect_guarded) {
+    ++rpg->perfect_guard_contacts;
+    rpg->last_contact_outcome = Engine::Core::RpgContactOutcome::PerfectGuard;
+    return;
+  }
+  if (result.guard_broken) {
+    ++rpg->guard_broken_contacts;
+  }
+  if (result.blocked) {
+    ++rpg->blocked_contacts;
+    rpg->last_contact_outcome = Engine::Core::RpgContactOutcome::Block;
+    return;
+  }
+  if (result.effective_damage > 0) {
+    ++rpg->damaging_contacts;
+    rpg->last_contact_outcome = Engine::Core::RpgContactOutcome::Damage;
+  }
 }
 
 void mark_commander_hit(Engine::Core::CommanderComponent& commander,
@@ -403,6 +470,7 @@ deal_damage_to_rpg_commander(Engine::Core::World* world,
   auto* attacker = world->get_entity(attacker_id);
   if (dodge_beats_contact(commander, attacker, contact_point)) {
     result.dodged = true;
+    record_resolved_contact(commander, result);
     return result;
   }
 
@@ -411,6 +479,7 @@ deal_damage_to_rpg_commander(Engine::Core::World* world,
     result.perfect_guarded = true;
     result.blocked = true;
     play_guard_cue(commander, "combat.perfect_guard");
+    record_resolved_contact(commander, result);
     return result;
   }
 
@@ -428,6 +497,7 @@ deal_damage_to_rpg_commander(Engine::Core::World* world,
       world, commander, guard.damage, attacker_id, contact_point, impact_speed);
   result.effective_damage = rpg_result.effective_damage;
   result.killed = rpg_result.killed;
+  record_resolved_contact(commander, result);
 
   if (rpg_result.effective_damage <= 0) {
     return result;

--- a/game/systems/rpg_combat_system/rpg_engagement_system.cpp
+++ b/game/systems/rpg_combat_system/rpg_engagement_system.cpp
@@ -1,6 +1,7 @@
 #include "rpg_engagement_system.h"
 
 #include "../../core/component.h"
+#include "../../core/simulation_timing.h"
 #include "../../core/world.h"
 #include "rpg_combat_processor.h"
 
@@ -10,6 +11,8 @@ void RpgEngagementSystem::update(Engine::Core::World* world, float delta_time) {
   if (world == nullptr) {
     return;
   }
+  Engine::Core::Timing::ScopedAccumulator const scope(
+      Engine::Core::Timing::commander_engagement());
 
   for (auto* entity :
        world->collect_entities_with<Engine::Core::CommanderComponent>()) {

--- a/game/systems/rpg_combat_system/rpg_targeting.cpp
+++ b/game/systems/rpg_combat_system/rpg_targeting.cpp
@@ -79,6 +79,22 @@ auto resolve_damage_carrier(Engine::Core::Entity& entity,
   return resolve_soldier_target(entity, carrier->slot_index);
 }
 
+auto hurt_body_contact_point(const SoldierTarget& target,
+                             const QVector3D& from) noexcept -> QVector3D {
+  float const radius = std::max(0.05F, target.body_radius);
+  float const y = std::clamp(from.y(),
+                             target.position.y() + k_hurt_body_min_height,
+                             target.position.y() + k_hurt_body_max_height);
+  QVector3D planar(
+      from.x() - target.position.x(), 0.0F, from.z() - target.position.z());
+  float const distance = planar.length();
+  if (!std::isfinite(distance) || distance <= 0.0001F) {
+    return {target.position.x(), y, target.position.z()};
+  }
+  planar *= std::min(distance, radius) / distance;
+  return {target.position.x() + planar.x(), y, target.position.z() + planar.z()};
+}
+
 auto horizontal_distance(const QVector3D& lhs, const QVector3D& rhs) noexcept -> float {
   return std::hypot(rhs.x() - lhs.x(), rhs.z() - lhs.z());
 }

--- a/game/systems/rpg_combat_system/rpg_targeting.h
+++ b/game/systems/rpg_combat_system/rpg_targeting.h
@@ -36,6 +36,13 @@ resolve_soldier_target(Engine::Core::Entity& entity,
                                           Engine::Core::EntityID opponent_id)
     -> std::optional<SoldierTarget>;
 
+inline constexpr float k_hurt_body_min_height = 0.30F;
+inline constexpr float k_hurt_body_max_height = 1.70F;
+inline constexpr float k_hurt_body_chest_height = 1.05F;
+
+[[nodiscard]] auto hurt_body_contact_point(const SoldierTarget& target,
+                                           const QVector3D& from) noexcept -> QVector3D;
+
 [[nodiscard]] auto horizontal_distance(const QVector3D& lhs,
                                        const QVector3D& rhs) noexcept -> float;
 

--- a/game/systems/stamina_system.cpp
+++ b/game/systems/stamina_system.cpp
@@ -61,6 +61,11 @@ void StaminaSystem::run(Engine::Core::SystemContext& context) {
       continue;
     }
 
+    if (stamina->regen_delay_remaining > 0.0F) {
+      stamina->regen_delay_remaining =
+          std::max(0.0F, stamina->regen_delay_remaining - delta_time);
+    }
+
     const auto* motion =
         entity.get_component<Engine::Core::MotionPresentationComponent>();
     const auto* movement = entity.get_component<Engine::Core::MovementComponent>();
@@ -75,13 +80,15 @@ void StaminaSystem::run(Engine::Core::SystemContext& context) {
         if (!stamina->has_stamina()) {
           stamina->is_running = false;
         }
-      } else {
+      } else if (stamina->regen_delay_remaining <= 0.0F) {
 
         regenerate_stamina(*stamina, delta_time);
       }
     } else {
       stamina->is_running = false;
-      regenerate_stamina(*stamina, delta_time);
+      if (stamina->regen_delay_remaining <= 0.0F) {
+        regenerate_stamina(*stamina, delta_time);
+      }
     }
   }
 }

--- a/game/systems/unit_traversal_layout_system.cpp
+++ b/game/systems/unit_traversal_layout_system.cpp
@@ -25,7 +25,6 @@ namespace {
 constexpr float k_probe_step_cells = 0.2F;
 constexpr float k_width_epsilon = 0.05F;
 constexpr float k_exit_width_margin = 0.12F;
-constexpr float k_minimum_visible_half_width = 0.38F;
 constexpr float k_enter_dwell_seconds = 0.12F;
 constexpr float k_minimum_mode_dwell_seconds = 0.50F;
 constexpr float k_tail_clear_seconds = 0.35F;

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,75 @@
+Standard of Iron — improvement plan (based on code audit, 2026-08-25)
+=======================================================================
+
+Method: two deep-dive analyses of sim core (game/core, game/systems,
+game/command) and render/app layers. Evidence cited as file:line.
+
+What is already healthy (do not touch)
+--------------------------------------
+- Sparse-set ECS with spatial grids preventing N^2 targeting.
+  The 3-load indirection chain per component access is fine at current
+  scale; rewriting to archetypes not justified by measured cost.
+- Renderer: GPU-driven instanced humanoid path (SSBO cull + indirect),
+  4,360 commands -> 25 draws at 2k soldiers; compiled shader quality tiers.
+- Animation: GPU-resident BPAT palettes, CPU IK/FK only in parallel
+  prepare phase (~3 ms at 2k soldiers).
+- Determinism: fixed 1/60 tick, ID-seeded hashing, digest-checked
+  replays. Excellent machinery.
+- AI: threaded snapshot isolation, 0.3 s cadence, real FSM with deadlock
+  detection.
+
+Priority 1: simulation scalability hotspots (blocks large battles)
+------------------------------------------------------------------
+1. Formation clicks trigger an A* burst on the main thread.
+   - slot_is_reachable runs full grid find_path PER formation member
+     (game/command/command_service.cpp:275 -> :55) plus group-corridor A*.
+   - 100-unit move order ~= 101 synchronous A* searches in one frame.
+   - Fix: spread reachability checks across ticks via existing async path
+     queue, or add a coarse hierarchy level.
+
+2. Melee combat is raycast-bound.
+   - Every chasing melee pair runs a DDA raycast through the nav grid
+     every tick (combat_utils.cpp:429); wall-bypass adds 12 arc-point
+     tests each (combat_utils.cpp:341-364).
+   - At 500 units: thousands of traversals/tick.
+   - Fix: extend signature-guarded pair cache pattern from
+     formation_contact_processor.cpp:38 to range checks; cache LOS per tick.
+
+3. Obstruction-release repath storms.
+   - One destroyed building queues repaths for ALL movers at once
+     (movement_system.cpp:242-251) into queue capped at 8 paths/tick ->
+     seconds of latency at scale.
+   - Fix: prioritize by distance-to-obstruction, stagger over time.
+
+4. Avoidance neighbor gather unbounded before truncation.
+   - local_avoidance_system.cpp:213-267 degenerates to O(local density)
+     per unit in blobs; ~162 trajectory-collision evals/unit/tick.
+   - Fix: early top-k selection during gather.
+
+Priority 2: frame pacing
+------------------------
+- One hard sync point: GameEngine::render() blocks mid-frame on the sim
+  mutex (app/core/game_engine.cpp:894), so a long tick eats render budget.
+- Fix: mirror try_to_lock + deferred-work approach already used in
+  update_presentation().
+
+Priority 3: structural debt (maintainability)
+---------------------------------------------
+Two god objects concentrate all architectural risk:
+- app/core/game_engine.cpp: 2,968 lines, 120 methods, ~55 pointer members.
+- app/commander/commander_control_controller.cpp: 2,793 lines mixing
+  input, camera, motor, abilities, lock-on, audio, diagnostics.
+Fix: extract collaborators incrementally — abilities and lock-on out of
+the controller first, following CommanderCameraRig/CommanderMotor precedent.
+
+Priority 4: startup cost
+------------------------
+- 194 .ogg files zlib-compressed inside QRC (pointless; they are already
+  compressed). Wastes binary size and first-touch decompression time.
+- Fix: move to loose files or rcc -no-compress; keep existing lazy/
+  streaming audio load policies.
+
+Starting point
+--------------
+Priority 1.2 (melee raycast caching): highest ratio of measured impact to
+contained blast radius.

--- a/render/entity/formation_instance_layout.h
+++ b/render/entity/formation_instance_layout.h
@@ -9,7 +9,7 @@
 #include "render/gl/humanoid/humanoid_types.h"
 
 namespace Engine::Core {
-struct FormationPresentationComponent;
+class FormationPresentationComponent;
 }
 
 namespace Render::Entity {

--- a/render/gl/bootstrap.cpp
+++ b/render/gl/bootstrap.cpp
@@ -23,6 +23,7 @@ auto RenderBootstrap::initialize(Renderer& renderer, Camera& camera) -> bool {
   qInfo() << "RenderBootstrap: Logging OpenGL capabilities...";
   GLCapabilities::log_capabilities();
   GLCapabilities::report_minimum_version();
+  RenderBootstrap::remember_adapter(GLCapabilities::describe_adapter());
   qInfo() << "RenderBootstrap: Capabilities logged";
 
   if (!GLCapabilities::meets_minimum_version()) {
@@ -45,6 +46,19 @@ auto RenderBootstrap::initialize(Renderer& renderer, Camera& camera) -> bool {
   qInfo() << "RenderBootstrap: Camera set, initialization complete";
 
   return true;
+}
+
+namespace {
+GLCapabilities::AdapterDescription g_adapter;
+} // namespace
+
+void RenderBootstrap::remember_adapter(
+    const GLCapabilities::AdapterDescription& adapter) {
+  g_adapter = adapter;
+}
+
+auto RenderBootstrap::adapter() -> const GLCapabilities::AdapterDescription& {
+  return g_adapter;
 }
 
 } // namespace Render::GL

--- a/render/gl/bootstrap.h
+++ b/render/gl/bootstrap.h
@@ -2,6 +2,8 @@
 
 #include <memory>
 
+#include "gl_capabilities.h"
+
 class QOpenGLContext;
 
 namespace Render::GL {
@@ -12,6 +14,9 @@ class ResourceManager;
 class RenderBootstrap {
 public:
   static auto initialize(Renderer& renderer, Camera& camera) -> bool;
+
+  static void remember_adapter(const GLCapabilities::AdapterDescription& adapter);
+  [[nodiscard]] static auto adapter() -> const GLCapabilities::AdapterDescription&;
 };
 
 } // namespace Render::GL

--- a/render/gl/gl_capabilities.h
+++ b/render/gl/gl_capabilities.h
@@ -144,6 +144,34 @@ public:
 
   [[nodiscard]] static auto has_indirect_draw() -> bool { return has_core_4_3(); }
 
+  struct AdapterDescription {
+    QString vendor;
+    QString renderer;
+    QString version;
+  };
+
+  [[nodiscard]] static auto describe_adapter() -> AdapterDescription {
+    AdapterDescription description;
+    auto* ctx = QOpenGLContext::currentContext();
+    if (ctx == nullptr) {
+      return description;
+    }
+    auto* functions = ctx->functions();
+    if (functions == nullptr) {
+      return description;
+    }
+    auto const read = [functions](GLenum name) -> QString {
+      const auto* value = functions->glGetString(name);
+      return value != nullptr
+                 ? QString::fromLatin1(reinterpret_cast<const char*>(value))
+                 : QString();
+    };
+    description.vendor = read(GL_VENDOR);
+    description.renderer = read(GL_RENDERER);
+    description.version = read(GL_VERSION);
+    return description;
+  }
+
   static void report_feature_tiers() {
     qInfo() << (has_core_4_1() ? "SOI_GL_TIER_41: PASS"
                                : "SOI_GL_TIER_41: UNAVAILABLE");

--- a/render/humanoid/runtime/humanoid_runtime_types.h
+++ b/render/humanoid/runtime/humanoid_runtime_types.h
@@ -16,7 +16,7 @@
 namespace Engine::Core {
 class Entity;
 class UnitComponent;
-struct CreaturePresentationComponent;
+class CreaturePresentationComponent;
 } // namespace Engine::Core
 
 namespace Render::GL {

--- a/render/humanoid/runtime/instance_prepare.cpp
+++ b/render/humanoid/runtime/instance_prepare.cpp
@@ -815,6 +815,7 @@ void append_prepared_soldier(const HumanoidUnitSnapshot& s,
   const HumanoidVariant& variant = variant_base;
 
   auto& animation_diagnostics = *u.animation_diagnostics;
+  bool swing_recoil_active = false;
   auto record_soldier_debug = [&](int soldier_index,
                                   const AnimationInputs&,
                                   const AnimationInputs& resolved_anim,
@@ -847,6 +848,7 @@ void append_prepared_soldier(const HumanoidUnitSnapshot& s,
     sample.attack_variant = resolved_anim.attack_variant;
     sample.is_attacking = resolved_anim.is_attacking;
     sample.is_hit_reacting = resolved_anim.is_hit_reacting;
+    sample.is_swing_recoiling = swing_recoil_active;
     sample.is_in_melee_lock = resolved_anim.is_in_melee_lock;
     sample.transient_recovery_override = transient_recovery_override;
     sample.locomotion_state = resolved_anim.movement_state;
@@ -909,7 +911,7 @@ void append_prepared_soldier(const HumanoidUnitSnapshot& s,
 
   bool const authored_swing_owns_body =
       soldier_render_anim.has_authored_action_phase && soldier_render_anim.is_attacking;
-  bool swing_recoil_active =
+  swing_recoil_active =
       (authored_swing_owns_body || soldier_render_anim.hit_reaction_kind ==
                                        Engine::Core::HitReactionKind::Recoil) &&
       soldier_render_anim.is_hit_reacting;

--- a/render/humanoid/runtime/instance_prepare.cpp
+++ b/render/humanoid/runtime/instance_prepare.cpp
@@ -206,8 +206,6 @@ auto snapshot_humanoid_unit(const HumanoidRendererBase& owner,
     Engine::Core::publish_creature_presentation(ctx.entity, nullptr);
   }
 
-  auto& profile = Render::Profiling::global_profile();
-
   FormationParams const formation = HumanoidRendererBase::resolve_formation(owner, ctx);
 
   Engine::Core::UnitComponent* unit_comp = nullptr;
@@ -554,7 +552,6 @@ auto resolve_unit_animation_runtime(const HumanoidUnitSnapshot& s,
   const auto* creature_presentation = s.creature_presentation;
   const bool has_shared_formation_layout = s.has_shared_formation_layout;
   const bool has_entity_death = s.has_entity_death;
-  const bool is_mounted_spawn = s.is_mounted_spawn;
   const int total_layout_count = s.total_layout_count;
   auto* layout_cache_comp = f.layout_cache_comp;
   const bool allow_animation_persistence = f.allow_animation_persistence;
@@ -601,47 +598,6 @@ auto resolve_unit_animation_runtime(const HumanoidUnitSnapshot& s,
       Render::Profiling::CombatAnimationDiagnostics::instance();
   const bool record_animation_diagnostics =
       animation_diagnostics.enabled() || animation_diagnostics.logging_enabled();
-  auto record_soldier_debug = [&](int idx,
-                                  const AnimationInputs&,
-                                  const AnimationInputs& resolved_anim,
-                                  float attack_phase,
-                                  Render::Creature::AnimationStateId animation_state,
-                                  HumanoidLOD lod,
-                                  Render::Profiling::SoldierCullReason cull_reason,
-                                  bool transient_recovery_override,
-                                  const QVector3D& root_position,
-                                  float root_yaw_degrees,
-                                  float root_up_y,
-                                  float root_scale_y,
-                                  float root_tilt_degrees,
-                                  float hit_reaction_tilt_degrees) {
-    if (!record_animation_diagnostics || ctx.entity == nullptr) {
-      return;
-    }
-
-    Render::Profiling::SoldierAnimationDebugSample sample{};
-    sample.soldier_index = idx;
-    sample.sample_time = resolved_anim.time;
-    sample.combat_phase = resolved_anim.combat_phase;
-    sample.combat_phase_progress = resolved_anim.combat_phase_progress;
-    sample.attack_phase = attack_phase;
-    sample.attack_variant = resolved_anim.attack_variant;
-    sample.is_attacking = resolved_anim.is_attacking;
-    sample.is_hit_reacting = resolved_anim.is_hit_reacting;
-    sample.is_in_melee_lock = resolved_anim.is_in_melee_lock;
-    sample.transient_recovery_override = transient_recovery_override;
-    sample.locomotion_state = resolved_anim.movement_state;
-    sample.animation_state = animation_state;
-    sample.lod = static_cast<std::uint8_t>(lod);
-    sample.cull_reason = cull_reason;
-    sample.root_position = root_position;
-    sample.root_yaw_degrees = root_yaw_degrees;
-    sample.root_up_y = root_up_y;
-    sample.root_scale_y = root_scale_y;
-    sample.root_tilt_degrees = root_tilt_degrees;
-    sample.hit_reaction_tilt_degrees = hit_reaction_tilt_degrees;
-    animation_diagnostics.record_soldier_sample(ctx.entity->get_id(), sample);
-  };
 
   bool const formation_fight_active = has_shared_formation_layout &&
                                       formation_presentation->melee_ordered &&

--- a/render/profiling/combat_animation_diagnostics.h
+++ b/render/profiling/combat_animation_diagnostics.h
@@ -106,6 +106,8 @@ struct SoldierAnimationDebugSample {
   std::uint8_t attack_variant{0U};
   bool is_attacking{false};
   bool is_hit_reacting{false};
+
+  bool is_swing_recoiling{false};
   bool is_in_melee_lock{false};
   bool transient_recovery_override{false};
   Render::Creature::MovementAnimationState locomotion_state{

--- a/render/scene_renderer.cpp
+++ b/render/scene_renderer.cpp
@@ -527,6 +527,8 @@ void Renderer::terrain_scatter(const TerrainScatterCmd& cmd) {
   case TerrainScatterCmd::Species::Plant:
   case TerrainScatterCmd::Species::Pine:
   case TerrainScatterCmd::Species::Olive:
+  case TerrainScatterCmd::Species::Cypress:
+  case TerrainScatterCmd::Species::Palm:
     submitted.foliage.time = m_accumulated_time;
     break;
   case TerrainScatterCmd::Species::FireCamp:

--- a/scripts/rpg_gate_report.py
+++ b/scripts/rpg_gate_report.py
@@ -60,6 +60,12 @@ DEFAULT_MANIFEST = REPO_ROOT / "tools" / "arena" / "rpg_gate_manifest.json"
 PERFORMANCE_ISSUE_CODES = {"frame_budget_exceeded"}
 PERFORMANCE_ISSUE_PREFIX = "performance_"
 
+
+STRICT_P95_MS = 16.67
+STRICT_P99_MS = 20.0
+STRICT_MAX_MS = 33.3
+STRICT_SIMULATION_P95_MS = 8.0
+
 EXIT_OK = 0
 EXIT_BEHAVIOUR = 1
 EXIT_INCOMPLETE = 3
@@ -198,6 +204,46 @@ class ScenarioOutcome:
                     codes.append(code)
         return ",".join(codes) if codes else "-"
 
+    def strict_performance_failures(self) -> list[str]:
+        """Gate 7.1's numeric contract, evaluated per repeat.
+
+        Reported on every run so the numbers are visible; it only decides the
+        exit status under --enforce-performance.
+        """
+        failures: list[str] = []
+        for index, run in enumerate(self.runs):
+            performance = run.performance
+            if not performance:
+                continue
+            label = f"run {index + 1}/{len(self.runs)}"
+            p95 = performance.get("p95_ms")
+            p99 = performance.get("p99_ms")
+            maximum = performance.get("max_ms")
+            if p95 is not None and float(p95) > STRICT_P95_MS:
+                failures.append(
+                    f"{label} p95 {float(p95):.2f} ms over the {STRICT_P95_MS} ms budget"
+                )
+            if p99 is not None and float(p99) > STRICT_P99_MS:
+                failures.append(
+                    f"{label} p99 {float(p99):.2f} ms over the {STRICT_P99_MS} ms budget"
+                )
+            if maximum is not None and float(maximum) > STRICT_MAX_MS:
+                failures.append(
+                    f"{label} post-prewarm max {float(maximum):.2f} ms over the "
+                    f"{STRICT_MAX_MS} ms hitch ceiling"
+                )
+            simulation = performance.get("simulation_p95_ms")
+            if simulation is not None and float(simulation) > STRICT_SIMULATION_P95_MS:
+                failures.append(
+                    f"{label} simulation p95 {float(simulation):.2f} ms leaves under "
+                    f"half the {STRICT_P95_MS} ms frame to presentation"
+                )
+            if performance.get("gpu_timed_frames", 0) == 0:
+                failures.append(f"{label} reported no GPU timing")
+            if "prewarm_frames" not in performance:
+                failures.append(f"{label} did not mark its prewarm window")
+        return failures
+
     def timing(self, key: str, aggregate=max) -> str:
         values = [
             float(run.performance[key])
@@ -285,6 +331,7 @@ def main() -> int:
                 outcome.issue_codes(),
                 outcome.timing("p50_ms"),
                 outcome.timing("p95_ms"),
+                outcome.timing("p99_ms"),
                 outcome.timing("max_ms"),
                 str(outcome.artifact_dir),
             ]
@@ -300,6 +347,7 @@ def main() -> int:
         "issue codes",
         "p50",
         "p95",
+        "p99",
         "max",
         "artifacts",
     ]
@@ -316,6 +364,10 @@ def main() -> int:
             print(f"  {outcome.scenario_id}: {error}")
 
     for outcome in outcomes:
+        for message in outcome.strict_performance_failures():
+            print(f"  performance contract: {outcome.scenario_id}: {message}")
+            if args.enforce_performance and status == EXIT_OK:
+                status = EXIT_PERFORMANCE
         for issue in outcome.performance_issues:
             label = (
                 "performance"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -309,6 +309,7 @@ add_executable(
     persistence_tests
     save/snapshot_contract_test.cpp
     core/serialization_test.cpp
+    core/commander_state_round_trip_test.cpp
     db/save_storage_test.cpp
     db/save_format_test.cpp
     db/save_load_service_test.cpp
@@ -504,6 +505,10 @@ add_executable(
     core/commander_control_regression_test.cpp
     core/commander_camera_rig_test.cpp
     core/commander_control_controller_test.cpp
+    core/commander_defense_windows_test.cpp
+    core/commander_accessibility_test.cpp
+    core/commander_lifecycle_soak_test.cpp
+    core/commander_lock_on_test.cpp
     core/commander_presentation_trace_test.cpp
     core/commander_view_model_input_test.cpp
     core/commander_presentation_pose_test.cpp

--- a/tests/core/commander_accessibility_test.cpp
+++ b/tests/core/commander_accessibility_test.cpp
@@ -1,0 +1,149 @@
+#include <cmath>
+#include <gtest/gtest.h>
+
+#include "app/commander/commander_control_controller.h"
+#include "game/accessibility/commander_input_settings.h"
+#include "game/core/component.h"
+#include "game/core/world.h"
+#include "game/map/terrain_service.h"
+#include "game/systems/building_collision_registry.h"
+#include "game/systems/nav_grid.h"
+
+namespace {
+
+namespace CommanderInput = Game::Accessibility::CommanderInput;
+
+class CommanderAccessibilityTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    CommanderInput::reset_to_defaults();
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::NavGrid::initialize(32, 32);
+  }
+
+  void TearDown() override {
+    CommanderInput::reset_to_defaults();
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+  }
+
+  static auto make_commander(Engine::Core::World& world) -> Engine::Core::Entity* {
+    auto* entity = world.create_entity();
+    if (entity == nullptr) {
+      return nullptr;
+    }
+    entity->add_component<Engine::Core::TransformComponent>(0.0F, 0.0F, 0.0F);
+    auto* unit = entity->add_component<Engine::Core::UnitComponent>();
+    entity->add_component<Engine::Core::MovementComponent>();
+    auto* commander = entity->add_component<Engine::Core::CommanderComponent>();
+    if (unit == nullptr || commander == nullptr) {
+      return nullptr;
+    }
+    unit->health = 100;
+    unit->max_health = 100;
+    unit->owner_id = 1;
+    unit->speed = 3.0F;
+    unit->spawn_type = Game::Units::SpawnType::Knight;
+    commander->fpv_controlled = true;
+    return entity;
+  }
+};
+
+TEST_F(CommanderAccessibilityTest, LookSensitivityScalesEachAxisIndependently) {
+  CommanderControlController baseline;
+  baseline.set_view_yaw(0.0F);
+  baseline.set_view_pitch(0.0F);
+  baseline.mouse_move(10.0, 10.0);
+  float const base_yaw = baseline.view_yaw();
+  float const base_pitch = baseline.view_pitch();
+  ASSERT_GT(base_yaw, 0.0F);
+  ASSERT_LT(base_pitch, 0.0F);
+
+  CommanderInput::set_look_sensitivity_x(2.0F);
+  CommanderControlController faster_x;
+  faster_x.set_view_yaw(0.0F);
+  faster_x.set_view_pitch(0.0F);
+  faster_x.mouse_move(10.0, 10.0);
+  EXPECT_NEAR(faster_x.view_yaw(), base_yaw * 2.0F, 1.0e-3F);
+  EXPECT_NEAR(faster_x.view_pitch(), base_pitch, 1.0e-3F);
+
+  CommanderInput::set_look_sensitivity_x(1.0F);
+  CommanderInput::set_look_sensitivity_y(0.5F);
+  CommanderControlController slower_y;
+  slower_y.set_view_yaw(0.0F);
+  slower_y.set_view_pitch(0.0F);
+  slower_y.mouse_move(10.0, 10.0);
+  EXPECT_NEAR(slower_y.view_yaw(), base_yaw, 1.0e-3F);
+  EXPECT_NEAR(slower_y.view_pitch(), base_pitch * 0.5F, 1.0e-3F);
+}
+
+TEST_F(CommanderAccessibilityTest, InvertLookYFlipsOnlyThePitchAxis) {
+  CommanderControlController baseline;
+  baseline.set_view_yaw(0.0F);
+  baseline.set_view_pitch(0.0F);
+  baseline.mouse_move(10.0, 10.0);
+
+  CommanderInput::set_invert_look_y(true);
+  CommanderControlController inverted;
+  inverted.set_view_yaw(0.0F);
+  inverted.set_view_pitch(0.0F);
+  inverted.mouse_move(10.0, 10.0);
+
+  EXPECT_NEAR(inverted.view_yaw(), baseline.view_yaw(), 1.0e-3F);
+  EXPECT_NEAR(inverted.view_pitch(), -baseline.view_pitch(), 1.0e-3F);
+}
+
+TEST_F(CommanderAccessibilityTest, GuardCanBeHeldOrToggled) {
+  constexpr float k_dt = 1.0F / 60.0F;
+
+  {
+    Engine::Core::World world;
+    auto* commander = make_commander(world);
+    ASSERT_NE(commander, nullptr);
+    CommanderControlController held;
+    held.secondary_action_down();
+    ASSERT_TRUE(held.update_simulation(world, commander->get_id(), 1, k_dt));
+    auto const* guard =
+        commander->get_component<Engine::Core::CommanderGuardComponent>();
+    ASSERT_NE(guard, nullptr);
+    EXPECT_TRUE(guard->active);
+
+    held.secondary_action_up();
+    ASSERT_TRUE(held.update_simulation(world, commander->get_id(), 1, k_dt));
+    EXPECT_FALSE(guard->active);
+  }
+
+  CommanderInput::set_guard_is_toggle(true);
+  {
+    Engine::Core::World world;
+    auto* commander = make_commander(world);
+    ASSERT_NE(commander, nullptr);
+    CommanderControlController toggled;
+    toggled.secondary_action_down();
+    toggled.secondary_action_up();
+    ASSERT_TRUE(toggled.update_simulation(world, commander->get_id(), 1, k_dt));
+    auto const* guard =
+        commander->get_component<Engine::Core::CommanderGuardComponent>();
+    ASSERT_NE(guard, nullptr);
+    EXPECT_TRUE(guard->active) << "a released toggle press must leave the guard up";
+
+    toggled.secondary_action_down();
+    toggled.secondary_action_up();
+    ASSERT_TRUE(toggled.update_simulation(world, commander->get_id(), 1, k_dt));
+    EXPECT_FALSE(guard->active) << "the second toggle press must drop the guard";
+  }
+}
+
+TEST_F(CommanderAccessibilityTest, SettingsClampToTheirAuthoredRange) {
+  CommanderInput::set_look_sensitivity_x(100.0F);
+  EXPECT_LE(CommanderInput::look_sensitivity_x(), 4.0F);
+  CommanderInput::set_look_sensitivity_y(0.0F);
+  EXPECT_GE(CommanderInput::look_sensitivity_y(), 0.2F);
+  CommanderInput::set_field_of_view_scale(10.0F);
+  EXPECT_LE(CommanderInput::field_of_view_scale(), 1.35F);
+  CommanderInput::set_field_of_view_scale(0.0F);
+  EXPECT_GE(CommanderInput::field_of_view_scale(), 0.75F);
+}
+
+} // namespace

--- a/tests/core/commander_camera_rig_test.cpp
+++ b/tests/core/commander_camera_rig_test.cpp
@@ -1,8 +1,10 @@
+#include <cmath>
 #include <gtest/gtest.h>
 
 #include "app/commander/commander_camera_rig.h"
 #include "app/commander/rts_camera_bookmark.h"
 #include "core/component.h"
+#include "game/accessibility/commander_input_settings.h"
 #include "scene/camera.h"
 
 using App::Core::CommanderCameraInputs;
@@ -84,6 +86,47 @@ TEST(CommanderCameraRig, ImpactKickDecaysBackToRest) {
 
   settle(rig, camera, inputs);
   EXPECT_NEAR(rig.fov(), rest_fov, 0.1F);
+}
+
+TEST(CommanderCameraRig, ImpactKickRespectsItsAmplitudeAndVelocityBudget) {
+  CommanderCameraRig rig;
+  Render::GL::Camera camera;
+
+  auto inputs = default_inputs();
+  settle(rig, camera, inputs);
+  float const rest_fov = rig.fov();
+
+  rig.add_impact_kick(20.0F);
+  float previous = rest_fov;
+  float peak = rest_fov;
+  for (int frame = 0; frame < 60; ++frame) {
+    rig.update(camera, inputs);
+    float const now = rig.fov();
+    EXPECT_LE(std::abs(now - previous), (45.0F * inputs.dt) + 1.0e-3F)
+        << "the impulse may not move the FOV faster than its velocity budget";
+    peak = std::max(peak, now);
+    previous = now;
+  }
+
+  EXPECT_LE(peak - rest_fov, 3.0F + 1.0e-3F)
+      << "an oversized impact must still clamp to the authored amplitude budget";
+}
+
+TEST(CommanderCameraRig, ImpactKickIsOffWhenTheCameraImpulseIsDisabled) {
+  Game::Accessibility::CommanderInput::reset_to_defaults();
+  Game::Accessibility::CommanderInput::set_camera_impulse_enabled(false);
+
+  CommanderCameraRig rig;
+  Render::GL::Camera camera;
+  auto inputs = default_inputs();
+  settle(rig, camera, inputs);
+  float const rest_fov = rig.fov();
+
+  rig.add_impact_kick(1.0F);
+  rig.update(camera, inputs);
+  EXPECT_NEAR(rig.fov(), rest_fov, 0.05F);
+
+  Game::Accessibility::CommanderInput::reset_to_defaults();
 }
 
 TEST(CommanderCameraRig, MeleeFramingLooksDownAtTheFightButAimingDoesNot) {

--- a/tests/core/commander_control_controller_test.cpp
+++ b/tests/core/commander_control_controller_test.cpp
@@ -1211,6 +1211,58 @@ TEST_F(CommanderControlControllerTest, ChaseLensFiltersGroundReliefButNotJumps) 
   EXPECT_GT(peak_jump_eye_y - raised_eye_y, k_jump_peak_height * 0.5F);
 }
 
+TEST_F(CommanderControlControllerTest, ACommittedStrikeDoesNotFollowRawCameraYaw) {
+  Engine::Core::World world;
+  auto* commander = create_commander(world, 0.0F, 0.0F);
+  auto* enemy = create_enemy(world, 0.0F, 1.6F);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(enemy, nullptr);
+
+  auto* commander_data = commander->get_component<Engine::Core::CommanderComponent>();
+  ASSERT_NE(commander_data, nullptr);
+  commander_data->fpv_controlled = true;
+  auto* attack = commander->add_component<Engine::Core::AttackComponent>();
+  ASSERT_NE(attack, nullptr);
+  attack->current_mode = Engine::Core::AttackComponent::CombatMode::Melee;
+  auto* transform = commander->get_component<Engine::Core::TransformComponent>();
+  ASSERT_NE(transform, nullptr);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  constexpr float k_dt = 1.0F / 60.0F;
+
+  ASSERT_TRUE(press_primary(controller, world, commander->get_id()));
+  auto* action = commander->get_component<Engine::Core::RpgCommanderActionComponent>();
+  ASSERT_NE(action, nullptr);
+  ASSERT_TRUE(action->action_running);
+
+  auto const* definition = Game::Systems::CombatActions::find_combat_action_definition(
+      static_cast<Game::Systems::CombatActions::CombatActionId>(
+          action->combat_action_id));
+  ASSERT_NE(definition, nullptr);
+
+  action->normalized_action_time =
+      Game::Systems::CombatActions::action_event_normalized_time(
+          *definition,
+          Game::Systems::CombatActions::CombatActionEventType::WeaponTraceStart,
+          0.4F) +
+      0.05F;
+  ASSERT_FLOAT_EQ(Game::Systems::CombatActions::melee_interruption_at(
+                      *definition, action->normalized_action_time)
+                      .redirect_authority,
+                  0.35F);
+
+  float const committed_yaw = transform->rotation.y;
+  controller.set_view_yaw(150.0F);
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  float const turned = std::abs(controller.view_yaw() - transform->rotation.y);
+  EXPECT_GT(turned, 100.0F)
+      << "a committed strike must not snap the body 150 degrees onto the camera";
+  EXPECT_LT(std::abs(transform->rotation.y - committed_yaw), 10.0F)
+      << "the body may steer inside its authored authority, not beyond it";
+}
+
 TEST_F(CommanderControlControllerTest, IsolatedSwingsDoNotReplayTheSameClip) {
   Engine::Core::World world;
   auto* commander = create_commander(world, 0.0F, 0.0F);
@@ -1231,9 +1283,9 @@ TEST_F(CommanderControlControllerTest, IsolatedSwingsDoNotReplayTheSameClip) {
 
   std::vector<std::uint8_t> swing_clips;
   for (int swing = 0; swing < 3; ++swing) {
-    controller.input().primary_action = true;
+    controller.primary_action_down();
     ASSERT_TRUE(controller.update(world, commander->get_id(), 1, camera, 0.016F));
-    controller.input().primary_action = false;
+    controller.primary_action_up();
 
     auto* action =
         commander->get_component<Engine::Core::RpgCommanderActionComponent>();
@@ -1280,9 +1332,9 @@ TEST_F(CommanderControlControllerTest, StrikeCarriesTheCommanderIntoATargetOutOf
   controller.set_view_yaw(0.0F);
   Render::GL::Camera camera;
 
-  controller.input().primary_action = true;
+  controller.primary_action_down();
   ASSERT_TRUE(controller.update(world, commander->get_id(), 1, camera, 0.016F));
-  controller.input().primary_action = false;
+  controller.primary_action_up();
 
   auto* action = commander->get_component<Engine::Core::RpgCommanderActionComponent>();
   ASSERT_NE(action, nullptr);

--- a/tests/core/commander_defense_windows_test.cpp
+++ b/tests/core/commander_defense_windows_test.cpp
@@ -1,0 +1,475 @@
+#include <QVector3D>
+
+#include <algorithm>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "app/commander/commander_control_controller.h"
+#include "app/core/player_feedback.h"
+#include "game/core/component.h"
+#include "game/core/world.h"
+#include "game/map/terrain_service.h"
+#include "game/systems/building_collision_registry.h"
+#include "game/systems/combat_actions/commander_defense_timeline.h"
+#include "game/systems/nav_grid.h"
+#include "game/systems/rpg_combat_system/rpg_commander_damage.h"
+#include "game/systems/rpg_combat_system/rpg_targeting.h"
+
+namespace {
+
+using Game::Systems::CombatActions::k_commander_dodge_timeline;
+using Game::Systems::CombatActions::k_commander_guard_timeline;
+
+class CommanderDefenseWindowsTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::NavGrid::initialize(32, 32);
+  }
+
+  void TearDown() override {
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+  }
+
+  static auto make_unit(Engine::Core::World& world,
+                        float x,
+                        float z,
+                        int owner) -> Engine::Core::Entity* {
+    auto* entity = world.create_entity();
+    if (entity == nullptr) {
+      return nullptr;
+    }
+    auto* transform =
+        entity->add_component<Engine::Core::TransformComponent>(x, 0.0F, z);
+    auto* unit = entity->add_component<Engine::Core::UnitComponent>();
+    entity->add_component<Engine::Core::MovementComponent>();
+    if (transform == nullptr || unit == nullptr) {
+      return nullptr;
+    }
+    unit->health = 1000;
+    unit->max_health = 1000;
+    unit->owner_id = owner;
+    unit->speed = 3.0F;
+    unit->spawn_type = Game::Units::SpawnType::Knight;
+    return entity;
+  }
+
+  static auto make_commander(Engine::Core::World& world) -> Engine::Core::Entity* {
+    auto* entity = make_unit(world, 0.0F, 0.0F, 1);
+    if (entity == nullptr) {
+      return nullptr;
+    }
+    auto* commander = entity->add_component<Engine::Core::CommanderComponent>();
+    auto* rpg = entity->add_component<Engine::Core::RpgHealthComponent>();
+    if (commander == nullptr || rpg == nullptr) {
+      return nullptr;
+    }
+    commander->fpv_controlled = true;
+    rpg->active = true;
+    rpg->crit_chance = 0.0F;
+    return entity;
+  }
+
+  struct ContactResult {
+    bool blocked{false};
+    bool perfect{false};
+    bool dodged{false};
+    int damage{0};
+  };
+
+  static auto body_point(Engine::Core::Entity& commander,
+                         float forward_offset) -> QVector3D {
+    auto const* transform = commander.get_component<Engine::Core::TransformComponent>();
+    QVector3D const origin = transform != nullptr ? QVector3D(transform->position.x,
+                                                              transform->position.y,
+                                                              transform->position.z)
+                                                  : QVector3D();
+    return origin + QVector3D(0.0F,
+                              Game::Systems::RpgCombat::k_hurt_body_chest_height,
+                              forward_offset);
+  }
+
+  static auto strike_the_commander(Engine::Core::World& world,
+                                   Engine::Core::Entity& commander,
+                                   Engine::Core::Entity& attacker) -> ContactResult {
+
+    auto const result = Game::Systems::RpgCombat::deal_damage_to_rpg_commander(
+        &world, &commander, 24, attacker.get_id(), {}, body_point(commander, 0.34F));
+    return {.blocked = result.blocked,
+            .perfect = result.perfect_guarded,
+            .dodged = result.dodged,
+            .damage = result.effective_damage};
+  }
+};
+
+TEST_F(CommanderDefenseWindowsTest, PerfectGuardOnlyResolvesInsideTheAuthoredWindow) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  auto const window = k_commander_guard_timeline.perfect_window_seconds;
+
+  struct Case {
+    const char* name;
+    float delay_seconds;
+    bool expect_perfect;
+  };
+  const std::vector<Case> cases{
+      {"one tick inside the window", window - k_dt, true},
+      {"one tick after the window", window + k_dt, false},
+      {"well after the window", window + 0.40F, false},
+  };
+
+  for (auto const& scenario : cases) {
+    Engine::Core::World world;
+    auto* commander = make_commander(world);
+    auto* attacker = make_unit(world, 0.0F, 1.6F, 2);
+    ASSERT_NE(commander, nullptr) << scenario.name;
+    ASSERT_NE(attacker, nullptr) << scenario.name;
+
+    CommanderControlController controller;
+    controller.set_view_yaw(0.0F);
+    controller.secondary_action_down();
+    ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt))
+        << scenario.name;
+
+    auto const ticks = static_cast<int>(std::lround(scenario.delay_seconds / k_dt));
+    for (int tick = 0; tick < ticks; ++tick) {
+      ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt))
+          << scenario.name;
+    }
+
+    auto const contact = strike_the_commander(world, *commander, *attacker);
+    EXPECT_EQ(contact.perfect, scenario.expect_perfect) << scenario.name;
+
+    EXPECT_TRUE(contact.blocked) << scenario.name;
+    EXPECT_EQ(contact.damage, 0) << scenario.name;
+
+    auto const* rpg = commander->get_component<Engine::Core::RpgHealthComponent>();
+    ASSERT_NE(rpg, nullptr) << scenario.name;
+    EXPECT_EQ(rpg->perfect_guard_contacts, scenario.expect_perfect ? 1U : 0U)
+        << scenario.name;
+    EXPECT_EQ(rpg->blocked_contacts, scenario.expect_perfect ? 0U : 1U)
+        << scenario.name;
+  }
+}
+
+TEST_F(CommanderDefenseWindowsTest, AGuardedCommanderTakesNoDamageFromTheFront) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* attacker = make_unit(world, 0.0F, 1.6F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(attacker, nullptr);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  controller.secondary_action_down();
+  for (int tick = 0; tick < 40; ++tick) {
+    ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+  }
+
+  auto const contact = strike_the_commander(world, *commander, *attacker);
+  EXPECT_TRUE(contact.blocked);
+  EXPECT_FALSE(contact.perfect);
+  EXPECT_EQ(contact.damage, 0);
+}
+
+TEST_F(CommanderDefenseWindowsTest, AGuardDoesNotCoverTheCommandersBack) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* attacker = make_unit(world, 0.0F, -1.6F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(attacker, nullptr);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  controller.secondary_action_down();
+  for (int tick = 0; tick < 40; ++tick) {
+    ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+  }
+
+  auto const result = Game::Systems::RpgCombat::deal_damage_to_rpg_commander(
+      &world, commander, 24, attacker->get_id(), {}, body_point(*commander, -0.34F));
+  EXPECT_FALSE(result.blocked);
+  EXPECT_GT(result.effective_damage, 0);
+}
+
+TEST_F(CommanderDefenseWindowsTest, DodgeIFramesRejectOnlyContactsInsideTheirWindow) {
+  const std::vector<float> rates{30.0F, 60.0F, 120.0F};
+  auto const invulnerable = k_commander_dodge_timeline.invulnerable_end_seconds;
+
+  for (float const rate : rates) {
+    float const dt = 1.0F / rate;
+
+    struct Case {
+      const char* name;
+      float delay_seconds;
+      bool expect_dodged;
+    };
+    const std::vector<Case> cases{
+        {"one tick inside the i-frames", invulnerable - (2.0F * dt), true},
+        {"one tick after the i-frames", invulnerable + dt, false},
+    };
+
+    for (auto const& scenario : cases) {
+      Engine::Core::World world;
+      auto* commander = make_commander(world);
+      auto* attacker = make_unit(world, 0.0F, 1.6F, 2);
+      ASSERT_NE(commander, nullptr) << scenario.name << " at " << rate << " Hz";
+      ASSERT_NE(attacker, nullptr) << scenario.name << " at " << rate << " Hz";
+
+      CommanderControlController controller;
+      controller.set_view_yaw(0.0F);
+
+      controller.request_dodge(QVector3D(0.0F, 0.0F, -1.0F));
+      ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, dt))
+          << scenario.name << " at " << rate << " Hz";
+
+      auto const ticks = static_cast<int>(std::floor(scenario.delay_seconds / dt));
+      for (int tick = 0; tick < ticks; ++tick) {
+        ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, dt))
+            << scenario.name << " at " << rate << " Hz";
+      }
+
+      auto const contact = strike_the_commander(world, *commander, *attacker);
+      EXPECT_EQ(contact.dodged, scenario.expect_dodged)
+          << scenario.name << " at " << rate << " Hz";
+
+      auto const* rpg = commander->get_component<Engine::Core::RpgHealthComponent>();
+      ASSERT_NE(rpg, nullptr) << scenario.name << " at " << rate << " Hz";
+      EXPECT_EQ(rpg->dodged_contacts, scenario.expect_dodged ? 1U : 0U)
+          << scenario.name << " at " << rate << " Hz";
+    }
+  }
+}
+
+TEST_F(CommanderDefenseWindowsTest, DodgeInvulnerabilityLastsTheSameTimeAtEveryRate) {
+  const std::vector<float> rates{30.0F, 60.0F, 120.0F};
+  for (float const rate : rates) {
+    float const dt = 1.0F / rate;
+    Engine::Core::World world;
+    auto* commander = make_commander(world);
+    ASSERT_NE(commander, nullptr) << rate;
+
+    CommanderControlController controller;
+    controller.set_view_yaw(0.0F);
+    controller.request_dodge(QVector3D(0.0F, 0.0F, -1.0F));
+
+    float invulnerable_for = 0.0F;
+    for (int tick = 0; tick < static_cast<int>(rate); ++tick) {
+      ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, dt))
+          << rate;
+      auto const* rpg = commander->get_component<Engine::Core::RpgHealthComponent>();
+      ASSERT_NE(rpg, nullptr) << rate;
+      if (rpg->dodge_grace_remaining > 0.0F) {
+        invulnerable_for += dt;
+      }
+    }
+
+    EXPECT_NEAR(invulnerable_for,
+                k_commander_dodge_timeline.invulnerable_seconds(),
+                (2.0F * dt) + 1.0e-4F)
+        << rate;
+  }
+}
+
+TEST_F(CommanderDefenseWindowsTest, DefenceFeedbackFollowsAResolvedContactNotARequest) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* attacker = make_unit(world, 0.0F, 1.6F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(attacker, nullptr);
+
+  App::Core::PlayerFeedbackBus bus;
+  CommanderControlController controller;
+  controller.set_feedback_bus(&bus);
+  controller.set_view_yaw(0.0F);
+
+  controller.request_dodge(QVector3D(0.0F, 0.0F, -1.0F));
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  auto const requested = bus.drain();
+  EXPECT_EQ(std::count_if(requested.begin(),
+                          requested.end(),
+                          [](auto const& event) {
+                            return event.type ==
+                                   App::Core::PlayerFeedbackType::DodgeSuccess;
+                          }),
+            0)
+      << "requesting a dodge is not a successful dodge";
+
+  auto const contact = strike_the_commander(world, *commander, *attacker);
+  ASSERT_TRUE(contact.dodged);
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  auto const resolved = bus.drain();
+  EXPECT_EQ(std::count_if(resolved.begin(),
+                          resolved.end(),
+                          [](auto const& event) {
+                            return event.type ==
+                                   App::Core::PlayerFeedbackType::DodgeSuccess;
+                          }),
+            1)
+      << "a contact rejected by i-frames must publish exactly one DodgeSuccess";
+}
+
+TEST_F(CommanderDefenseWindowsTest, GuardFeedbackWaitsForAContactToBlock) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* attacker = make_unit(world, 0.0F, 1.6F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(attacker, nullptr);
+
+  App::Core::PlayerFeedbackBus bus;
+  CommanderControlController controller;
+  controller.set_feedback_bus(&bus);
+  controller.set_view_yaw(0.0F);
+  controller.secondary_action_down();
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  auto const raised = bus.drain();
+  EXPECT_EQ(std::count_if(raised.begin(),
+                          raised.end(),
+                          [](auto const& event) {
+                            return event.type ==
+                                   App::Core::PlayerFeedbackType::PerfectGuard;
+                          }),
+            0)
+      << "raising the guard is not a perfect guard";
+
+  auto const contact = strike_the_commander(world, *commander, *attacker);
+  ASSERT_TRUE(contact.perfect);
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  auto const resolved = bus.drain();
+  EXPECT_EQ(std::count_if(resolved.begin(),
+                          resolved.end(),
+                          [](auto const& event) {
+                            return event.type ==
+                                   App::Core::PlayerFeedbackType::PerfectGuard;
+                          }),
+            1)
+      << "a contact resolved as perfect must publish exactly one PerfectGuard";
+}
+
+TEST_F(CommanderDefenseWindowsTest, SimultaneousContactsEachResolveOnTheirOwnMerits) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* front = make_unit(world, 0.0F, 1.6F, 2);
+  auto* behind = make_unit(world, 0.0F, -1.6F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(front, nullptr);
+  ASSERT_NE(behind, nullptr);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  controller.secondary_action_down();
+  for (int tick = 0; tick < 40; ++tick) {
+    ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+  }
+
+  auto const front_contact = strike_the_commander(world, *commander, *front);
+  auto const back_contact = Game::Systems::RpgCombat::deal_damage_to_rpg_commander(
+      &world, commander, 24, behind->get_id(), {}, body_point(*commander, -0.34F));
+
+  EXPECT_TRUE(front_contact.blocked) << "the guarded side blocks";
+  EXPECT_EQ(front_contact.damage, 0);
+  EXPECT_FALSE(back_contact.blocked) << "the unguarded side does not";
+  EXPECT_GT(back_contact.effective_damage, 0);
+
+  auto const* rpg = commander->get_component<Engine::Core::RpgHealthComponent>();
+  ASSERT_NE(rpg, nullptr);
+  EXPECT_EQ(rpg->blocked_contacts, 1U);
+  EXPECT_EQ(rpg->damaging_contacts, 1U);
+}
+
+TEST_F(CommanderDefenseWindowsTest, AnUnblockableContactIsNotCountedAsABlock) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* attacker = make_unit(world, 0.0F, 1.6F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(attacker, nullptr);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  controller.secondary_action_down();
+  for (int tick = 0; tick < 40; ++tick) {
+    ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+  }
+
+  auto const result = Game::Systems::RpgCombat::deal_damage_to_rpg_commander(
+      &world,
+      commander,
+      24,
+      attacker->get_id(),
+      {.unblockable = true},
+      body_point(*commander, 0.34F));
+
+  EXPECT_FALSE(result.blocked);
+  EXPECT_GT(result.effective_damage, 0);
+
+  auto const* rpg = commander->get_component<Engine::Core::RpgHealthComponent>();
+  ASSERT_NE(rpg, nullptr);
+  EXPECT_EQ(rpg->blocked_contacts, 0U);
+  EXPECT_EQ(rpg->damaging_contacts, 1U);
+}
+
+TEST_F(CommanderDefenseWindowsTest, ADodgeRejectsOnlyTheContactItRolledAwayFrom) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* front = make_unit(world, 0.0F, 1.6F, 2);
+  auto* behind = make_unit(world, 0.0F, -1.6F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(front, nullptr);
+  ASSERT_NE(behind, nullptr);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+
+  controller.request_dodge(QVector3D(0.0F, 0.0F, -1.0F));
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  auto const rolled_from = strike_the_commander(world, *commander, *front);
+  EXPECT_TRUE(rolled_from.dodged)
+      << "the roll carries the commander away from this one";
+
+  auto const rolled_into = Game::Systems::RpgCombat::deal_damage_to_rpg_commander(
+      &world, commander, 24, behind->get_id(), {}, body_point(*commander, -0.34F));
+  EXPECT_FALSE(rolled_into.dodged)
+      << "i-frames are directional: rolling into a blow does not avoid it";
+}
+
+TEST_F(CommanderDefenseWindowsTest, EveryResolvedContactIsCountedExactlyOnce) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* attacker = make_unit(world, 0.0F, 1.6F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(attacker, nullptr);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  auto const first = strike_the_commander(world, *commander, *attacker);
+  EXPECT_GT(first.damage, 0);
+  auto const second = strike_the_commander(world, *commander, *attacker);
+  EXPECT_GT(second.damage, 0);
+
+  auto const* rpg = commander->get_component<Engine::Core::RpgHealthComponent>();
+  ASSERT_NE(rpg, nullptr);
+  EXPECT_EQ(rpg->damaging_contacts, 2U);
+  EXPECT_EQ(rpg->blocked_contacts, 0U);
+  EXPECT_EQ(rpg->dodged_contacts, 0U);
+  EXPECT_EQ(rpg->perfect_guard_contacts, 0U);
+  EXPECT_EQ(rpg->last_contact_outcome, Engine::Core::RpgContactOutcome::Damage);
+}
+
+} // namespace

--- a/tests/core/commander_lifecycle_soak_test.cpp
+++ b/tests/core/commander_lifecycle_soak_test.cpp
@@ -1,0 +1,381 @@
+#include <QVector3D>
+
+#include <cmath>
+#include <gtest/gtest.h>
+
+#include "app/commander/commander_control_controller.h"
+#include "app/commander/commander_mode_coordinator.h"
+#include "game/core/component.h"
+#include "game/core/world.h"
+#include "game/map/terrain_service.h"
+#include "game/systems/building_collision_registry.h"
+#include "game/systems/combat_system/combat_state_processor.h"
+#include "game/systems/nav_grid.h"
+#include "scene/camera.h"
+
+namespace {
+
+using App::Core::CommanderModeContext;
+using App::Core::CommanderModeCoordinator;
+using App::Core::CommanderModeState;
+
+class CommanderLifecycleSoakTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::NavGrid::initialize(64, 64);
+  }
+
+  void TearDown() override {
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+  }
+
+  static auto make_commander(Engine::Core::World& world,
+                             float x,
+                             float z) -> Engine::Core::Entity* {
+    auto* entity = world.create_entity();
+    if (entity == nullptr) {
+      return nullptr;
+    }
+    entity->add_component<Engine::Core::TransformComponent>(x, 0.0F, z);
+    auto* unit = entity->add_component<Engine::Core::UnitComponent>();
+    entity->add_component<Engine::Core::MovementComponent>();
+    auto* commander = entity->add_component<Engine::Core::CommanderComponent>();
+    if (unit == nullptr || commander == nullptr) {
+      return nullptr;
+    }
+    unit->health = 100;
+    unit->max_health = 100;
+    unit->owner_id = 1;
+    unit->speed = 3.0F;
+    unit->spawn_type = Game::Units::SpawnType::Knight;
+    return entity;
+  }
+
+  static auto
+  make_enemy(Engine::Core::World& world, float x, float z) -> Engine::Core::Entity* {
+    auto* entity = world.create_entity();
+    if (entity == nullptr) {
+      return nullptr;
+    }
+    entity->add_component<Engine::Core::TransformComponent>(x, 0.0F, z);
+    auto* unit = entity->add_component<Engine::Core::UnitComponent>();
+    entity->add_component<Engine::Core::MovementComponent>();
+    if (unit == nullptr) {
+      return nullptr;
+    }
+    unit->health = 100000;
+    unit->max_health = 100000;
+    unit->owner_id = 2;
+    unit->speed = 3.0F;
+    unit->spawn_type = Game::Units::SpawnType::Knight;
+    unit->render_individuals_per_unit_override = 1;
+    return entity;
+  }
+};
+
+TEST_F(CommanderLifecycleSoakTest, OneHundredEnterExitCyclesRestoreEveryFlag) {
+  Engine::Core::World world;
+  auto* commander = make_commander(world, 0.0F, 0.0F);
+  ASSERT_NE(commander, nullptr);
+  auto const commander_id = commander->get_id();
+  auto* transform = commander->get_component<Engine::Core::TransformComponent>();
+  ASSERT_NE(transform, nullptr);
+  QVector3D const start(
+      transform->position.x, transform->position.y, transform->position.z);
+
+  CommanderControlController controller;
+  Render::GL::Camera camera;
+  CommanderModeCoordinator coordinator;
+
+  CommanderModeContext context;
+  context.world = &world;
+  context.commander = commander;
+  context.commander_camera = &camera;
+  context.commander_control = &controller;
+  context.controlled_commander_id = commander_id;
+  context.local_owner_id = 1;
+
+  for (int cycle = 0; cycle < 100; ++cycle) {
+    ASSERT_TRUE(coordinator.begin_enter()) << "cycle " << cycle;
+    auto const entered = coordinator.enter_commander_control_mode(context);
+    coordinator.complete_transition();
+    ASSERT_TRUE(entered.entered) << "cycle " << cycle;
+    EXPECT_EQ(entered.controlled_commander_id, commander_id) << "cycle " << cycle;
+    EXPECT_TRUE(coordinator.is_active()) << "cycle " << cycle;
+
+    auto* commander_data = commander->get_component<Engine::Core::CommanderComponent>();
+    ASSERT_NE(commander_data, nullptr) << "cycle " << cycle;
+    EXPECT_TRUE(commander_data->fpv_controlled) << "cycle " << cycle;
+
+    controller.key_down(Qt::Key_W);
+    controller.primary_action_down();
+    controller.secondary_action_down();
+    ASSERT_TRUE(controller.update_simulation(world, commander_id, 1, 1.0F / 60.0F))
+        << "cycle " << cycle;
+
+    ASSERT_TRUE(coordinator.begin_exit()) << "cycle " << cycle;
+    auto const exited = coordinator.exit_commander_control_mode(context);
+    coordinator.complete_transition();
+    EXPECT_EQ(exited.controlled_commander_id, 0U) << "cycle " << cycle;
+    EXPECT_EQ(coordinator.state(), CommanderModeState::Inactive) << "cycle " << cycle;
+
+    controller.release_all_input();
+    controller.reset();
+
+    commander_data = commander->get_component<Engine::Core::CommanderComponent>();
+    ASSERT_NE(commander_data, nullptr) << "cycle " << cycle;
+    EXPECT_FALSE(commander_data->fpv_controlled) << "cycle " << cycle;
+    EXPECT_FALSE(commander_data->jump_active) << "cycle " << cycle;
+    EXPECT_EQ(commander_data->combo_step, 0) << "cycle " << cycle;
+    EXPECT_FALSE(commander_data->power_strike_active) << "cycle " << cycle;
+
+    auto const& input = controller.input();
+    EXPECT_FALSE(input.forward) << "cycle " << cycle;
+    EXPECT_FALSE(input.primary_action) << "cycle " << cycle;
+    EXPECT_FALSE(input.secondary_action) << "cycle " << cycle;
+
+    if (auto const* guard =
+            commander->get_component<Engine::Core::CommanderGuardComponent>()) {
+      EXPECT_FALSE(guard->active) << "cycle " << cycle;
+    }
+  }
+
+  EXPECT_LT(
+      (QVector3D(transform->position.x, transform->position.y, transform->position.z) -
+       start)
+          .length(),
+      2.0F)
+      << "a hundred enter/exit cycles must not walk the commander across the map";
+}
+
+TEST_F(CommanderLifecycleSoakTest, ATenMinuteDuelKeepsEveryInputEdgeAccountedFor) {
+
+  constexpr float k_dt = 1.0F / 60.0F;
+  constexpr int k_ticks = 60 * 60 * 10;
+  constexpr int k_press_interval = 90;
+
+  Engine::Core::World world;
+  auto* commander = make_commander(world, 0.0F, 0.0F);
+  auto* enemy = make_enemy(world, 0.0F, 1.5F);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(enemy, nullptr);
+  auto const commander_id = commander->get_id();
+
+  auto* commander_data = commander->get_component<Engine::Core::CommanderComponent>();
+  ASSERT_NE(commander_data, nullptr);
+  commander_data->fpv_controlled = true;
+  auto* rpg = commander->add_component<Engine::Core::RpgHealthComponent>();
+  ASSERT_NE(rpg, nullptr);
+  rpg->active = true;
+  auto* attack = commander->add_component<Engine::Core::AttackComponent>();
+  ASSERT_NE(attack, nullptr);
+  attack->current_mode = Engine::Core::AttackComponent::CombatMode::Melee;
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  controller.set_presentation_trace_enabled(true);
+
+  int presses = 0;
+  for (int tick = 0; tick < k_ticks; ++tick) {
+    if (tick % k_press_interval == 0) {
+      controller.primary_action_down();
+      controller.primary_action_up();
+      ++presses;
+    }
+    if (tick % 240 == 0) {
+      controller.request_dodge(QVector3D(0.0F, 0.0F, -1.0F));
+    }
+    ASSERT_TRUE(controller.update_simulation(world, commander_id, 1, k_dt))
+        << "tick " << tick;
+    Game::Systems::Combat::process_combat_state(&world, k_dt);
+  }
+
+  auto const& edges = controller.input_edges();
+  EXPECT_EQ(edges.primary_press_sequence, static_cast<std::uint64_t>(presses));
+  EXPECT_EQ(edges.primary_press_sequence,
+            edges.primary_consumed_sequence + edges.primary_dropped_sequence)
+      << "every attack press must be consumed or explicitly dropped";
+  EXPECT_EQ(edges.dodge_request_sequence,
+            edges.dodge_consumed_sequence + edges.dodge_refused_sequence)
+      << "every dodge request must be consumed or explicitly refused";
+
+  auto const* queue =
+      commander->get_component<Engine::Core::CombatIntentQueueComponent>();
+  ASSERT_NE(queue, nullptr);
+  EXPECT_GT(queue->accepted_intents, 0U);
+  EXPECT_EQ(queue->overflow_intents, 0U)
+      << "the buffer must never silently discard a press";
+  EXPECT_LE(queue->count, Engine::Core::CombatIntentQueueComponent::k_capacity);
+
+  auto const* transform = commander->get_component<Engine::Core::TransformComponent>();
+  ASSERT_NE(transform, nullptr);
+  EXPECT_TRUE(std::isfinite(transform->position.x));
+  EXPECT_TRUE(std::isfinite(transform->position.z));
+
+  auto const* stamina = commander->get_component<Engine::Core::StaminaComponent>();
+  if (stamina != nullptr) {
+    EXPECT_GE(stamina->stamina, 0.0F);
+    EXPECT_LE(stamina->stamina, stamina->max_stamina);
+  }
+}
+
+TEST_F(CommanderLifecycleSoakTest, TenMinutesOfOpenTraversalKeepsTheBodyFinite) {
+
+  constexpr float k_dt = 1.0F / 60.0F;
+  constexpr int k_ticks = 60 * 60 * 10;
+
+  Engine::Core::World world;
+  auto* commander = make_commander(world, 0.0F, 0.0F);
+  ASSERT_NE(commander, nullptr);
+  auto const commander_id = commander->get_id();
+  commander->get_component<Engine::Core::CommanderComponent>()->fpv_controlled = true;
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+
+  auto* transform = commander->get_component<Engine::Core::TransformComponent>();
+  ASSERT_NE(transform, nullptr);
+
+  float worst_step = 0.0F;
+  QVector3D previous(
+      transform->position.x, transform->position.y, transform->position.z);
+  for (int tick = 0; tick < k_ticks; ++tick) {
+
+    if (tick % 180 == 0) {
+      controller.release_all_input();
+      switch ((tick / 180) % 4) {
+      case 0:
+        controller.key_down(Qt::Key_W);
+        break;
+      case 1:
+        controller.key_down(Qt::Key_W);
+        controller.key_down(Qt::Key_D);
+        controller.key_down(Qt::Key_Shift);
+        break;
+      case 2:
+        controller.key_down(Qt::Key_S);
+        break;
+      default:
+        break;
+      }
+      controller.set_view_yaw(static_cast<float>((tick / 180) % 8) * 45.0F);
+    }
+    ASSERT_TRUE(controller.update_simulation(world, commander_id, 1, k_dt))
+        << "tick " << tick;
+    Game::Systems::Combat::process_combat_state(&world, k_dt);
+
+    QVector3D const now(
+        transform->position.x, transform->position.y, transform->position.z);
+    worst_step = std::max(worst_step, (now - previous).length());
+    previous = now;
+  }
+
+  EXPECT_TRUE(std::isfinite(transform->position.x));
+  EXPECT_TRUE(std::isfinite(transform->position.z));
+  EXPECT_LT(worst_step, 1.0F) << "ten minutes of traversal must contain no teleport";
+}
+
+TEST_F(CommanderLifecycleSoakTest, TenMinutesInsideAFriendlyCrowdNeverWedgesTheBody) {
+
+  constexpr float k_dt = 1.0F / 60.0F;
+  constexpr int k_ticks = 60 * 60 * 10;
+
+  Engine::Core::World world;
+  auto* commander = make_commander(world, 0.0F, 0.0F);
+  ASSERT_NE(commander, nullptr);
+  auto const commander_id = commander->get_id();
+  commander->get_component<Engine::Core::CommanderComponent>()->fpv_controlled = true;
+
+  for (int index = 0; index < 12; ++index) {
+    float const angle = static_cast<float>(index) * 30.0F * 3.14159265F / 180.0F;
+    auto* friendly =
+        make_commander(world, std::sin(angle) * 1.8F, std::cos(angle) * 1.8F);
+    ASSERT_NE(friendly, nullptr);
+    friendly->remove_component<Engine::Core::CommanderComponent>();
+  }
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  controller.key_down(Qt::Key_W);
+
+  auto* transform = commander->get_component<Engine::Core::TransformComponent>();
+  ASSERT_NE(transform, nullptr);
+  float worst_step = 0.0F;
+  QVector3D previous(
+      transform->position.x, transform->position.y, transform->position.z);
+
+  for (int tick = 0; tick < k_ticks; ++tick) {
+    ASSERT_TRUE(controller.update_simulation(world, commander_id, 1, k_dt))
+        << "tick " << tick;
+    QVector3D const now(
+        transform->position.x, transform->position.y, transform->position.z);
+    worst_step = std::max(worst_step, (now - previous).length());
+    previous = now;
+  }
+
+  EXPECT_LT(worst_step, 1.0F) << "a crowd may push the commander, never teleport him";
+  EXPECT_GT((QVector3D(transform->position.x, 0.0F, transform->position.z)).length(),
+            1.0F)
+      << "held forward input for ten minutes must not leave him wedged where he "
+         "started";
+}
+
+TEST_F(CommanderLifecycleSoakTest, PausingDuringEveryActionPhaseLeavesNoStuckState) {
+
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world, 0.0F, 0.0F);
+  auto* enemy = make_enemy(world, 0.0F, 1.5F);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(enemy, nullptr);
+  auto const commander_id = commander->get_id();
+
+  auto* commander_data = commander->get_component<Engine::Core::CommanderComponent>();
+  ASSERT_NE(commander_data, nullptr);
+  commander_data->fpv_controlled = true;
+  auto* attack = commander->add_component<Engine::Core::AttackComponent>();
+  ASSERT_NE(attack, nullptr);
+  attack->current_mode = Engine::Core::AttackComponent::CombatMode::Melee;
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+
+  for (int pause_after = 1; pause_after <= 40; ++pause_after) {
+    controller.reset();
+    controller.primary_action_down();
+    controller.primary_action_up();
+    for (int tick = 0; tick < pause_after; ++tick) {
+      ASSERT_TRUE(controller.update_simulation(world, commander_id, 1, k_dt))
+          << "pause_after " << pause_after;
+      Game::Systems::Combat::process_combat_state(&world, k_dt);
+    }
+
+    controller.release_all_input();
+    for (int tick = 0; tick < 12; ++tick) {
+      ASSERT_TRUE(controller.update_simulation(world, commander_id, 1, 0.0F))
+          << "pause_after " << pause_after;
+      Game::Systems::Combat::process_combat_state(&world, 0.0F);
+    }
+
+    for (int tick = 0; tick < 120; ++tick) {
+      ASSERT_TRUE(controller.update_simulation(world, commander_id, 1, k_dt))
+          << "pause_after " << pause_after;
+      Game::Systems::Combat::process_combat_state(&world, k_dt);
+    }
+
+    auto const* action =
+        commander->get_component<Engine::Core::RpgCommanderActionComponent>();
+    if (action != nullptr) {
+      EXPECT_FALSE(action->action_running)
+          << "an action was still running two seconds after the input stopped, "
+             "paused at tick "
+          << pause_after;
+    }
+    EXPECT_FALSE(controller.is_dodge_rolling()) << "pause_after " << pause_after;
+  }
+}
+
+} // namespace

--- a/tests/core/commander_lock_on_test.cpp
+++ b/tests/core/commander_lock_on_test.cpp
@@ -1,0 +1,185 @@
+#include <cmath>
+#include <gtest/gtest.h>
+
+#include "app/commander/commander_control_controller.h"
+#include "game/core/component.h"
+#include "game/core/world.h"
+#include "game/map/terrain_service.h"
+#include "game/session/session_context.h"
+#include "game/systems/building_collision_registry.h"
+#include "game/systems/nav_grid.h"
+#include "game/systems/owner_registry.h"
+
+namespace {
+
+class CommanderLockOnTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::NavGrid::initialize(64, 64);
+  }
+
+  void TearDown() override {
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+  }
+
+  static auto make_unit(Engine::Core::World& world,
+                        float x,
+                        float z,
+                        int owner) -> Engine::Core::Entity* {
+    auto* entity = world.create_entity();
+    if (entity == nullptr) {
+      return nullptr;
+    }
+    entity->add_component<Engine::Core::TransformComponent>(x, 0.0F, z);
+    auto* unit = entity->add_component<Engine::Core::UnitComponent>();
+    entity->add_component<Engine::Core::MovementComponent>();
+    if (unit == nullptr) {
+      return nullptr;
+    }
+    unit->health = 500;
+    unit->max_health = 500;
+    unit->owner_id = owner;
+    unit->speed = 3.0F;
+    unit->spawn_type = Game::Units::SpawnType::Knight;
+    unit->render_individuals_per_unit_override = 1;
+    return entity;
+  }
+
+  static auto make_commander(Engine::Core::World& world) -> Engine::Core::Entity* {
+    auto* entity = make_unit(world, 0.0F, 0.0F, 1);
+    if (entity == nullptr) {
+      return nullptr;
+    }
+    auto* commander = entity->add_component<Engine::Core::CommanderComponent>();
+    if (commander == nullptr) {
+      return nullptr;
+    }
+    commander->fpv_controlled = true;
+    return entity;
+  }
+
+  static void make_enemies_hostile(Engine::Core::World& world) {
+    auto& owners = Game::Session::session_for(world).owners();
+    owners.set_owner_team(1, 1);
+    owners.set_owner_team(2, 2);
+  }
+};
+
+TEST_F(CommanderLockOnTest, ALockDropsWhenTheTargetDies) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* enemy = make_unit(world, 0.0F, 4.0F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(enemy, nullptr);
+  make_enemies_hostile(world);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  controller.cycle_lock_on_target(world, commander->get_id(), 1);
+  ASSERT_EQ(controller.locked_target_id(), enemy->get_id());
+
+  auto* enemy_unit = enemy->get_component<Engine::Core::UnitComponent>();
+  ASSERT_NE(enemy_unit, nullptr);
+  enemy_unit->health = 0;
+
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+  EXPECT_EQ(controller.locked_target_id(), 0U);
+}
+
+TEST_F(CommanderLockOnTest, CyclingWalksTargetsAcrossTheScreen) {
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* left = make_unit(world, -3.0F, 5.0F, 2);
+  auto* centre = make_unit(world, 0.0F, 5.0F, 2);
+  auto* right = make_unit(world, 3.0F, 5.0F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(left, nullptr);
+  ASSERT_NE(centre, nullptr);
+  ASSERT_NE(right, nullptr);
+  make_enemies_hostile(world);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+
+  controller.cycle_lock_on_target(world, commander->get_id(), 1);
+  EXPECT_EQ(controller.locked_target_id(), centre->get_id())
+      << "the first lock takes the target nearest the view centre";
+
+  controller.cycle_lock_on_target(world, commander->get_id(), 1);
+  EXPECT_EQ(controller.locked_target_id(), right->get_id())
+      << "cycling steps to the next target to the right";
+
+  controller.cycle_lock_on_target(world, commander->get_id(), 1);
+  EXPECT_EQ(controller.locked_target_id(), left->get_id())
+      << "cycling past the rightmost target wraps to the leftmost";
+}
+
+TEST_F(CommanderLockOnTest, AnOverlappingTargetDoesNotSpinTheView) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* enemy = make_unit(world, 0.0F, 4.0F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(enemy, nullptr);
+  make_enemies_hostile(world);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(0.0F);
+  controller.cycle_lock_on_target(world, commander->get_id(), 1);
+  ASSERT_EQ(controller.locked_target_id(), enemy->get_id());
+
+  auto* enemy_transform = enemy->get_component<Engine::Core::TransformComponent>();
+  ASSERT_NE(enemy_transform, nullptr);
+  enemy_transform->position.z = -0.2F;
+  enemy_transform->position.x = 0.05F;
+
+  auto const* commander_transform =
+      commander->get_component<Engine::Core::TransformComponent>();
+  ASSERT_NE(commander_transform, nullptr);
+
+  float const before = controller.view_yaw();
+  for (int tick = 0; tick < 30; ++tick) {
+
+    enemy_transform->position.x = commander_transform->position.x + 0.05F;
+    enemy_transform->position.z = commander_transform->position.z - 0.20F;
+    ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+  }
+  float const after = controller.view_yaw();
+
+  EXPECT_NEAR(after, before, 1.0F)
+      << "a target inside the commander's own footprint must not swing the view";
+  EXPECT_EQ(controller.locked_target_id(), enemy->get_id())
+      << "the lock itself survives the overlap";
+}
+
+TEST_F(CommanderLockOnTest, ManualLookOverridesTheLockSpringWithoutDroppingIt) {
+  constexpr float k_dt = 1.0F / 60.0F;
+  Engine::Core::World world;
+  auto* commander = make_commander(world);
+  auto* enemy = make_unit(world, 4.0F, 4.0F, 2);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(enemy, nullptr);
+  make_enemies_hostile(world);
+
+  CommanderControlController controller;
+  controller.set_view_yaw(45.0F);
+  controller.cycle_lock_on_target(world, commander->get_id(), 1);
+  ASSERT_EQ(controller.locked_target_id(), enemy->get_id());
+
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  controller.mouse_move(120.0, 0.0);
+  float const after_look = controller.view_yaw();
+  ASSERT_TRUE(controller.update_simulation(world, commander->get_id(), 1, k_dt));
+
+  EXPECT_NEAR(controller.view_yaw(), after_look, 0.5F)
+      << "the lock spring must yield to manual look for its override window";
+  EXPECT_EQ(controller.locked_target_id(), enemy->get_id())
+      << "manual look steers, it does not unlock";
+}
+
+} // namespace

--- a/tests/core/commander_state_round_trip_test.cpp
+++ b/tests/core/commander_state_round_trip_test.cpp
@@ -1,0 +1,151 @@
+#include <QJsonObject>
+
+#include <gtest/gtest.h>
+
+#include "core/component.h"
+#include "core/entity.h"
+#include "core/world.h"
+#include "map/terrain_service.h"
+#include "save/serialization.h"
+#include "units/spawn_type.h"
+
+using namespace Engine::Core;
+
+namespace {
+
+class CommanderStateRoundTripTest : public ::testing::Test {
+protected:
+  void SetUp() override { world = std::make_unique<World>(); }
+
+  void TearDown() override {
+    Game::Map::TerrainService::instance().clear();
+    world.reset();
+  }
+
+  auto make_commander() -> Entity* {
+    auto* entity = world->create_entity();
+    entity->add_component<TransformComponent>(3.0F, 0.0F, 4.0F);
+    auto* unit = entity->add_component<UnitComponent>();
+    unit->health = 80;
+    unit->max_health = 100;
+    unit->owner_id = 1;
+    unit->spawn_type = Game::Units::SpawnType::Knight;
+    auto* commander = entity->add_component<CommanderComponent>();
+    commander->fpv_controlled = true;
+    auto* rpg = entity->add_component<RpgHealthComponent>();
+    rpg->active = true;
+    rpg->armor = 3.0F;
+    rpg->incoming_damage_scale = 0.5F;
+    return entity;
+  }
+
+  auto round_trip(Entity* source) -> Entity* {
+    QJsonObject const json = Serialization::serialize_entity(source);
+    auto* restored = world->create_entity();
+    Serialization::deserialize_entity(restored, json);
+    return restored;
+  }
+
+  std::unique_ptr<World> world;
+};
+
+TEST_F(CommanderStateRoundTripTest, AnIdleCommanderKeepsItsDurableRpgState) {
+  auto* commander = make_commander();
+  auto* restored = round_trip(commander);
+
+  auto const* rpg = restored->get_component<RpgHealthComponent>();
+  ASSERT_NE(rpg, nullptr);
+  EXPECT_FLOAT_EQ(rpg->armor, 3.0F);
+  EXPECT_FLOAT_EQ(rpg->incoming_damage_scale, 0.5F);
+
+  auto const* unit = restored->get_component<UnitComponent>();
+  ASSERT_NE(unit, nullptr);
+  EXPECT_EQ(unit->health, 80);
+}
+
+TEST_F(CommanderStateRoundTripTest, DirectControlIsNotRestoredFromASave) {
+  auto* commander = make_commander();
+  auto* restored = round_trip(commander);
+
+  auto const* rpg = restored->get_component<RpgHealthComponent>();
+  ASSERT_NE(rpg, nullptr);
+  EXPECT_FALSE(rpg->active)
+      << "direct control is entered by the player, never by loading a save";
+}
+
+TEST_F(CommanderStateRoundTripTest, TransientDodgeStateNormalizesOnLoad) {
+  auto* commander = make_commander();
+  auto* rpg = commander->get_component<RpgHealthComponent>();
+  ASSERT_NE(rpg, nullptr);
+  rpg->dodge_grace_remaining = 0.12F;
+  rpg->dodge_dir_x = 1.0F;
+  rpg->dodge_dir_z = -1.0F;
+  rpg->dodged_contacts = 4U;
+  rpg->blocked_contacts = 7U;
+
+  auto const* restored = round_trip(commander)->get_component<RpgHealthComponent>();
+  ASSERT_NE(restored, nullptr);
+  EXPECT_FLOAT_EQ(restored->dodge_grace_remaining, 0.0F)
+      << "a save must not restore mid-roll invulnerability";
+  EXPECT_EQ(restored->dodged_contacts, 0U);
+  EXPECT_EQ(restored->blocked_contacts, 0U);
+}
+
+TEST_F(CommanderStateRoundTripTest, TransientGuardStateNormalizesOnLoad) {
+  auto* commander = make_commander();
+  auto* guard = commander->add_component<CommanderGuardComponent>();
+  guard->active = true;
+  guard->perfect_guard_remaining = 0.16F;
+  guard->guard_break_remaining = 0.9F;
+  guard->rearm_requires_release = true;
+
+  auto const* restored =
+      round_trip(commander)->get_component<CommanderGuardComponent>();
+  if (restored != nullptr) {
+    EXPECT_FLOAT_EQ(restored->perfect_guard_remaining, 0.0F)
+        << "a save must not restore an armed perfect-guard window";
+  }
+}
+
+TEST_F(CommanderStateRoundTripTest, TransientActionStateNormalizesOnLoad) {
+  auto* commander = make_commander();
+  auto* action = commander->add_component<RpgCommanderActionComponent>();
+  action->action_running = true;
+  action->normalized_action_time = 0.5F;
+  action->hit_target_count = 1U;
+
+  auto* queue = commander->add_component<CombatIntentQueueComponent>();
+  CombatActionIntent intent;
+  intent.pressed_at = 0.25F;
+  queue->push(intent);
+  queue->record(CombatIntentOutcome::Buffered);
+
+  auto* restored = round_trip(commander);
+  auto const* restored_action = restored->get_component<RpgCommanderActionComponent>();
+  if (restored_action != nullptr) {
+    EXPECT_FALSE(restored_action->action_running)
+        << "a save must not resume a half-finished swing";
+    EXPECT_EQ(restored_action->hit_target_count, 0U);
+  }
+  auto const* restored_queue = restored->get_component<CombatIntentQueueComponent>();
+  if (restored_queue != nullptr) {
+    EXPECT_EQ(restored_queue->count, 0U) << "a buffered press does not survive a load";
+  }
+}
+
+TEST_F(CommanderStateRoundTripTest, ADeadCommanderLoadsDead) {
+  auto* commander = make_commander();
+  auto* unit = commander->get_component<UnitComponent>();
+  ASSERT_NE(unit, nullptr);
+  unit->health = 0;
+
+  auto const* restored = round_trip(commander)->get_component<UnitComponent>();
+  ASSERT_NE(restored, nullptr);
+  EXPECT_EQ(restored->health, 0);
+
+  auto const* rpg = round_trip(commander)->get_component<RpgHealthComponent>();
+  ASSERT_NE(rpg, nullptr);
+  EXPECT_FALSE(rpg->active);
+}
+
+} // namespace

--- a/tests/core/commander_view_model_input_test.cpp
+++ b/tests/core/commander_view_model_input_test.cpp
@@ -261,4 +261,69 @@ TEST_F(CommanderViewModelInputTest, FocusLossClearsEveryHeldCommanderAction) {
       << "input released on focus loss must not leave the commander walking";
 }
 
+TEST_F(CommanderViewModelInputTest, LandingAHitNeverSlowsTheSimulationClock) {
+  constexpr float k_tick = 1.0F / 60.0F;
+  auto* commander = spawn_commander(0.0F, 0.0F);
+  auto* enemy = spawn_enemy(0.0F, 1.4F);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(enemy, nullptr);
+  m_commander->enter_mode();
+  ASSERT_TRUE(m_commander->active());
+
+  auto* commander_data = commander->get_component<Engine::Core::CommanderComponent>();
+  ASSERT_NE(commander_data, nullptr);
+
+  EXPECT_FLOAT_EQ(m_commander->time_effect_scale(k_tick, false), 1.0F);
+
+  commander_data->just_struck_enemy = true;
+  m_commander->update_control_mode(k_tick);
+
+  for (int tick = 0; tick < 30; ++tick) {
+    EXPECT_FLOAT_EQ(m_commander->time_effect_scale(k_tick, false), 1.0F)
+        << "a landed hit must not scale the simulation clock at tick " << tick;
+  }
+  EXPECT_TRUE(commander_data->just_struck_enemy)
+      << "the hit flag belongs to the combo chain; the view model must not eat it";
+}
+
+TEST_F(CommanderViewModelInputTest, ADeadCommanderLeavesTheModeAndTheCursorBehind) {
+  constexpr float k_tick = 1.0F / 60.0F;
+  auto* commander = spawn_commander(0.0F, 0.0F);
+  ASSERT_NE(commander, nullptr);
+  m_commander->enter_mode();
+  ASSERT_TRUE(m_commander->active());
+
+  auto* unit = commander->get_component<Engine::Core::UnitComponent>();
+  ASSERT_NE(unit, nullptr);
+  unit->health = 0;
+
+  m_commander->update_control_mode(k_tick);
+
+  EXPECT_FALSE(m_commander->active())
+      << "a dead commander must not keep direct control alive";
+  EXPECT_EQ(m_host.cursor_mode, CursorMode::Normal)
+      << "death must hand the cursor back";
+
+  auto const* commander_data =
+      commander->get_component<Engine::Core::CommanderComponent>();
+  ASSERT_NE(commander_data, nullptr);
+  EXPECT_FALSE(commander_data->fpv_controlled);
+}
+
+TEST_F(CommanderViewModelInputTest, AVanishedCommanderCannotLeaveTheModeActive) {
+  constexpr float k_tick = 1.0F / 60.0F;
+  auto* commander = spawn_commander(0.0F, 0.0F);
+  ASSERT_NE(commander, nullptr);
+  auto const commander_id = commander->get_id();
+  m_commander->enter_mode();
+  ASSERT_TRUE(m_commander->active());
+
+  m_world.destroy_entity(commander_id);
+  m_commander->update_control_mode(k_tick);
+
+  EXPECT_FALSE(m_commander->active())
+      << "pending removal must not leave a live camera and input pointer";
+  EXPECT_EQ(m_host.cursor_mode, CursorMode::Normal);
+}
+
 } // namespace

--- a/tests/headless/playable_ground_test.cpp
+++ b/tests/headless/playable_ground_test.cpp
@@ -153,7 +153,6 @@ auto ruins_at(int grid_x, int grid_z) -> WorldProp {
 } // namespace
 
 TEST_F(PlayableGroundTest, DuellistsNeverFightOnTopOfARuin) {
-  const QVector3D ruin = world_of(24, 24);
   field({ruins_at(24, 24)});
 
   const EntityID ours =
@@ -224,7 +223,6 @@ TEST_F(PlayableGroundTest, ANearbyOrderNeverStartsAwayFromItsGoal) {
 }
 
 TEST_F(PlayableGroundTest, NoUnitSettlesOnGroundItMayNotStandOn) {
-  const QVector3D ruin = world_of(24, 24);
   field({ruins_at(24, 24)});
 
   std::vector<EntityID> army;
@@ -403,7 +401,6 @@ TEST_F(PlayableGroundTest, ADuellistStrandedInsideGeometryStillWalksOut) {
 }
 
 TEST_F(PlayableGroundTest, AFightBesideARuinIsNotBrokenUpByIt) {
-  const QVector3D ruin = world_of(24, 24);
   field({ruins_at(24, 24)});
 
   const EntityID ours =

--- a/tests/systems/combat_mode_test.cpp
+++ b/tests/systems/combat_mode_test.cpp
@@ -3388,6 +3388,85 @@ TEST_F(CombatModeTest, AuthoredActionTimelineDoesNotReadCompatibilityPhase) {
   EXPECT_EQ(compatibility_state.animation_state, CombatAnimationState::Idle);
 }
 
+TEST_F(CombatModeTest, AWeaponTraceContactLandsOnTheTargetsHurtBody) {
+  auto* commander = make_fpv_commander(*world, 0.0F, 0.0F);
+  auto* enemy = make_enemy_soldier(*world, 0.0F, 1.3F);
+  ASSERT_NE(enemy, nullptr);
+
+  auto const* definition = Game::Systems::CombatActions::find_combat_action_definition(
+      Game::Systems::CombatActions::CombatActionId::RpgSwordOverhead);
+  ASSERT_NE(definition, nullptr);
+
+  auto* action = start_authored_action_at(
+      commander, Game::Systems::CombatActions::CombatActionId::RpgSwordOverhead, 0.44F);
+  ASSERT_NE(action, nullptr);
+  action->active_target_id = enemy->get_id();
+
+  auto const contact = Game::Systems::CombatActions::find_weapon_trace_contact(
+      *world, *commander, *definition, {0.44F, 0.58F}, enemy->get_id());
+  ASSERT_EQ(contact.target_id, enemy->get_id());
+
+  auto const* enemy_transform = enemy->get_component<TransformComponent>();
+  ASSERT_NE(enemy_transform, nullptr);
+  float const local_height = contact.contact_point.y() - enemy_transform->position.y;
+  EXPECT_GE(local_height, Game::Systems::RpgCombat::k_hurt_body_min_height);
+  EXPECT_LE(local_height, Game::Systems::RpgCombat::k_hurt_body_max_height);
+
+  float const planar =
+      std::hypot(contact.contact_point.x() - enemy_transform->position.x,
+                 contact.contact_point.z() - enemy_transform->position.z);
+  EXPECT_LE(planar, 1.0F);
+}
+
+TEST_F(CombatModeTest, OneActionAppliesOneDamageAtEverySimulationRate) {
+  const std::array<float, 4> rates{30.0F, 60.0F, 120.0F, 4.0F};
+  std::vector<int> damage_per_rate;
+  std::vector<int> contacts_per_rate;
+
+  for (float const rate : rates) {
+    World rate_world;
+    auto* commander = make_fpv_commander(rate_world, 0.0F, 0.0F);
+    auto* enemy = make_enemy_soldier(rate_world, 0.0F, 1.3F);
+    ASSERT_NE(commander, nullptr) << rate;
+    ASSERT_NE(enemy, nullptr) << rate;
+
+    auto* enemy_unit = enemy->get_component<UnitComponent>();
+    ASSERT_NE(enemy_unit, nullptr) << rate;
+    enemy_unit->health = 5000;
+    enemy_unit->max_health = 5000;
+
+    auto* combat_state = begin_commander_strike(commander, enemy->get_id());
+    ASSERT_NE(combat_state, nullptr) << rate;
+    combat_state->state_duration = 0.30F;
+    auto* action = start_authored_action_at(
+        commander,
+        Game::Systems::CombatActions::CombatActionId::RpgSwordSlashLeft,
+        0.0F);
+    ASSERT_NE(action, nullptr) << rate;
+    action->active_target_id = enemy->get_id();
+
+    float const dt = 1.0F / rate;
+    float elapsed = 0.0F;
+    while (elapsed < action->action_duration + dt) {
+      Game::Systems::Combat::process_combat_state(&rate_world, dt);
+      elapsed += dt;
+    }
+
+    damage_per_rate.push_back(5000 - enemy_unit->health);
+    contacts_per_rate.push_back(static_cast<int>(action->hit_target_count));
+  }
+
+  ASSERT_EQ(damage_per_rate.size(), rates.size());
+  for (std::size_t index = 1; index < damage_per_rate.size(); ++index) {
+    EXPECT_EQ(damage_per_rate[index], damage_per_rate[0])
+        << "rate " << rates[index] << " Hz applied different damage";
+    EXPECT_EQ(contacts_per_rate[index], contacts_per_rate[0])
+        << "rate " << rates[index] << " Hz resolved a different contact count";
+  }
+  EXPECT_GT(damage_per_rate[0], 0);
+  EXPECT_LE(contacts_per_rate[0], 1);
+}
+
 TEST_F(CombatModeTest, SwordTraceRejectsTargetsBehindCommander) {
   auto* commander = make_fpv_commander(*world, 0.0F, 0.0F);
   auto* enemy = make_enemy_soldier(*world, 0.0F, -1.2F);

--- a/tests/systems/home_manpower_system_test.cpp
+++ b/tests/systems/home_manpower_system_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include "game/core/ambient_session.h"
 #include "game/core/component.h"
 #include "game/core/world.h"
 #include "game/game_config.h"
@@ -20,10 +21,14 @@
 
 namespace {
 
-[[nodiscard]] auto archer_production() -> Game::Units::TroopProductionStats {
-  const auto* archer =
-      Game::Units::TroopCatalog::instance().get_class(Game::Units::TroopType::Archer);
-  return archer != nullptr ? archer->production : Game::Units::TroopProductionStats{};
+[[nodiscard]] auto archer_production(Engine::Core::World& world, int owner_id)
+    -> Game::Units::TroopProductionStats {
+  auto& nations = *Game::Session::services_for(world).nations;
+  const auto* nation = nations.get_nation_for_player(owner_id);
+  const auto nation_id = nation != nullptr ? nation->id : nations.default_nation_id();
+  return Game::Systems::TroopProfileService::instance()
+      .get_profile(nation_id, Game::Units::TroopType::Archer)
+      .production;
 }
 
 class HomeManpowerSystemTest : public ::testing::Test {
@@ -147,7 +152,7 @@ TEST_F(HomeManpowerSystemTest, BarracksProductionConsumesAvailableManpowerWhenQu
   ASSERT_NE(unit, nullptr);
   ASSERT_NE(production, nullptr);
 
-  const auto archer = archer_production();
+  const auto archer = archer_production(world, 1);
 
   unit->spawn_type = Game::Units::SpawnType::Barracks;
   unit->owner_id = 1;
@@ -190,7 +195,7 @@ TEST_F(HomeManpowerSystemTest, BarracksProductionRequiresConfiguredResources) {
   ASSERT_NE(unit, nullptr);
   ASSERT_NE(production, nullptr);
 
-  const auto archer = archer_production();
+  const auto archer = archer_production(world, 1);
 
   unit->spawn_type = Game::Units::SpawnType::Barracks;
   unit->owner_id = 1;

--- a/tests/systems/rpg_engagement_system_test.cpp
+++ b/tests/systems/rpg_engagement_system_test.cpp
@@ -239,6 +239,104 @@ TEST_F(RpgEngagementSystemTest, FormationOpponentsAreNeverDraggedByTheRing) {
   EXPECT_TRUE(single_tf->has_desired_yaw);
 }
 
+TEST_F(RpgEngagementSystemTest, AtMostOnePresserComesFromBehindTheCommander) {
+  auto* commander = create_unit(world, 0.0F, 0.0F, 1);
+  auto* commander_transform = commander->get_component<TransformComponent>();
+  ASSERT_NE(commander_transform, nullptr);
+  commander_transform->rotation.y = 0.0F;
+
+  for (int index = 0; index < 8; ++index) {
+    float const angle = static_cast<float>(index) * 45.0F * 3.14159265F / 180.0F;
+    create_unit(world, std::sin(angle) * 2.2F, std::cos(angle) * 2.2F, 2);
+  }
+
+  Game::Systems::RpgCombat::refresh_commander_engagement(&world, commander->get_id());
+  auto* engagement = commander->get_component<RpgEngagementComponent>();
+  ASSERT_NE(engagement, nullptr);
+
+  int behind = 0;
+  for (auto const& slot : engagement->engagement_slots) {
+    if (slot.pressing && std::abs(slot.signed_angle_degrees) > 100.0F) {
+      ++behind;
+    }
+  }
+  EXPECT_LE(behind, 1)
+      << "a crowd may not press from outside the arc the player can see";
+  EXPECT_GT(engagement->pressing_count(), 0);
+}
+
+TEST_F(RpgEngagementSystemTest, TheAttackerBudgetIsDeterministic) {
+  auto build = [](World& target) {
+    auto* commander = create_unit(target, 0.0F, 0.0F, 1);
+    commander->get_component<TransformComponent>()->rotation.y = 0.0F;
+    for (int index = 0; index < 9; ++index) {
+      float const angle = static_cast<float>(index) * 40.0F * 3.14159265F / 180.0F;
+      create_unit(target, std::sin(angle) * 2.4F, std::cos(angle) * 2.4F, 2);
+    }
+    return commander->get_id();
+  };
+
+  World first;
+  World second;
+  auto const first_id = build(first);
+  auto const second_id = build(second);
+
+  Game::Systems::RpgCombat::refresh_commander_engagement(&first, first_id);
+  Game::Systems::RpgCombat::refresh_commander_engagement(&second, second_id);
+
+  auto pressers = [](World& target, EntityID commander_id) {
+    std::vector<EntityID> ids;
+    auto const* engagement =
+        target.get_entity(commander_id)->get_component<RpgEngagementComponent>();
+    for (auto const& slot : engagement->engagement_slots) {
+      if (slot.pressing) {
+        ids.push_back(slot.entity_id);
+      }
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+  };
+
+  EXPECT_EQ(pressers(first, first_id), pressers(second, second_id))
+      << "the same ring must choose the same attackers in two identical worlds";
+}
+
+TEST_F(RpgEngagementSystemTest, ACrowdCannotHoldEveryBearingForever) {
+  auto* commander = create_unit(world, 0.0F, 0.0F, 1);
+  commander->get_component<TransformComponent>()->rotation.y = 0.0F;
+  for (int index = 0; index < 10; ++index) {
+    float const angle = static_cast<float>(index) * 36.0F * 3.14159265F / 180.0F;
+    create_unit(world, std::sin(angle) * 2.3F, std::cos(angle) * 2.3F, 2);
+  }
+
+  auto* engagement =
+      Engine::Core::get_or_add_component<RpgEngagementComponent>(commander);
+  ASSERT_NE(engagement, nullptr);
+
+  int const crowd = 10;
+  int const capacity = std::clamp(1 + (crowd / 3), 1, 4);
+  std::vector<EntityID> ever_pressed;
+
+  constexpr float k_dt = 1.0F / 60.0F;
+  for (int tick = 0; tick < 600; ++tick) {
+    engagement->pressure_clock += k_dt;
+    Game::Systems::RpgCombat::refresh_commander_engagement(&world, commander->get_id());
+    EXPECT_LE(engagement->pressing_count(), capacity)
+        << "the ring exceeded its budget at tick " << tick;
+    for (auto const& slot : engagement->engagement_slots) {
+      if (slot.pressing &&
+          std::find(ever_pressed.begin(), ever_pressed.end(), slot.entity_id) ==
+              ever_pressed.end()) {
+        ever_pressed.push_back(slot.entity_id);
+      }
+    }
+  }
+
+  EXPECT_GT(ever_pressed.size(), static_cast<std::size_t>(capacity))
+      << "ten seconds of pressure must rotate through the crowd, not pin the same "
+         "attackers on the commander forever";
+}
+
 TEST_F(RpgEngagementSystemTest, IdealEngageDistanceScalesWithWeaponReach) {
   auto* commander = create_unit(world, 0.0F, 0.0F, 1);
 

--- a/tests/tools/arena_promo_spec_test.cpp
+++ b/tests/tools/arena_promo_spec_test.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cmath>
 #include <gtest/gtest.h>
+#include <utility>
 #include <vector>
 
 #include "tools/arena/promo_spec.h"

--- a/tests/tools/arena_rpg_gate_manifest_test.cpp
+++ b/tests/tools/arena_rpg_gate_manifest_test.cpp
@@ -40,7 +40,8 @@ auto registered_rpg_ids() -> std::set<QString> {
 
 auto manifest_ids(const QJsonObject& manifest) -> std::set<QString> {
   std::set<QString> ids;
-  for (const auto& value : manifest.value(QStringLiteral("scenarios")).toArray()) {
+  QJsonArray const scenarios = manifest.value(QStringLiteral("scenarios")).toArray();
+  for (const QJsonValue value : scenarios) {
     ids.insert(value.toObject().value(QStringLiteral("id")).toString());
   }
   return ids;
@@ -91,7 +92,8 @@ TEST(ArenaRpgGateManifestTest, EveryGateEntryNamesARegisteredScenario) {
 
 TEST(ArenaRpgGateManifestTest, EveryEntryCarriesAKnownStatusAndOwningGate) {
   const QJsonObject manifest = load_manifest();
-  for (const auto& value : manifest.value(QStringLiteral("scenarios")).toArray()) {
+  QJsonArray const scenarios = manifest.value(QStringLiteral("scenarios")).toArray();
+  for (const QJsonValue value : scenarios) {
     const QJsonObject entry = value.toObject();
     const QString id = entry.value(QStringLiteral("id")).toString();
     const QString status = entry.value(QStringLiteral("status")).toString();

--- a/tests/tools/arena_scenario_runner_test.cpp
+++ b/tests/tools/arena_scenario_runner_test.cpp
@@ -900,17 +900,20 @@ TEST(ArenaScenarioRunnerTest, FrameBudgetReportsMeasuredPercentilesAndFps) {
   budget.kind = Arena::ArenaExpectationKind::FrameBudget;
   budget.threshold = 9.99F;
   scenario.expectations = {budget};
+  scenario.duration_seconds = 3.0F;
   Arena::ArenaScenarioRunner runner(world, make_entity_host(world), scenario);
   ASSERT_TRUE(runner.start());
 
+  runner.update(Arena::k_arena_prewarm_seconds + 0.05F);
   for (double const frame_ms : {4.0, 5.0, 6.0, 7.0, 8.0}) {
     Arena::ArenaRenderedFrameTimings timings;
     timings.total_ms = frame_ms;
     timings.visible_soldiers = 24U;
     timings.draw_calls = 12U;
+    timings.gpu_color_ms = 1.0;
     runner.observe_rendered_frame(timings);
   }
-  runner.update(1.0F);
+  runner.update(3.0F);
 
   auto const& report = runner.report();
   ASSERT_TRUE(report.passed()) << report.summary().toStdString();
@@ -926,9 +929,10 @@ TEST(ArenaScenarioRunnerTest, FrameBudgetReportsMeasuredPercentilesAndFps) {
                                                        "instanced instances")));
 }
 
-TEST(ArenaScenarioRunnerTest, FrameBudgetRejectsAnEmptyTroopRender) {
+TEST(ArenaScenarioRunnerTest, PrewarmFramesAreReportedButNotBudgeted) {
   Engine::Core::World world;
   auto scenario = minimal_definition();
+  scenario.duration_seconds = 3.0F;
   Arena::ArenaExpectation budget;
   budget.kind = Arena::ArenaExpectationKind::FrameBudget;
   budget.threshold = 9.99F;
@@ -936,8 +940,79 @@ TEST(ArenaScenarioRunnerTest, FrameBudgetRejectsAnEmptyTroopRender) {
   Arena::ArenaScenarioRunner runner(world, make_entity_host(world), scenario);
   ASSERT_TRUE(runner.start());
 
+  {
+
+    Arena::ArenaRenderedFrameTimings startup;
+    startup.total_ms = 480.0;
+    startup.visible_soldiers = 24U;
+    startup.draw_calls = 12U;
+    startup.gpu_color_ms = 1.0;
+    runner.observe_rendered_frame(startup);
+  }
+
+  runner.update(Arena::k_arena_prewarm_seconds + 0.05F);
+  for (int frame = 0; frame < 5; ++frame) {
+    Arena::ArenaRenderedFrameTimings timings;
+    timings.total_ms = 6.0;
+    timings.visible_soldiers = 24U;
+    timings.draw_calls = 12U;
+    timings.gpu_color_ms = 1.0;
+    runner.observe_rendered_frame(timings);
+  }
+  runner.update(3.0F);
+
+  auto const& report = runner.report();
+  EXPECT_TRUE(report.passed()) << report.summary().toStdString();
+  EXPECT_EQ(report.frame_time_samples, 5U);
+  EXPECT_DOUBLE_EQ(report.frame_time_max_ms, 6.0);
+  EXPECT_EQ(report.prewarm_frames, 1U);
+  EXPECT_DOUBLE_EQ(report.prewarm_max_ms, 480.0);
+  EXPECT_EQ(report.gpu_timed_frames, 5U);
+}
+
+TEST(ArenaScenarioRunnerTest, AFrameBudgetWithoutGpuTimingIsReportedAsMissing) {
+  Engine::Core::World world;
+  auto scenario = minimal_definition();
+  scenario.duration_seconds = 3.0F;
+  Arena::ArenaExpectation budget;
+  budget.kind = Arena::ArenaExpectationKind::FrameBudget;
+  budget.threshold = 9.99F;
+  scenario.expectations = {budget};
+  Arena::ArenaScenarioRunner runner(world, make_entity_host(world), scenario);
+  ASSERT_TRUE(runner.start());
+
+  runner.update(Arena::k_arena_prewarm_seconds + 0.05F);
+  for (int frame = 0; frame < 5; ++frame) {
+    Arena::ArenaRenderedFrameTimings timings;
+    timings.total_ms = 6.0;
+    timings.visible_soldiers = 24U;
+    timings.draw_calls = 12U;
+    runner.observe_rendered_frame(timings);
+  }
+  runner.update(3.0F);
+
+  auto const& report = runner.report();
+  EXPECT_EQ(report.gpu_timed_frames, 0U);
+  auto const& issues = report.issues;
+  EXPECT_TRUE(std::any_of(issues.begin(), issues.end(), [](auto const& issue) {
+    return issue.code == QStringLiteral("performance_gpu_timing_missing");
+  }));
+}
+
+TEST(ArenaScenarioRunnerTest, FrameBudgetRejectsAnEmptyTroopRender) {
+  Engine::Core::World world;
+  auto scenario = minimal_definition();
+  Arena::ArenaExpectation budget;
+  budget.kind = Arena::ArenaExpectationKind::FrameBudget;
+  budget.threshold = 9.99F;
+  scenario.expectations = {budget};
+  scenario.duration_seconds = 3.0F;
+  Arena::ArenaScenarioRunner runner(world, make_entity_host(world), scenario);
+  ASSERT_TRUE(runner.start());
+
+  runner.update(Arena::k_arena_prewarm_seconds + 0.05F);
   runner.observe_rendered_frame(1.0);
-  runner.update(1.0F);
+  runner.update(3.0F);
 
   EXPECT_TRUE(contains_code(runner.report(),
                             QStringLiteral("performance_scene_rendered_no_creatures")));

--- a/tests/wildlife/wildlife_system_test.cpp
+++ b/tests/wildlife/wildlife_system_test.cpp
@@ -873,7 +873,6 @@ TEST_F(WildlifeSystemTest, AMapThatNeverAuthoredWildlifeStillGetsAPopulation) {
       << "derived spawn areas landed on ground the spawner refuses";
   EXPECT_GT(count_species(world, Species::Wolf), 0);
 
-  const auto& terrain = Game::Map::TerrainService::instance();
   for (auto* entity : world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
     const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
     ASSERT_NE(transform, nullptr);
@@ -908,7 +907,6 @@ TEST_F(WildlifeSystemTest, ShippedForestMapPopulatesEverySpeciesItEnables) {
   }
   EXPECT_TRUE(birds_seen) << "no flyover crossed the map in two minutes";
 
-  const auto& terrain = Game::Map::TerrainService::instance();
   for (auto* entity : world.collect_entities_with<Engine::Core::WildlifeComponent>()) {
     const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
     ASSERT_NE(transform, nullptr);

--- a/tools/arena/arena_city_scenarios.cpp
+++ b/tools/arena/arena_city_scenarios.cpp
@@ -25,8 +25,10 @@ using Trigger = ScenarioTriggerKind;
 using Troop = Game::Units::TroopType;
 
 [[nodiscard]] auto plot_hash(int a, int b, int c) -> unsigned {
-  unsigned value =
-      static_cast<unsigned>((a * 73856093) ^ (b * 19349663) ^ (c * 83492791));
+
+  unsigned value = (static_cast<unsigned>(a) * 73856093U) ^
+                   (static_cast<unsigned>(b) * 19349663U) ^
+                   (static_cast<unsigned>(c) * 83492791U);
   value ^= value >> 13U;
   value *= 2246822519U;
   value ^= value >> 16U;

--- a/tools/arena/arena_city_scenarios.cpp
+++ b/tools/arena/arena_city_scenarios.cpp
@@ -40,7 +40,6 @@ using Troop = Game::Units::TroopType;
 }
 
 constexpr int k_grid_extent = 768;
-constexpr float k_world_half = 384.0F;
 constexpr float k_content_half = 300.0F;
 
 constexpr float k_gate_tower_exclusion = 12.0F;

--- a/tools/arena/arena_scenario.cpp
+++ b/tools/arena/arena_scenario.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <limits>
 #include <numbers>
+#include <optional>
 #include <utility>
 
 #include "game/command/command.h"
@@ -51,6 +52,8 @@ namespace {
 constexpr float k_default_response_seconds = 0.45F;
 constexpr float k_default_idle_seconds = 1.25F;
 constexpr float k_default_engagement_distance = 7.0F;
+constexpr float k_spawn_settle_seconds = 0.10F;
+
 constexpr float k_default_root_step = 0.8F;
 constexpr float k_default_frame_budget_ms = 33.34F;
 constexpr float k_default_fall_up_y = 0.72F;
@@ -161,6 +164,8 @@ auto command_name(ScenarioCommandKind kind) -> QString {
     return QStringLiteral("SetFarmGrowth");
   case ScenarioCommandKind::RpgMove:
     return QStringLiteral("RpgMove");
+  case ScenarioCommandKind::RpgCycleLockOn:
+    return QStringLiteral("RpgCycleLockOn");
   case ScenarioCommandKind::ReloadUndeadZoneState:
     return QStringLiteral("ReloadUndeadZoneState");
   }
@@ -298,14 +303,43 @@ auto commander_trace_json(const App::Core::CommanderPresentationTrace& trace)
        static_cast<qint64>(combat.hit_confirm_sequence)},
       {QStringLiteral("action_hit_count"), combat.action_hit_count},
       {QStringLiteral("health"), combat.health},
-      {QStringLiteral("stamina"), combat.stamina}};
+      {QStringLiteral("stamina"), combat.stamina},
+      {QStringLiteral("queue_outcome"),
+       QString::fromLatin1(
+           App::Core::combat_intent_outcome_name(combat.queue_outcome))},
+      {QStringLiteral("queue_outcome_age"), combat.queue_outcome_age},
+      {QStringLiteral("queue_accepted"), static_cast<qint64>(combat.queue_accepted)},
+      {QStringLiteral("queue_buffered"), static_cast<qint64>(combat.queue_buffered)},
+      {QStringLiteral("queue_refused"), static_cast<qint64>(combat.queue_refused)},
+      {QStringLiteral("queue_expired"), static_cast<qint64>(combat.queue_expired)},
+      {QStringLiteral("queue_overflow"), static_cast<qint64>(combat.queue_overflow)},
+      {QStringLiteral("action_window_start"), combat.action_window_start},
+      {QStringLiteral("action_window_end"), combat.action_window_end},
+      {QStringLiteral("blocked_contacts"),
+       static_cast<qint64>(combat.blocked_contacts)},
+      {QStringLiteral("perfect_guard_contacts"),
+       static_cast<qint64>(combat.perfect_guard_contacts)},
+      {QStringLiteral("dodged_contacts"), static_cast<qint64>(combat.dodged_contacts)},
+      {QStringLiteral("damaging_contacts"),
+       static_cast<qint64>(combat.damaging_contacts)},
+      {QStringLiteral("guard_broken_contacts"),
+       static_cast<qint64>(combat.guard_broken_contacts)}};
+
+  QJsonObject const costs_json{
+      {QStringLiteral("motor_ms"), trace.costs.motor_ms},
+      {QStringLiteral("targeting_ms"), trace.costs.targeting_ms},
+      {QStringLiteral("weapon_trace_ms"), trace.costs.weapon_trace_ms},
+      {QStringLiteral("engagement_ms"), trace.costs.engagement_ms},
+      {QStringLiteral("camera_ms"), trace.costs.camera_ms},
+      {QStringLiteral("total_ms"), trace.costs.total_ms()}};
 
   return QJsonObject{{QStringLiteral("sequence"), static_cast<qint64>(trace.sequence)},
                      {QStringLiteral("time_seconds"), trace.time_seconds},
                      {QStringLiteral("input"), input_json},
                      {QStringLiteral("motor"), motor_json},
                      {QStringLiteral("camera"), camera_json},
-                     {QStringLiteral("combat"), combat_json}};
+                     {QStringLiteral("combat"), combat_json},
+                     {QStringLiteral("costs"), costs_json}};
 }
 
 auto expectation_requires_zone(ArenaExpectationKind kind) -> bool {
@@ -610,6 +644,8 @@ struct ArenaScenarioRunner::Impl {
     float declared_surface_gap{0.0F};
     QString animation;
     QString visual;
+    bool swing_recoil{false};
+    float hit_reaction_tilt_degrees{0.0F};
     float attack_phase{0.0F};
     std::uint32_t transitions{0};
     bool culled{false};
@@ -1629,6 +1665,18 @@ struct ArenaScenarioRunner::Impl {
           continue;
         }
         host.request_rpg_dodge(entity_id, step.destination);
+      }
+      break;
+    case ScenarioCommandKind::RpgCycleLockOn:
+      for (auto entity_id : ids(step.group)) {
+        if (!host.cycle_rpg_lock_on) {
+          add_issue(
+              QStringLiteral("rpg_lock_on_unavailable"),
+              QStringLiteral("%1 has no RPG lock-on host callback").arg(step.group),
+              entity_id);
+          continue;
+        }
+        host.cycle_rpg_lock_on(entity_id);
       }
       break;
     case ScenarioCommandKind::RpgMove:
@@ -2867,8 +2915,11 @@ struct ArenaScenarioRunner::Impl {
       if (observed_movement) {
         visible_movement[group] = true;
       }
-      if (soldier.visual_state == Render::Profiling::SoldierVisualState::HitReaction &&
-          !culled) {
+      if (!culled &&
+          (soldier.visual_state == Render::Profiling::SoldierVisualState::HitReaction ||
+           (soldier.is_swing_recoiling &&
+            std::abs(soldier.hit_reaction_tilt_degrees) > 0.05F))) {
+
         visible_hit_reactions[group] = true;
       }
       if ((soldier.visual_state == Render::Profiling::SoldierVisualState::Dying ||
@@ -2906,6 +2957,8 @@ struct ArenaScenarioRunner::Impl {
                Render::Profiling::animation_state_name(soldier.animation_state)),
            QString::fromLatin1(
                Render::Profiling::soldier_visual_state_name(soldier.visual_state)),
+           soldier.is_swing_recoiling,
+           soldier.hit_reaction_tilt_degrees,
            soldier.attack_phase,
            soldier.transitions_last_second,
            culled,
@@ -3010,11 +3063,17 @@ struct ArenaScenarioRunner::Impl {
                       soldier.soldier_index);
           }
         }
+
+        float const frame_budget_scale =
+            std::max(1.0F, (elapsed - previous.observed_at) * 60.0F);
+
         if (expectation.kind == ArenaExpectationKind::NoRootTeleport &&
             previous.initialized && !previous.culled && !culled &&
+            elapsed >= k_spawn_settle_seconds &&
             elapsed - previous.observed_at <= 0.05F) {
-          float const allowed = expectation.threshold > 0.0F ? expectation.threshold
-                                                             : k_default_root_step;
+          float const allowed = (expectation.threshold > 0.0F ? expectation.threshold
+                                                              : k_default_root_step) *
+                                frame_budget_scale;
           if (step > allowed) {
             add_issue(QStringLiteral("render_root_teleport"),
                       QStringLiteral("%1 entity %2 soldier %3 render root jumped %4 m "
@@ -3079,8 +3138,10 @@ struct ArenaScenarioRunner::Impl {
               soldier.visual_state == Render::Profiling::SoldierVisualState::Dead;
           bool const root_planted = step <= k_planted_root_step;
           if (!locomoting && root_planted) {
-            float const allowed = expectation.threshold > 0.0F ? expectation.threshold
-                                                               : k_default_foot_slide;
+            float const allowed =
+                (expectation.threshold > 0.0F ? expectation.threshold
+                                              : k_default_foot_slide) *
+                frame_budget_scale;
             float const ground_y = soldier.root_position.y();
             float planted_slide = 0.0F;
             auto const consider_foot = [&](const QVector3D& now,
@@ -3112,8 +3173,9 @@ struct ArenaScenarioRunner::Impl {
 
         if (expectation.kind == ArenaExpectationKind::NoWeaponTeleport &&
             joints_comparable) {
-          float const allowed = expectation.threshold > 0.0F ? expectation.threshold
-                                                             : k_default_hand_step;
+          float const allowed = (expectation.threshold > 0.0F ? expectation.threshold
+                                                              : k_default_hand_step) *
+                                frame_budget_scale;
           float const step_l = (soldier.hand_l_world - previous.hand_l_world).length();
           float const step_r = (soldier.hand_r_world - previous.hand_r_world).length();
           float const worst = std::max(step_l, step_r);
@@ -3132,8 +3194,9 @@ struct ArenaScenarioRunner::Impl {
 
         if (expectation.kind == ArenaExpectationKind::NoPelvisSnap &&
             joints_comparable) {
-          float const allowed = expectation.threshold > 0.0F ? expectation.threshold
-                                                             : k_default_pelvis_step;
+          float const allowed = (expectation.threshold > 0.0F ? expectation.threshold
+                                                              : k_default_pelvis_step) *
+                                frame_budget_scale;
           float const turn = std::abs(shortest_degrees(soldier.pelvis_yaw_degrees,
                                                        previous.pelvis_yaw_degrees));
           if (turn > allowed) {
@@ -3857,7 +3920,7 @@ struct ArenaScenarioRunner::Impl {
         break;
       }
       case ArenaExpectationKind::CommanderBoomIsContinuous: {
-        float const allowed =
+        float const budget =
             expectation.threshold > 0.0F ? expectation.threshold : 0.35F;
         auto const frames = commander_frames();
         float previous_boom = 0.0F;
@@ -3872,6 +3935,7 @@ struct ArenaScenarioRunner::Impl {
           if (have_previous) {
             float const step = shot.boom_resolved - previous_boom;
 
+            float const allowed = budget * std::max(1.0F, shot.dt * 60.0F);
             if (step > allowed) {
               add_issue(QStringLiteral("commander_boom_discontinuity"),
                         QStringLiteral("camera boom extended %1 m in one frame at %2 s "
@@ -3935,12 +3999,14 @@ struct ArenaScenarioRunner::Impl {
         break;
       }
       case ArenaExpectationKind::CommanderMotorCorrectionWithin: {
-        float const allowed =
+        float const budget =
             expectation.threshold > 0.0F ? expectation.threshold : 0.08F;
         for (auto const* frame : commander_frames()) {
           auto const& motor = frame->commander.motor;
           float const correction =
               std::max(motor.snap_back_distance, motor.separation_push);
+
+          float const allowed = budget * std::max(1.0F, motor.dt * 60.0F);
           if (correction > allowed) {
             add_issue(
                 QStringLiteral("commander_motor_correction"),
@@ -4020,6 +4086,166 @@ struct ArenaScenarioRunner::Impl {
                   .arg(last.dodge_request_sequence)
                   .arg(last.dodge_consumed_sequence)
                   .arg(last.dodge_refused_sequence));
+        }
+        break;
+      }
+      case ArenaExpectationKind::CommanderCombatCounterWithin: {
+        auto const frames = commander_frames();
+        if (frames.empty()) {
+          add_issue(QStringLiteral("commander_combat_not_traced"),
+                    QStringLiteral("no commander presentation trace was recorded, so "
+                                   "%1 cannot be counted")
+                        .arg(expectation.counter_key));
+          break;
+        }
+        auto const counter_of =
+            [&expectation](
+                const App::Core::CommanderCombatTrace& combat) -> std::uint32_t {
+          auto const& key = expectation.counter_key;
+          if (key == QLatin1String("accepted")) {
+            return combat.queue_accepted;
+          }
+          if (key == QLatin1String("buffered")) {
+            return combat.queue_buffered;
+          }
+          if (key == QLatin1String("refused")) {
+            return combat.queue_refused;
+          }
+          if (key == QLatin1String("expired")) {
+            return combat.queue_expired;
+          }
+          if (key == QLatin1String("overflow")) {
+            return combat.queue_overflow;
+          }
+          if (key == QLatin1String("block")) {
+            return combat.blocked_contacts;
+          }
+          if (key == QLatin1String("perfect_guard")) {
+            return combat.perfect_guard_contacts;
+          }
+          if (key == QLatin1String("dodge")) {
+            return combat.dodged_contacts;
+          }
+          if (key == QLatin1String("damage")) {
+            return combat.damaging_contacts;
+          }
+          if (key == QLatin1String("guard_break")) {
+            return combat.guard_broken_contacts;
+          }
+          return 0U;
+        };
+
+        float const window_start = expectation.start_seconds;
+        float const window_end = expectation.end_seconds > 0.0F
+                                     ? expectation.end_seconds
+                                     : std::numeric_limits<float>::max();
+        std::optional<std::uint32_t> first;
+        std::uint32_t last_value = 0U;
+        bool have_last = false;
+        for (auto const* frame : frames) {
+          if (frame->time_seconds < window_start) {
+            first = counter_of(frame->commander.combat);
+            continue;
+          }
+          if (frame->time_seconds > window_end) {
+            break;
+          }
+          if (!first.has_value()) {
+            first = counter_of(frame->commander.combat);
+          }
+          last_value = counter_of(frame->commander.combat);
+          have_last = true;
+        }
+        if (!have_last) {
+          add_issue(QStringLiteral("commander_combat_counter_window_empty"),
+                    QStringLiteral("no traced frame fell inside %1 s - %2 s for %3")
+                        .arg(window_start, 0, 'f', 2)
+                        .arg(expectation.end_seconds, 0, 'f', 2)
+                        .arg(expectation.counter_key));
+          break;
+        }
+        auto const observed = last_value - first.value_or(0U);
+        auto const minimum =
+            static_cast<std::uint32_t>(std::max(0.0F, expectation.threshold));
+        if (observed < minimum) {
+          add_issue(QStringLiteral("commander_combat_counter_too_low"),
+                    QStringLiteral("%1 was counted %2 times between %3 s and %4 s but "
+                                   "at least %5 were required")
+                        .arg(expectation.counter_key)
+                        .arg(observed)
+                        .arg(window_start, 0, 'f', 2)
+                        .arg(window_end, 0, 'f', 2)
+                        .arg(minimum));
+          break;
+        }
+        if (expectation.maximum >= 0.0F) {
+          auto const maximum = static_cast<std::uint32_t>(expectation.maximum);
+          if (observed > maximum) {
+            add_issue(QStringLiteral("commander_combat_counter_too_high"),
+                      QStringLiteral("%1 was counted %2 times between %3 s and %4 s "
+                                     "but at most %5 are allowed")
+                          .arg(expectation.counter_key)
+                          .arg(observed)
+                          .arg(window_start, 0, 'f', 2)
+                          .arg(window_end, 0, 'f', 2)
+                          .arg(maximum));
+          }
+        }
+        break;
+      }
+      case ArenaExpectationKind::CommanderLockStateWithin: {
+        auto const frames = commander_frames();
+        if (frames.empty()) {
+          add_issue(QStringLiteral("commander_lock_not_traced"),
+                    QStringLiteral("no commander presentation trace was recorded, so "
+                                   "the lock state cannot be read"));
+          break;
+        }
+        float const window_start = expectation.start_seconds;
+        float const window_end = expectation.end_seconds > 0.0F
+                                     ? expectation.end_seconds
+                                     : std::numeric_limits<float>::max();
+        std::vector<std::uint64_t> locks;
+        for (auto const* frame : frames) {
+          if (frame->time_seconds < window_start || frame->time_seconds > window_end) {
+            continue;
+          }
+          locks.push_back(frame->commander.combat.locked_target_id);
+        }
+        if (locks.empty()) {
+          add_issue(QStringLiteral("commander_lock_window_empty"),
+                    QStringLiteral("no traced frame fell inside %1 s - %2 s")
+                        .arg(window_start, 0, 'f', 2)
+                        .arg(expectation.end_seconds, 0, 'f', 2));
+          break;
+        }
+        auto const& key = expectation.counter_key;
+        if (key == QLatin1String("held")) {
+          auto const lost = std::find(locks.begin(), locks.end(), 0U);
+          if (lost != locks.end()) {
+            add_issue(QStringLiteral("commander_lock_not_held"),
+                      QStringLiteral("the lock was empty inside %1 s - %2 s")
+                          .arg(window_start, 0, 'f', 2)
+                          .arg(window_end, 0, 'f', 2));
+          }
+        } else if (key == QLatin1String("cleared")) {
+          auto const still_locked = std::find_if(
+              locks.begin(), locks.end(), [](std::uint64_t id) { return id != 0U; });
+          if (still_locked != locks.end()) {
+            add_issue(QStringLiteral("commander_lock_not_cleared"),
+                      QStringLiteral("entity %1 was still locked inside %2 s - %3 s")
+                          .arg(*still_locked)
+                          .arg(window_start, 0, 'f', 2)
+                          .arg(window_end, 0, 'f', 2));
+          }
+        } else if (key == QLatin1String("changed")) {
+          if (locks.front() == locks.back()) {
+            add_issue(QStringLiteral("commander_lock_did_not_change"),
+                      QStringLiteral("the lock stayed on entity %1 across %2 s - %3 s")
+                          .arg(locks.front())
+                          .arg(window_start, 0, 'f', 2)
+                          .arg(window_end, 0, 'f', 2));
+          }
         }
         break;
       }
@@ -4230,12 +4456,24 @@ struct ArenaScenarioRunner::Impl {
         std::uint64_t peak_rigged_single_draws = 0U;
         std::uint64_t peak_shadow_rigged_instanced_instances = 0U;
         std::uint64_t peak_shadow_rigged_single_draws = 0U;
+        std::uint64_t prewarm_frames = 0U;
+        double prewarm_max_ms = 0.0;
+        std::uint64_t gpu_timed_frames = 0U;
         for (auto const& frame : trace) {
           bool const after_start =
               frame.time_seconds + 1.0e-5F >= expectation.start_seconds;
           bool const before_end =
               expectation.end_seconds <= 0.0F ||
               frame.time_seconds <= expectation.end_seconds + 1.0e-5F;
+          if (frame.time_seconds < k_arena_prewarm_seconds) {
+
+            ++prewarm_frames;
+            prewarm_max_ms = std::max(prewarm_max_ms, frame.frame_time_ms);
+            continue;
+          }
+          if (frame.timings.gpu_color_ms > 0.0 || frame.timings.gpu_shadow_ms > 0.0) {
+            ++gpu_timed_frames;
+          }
           if (after_start && before_end) {
             samples.push_back(frame.frame_time_ms);
             peak_visible_soldiers =
@@ -4266,15 +4504,70 @@ struct ArenaScenarioRunner::Impl {
             samples.size() - 1U, ((samples.size() * 95U) + 99U) / 100U - 1U);
         std::size_t const p50_index = std::min<std::size_t>(
             samples.size() - 1U, ((samples.size() * 50U) + 99U) / 100U - 1U);
+        std::size_t const p99_index = std::min<std::size_t>(
+            samples.size() - 1U, ((samples.size() * 99U) + 99U) / 100U - 1U);
         double const p50 = samples[p50_index];
         double const p95 = samples[p95_index];
+        double const p99 = samples[p99_index];
         double const maximum = samples.back();
 
         report.frame_time_samples = samples.size();
         report.frame_budget_ms = budget;
         report.frame_time_p50_ms = p50;
         report.frame_time_p95_ms = p95;
+        report.frame_time_p99_ms = p99;
         report.frame_time_max_ms = maximum;
+        report.prewarm_frames = prewarm_frames;
+        report.prewarm_max_ms = prewarm_max_ms;
+        report.prewarm_seconds = k_arena_prewarm_seconds;
+        report.gpu_timed_frames = gpu_timed_frames;
+
+        auto percentile_of = [this](auto&& pick) -> double {
+          std::vector<double> values;
+          values.reserve(trace.size());
+          for (auto const& frame : this->trace) {
+            if (frame.time_seconds < k_arena_prewarm_seconds ||
+                !frame.commander.valid) {
+              continue;
+            }
+            values.push_back(static_cast<double>(pick(frame.commander.costs)));
+          }
+          if (values.empty()) {
+            return 0.0;
+          }
+          std::sort(values.begin(), values.end());
+          std::size_t const index = std::min<std::size_t>(
+              values.size() - 1U, ((values.size() * 95U) + 99U) / 100U - 1U);
+          return values[index];
+        };
+        report.rpg_cost_p95_motor_ms =
+            percentile_of([](auto const& costs) { return costs.motor_ms; });
+        report.rpg_cost_p95_targeting_ms =
+            percentile_of([](auto const& costs) { return costs.targeting_ms; });
+        report.rpg_cost_p95_weapon_trace_ms =
+            percentile_of([](auto const& costs) { return costs.weapon_trace_ms; });
+        report.rpg_cost_p95_engagement_ms =
+            percentile_of([](auto const& costs) { return costs.engagement_ms; });
+        report.rpg_cost_p95_camera_ms =
+            percentile_of([](auto const& costs) { return costs.camera_ms; });
+        report.rpg_cost_p95_total_ms =
+            percentile_of([](auto const& costs) { return costs.total_ms(); });
+
+        std::vector<double> simulation_samples;
+        simulation_samples.reserve(trace.size());
+        for (auto const& frame : trace) {
+          if (frame.time_seconds < k_arena_prewarm_seconds) {
+            continue;
+          }
+          simulation_samples.push_back(frame.timings.simulation_ms);
+        }
+        if (!simulation_samples.empty()) {
+          std::sort(simulation_samples.begin(), simulation_samples.end());
+          std::size_t const simulation_index = std::min<std::size_t>(
+              simulation_samples.size() - 1U,
+              ((simulation_samples.size() * 95U) + 99U) / 100U - 1U);
+          report.simulation_p95_ms = simulation_samples[simulation_index];
+        }
         report.peak_visible_soldiers = peak_visible_soldiers;
         report.peak_draw_commands = peak_draw_commands;
         report.peak_rigged_commands = peak_rigged_commands;
@@ -4302,11 +4595,18 @@ struct ArenaScenarioRunner::Impl {
         }
 
         if (p95 > budget || maximum > budget * 10.0) {
-          add_issue(QStringLiteral("frame_budget_exceeded"),
-                    QStringLiteral("render frame p95/max was %1/%2 ms (budget %3 ms)")
-                        .arg(p95, 0, 'f', 2)
-                        .arg(maximum, 0, 'f', 2)
-                        .arg(budget, 0, 'f', 2));
+          add_issue(
+              QStringLiteral("frame_budget_exceeded"),
+              QStringLiteral("render frame p95/p99/max was %1/%2/%3 ms (budget %4 ms)")
+                  .arg(p95, 0, 'f', 2)
+                  .arg(p99, 0, 'f', 2)
+                  .arg(maximum, 0, 'f', 2)
+                  .arg(budget, 0, 'f', 2));
+        }
+        if (gpu_timed_frames == 0U) {
+          add_issue(QStringLiteral("performance_gpu_timing_missing"),
+                    QStringLiteral("no post-prewarm frame reported a GPU timing, so "
+                                   "the frame budget cannot be attributed"));
         }
         break;
       }
@@ -4863,8 +5163,27 @@ auto ArenaScenarioRunner::write_artifacts(const QString& directory,
             {QStringLiteral("budget_ms"), m_impl->report.frame_budget_ms},
             {QStringLiteral("p50_ms"), m_impl->report.frame_time_p50_ms},
             {QStringLiteral("p95_ms"), m_impl->report.frame_time_p95_ms},
+            {QStringLiteral("p99_ms"), m_impl->report.frame_time_p99_ms},
             {QStringLiteral("max_ms"), m_impl->report.frame_time_max_ms},
             {QStringLiteral("p95_fps"), p95_fps},
+            {QStringLiteral("prewarm_seconds"), m_impl->report.prewarm_seconds},
+            {QStringLiteral("prewarm_frames"),
+             static_cast<qint64>(m_impl->report.prewarm_frames)},
+            {QStringLiteral("prewarm_max_ms"), m_impl->report.prewarm_max_ms},
+            {QStringLiteral("gpu_timed_frames"),
+             static_cast<qint64>(m_impl->report.gpu_timed_frames)},
+            {QStringLiteral("rpg_cost_p95_ms"),
+             QJsonObject{
+                 {QStringLiteral("motor"), m_impl->report.rpg_cost_p95_motor_ms},
+                 {QStringLiteral("targeting"),
+                  m_impl->report.rpg_cost_p95_targeting_ms},
+                 {QStringLiteral("weapon_trace"),
+                  m_impl->report.rpg_cost_p95_weapon_trace_ms},
+                 {QStringLiteral("engagement"),
+                  m_impl->report.rpg_cost_p95_engagement_ms},
+                 {QStringLiteral("camera"), m_impl->report.rpg_cost_p95_camera_ms},
+                 {QStringLiteral("total"), m_impl->report.rpg_cost_p95_total_ms}}},
+            {QStringLiteral("simulation_p95_ms"), m_impl->report.simulation_p95_ms},
             {QStringLiteral("peak_visible_soldiers"),
              static_cast<qint64>(m_impl->report.peak_visible_soldiers)},
             {QStringLiteral("peak_draw_commands"),
@@ -5054,6 +5373,9 @@ auto ArenaScenarioRunner::write_artifacts(const QString& directory,
           {QStringLiteral("declared_surface_gap"), soldier.declared_surface_gap},
           {QStringLiteral("animation"), soldier.animation},
           {QStringLiteral("visual"), soldier.visual},
+          {QStringLiteral("swing_recoil"), soldier.swing_recoil},
+          {QStringLiteral("hit_reaction_tilt_degrees"),
+           soldier.hit_reaction_tilt_degrees},
           {QStringLiteral("attack_phase"), soldier.attack_phase},
           {QStringLiteral("transitions_last_second"),
            static_cast<qint64>(soldier.transitions)},

--- a/tools/arena/arena_scenario.h
+++ b/tools/arena/arena_scenario.h
@@ -84,6 +84,7 @@ enum class ScenarioCommandKind : std::uint8_t {
   RpgGuard,
   RpgDodge,
   RpgMove,
+  RpgCycleLockOn,
 
   RepairStructure,
   DeliverToStructure,
@@ -291,6 +292,8 @@ enum class ArenaExpectationKind : std::uint8_t {
   CommanderSpeedIsContinuous,
   CommanderInputEdgesAllConsumed,
   CommanderContactCountAtMost,
+  CommanderCombatCounterWithin,
+  CommanderLockStateWithin,
 };
 
 struct ArenaExpectation {
@@ -298,6 +301,9 @@ struct ArenaExpectation {
   QString group;
   QString target_group;
   QString zone_id;
+
+  QString counter_key;
+  float maximum{-1.0F};
   float start_seconds{0.0F};
   float end_seconds{0.0F};
   float threshold{0.0F};
@@ -387,6 +393,8 @@ struct ArenaScenarioIssue {
   int soldier_index{-1};
 };
 
+inline constexpr float k_arena_prewarm_seconds = 0.75F;
+
 struct ArenaScenarioReport {
   QString scenario_id;
   float elapsed_seconds{0.0F};
@@ -396,7 +404,21 @@ struct ArenaScenarioReport {
   double frame_budget_ms{0.0};
   double frame_time_p50_ms{0.0};
   double frame_time_p95_ms{0.0};
+  double frame_time_p99_ms{0.0};
   double frame_time_max_ms{0.0};
+
+  std::uint64_t prewarm_frames{0};
+  double prewarm_max_ms{0.0};
+  double prewarm_seconds{k_arena_prewarm_seconds};
+  std::uint64_t gpu_timed_frames{0};
+
+  double rpg_cost_p95_motor_ms{0.0};
+  double rpg_cost_p95_targeting_ms{0.0};
+  double rpg_cost_p95_weapon_trace_ms{0.0};
+  double rpg_cost_p95_engagement_ms{0.0};
+  double rpg_cost_p95_camera_ms{0.0};
+  double rpg_cost_p95_total_ms{0.0};
+  double simulation_p95_ms{0.0};
   std::uint64_t peak_visible_soldiers{0};
   std::uint64_t peak_draw_commands{0};
   std::uint64_t peak_rigged_commands{0};
@@ -446,6 +468,8 @@ struct ArenaScenarioHost {
   std::function<void(Engine::Core::EntityID, bool)> set_rpg_attack_held;
   std::function<void(Engine::Core::EntityID, bool)> set_rpg_guard;
   std::function<void(Engine::Core::EntityID, const QVector3D&)> request_rpg_dodge;
+  std::function<void(Engine::Core::EntityID)> cycle_rpg_lock_on;
+  std::function<auto(Engine::Core::EntityID)->Engine::Core::EntityID> rpg_locked_target;
 
   std::function<void(Engine::Core::EntityID, const QVector3D&, bool)>
       set_rpg_move_input;

--- a/tools/arena/arena_scenario_catalog.cpp
+++ b/tools/arena/arena_scenario_catalog.cpp
@@ -923,7 +923,8 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
                        1,
                        {0.0F, 0.0F, 0.5F},
                        6);
-    enemy.health_override = enemy.max_health_override = 500;
+
+    enemy.health_override = enemy.max_health_override = 4000;
     s.groups = {commander, enemy};
     s.steps = {
         at(0.15F,
@@ -1502,14 +1503,101 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
 
   {
     auto s = definition(
-        QString::fromLatin1(k_rpg_combo_cadence_id),
-        QStringLiteral("RPG Combo Cadence"),
+        QString::fromLatin1(k_rpg_one_press_one_attack_id),
+        QStringLiteral("RPG One Press One Attack"),
         QStringLiteral(
-            "Behind-head commander holds the attack input against a six-soldier "
-            "formation. Every swing has to chain out of the previous one inside "
-            "its cancel window, so a held attack reads as a combo rather than as "
-            "one committed animation the player waits out."),
+            "Three deliberate attack presses, well clear of each other, then the "
+            "attack input held down for a second. One press has to request exactly "
+            "one attack and holding must never repeat it: melee auto-repeat is not "
+            "a contract this mode offers."),
         7.0F);
+    s.rpg_mode = true;
+    s.rpg_commander_group = QStringLiteral("rpg_commander");
+    s.suppress_terrain_scatter = true;
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    auto commander = group(QStringLiteral("rpg_commander"),
+                           Troop::RomanVeteranConsul,
+                           1,
+                           1,
+                           {0.0F, 0.0F, -1.8F},
+                           1);
+    commander.facing_degrees = 0.0F;
+    auto enemy = group(QStringLiteral("training_dummy"),
+                       Troop::Swordsman,
+                       2,
+                       1,
+                       {0.0F, 0.0F, 0.5F},
+                       1);
+    enemy.health_override = enemy.max_health_override = 6000;
+    s.groups = {commander, enemy};
+
+    auto hold_attack = [](float time, bool held) {
+      auto step = at(time, Command::RpgAttackHold, QStringLiteral("rpg_commander"));
+      step.enabled = held;
+      return step;
+    };
+    s.steps = {
+        at(0.60F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        at(2.10F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        at(3.60F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        hold_attack(5.00F, true),
+        hold_attack(6.60F, false),
+    };
+    add_visual_stability(
+        s, {QStringLiteral("rpg_commander"), QStringLiteral("training_dummy")});
+
+    {
+      auto three_presses = expectation(Expect::CommanderCombatCounterWithin,
+                                       QStringLiteral("rpg_commander"),
+                                       {},
+                                       3.0F,
+                                       0.0F);
+      three_presses.counter_key = QStringLiteral("accepted");
+      three_presses.end_seconds = 4.90F;
+      three_presses.maximum = 3.0F;
+      s.expectations.push_back(three_presses);
+    }
+    {
+      auto held_press = expectation(Expect::CommanderCombatCounterWithin,
+                                    QStringLiteral("rpg_commander"),
+                                    {},
+                                    1.0F,
+                                    4.95F);
+      held_press.counter_key = QStringLiteral("accepted");
+      held_press.end_seconds = 7.0F;
+      held_press.maximum = 1.0F;
+      s.expectations.push_back(held_press);
+    }
+    {
+      auto no_expiry = expectation(Expect::CommanderCombatCounterWithin,
+                                   QStringLiteral("rpg_commander"));
+      no_expiry.counter_key = QStringLiteral("expired");
+      no_expiry.maximum = 0.0F;
+      s.expectations.push_back(no_expiry);
+    }
+    s.expectations.push_back(expectation(Expect::CommanderContactCountAtMost,
+                                         QStringLiteral("rpg_commander"),
+                                         {},
+                                         1.0F));
+    s.expectations.push_back(
+        expectation(Expect::AttackAnimationObserved, QStringLiteral("rpg_commander")));
+    s.expectations.push_back(expectation(Expect::NoFullscreenFlash));
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
+        QString::fromLatin1(k_rpg_attack_buffer_window_id),
+        QStringLiteral("RPG Attack Buffer Window"),
+        QStringLiteral(
+            "Timed individual presses against the authored action timeline: one "
+            "clean press, one pressed late enough in the previous swing that the "
+            "buffer carries it into the next, and one pressed so early that the "
+            "buffer must let it expire rather than storing a swing the player has "
+            "forgotten about. Replaces the held-input combo cadence case."),
+        8.0F);
     s.rpg_mode = true;
     s.rpg_commander_group = QStringLiteral("rpg_commander");
     s.suppress_terrain_scatter = true;
@@ -1529,35 +1617,467 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
                        1,
                        {0.0F, 0.0F, 0.5F},
                        6);
-    enemy.health_override = enemy.max_health_override = 4000;
+    enemy.health_override = enemy.max_health_override = 6000;
     s.groups = {commander, enemy};
 
-    auto hold_attack = [](float time, bool held) {
-      auto step = at(time, Command::RpgAttackHold, QStringLiteral("rpg_commander"));
-      step.enabled = held;
-      return step;
-    };
     s.steps = {
-        hold_attack(0.40F, true),
-        hold_attack(5.60F, false),
+
+        at(0.60F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+
+        at(1.20F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+
+        at(3.50F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+
+        at(3.90F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
     };
     add_visual_stability(
         s, {QStringLiteral("rpg_commander"), QStringLiteral("enemy_formation")});
 
-    s.expectations.push_back(expectation(Expect::RpgSwingCadenceWithin,
+    {
+      auto buffered = expectation(Expect::CommanderCombatCounterWithin,
+                                  QStringLiteral("rpg_commander"),
+                                  {},
+                                  1.0F,
+                                  1.15F);
+      buffered.counter_key = QStringLiteral("buffered");
+      buffered.end_seconds = 2.40F;
+      s.expectations.push_back(buffered);
+    }
+    {
+      auto carried = expectation(Expect::CommanderCombatCounterWithin,
+                                 QStringLiteral("rpg_commander"),
+                                 {},
+                                 1.0F,
+                                 1.15F);
+      carried.counter_key = QStringLiteral("accepted");
+      carried.end_seconds = 2.40F;
+      carried.maximum = 1.0F;
+      s.expectations.push_back(carried);
+    }
+    {
+      auto expired = expectation(Expect::CommanderCombatCounterWithin,
+                                 QStringLiteral("rpg_commander"),
+                                 {},
+                                 1.0F,
+                                 3.85F);
+      expired.counter_key = QStringLiteral("expired");
+      expired.end_seconds = 5.60F;
+      s.expectations.push_back(expired);
+
+      auto not_carried = expectation(Expect::CommanderCombatCounterWithin,
+                                     QStringLiteral("rpg_commander"),
+                                     {},
+                                     0.0F,
+                                     3.85F);
+      not_carried.counter_key = QStringLiteral("accepted");
+      not_carried.end_seconds = 5.60F;
+      not_carried.maximum = 0.0F;
+      s.expectations.push_back(not_carried);
+    }
+    {
+      auto overflow = expectation(Expect::CommanderCombatCounterWithin,
+                                  QStringLiteral("rpg_commander"));
+      overflow.counter_key = QStringLiteral("overflow");
+      overflow.maximum = 0.0F;
+      s.expectations.push_back(overflow);
+    }
+    s.expectations.push_back(expectation(Expect::CommanderContactCountAtMost,
                                          QStringLiteral("rpg_commander"),
                                          {},
-                                         1.10F,
-                                         0.0F,
-                                         5.0F));
-    s.expectations.push_back(
-        expectation(Expect::AttackAnimationObserved, QStringLiteral("rpg_commander")));
+                                         1.0F));
     s.expectations.push_back(expectation(Expect::RpgStrikeAnimationMatched,
                                          QStringLiteral("rpg_commander")));
     s.expectations.push_back(expectation(Expect::RpgDamageContactObserved,
                                          QStringLiteral("enemy_formation")));
+    s.expectations.push_back(expectation(Expect::NoFullscreenFlash));
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
+        QString::fromLatin1(k_rpg_attack_whiff_recovery_id),
+        QStringLiteral("RPG Attack Whiff Recovery"),
+        QStringLiteral(
+            "Two attacks swung at empty air with the nearest enemy well outside "
+            "reach. A miss still commits to its authored timeline and recovers "
+            "from it, and it must never invent a contact to justify itself."),
+        6.0F);
+    s.rpg_mode = true;
+    s.rpg_commander_group = QStringLiteral("rpg_commander");
+    s.suppress_terrain_scatter = true;
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    auto commander = group(QStringLiteral("rpg_commander"),
+                           Troop::RomanVeteranConsul,
+                           1,
+                           1,
+                           {0.0F, 0.0F, 0.0F},
+                           1);
+    commander.facing_degrees = 0.0F;
+    auto enemy = group(QStringLiteral("distant_enemy"),
+                       Troop::Swordsman,
+                       2,
+                       1,
+                       {0.0F, 0.0F, 22.0F},
+                       1);
+    enemy.health_override = enemy.max_health_override = 6000;
+    s.groups = {commander, enemy};
+    s.steps = {
+        at(0.60F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        at(3.20F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+    };
+    add_visual_stability(s, {QStringLiteral("rpg_commander")});
+
+    {
+      auto accepted = expectation(Expect::CommanderCombatCounterWithin,
+                                  QStringLiteral("rpg_commander"),
+                                  {},
+                                  2.0F);
+      accepted.counter_key = QStringLiteral("accepted");
+      accepted.maximum = 2.0F;
+      s.expectations.push_back(accepted);
+    }
+    s.expectations.push_back(expectation(Expect::CommanderContactCountAtMost,
+                                         QStringLiteral("rpg_commander"),
+                                         {},
+                                         1.0F));
     s.expectations.push_back(
-        expectation(Expect::GroupHealthReduced, QStringLiteral("enemy_formation")));
+        expectation(Expect::AttackAnimationObserved, QStringLiteral("rpg_commander")));
+    s.expectations.push_back(
+        expectation(Expect::AttackRecoveryObserved, QStringLiteral("rpg_commander")));
+    s.expectations.push_back(
+        expectation(Expect::NoActiveCombatAtEnd, QStringLiteral("rpg_commander")));
+    s.expectations.push_back(
+        expectation(Expect::GroupHealthUnchanged, QStringLiteral("distant_enemy")));
+    s.expectations.push_back(expectation(Expect::NoFullscreenFlash));
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
+        QString::fromLatin1(k_rpg_attack_wall_contact_id),
+        QStringLiteral("RPG Attack Into A Wall"),
+        QStringLiteral(
+            "The commander closes on a house with an enemy standing on the far "
+            "side of it and swings. Authored root motion has to stop at the "
+            "facade with the rest of the motor's rules, and the weapon trace may "
+            "never reach a body through a structure."),
+        8.0F);
+    s.rpg_mode = true;
+    s.rpg_commander_group = QStringLiteral("rpg_commander");
+    s.suppress_terrain_scatter = true;
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    auto commander = group(QStringLiteral("rpg_commander"),
+                           Troop::RomanVeteranConsul,
+                           1,
+                           1,
+                           {0.0F, 0.0F, -4.0F},
+                           1);
+    commander.facing_degrees = 0.0F;
+    auto home = building(QStringLiteral("wall_home"),
+                         Game::Units::SpawnType::Home,
+                         Nation::RomanRepublic,
+                         1,
+                         1,
+                         {0.0F, 0.0F, 0.0F});
+    home.health_override = home.max_health_override = 8000;
+    auto enemy = group(QStringLiteral("sheltered_enemy"),
+                       Troop::Swordsman,
+                       2,
+                       1,
+                       {0.0F, 0.0F, 2.6F},
+                       1);
+    enemy.health_override = enemy.max_health_override = 6000;
+    s.groups = {commander, home, enemy};
+
+    auto move =
+        [](float time, QVector3D axes, bool run, std::optional<float> yaw = {}) {
+          auto step = at(time, Command::RpgMove, QStringLiteral("rpg_commander"));
+          step.destination = axes;
+          step.value = run ? 1 : 0;
+          step.rpg_view_yaw_degrees = yaw;
+          return step;
+        };
+    s.steps = {
+        move(0.30F, {0.0F, 0.0F, 1.0F}, false, 0.0F),
+        move(2.60F, {0.0F, 0.0F, 0.0F}, false),
+        at(3.00F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        at(5.00F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+    };
+    add_visual_stability(s, {QStringLiteral("rpg_commander")});
+
+    {
+      auto accepted = expectation(Expect::CommanderCombatCounterWithin,
+                                  QStringLiteral("rpg_commander"),
+                                  {},
+                                  2.0F);
+      accepted.counter_key = QStringLiteral("accepted");
+      accepted.maximum = 2.0F;
+      s.expectations.push_back(accepted);
+    }
+    s.expectations.push_back(
+        expectation(Expect::GroupHealthUnchanged, QStringLiteral("sheltered_enemy")));
+    s.expectations.push_back(expectation(Expect::CommanderContactCountAtMost,
+                                         QStringLiteral("rpg_commander"),
+                                         {},
+                                         1.0F));
+    s.expectations.push_back(expectation(Expect::NoFullscreenFlash));
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
+        QString::fromLatin1(k_rpg_stamina_refusal_id),
+        QStringLiteral("RPG Stamina Refusal And Recovery"),
+        QStringLiteral(
+            "Attacks pressed until the stamina pool cannot pay for one, then a "
+            "pause, then one more. Every insufficient-stamina press has to come "
+            "back as a counted refusal rather than a dead click, and the pool has "
+            "to recover enough to swing again."),
+        14.0F);
+    s.rpg_mode = true;
+    s.rpg_commander_group = QStringLiteral("rpg_commander");
+    s.suppress_terrain_scatter = true;
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    auto commander = group(QStringLiteral("rpg_commander"),
+                           Troop::RomanVeteranConsul,
+                           1,
+                           1,
+                           {0.0F, 0.0F, -1.8F},
+                           1);
+    commander.facing_degrees = 0.0F;
+    auto enemy = group(QStringLiteral("training_dummy"),
+                       Troop::Swordsman,
+                       2,
+                       1,
+                       {0.0F, 0.0F, 0.5F},
+                       1);
+    enemy.health_override = enemy.max_health_override = 9000;
+    s.groups = {commander, enemy};
+
+    s.steps.reserve(14);
+    for (int index = 0; index < 12; ++index) {
+      s.steps.push_back(at(0.60F + (0.85F * static_cast<float>(index)),
+                           Command::RpgPrimaryAttack,
+                           QStringLiteral("rpg_commander")));
+    }
+    s.steps.push_back(
+        at(13.20F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")));
+    add_visual_stability(
+        s, {QStringLiteral("rpg_commander"), QStringLiteral("training_dummy")});
+
+    {
+      auto refused = expectation(Expect::CommanderCombatCounterWithin,
+                                 QStringLiteral("rpg_commander"),
+                                 {},
+                                 1.0F);
+      refused.counter_key = QStringLiteral("refused");
+      refused.end_seconds = 11.0F;
+      s.expectations.push_back(refused);
+    }
+    {
+      auto recovered = expectation(Expect::CommanderCombatCounterWithin,
+                                   QStringLiteral("rpg_commander"),
+                                   {},
+                                   1.0F,
+                                   13.10F);
+      recovered.counter_key = QStringLiteral("accepted");
+      recovered.end_seconds = 14.0F;
+      s.expectations.push_back(recovered);
+    }
+    s.expectations.push_back(expectation(Expect::CommanderContactCountAtMost,
+                                         QStringLiteral("rpg_commander"),
+                                         {},
+                                         1.0F));
+    s.expectations.push_back(expectation(Expect::NoFullscreenFlash));
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
+        QString::fromLatin1(k_rpg_skirmish_three_attackers_id),
+        QStringLiteral("RPG Three Attacker Skirmish"),
+        QStringLiteral(
+            "Three swordsmen close on a guarding commander from three sides. The "
+            "engagement ring decides who may press, and the commander has to keep "
+            "getting readable openings: a crowd may not chain unavoidable contacts "
+            "or hold him staggered until he dies."),
+        12.0F);
+    s.rpg_mode = true;
+    s.rpg_commander_group = QStringLiteral("rpg_commander");
+    s.suppress_terrain_scatter = true;
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    auto commander = group(QStringLiteral("rpg_commander"),
+                           Troop::RomanVeteranConsul,
+                           1,
+                           1,
+                           {0.0F, 0.0F, 0.0F},
+                           1);
+    commander.facing_degrees = 0.0F;
+    auto front = group(QStringLiteral("attacker_front"),
+                       Troop::Swordsman,
+                       2,
+                       1,
+                       {0.0F, 0.0F, 3.2F},
+                       1);
+    auto left = group(QStringLiteral("attacker_left"),
+                      Troop::Swordsman,
+                      2,
+                      1,
+                      {-3.0F, 0.0F, 1.4F},
+                      1);
+    auto right = group(QStringLiteral("attacker_right"),
+                       Troop::Swordsman,
+                       2,
+                       1,
+                       {3.0F, 0.0F, 1.4F},
+                       1);
+    front.health_override = front.max_health_override = 4000;
+    left.health_override = left.max_health_override = 4000;
+    right.health_override = right.max_health_override = 4000;
+    s.groups = {commander, front, left, right};
+
+    auto guard = [](float time, bool enabled) {
+      auto step = at(time, Command::RpgGuard, QStringLiteral("rpg_commander"));
+      step.enabled = enabled;
+      return step;
+    };
+    s.steps = {
+        guard(0.20F, true),
+        at(0.40F,
+           Command::Attack,
+           QStringLiteral("attacker_front"),
+           QStringLiteral("rpg_commander")),
+        at(0.40F,
+           Command::Attack,
+           QStringLiteral("attacker_left"),
+           QStringLiteral("rpg_commander")),
+        at(0.40F,
+           Command::Attack,
+           QStringLiteral("attacker_right"),
+           QStringLiteral("rpg_commander")),
+        at(4.00F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        at(6.00F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        at(8.00F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+    };
+    add_visual_stability(s,
+                         {QStringLiteral("rpg_commander"),
+                          QStringLiteral("attacker_front"),
+                          QStringLiteral("attacker_left"),
+                          QStringLiteral("attacker_right")});
+
+    {
+      auto swings = expectation(Expect::CommanderCombatCounterWithin,
+                                QStringLiteral("rpg_commander"),
+                                {},
+                                2.0F,
+                                3.90F);
+      swings.counter_key = QStringLiteral("accepted");
+      swings.end_seconds = 12.0F;
+      s.expectations.push_back(swings);
+    }
+    s.expectations.push_back(expectation(Expect::CommanderContactCountAtMost,
+                                         QStringLiteral("rpg_commander"),
+                                         {},
+                                         1.0F));
+    s.expectations.push_back(
+        expectation(Expect::GroupExists, QStringLiteral("rpg_commander")));
+    s.expectations.push_back(expectation(Expect::NoFullscreenFlash));
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
+        QString::fromLatin1(k_rpg_lock_cycle_id),
+        QStringLiteral("RPG Lock Cycle, Occlusion And Death"),
+        QStringLiteral(
+            "A third enemy stands directly behind a house on the view centre while "
+            "two others stand clear of it. Lock-on must refuse the occluded one, "
+            "cycle across the screen between the two it can see, and drop the lock "
+            "when the locked target dies rather than falling through to the one it "
+            "cannot see."),
+        7.0F);
+    s.rpg_mode = true;
+    s.rpg_commander_group = QStringLiteral("rpg_commander");
+    s.suppress_terrain_scatter = true;
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    auto commander = group(QStringLiteral("rpg_commander"),
+                           Troop::RomanVeteranConsul,
+                           1,
+                           1,
+                           {0.0F, 0.0F, 0.0F},
+                           1);
+    commander.facing_degrees = 0.0F;
+    auto shelter = building(QStringLiteral("lock_shelter"),
+                            Game::Units::SpawnType::Home,
+                            Nation::RomanRepublic,
+                            1,
+                            1,
+                            {0.0F, 0.0F, 5.0F});
+    shelter.health_override = shelter.max_health_override = 8000;
+    auto hidden = group(
+        QStringLiteral("hidden_enemy"), Troop::Swordsman, 2, 1, {0.0F, 0.0F, 7.6F}, 1);
+    auto left = group(
+        QStringLiteral("left_enemy"), Troop::Swordsman, 2, 1, {-1.6F, 0.0F, 6.0F}, 1);
+    auto right = group(
+        QStringLiteral("right_enemy"), Troop::Swordsman, 2, 1, {4.0F, 0.0F, 6.0F}, 1);
+    hidden.health_override = hidden.max_health_override = 4000;
+    left.health_override = left.max_health_override = 4000;
+    right.health_override = right.max_health_override = 4000;
+    s.groups = {commander, shelter, hidden, left, right};
+
+    auto kill = [](float time, QString target) {
+      auto step = at(time, Command::SetHealth, std::move(target));
+      step.value = 0;
+      return step;
+    };
+    s.steps = {
+        at(0.50F, Command::RpgCycleLockOn, QStringLiteral("rpg_commander")),
+        at(1.60F, Command::RpgCycleLockOn, QStringLiteral("rpg_commander")),
+        kill(3.00F, QStringLiteral("left_enemy")),
+        kill(3.00F, QStringLiteral("right_enemy")),
+    };
+    add_visual_stability(s, {QStringLiteral("rpg_commander")});
+
+    {
+      auto held = expectation(Expect::CommanderLockStateWithin,
+                              QStringLiteral("rpg_commander"),
+                              {},
+                              0.0F,
+                              0.70F);
+      held.counter_key = QStringLiteral("held");
+      held.end_seconds = 2.90F;
+      s.expectations.push_back(held);
+    }
+    {
+      auto changed = expectation(Expect::CommanderLockStateWithin,
+                                 QStringLiteral("rpg_commander"),
+                                 {},
+                                 0.0F,
+                                 1.50F);
+      changed.counter_key = QStringLiteral("changed");
+      changed.end_seconds = 2.90F;
+      s.expectations.push_back(changed);
+    }
+    {
+      auto cleared = expectation(Expect::CommanderLockStateWithin,
+                                 QStringLiteral("rpg_commander"),
+                                 {},
+                                 0.0F,
+                                 4.00F);
+      cleared.counter_key = QStringLiteral("cleared");
+      cleared.end_seconds = 7.00F;
+      s.expectations.push_back(cleared);
+    }
     s.expectations.push_back(expectation(Expect::NoFullscreenFlash));
     result.push_back(std::move(s));
   }

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -68,7 +68,14 @@ inline constexpr char k_rpg_motor_figure_eight_id[] = "rpg_motor_figure_eight";
 inline constexpr char k_rpg_locomotion_hitch_id[] = "rpg_locomotion_hitch";
 inline constexpr char k_rpg_close_quarters_id[] = "rpg_close_quarters";
 inline constexpr char k_rpg_obstacle_slide_id[] = "rpg_obstacle_slide";
-inline constexpr char k_rpg_combo_cadence_id[] = "rpg_combo_cadence";
+inline constexpr char k_rpg_one_press_one_attack_id[] = "rpg_one_press_one_attack";
+inline constexpr char k_rpg_attack_buffer_window_id[] = "rpg_attack_buffer_window";
+inline constexpr char k_rpg_attack_whiff_recovery_id[] = "rpg_attack_whiff_recovery";
+inline constexpr char k_rpg_attack_wall_contact_id[] = "rpg_attack_wall_contact";
+inline constexpr char k_rpg_stamina_refusal_id[] = "rpg_stamina_refusal_and_recovery";
+inline constexpr char k_rpg_skirmish_three_attackers_id[] =
+    "rpg_skirmish_three_attackers";
+inline constexpr char k_rpg_lock_cycle_id[] = "rpg_lock_occlusion_death_cycle";
 inline constexpr char k_rpg_pass_ranks_id[] = "rpg_pass_ranks";
 inline constexpr char k_rpg_strike_lunge_id[] = "rpg_strike_lunge";
 inline constexpr char k_rpg_bow_volley_id[] = "rpg_bow_volley";

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -66,6 +66,7 @@
 #include "game/systems/owner_registry.h"
 #include "game/systems/player_resource_registry.h"
 #include "game/systems/projectile_system.h"
+#include "game/systems/run_stamina.h"
 #include "game/systems/selection_system.h"
 #include "game/systems/target_focus.h"
 #include "game/systems/troop_count_registry.h"
@@ -3906,6 +3907,21 @@ void ArenaViewport::load_scenario(const QString& scenario_id) {
     m_rpg_commander_controller->set_view_pitch(
         std::asin(std::clamp(direction.y(), -1.0F, 1.0F)) * k_radians_to_degrees);
   };
+  host.cycle_rpg_lock_on = [this](Engine::Core::EntityID entity_id) {
+    if (m_world == nullptr || m_rpg_commander_controller == nullptr ||
+        entity_id != m_rpg_commander_id) {
+      return;
+    }
+    m_rpg_commander_controller->cycle_lock_on_target(
+        *m_world, m_rpg_commander_id, k_local_owner_id);
+  };
+  host.rpg_locked_target =
+      [this](Engine::Core::EntityID entity_id) -> Engine::Core::EntityID {
+    if (m_rpg_commander_controller == nullptr || entity_id != m_rpg_commander_id) {
+      return 0;
+    }
+    return m_rpg_commander_controller->locked_target_id();
+  };
   host.request_rpg_dodge = [this](Engine::Core::EntityID entity_id,
                                   const QVector3D& world_direction) {
     if (m_rpg_commander_controller != nullptr && entity_id == m_rpg_commander_id) {
@@ -4150,6 +4166,13 @@ void ArenaViewport::configure_rpg_scenario_commander(Engine::Core::EntityID enti
   commander->posture = 0.0F;
   commander->punish_window_remaining = 0.0F;
   Game::Systems::CombatRules::clear_rts_combat_tracking(entity);
+
+  if (auto* stamina = Game::Systems::ensure_run_stamina(*entity)) {
+    stamina->stamina = stamina->max_stamina;
+    stamina->regen_delay_remaining = 0.0F;
+    stamina->is_running = false;
+    stamina->run_requested = false;
+  }
 
   auto* rpg =
       Engine::Core::get_or_add_component<Engine::Core::RpgHealthComponent>(entity);

--- a/tools/arena/main.cpp
+++ b/tools/arena/main.cpp
@@ -9,6 +9,7 @@
 #include <QJsonObject>
 #include <QSet>
 #include <QSurfaceFormat>
+#include <QSysInfo>
 #include <QTextStream>
 #include <QTimer>
 
@@ -28,6 +29,7 @@
 #include "game/session/session_context.h"
 #include "promo_runner.h"
 #include "promo_spec.h"
+#include "render/gl/bootstrap.h"
 #include "render/gl/context_requirements.h"
 #include "render/graphics_settings.h"
 #include "render/profiling/frame_profile.h"
@@ -36,6 +38,46 @@
 #include "utils/resource_utils.h"
 
 namespace {
+
+[[nodiscard]] auto host_cpu_model() -> QString {
+
+  QFile info(QStringLiteral("/proc/cpuinfo"));
+  if (!info.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return QSysInfo::currentCpuArchitecture();
+  }
+  const QString contents = QString::fromUtf8(info.readAll());
+  for (auto const& line : contents.split(QLatin1Char('\n'))) {
+    if (!line.startsWith(QStringLiteral("model name"))) {
+      continue;
+    }
+    int const separator = line.indexOf(QLatin1Char(':'));
+    if (separator >= 0) {
+      return line.mid(separator + 1).trimmed();
+    }
+  }
+  return QSysInfo::currentCpuArchitecture();
+}
+
+[[nodiscard]] auto reference_hardware(const ArenaViewport* viewport) -> QJsonObject {
+  auto const& adapter = Render::GL::RenderBootstrap::adapter();
+  QJsonObject hardware{
+      {QStringLiteral("cpu"), host_cpu_model()},
+      {QStringLiteral("gpu_vendor"),
+       adapter.vendor.isEmpty() ? QStringLiteral("unknown") : adapter.vendor},
+      {QStringLiteral("gpu_renderer"),
+       adapter.renderer.isEmpty() ? QStringLiteral("unknown") : adapter.renderer},
+      {QStringLiteral("gl_version"),
+       adapter.version.isEmpty() ? QStringLiteral("unknown") : adapter.version},
+      {QStringLiteral("os"), QSysInfo::prettyProductName()},
+      {QStringLiteral("kernel"), QSysInfo::kernelVersion()}};
+  if (viewport != nullptr) {
+    hardware.insert(QStringLiteral("viewport_width"),
+                    static_cast<int>(std::lround(viewport->width())));
+    hardware.insert(QStringLiteral("viewport_height"),
+                    static_cast<int>(std::lround(viewport->height())));
+  }
+  return hardware;
+}
 
 auto parse_time_of_day(const QString& value) -> std::optional<Game::Map::TimeOfDay> {
   QString const normalized = value.trimmed().toLower();
@@ -882,7 +924,8 @@ auto main(int argc, char** argv) -> int {
           {QStringLiteral("capture_interval_seconds"), capture_interval},
           {QStringLiteral("detailed_profiling"), detailed_profiling},
           {QStringLiteral("watchdog_multiplier"), watchdog_multiplier},
-          {QStringLiteral("renderer"), QStringLiteral("ArenaViewport/OpenGL")}};
+          {QStringLiteral("renderer"), QStringLiteral("ArenaViewport/OpenGL")},
+          {QStringLiteral("reference_hardware"), reference_hardware(viewport)}};
       config_file.write(QJsonDocument(config).toJson(QJsonDocument::Indented));
     }
     qInfo().noquote() << QStringLiteral("Running rendered Arena scenario: %1").arg(id);

--- a/tools/arena/rpg_gate_manifest.json
+++ b/tools/arena/rpg_gate_manifest.json
@@ -3,11 +3,15 @@
   "unit_test_filters": [
     {
       "binary": "app_tests",
-      "filter": "CommanderCameraRig*:CommanderControlControllerTest.*:CommanderDirectControlLatencyTest.*:CommanderModeTransitionTest.*:CommanderControlRegressionTest.*:CommanderPresentationTraceTest.*:CommanderDisplacementSourceTest.*"
+      "filter": "CommanderCameraRig*:CommanderControlControllerTest.*:CommanderDirectControlLatencyTest.*:CommanderModeTransitionTest.*:CommanderControlRegressionTest.*:CommanderPresentationTraceTest.*:CommanderDisplacementSourceTest.*:CommanderDefenseWindowsTest.*:CommanderAccessibilityTest.*:CommanderLifecycleSoakTest.*"
     },
     {
       "binary": "arena_tests",
       "filter": "ArenaRpgGateManifestTest.*:ArenaCommanderMetricsTest.*:ArenaScenariosTest.*"
+    },
+    {
+      "binary": "combat_balance_tests",
+      "filter": "CombatModeTest.*"
     }
   ],
   "scenario_defaults": {
@@ -19,24 +23,57 @@
   "scenarios": [
     {
       "id": "rpg_melee_contact",
-      "status": "expected_red",
+      "status": "required_green",
       "gate": "6",
-      "notes": "A struck enemy never enters a visible hit reaction: it stays in AttackSword through the whole contact window and goes straight to Dying. This was a coin flip until 2026-08-24. The renderer's animation clock was not reset at batch scenario start, so each run sampled the victim's attack clip at a different phase; at some phases the reaction won and the scenario passed. With the clock reset the run is deterministic and it fails 5 of 5 at 5.40 s, with 0 of ~1900 enemy soldier samples in HitReaction against 17 before. The commander's own reaction still shows for 72 samples, so the reaction path works -- it is the victim's in-progress attack that outranks it. Gate 6 owns the fix: 'contact must read with camera motion disabled'. Also carries the melee pose divergence: Body and camera agree to 0.0000 m in every scenario that does not swing a weapon. In melee they diverge by a constant 0.2144 m -- the same value in four separate scenarios, so it is a fixed offset applied during engagement, not jitter, and it is present on frames where combat.action_running is false as well as true. That is Gate 3's 'the clip root and the world root may not independently lunge': the renderer moves the visual root for melee while the motor, and therefore the camera anchor, does not.",
-      "issue_codes": [
-        "no_visible_hit_reaction",
-        "commander_presented_pose_disagreement"
-      ]
+      "notes": "Green. Two separate defects, neither the one the earlier note guessed. First, the scenario was authored with 500 unit health across six soldiers, so every commander strike was lethal and the victim went to Die: a killing blow is not a hit reaction. Enemy health is 4000 now, so a struck soldier survives to react. Second, a soldier struck mid-swing deliberately does not play the full-body flinch -- instance_prepare turns it into a swing recoil so the swing is not cut in half -- and nothing reported that, so the instrument saw only 'Attack'. The recoil and its tilt are on every soldier sample now (swing_recoil, hit_reaction_tilt_degrees) and HitReactionObserved accepts a recoil with real tilt. The struck soldier recoils 5.77 degrees for 17 frames per contact."
     },
     {
       "id": "rpg_defense_contact",
-      "status": "expected_red",
+      "status": "required_green",
       "gate": "5",
-      "issue_codes": [
-        "rpg_block_contact_not_observed",
-        "rpg_health_changed",
-        "commander_presented_pose_disagreement"
-      ],
-      "notes": "No block contact is published and protected health is lost; guard/dodge feedback is fired on request rather than on a resolved contact. Also carries the melee pose divergence: Body and camera agree to 0.0000 m in every scenario that does not swing a weapon. In melee they diverge by a constant 0.2144 m -- the same value in four separate scenarios, so it is a fixed offset applied during engagement, not jitter, and it is present on frames where combat.action_running is false as well as true. That is Gate 3's 'the clip root and the world root may not independently lunge': the renderer moves the visual root for melee while the motor, and therefore the camera anchor, does not."
+      "notes": "Green. Two defects, both Gate 5. The incoming contact point was a point on the attacker's blade -- 2.04 m above the ground for an overhead swing -- and the guard test measured it against a 0.60 m plate at chest height, so a frontal sword blow landed a metre outside the guard and was never a block. The weapon trace now resolves every contact onto the target's hurt body, and ordinary blocking is the authored guard arc while the plate test is what a perfect guard has to meet. The block is published and protected health is unchanged."
+    },
+    {
+      "id": "rpg_one_press_one_attack",
+      "status": "required_green",
+      "gate": "5",
+      "notes": "Three deliberate presses and one held input. Melee auto-repeat is gone, so a press requests exactly one attack and a held button requests exactly one more."
+    },
+    {
+      "id": "rpg_attack_buffer_window",
+      "status": "required_green",
+      "gate": "5",
+      "notes": "Replaces rpg_combo_cadence. Deliberate timed presses against the authored timeline: a clean press, a late press the 0.15 s buffer carries into the next swing, and a press so early the buffer must let it expire. The old scenario held the button and asserted a swing cadence, which is exactly the auto-repeat contract Gate 5.1 removes."
+    },
+    {
+      "id": "rpg_attack_whiff_recovery",
+      "status": "required_green",
+      "gate": "5",
+      "notes": "Two swings at empty air. A miss commits to its timeline, recovers, and invents no contact."
+    },
+    {
+      "id": "rpg_attack_wall_contact",
+      "status": "required_green",
+      "gate": "5",
+      "notes": "Swings into a house with an enemy sheltering behind it. Root motion stops at the facade and the weapon trace never reaches a body through a structure."
+    },
+    {
+      "id": "rpg_stamina_refusal_and_recovery",
+      "status": "required_green",
+      "gate": "5",
+      "notes": "Presses until the pool cannot pay, then one more after a pause. Every refusal is counted; none is a dead click."
+    },
+    {
+      "id": "rpg_skirmish_three_attackers",
+      "status": "required_green",
+      "gate": "5",
+      "notes": "Three attackers, engagement-ring budget, and the commander still gets openings to swing in."
+    },
+    {
+      "id": "rpg_lock_occlusion_death_cycle",
+      "status": "required_green",
+      "gate": "5",
+      "notes": "Lock-on refuses a target it has no line of sight to, cycles across the screen between the two it can see, and drops the lock when the locked target dies instead of falling through to the occluded one."
     },
     {
       "id": "rpg_projectile_block",
@@ -46,9 +83,10 @@
     },
     {
       "id": "rpg_escort_crowd",
-      "status": "required_green",
+      "status": "expected_red",
       "gate": "3",
-      "notes": "Green. The renderer was applying combat root motion -- lunge and hit reaction -- as a world translation on top of the motor's own displacement, so the drawn body sat up to 0.2144 m from the point the camera was framing. For a simulation-owned body the renderer now owns pose only: the lean, pitch and squash still play, the world offset does not. CommanderPresentedPoseAgrees holds it at 0.01 m."
+      "notes": "Regressed at HEAD (35d87259), before the Gate 5 work and independent of it: three enemy_line soldiers jump 1.4-1.6 m of render root in one frame at 0.23 s and one is submitted with a 0.70 body up-vector while alive at 2.18 s. Bisected by running the scenario on a pristine checkout of 35d87259, where it fails identically; the last green run is artifacts/rpg-gates/run-20260824-231504, taken from the dirty worktree that became that commit. Owned by Gate 3 (pose agreement), pinned here so the Gate 5 slice is not masked by it.",
+      "issue_codes": ["render_root_teleport", "unexpected_fall_pose"]
     },
     {
       "id": "rpg_locomotion",
@@ -74,16 +112,6 @@
       "status": "required_green",
       "gate": "2",
       "notes": "Green since the commander's body collision and line of sight stopped using the RTS navigation footprint. 'home' registers a 4.3 x 4.4 m nav box for a building drawn 2.36 x 2.42 m, so a person-sized commander was stopped a metre short of every facade and the camera's obstruction ray fired on empty air. Person-scale queries now use the drawn extents from BuildingCollisionRegistry::get_building_body(); the nav footprint and its grid padding are untouched, so RTS formations keep their spacing."
-    },
-    {
-      "id": "rpg_combo_cadence",
-      "status": "expected_red",
-      "gate": "5",
-      "issue_codes": [
-        "rpg_swing_cadence_too_slow",
-        "commander_presented_pose_disagreement"
-      ],
-      "notes": "A held attack left a 1.25 s gap against a 1.10 s contract. This scenario is replaced by deliberate timed presses once melee auto-repeat is removed; it is not loosened until it passes. Also carries the melee pose divergence: Body and camera agree to 0.0000 m in every scenario that does not swing a weapon. In melee they diverge by a constant 0.2144 m -- the same value in four separate scenarios, so it is a fixed offset applied during engagement, not jitter, and it is present on frames where combat.action_running is false as well as true. That is Gate 3's 'the clip root and the world root may not independently lunge': the renderer moves the visual root for melee while the motor, and therefore the camera anchor, does not."
     },
     {
       "id": "rpg_pass_ranks",

--- a/tools/bpat_baker/main.cpp
+++ b/tools/bpat_baker/main.cpp
@@ -108,6 +108,13 @@ bool bake_species_manifest(const std::filesystem::path& out_dir,
   const Render::Creature::CreatureRuntimeManifest& manifest = *recipe.runtime;
 
   auto const bind_palette = manifest.bind_palette();
+  if (bind_palette.empty()) {
+    std::cerr << "[bpat_baker] " << manifest.species_name
+              << ": runtime manifest returned an empty bind palette"
+              << " (source creature package missing, unreadable, or rejected"
+                 " by its integrity check); cannot bake\n";
+    return false;
+  }
   std::vector<QMatrix4x4> inverse_bind;
   inverse_bind.reserve(bind_palette.size());
   for (const QMatrix4x4& m : bind_palette) {

--- a/ui/commander_portrait_view.cpp
+++ b/ui/commander_portrait_view.cpp
@@ -39,8 +39,6 @@ constexpr float k_default_focus_height = 1.31F;
 
 constexpr float k_focus_tau = 0.30F;
 
-constexpr float k_body_yaw_degrees = 14.0F;
-
 constexpr float k_max_frame_seconds = 0.1F;
 
 constexpr float k_head_radius = Render::GL::HumanProportions::HEAD_RADIUS;

--- a/ui/preferences.cpp
+++ b/ui/preferences.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <limits>
 
+#include "../game/accessibility/commander_input_settings.h"
 #include "../game/accessibility/motion_settings.h"
 #include "../game/accessibility/team_identity.h"
 #include "app/core/user_settings.h"
@@ -41,6 +42,14 @@ UiPreferences::UiPreferences(QObject* parent)
     , m_edge_scroll_enabled(UserSettings::load_ui_edge_scroll_enabled())
     , m_edge_scroll_sensitivity(UserSettings::load_ui_edge_scroll_sensitivity())
     , m_camera_motion_scale(UserSettings::load_ui_camera_motion_scale())
+    , m_commander_look_sensitivity_x(UserSettings::load_commander_look_sensitivity_x())
+    , m_commander_look_sensitivity_y(UserSettings::load_commander_look_sensitivity_y())
+    , m_commander_invert_look_y(UserSettings::load_commander_invert_look_y())
+    , m_commander_camera_impulse(UserSettings::load_commander_camera_impulse())
+    , m_commander_head_bob(UserSettings::load_commander_head_bob())
+    , m_commander_field_of_view_scale(
+          UserSettings::load_commander_field_of_view_scale())
+    , m_commander_guard_is_toggle(UserSettings::load_commander_guard_is_toggle())
     , m_damage_numbers(UserSettings::load_ui_damage_numbers())
     , m_damage_number_mode(UserSettings::load_ui_damage_number_mode())
     , m_camera_legend_seen(UserSettings::load_ui_camera_legend_seen())
@@ -53,6 +62,109 @@ UiPreferences::UiPreferences(QObject* parent)
   Game::Accessibility::MotionSettings::set_camera_motion_scale(
       static_cast<float>(m_camera_motion_scale));
   Game::Accessibility::MotionSettings::set_reduced_motion(m_reduced_motion);
+  publish_commander_input_settings();
+}
+
+void UiPreferences::publish_commander_input_settings() const {
+  namespace CommanderInput = Game::Accessibility::CommanderInput;
+  CommanderInput::set_look_sensitivity_x(
+      static_cast<float>(m_commander_look_sensitivity_x));
+  CommanderInput::set_look_sensitivity_y(
+      static_cast<float>(m_commander_look_sensitivity_y));
+  CommanderInput::set_invert_look_y(m_commander_invert_look_y);
+  CommanderInput::set_camera_impulse_enabled(m_commander_camera_impulse);
+  CommanderInput::set_head_bob_enabled(m_commander_head_bob);
+  CommanderInput::set_field_of_view_scale(
+      static_cast<float>(m_commander_field_of_view_scale));
+  CommanderInput::set_guard_is_toggle(m_commander_guard_is_toggle);
+}
+
+void UiPreferences::set_commander_look_sensitivity_x(qreal scale) {
+  if (!is_finite_scale(scale)) {
+    return;
+  }
+  const qreal clamped = std::clamp<qreal>(scale,
+                                          UserSettings::kMinCommanderLookSensitivity,
+                                          UserSettings::kMaxCommanderLookSensitivity);
+  if (qFuzzyCompare(clamped, m_commander_look_sensitivity_x)) {
+    return;
+  }
+  m_commander_look_sensitivity_x = clamped;
+  UserSettings::save_commander_look_sensitivity_x(clamped);
+  publish_commander_input_settings();
+  emit commander_input_changed();
+}
+
+void UiPreferences::set_commander_look_sensitivity_y(qreal scale) {
+  if (!is_finite_scale(scale)) {
+    return;
+  }
+  const qreal clamped = std::clamp<qreal>(scale,
+                                          UserSettings::kMinCommanderLookSensitivity,
+                                          UserSettings::kMaxCommanderLookSensitivity);
+  if (qFuzzyCompare(clamped, m_commander_look_sensitivity_y)) {
+    return;
+  }
+  m_commander_look_sensitivity_y = clamped;
+  UserSettings::save_commander_look_sensitivity_y(clamped);
+  publish_commander_input_settings();
+  emit commander_input_changed();
+}
+
+void UiPreferences::set_commander_invert_look_y(bool enabled) {
+  if (enabled == m_commander_invert_look_y) {
+    return;
+  }
+  m_commander_invert_look_y = enabled;
+  UserSettings::save_commander_invert_look_y(enabled);
+  publish_commander_input_settings();
+  emit commander_input_changed();
+}
+
+void UiPreferences::set_commander_camera_impulse(bool enabled) {
+  if (enabled == m_commander_camera_impulse) {
+    return;
+  }
+  m_commander_camera_impulse = enabled;
+  UserSettings::save_commander_camera_impulse(enabled);
+  publish_commander_input_settings();
+  emit commander_input_changed();
+}
+
+void UiPreferences::set_commander_head_bob(bool enabled) {
+  if (enabled == m_commander_head_bob) {
+    return;
+  }
+  m_commander_head_bob = enabled;
+  UserSettings::save_commander_head_bob(enabled);
+  publish_commander_input_settings();
+  emit commander_input_changed();
+}
+
+void UiPreferences::set_commander_field_of_view_scale(qreal scale) {
+  if (!is_finite_scale(scale)) {
+    return;
+  }
+  const qreal clamped = std::clamp<qreal>(scale,
+                                          UserSettings::kMinCommanderFieldOfViewScale,
+                                          UserSettings::kMaxCommanderFieldOfViewScale);
+  if (qFuzzyCompare(clamped, m_commander_field_of_view_scale)) {
+    return;
+  }
+  m_commander_field_of_view_scale = clamped;
+  UserSettings::save_commander_field_of_view_scale(clamped);
+  publish_commander_input_settings();
+  emit commander_input_changed();
+}
+
+void UiPreferences::set_commander_guard_is_toggle(bool enabled) {
+  if (enabled == m_commander_guard_is_toggle) {
+    return;
+  }
+  m_commander_guard_is_toggle = enabled;
+  UserSettings::save_commander_guard_is_toggle(enabled);
+  publish_commander_input_settings();
+  emit commander_input_changed();
 }
 
 auto UiPreferences::instance() -> UiPreferences* {
@@ -292,4 +404,11 @@ void UiPreferences::reset_to_defaults() {
   set_damage_number_mode(QStringLiteral("all"));
   set_camera_legend_seen(false);
   set_screen_effect_intensity(UserSettings::kDefaultScreenEffectIntensity);
+  set_commander_look_sensitivity_x(UserSettings::kDefaultCommanderLookSensitivity);
+  set_commander_look_sensitivity_y(UserSettings::kDefaultCommanderLookSensitivity);
+  set_commander_invert_look_y(false);
+  set_commander_camera_impulse(true);
+  set_commander_head_bob(true);
+  set_commander_field_of_view_scale(UserSettings::kDefaultCommanderFieldOfViewScale);
+  set_commander_guard_is_toggle(false);
 }

--- a/ui/preferences.h
+++ b/ui/preferences.h
@@ -39,6 +39,20 @@ class UiPreferences : public QObject {
                  NOTIFY tutorial_completed_changed)
   Q_PROPERTY(qreal screenEffectIntensity READ screen_effect_intensity WRITE
                  set_screen_effect_intensity NOTIFY screen_effect_intensity_changed)
+  Q_PROPERTY(qreal commanderLookSensitivityX READ commander_look_sensitivity_x WRITE
+                 set_commander_look_sensitivity_x NOTIFY commander_input_changed)
+  Q_PROPERTY(qreal commanderLookSensitivityY READ commander_look_sensitivity_y WRITE
+                 set_commander_look_sensitivity_y NOTIFY commander_input_changed)
+  Q_PROPERTY(bool commanderInvertLookY READ commander_invert_look_y WRITE
+                 set_commander_invert_look_y NOTIFY commander_input_changed)
+  Q_PROPERTY(bool commanderCameraImpulse READ commander_camera_impulse WRITE
+                 set_commander_camera_impulse NOTIFY commander_input_changed)
+  Q_PROPERTY(bool commanderHeadBob READ commander_head_bob WRITE set_commander_head_bob
+                 NOTIFY commander_input_changed)
+  Q_PROPERTY(qreal commanderFieldOfViewScale READ commander_field_of_view_scale WRITE
+                 set_commander_field_of_view_scale NOTIFY commander_input_changed)
+  Q_PROPERTY(bool commanderGuardIsToggle READ commander_guard_is_toggle WRITE
+                 set_commander_guard_is_toggle NOTIFY commander_input_changed)
   Q_PROPERTY(QStringList colorVisionModes READ color_vision_modes CONSTANT)
   Q_PROPERTY(qreal minUiScale READ min_ui_scale CONSTANT)
   Q_PROPERTY(qreal maxUiScale READ max_ui_scale CONSTANT)
@@ -79,6 +93,26 @@ public:
     return m_screen_effect_intensity;
   }
 
+  [[nodiscard]] auto commander_look_sensitivity_x() const -> qreal {
+    return m_commander_look_sensitivity_x;
+  }
+  [[nodiscard]] auto commander_look_sensitivity_y() const -> qreal {
+    return m_commander_look_sensitivity_y;
+  }
+  [[nodiscard]] auto commander_invert_look_y() const -> bool {
+    return m_commander_invert_look_y;
+  }
+  [[nodiscard]] auto commander_camera_impulse() const -> bool {
+    return m_commander_camera_impulse;
+  }
+  [[nodiscard]] auto commander_head_bob() const -> bool { return m_commander_head_bob; }
+  [[nodiscard]] auto commander_field_of_view_scale() const -> qreal {
+    return m_commander_field_of_view_scale;
+  }
+  [[nodiscard]] auto commander_guard_is_toggle() const -> bool {
+    return m_commander_guard_is_toggle;
+  }
+
   [[nodiscard]] auto effective_team_patterns() const -> bool;
 
   [[nodiscard]] static auto color_vision_modes() -> QStringList;
@@ -101,6 +135,13 @@ public:
   void set_camera_legend_seen(bool seen);
   void set_tutorial_completed(bool completed);
   void set_screen_effect_intensity(qreal intensity);
+  void set_commander_look_sensitivity_x(qreal scale);
+  void set_commander_look_sensitivity_y(qreal scale);
+  void set_commander_invert_look_y(bool enabled);
+  void set_commander_camera_impulse(bool enabled);
+  void set_commander_head_bob(bool enabled);
+  void set_commander_field_of_view_scale(qreal scale);
+  void set_commander_guard_is_toggle(bool enabled);
 
   Q_INVOKABLE void reset_to_defaults();
 
@@ -119,9 +160,11 @@ signals:
   void camera_legend_seen_changed();
   void tutorial_completed_changed();
   void screen_effect_intensity_changed();
+  void commander_input_changed();
 
 private:
   explicit UiPreferences(QObject* parent = nullptr);
+  void publish_commander_input_settings() const;
 
   static UiPreferences* m_instance;
 
@@ -134,6 +177,13 @@ private:
   bool m_edge_scroll_enabled;
   qreal m_edge_scroll_sensitivity;
   qreal m_camera_motion_scale;
+  qreal m_commander_look_sensitivity_x;
+  qreal m_commander_look_sensitivity_y;
+  bool m_commander_invert_look_y;
+  bool m_commander_camera_impulse;
+  bool m_commander_head_bob;
+  qreal m_commander_field_of_view_scale;
+  bool m_commander_guard_is_toggle;
   bool m_damage_numbers;
   QString m_damage_number_mode;
   bool m_camera_legend_seen;


### PR DESCRIPTION
…ter perf gates

- Remove melee auto-repeat so one press equals one attack; make the combat intent queue observable by counting accepted/buffered/refused/expired/ overflow outcomes and restore the authored 0.15 s buffer window
- Add commander input accessibility settings (look sensitivity X/Y, invert look, camera impulse and head bob toggles, FOV scale, guard-as-toggle) persisted through user settings and the preferences UI
- Harden commander controls and camera rig: presentation tracing hooks, lock-on handling, dodge/guard flow, and shared simulation timing helpers
- Expand the arena scenario catalog and RPG gate manifest; add strict p95/p99/max frame-time thresholds to rpg_gate_report.py behind --enforce-performance
- Document each defect and its measurement in docs/RPG_PLAYABILITY.md; replace stale todo.md with an audited improvement plan (notes.txt)
- Add coverage: defense windows, commander lifecycle soak, lock-on, state round-trip, view-model input, combat mode, and engagement system