### PR TITLE
feat: soldier counts on the HUD, overlay-safe focus, beat-aligned promos

### DIFF
--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -2375,6 +2375,8 @@ auto GameEngine::describe_focus_entity(Engine::Core::EntityID id) const
            : true);
   info.health = described.health;
   info.max_health = described.max_health;
+  info.soldiers = described.soldiers;
+  info.max_soldiers = described.max_soldiers;
   info.health_ratio =
       described.max_health > 0
           ? static_cast<double>(std::clamp(described.health, 0, described.max_health)) /

--- a/app/models/selected_units_model.cpp
+++ b/app/models/selected_units_model.cpp
@@ -7,6 +7,24 @@
 #include "app/world/unit_queries.h"
 #include "game/render_bridge/selection_controller.h"
 
+namespace {
+
+auto health_ratio_of(const App::World::UnitDescription& unit) -> double {
+  if (unit.max_health <= 0) {
+    return 0.0;
+  }
+  return static_cast<double>(std::clamp(unit.health, 0, unit.max_health)) /
+         static_cast<double>(unit.max_health);
+}
+
+auto activity_text(const Game::Systems::UnitActivity& activity, bool state) -> QString {
+  const auto text = state ? Game::Systems::activity_state_id(activity.state)
+                          : Game::Systems::activity_kind_id(activity.kind);
+  return QString::fromUtf8(text.data(), static_cast<int>(text.size()));
+}
+
+} // namespace
+
 SelectedUnitsModel::SelectedUnitsModel(const App::Core::ClientContext& context,
                                        QObject* parent)
     : QAbstractListModel(parent)
@@ -38,11 +56,8 @@ auto SelectedUnitsModel::data(const QModelIndex& index, int role) const -> QVari
     return {};
   }
   if (role == ActivityRole || role == ActivityStateRole) {
-    const auto activity = App::World::unit_activity(m_context.world, id);
-    const auto text = role == ActivityRole
-                          ? Game::Systems::activity_kind_id(activity.kind)
-                          : Game::Systems::activity_state_id(activity.state);
-    return QString::fromUtf8(text.data(), static_cast<int>(text.size()));
+    return activity_text(App::World::unit_activity(m_context.world, id),
+                         role == ActivityStateRole);
   }
 
   App::World::UnitDescription unit;
@@ -58,11 +73,14 @@ auto SelectedUnitsModel::data(const QModelIndex& index, int role) const -> QVari
   if (role == max_healthRole) {
     return unit.max_health;
   }
+  if (role == SoldiersRole) {
+    return unit.soldiers;
+  }
+  if (role == MaxSoldiersRole) {
+    return unit.max_soldiers;
+  }
   if (role == HealthRatioRole) {
-    return unit.max_health > 0
-               ? static_cast<double>(std::clamp(unit.health, 0, unit.max_health)) /
-                     static_cast<double>(unit.max_health)
-               : 0.0;
+    return health_ratio_of(unit);
   }
   if (role == NationRole) {
     return unit.nation;
@@ -88,6 +106,8 @@ auto SelectedUnitsModel::roleNames() const -> QHash<int, QByteArray> {
           {HealthRole, "health"},
           {max_healthRole, "max_health"},
           {HealthRatioRole, "health_ratio"},
+          {SoldiersRole, "soldiers"},
+          {MaxSoldiersRole, "max_soldiers"},
           {NationRole, "nation"},
           {StaminaRatioRole, "stamina_ratio"},
           {IsRunningRole, "is_running"},
@@ -99,17 +119,29 @@ auto SelectedUnitsModel::roleNames() const -> QHash<int, QByteArray> {
 auto SelectedUnitsModel::grouped_by_type() const -> QVariantList {
   QVariantList units;
   units.reserve(static_cast<int>(m_ids.size()));
-  for (int row = 0; row < rowCount(); ++row) {
-    const QModelIndex model_index = index(row, 0);
+
+  for (const auto id : m_ids) {
+    App::World::UnitDescription described;
+    if (!App::World::describe_unit(m_context.world, id, described)) {
+      continue;
+    }
+    QString type_key;
+    (void)App::World::unit_type_key(m_context.world, id, type_key);
+    App::World::UnitStamina stamina;
+    (void)App::World::describe_unit_stamina(m_context.world, id, stamina);
+    const auto activity = App::World::unit_activity(m_context.world, id);
+
     QVariantMap unit;
-    unit[QStringLiteral("unit_type")] = data(model_index, UnitTypeRole);
-    unit[QStringLiteral("name")] = data(model_index, NameRole);
-    unit[QStringLiteral("nation")] = data(model_index, NationRole);
-    unit[QStringLiteral("health_ratio")] = data(model_index, HealthRatioRole);
-    unit[QStringLiteral("stamina_ratio")] = data(model_index, StaminaRatioRole);
-    unit[QStringLiteral("can_run")] = data(model_index, CanRunRole);
-    unit[QStringLiteral("activity")] = data(model_index, ActivityRole);
-    unit[QStringLiteral("activity_state")] = data(model_index, ActivityStateRole);
+    unit[QStringLiteral("unit_type")] = type_key;
+    unit[QStringLiteral("name")] = described.name;
+    unit[QStringLiteral("nation")] = described.nation;
+    unit[QStringLiteral("health_ratio")] = health_ratio_of(described);
+    unit[QStringLiteral("soldiers")] = described.soldiers;
+    unit[QStringLiteral("max_soldiers")] = described.max_soldiers;
+    unit[QStringLiteral("stamina_ratio")] = static_cast<double>(stamina.ratio);
+    unit[QStringLiteral("can_run")] = stamina.can_run;
+    unit[QStringLiteral("activity")] = activity_text(activity, false);
+    unit[QStringLiteral("activity_state")] = activity_text(activity, true);
     units.append(unit);
   }
   return App::Models::selection_groups_to_variant(
@@ -145,6 +177,8 @@ void SelectedUnitsModel::refresh() {
                        {HealthRole,
                         max_healthRole,
                         HealthRatioRole,
+                        SoldiersRole,
+                        MaxSoldiersRole,
                         StaminaRatioRole,
                         IsRunningRole,
                         CanRunRole,

--- a/app/models/selected_units_model.h
+++ b/app/models/selected_units_model.h
@@ -19,6 +19,8 @@ struct SelectionGroup {
   QString nation;
   int count = 0;
   int wounded_count = 0;
+  int soldiers = 0;
+  int max_soldiers = 0;
 
   double health = 0.0;
   double stamina = 1.0;
@@ -48,6 +50,8 @@ public:
     HealthRole,
     max_healthRole,
     HealthRatioRole,
+    SoldiersRole,
+    MaxSoldiersRole,
     NationRole,
     StaminaRatioRole,
     IsRunningRole,

--- a/app/models/selection_grouping.cpp
+++ b/app/models/selection_grouping.cpp
@@ -58,6 +58,12 @@ auto group_selection_by_type(const QVariantList& units) -> std::vector<Selection
 
     const auto offset = static_cast<std::size_t>(std::distance(groups.begin(), match));
     match->count += 1;
+    const int max_soldiers =
+        std::max(0, unit.value(QStringLiteral("max_soldiers")).toInt());
+    const int soldiers =
+        std::clamp(unit.value(QStringLiteral("soldiers")).toInt(), 0, max_soldiers);
+    match->max_soldiers += max_soldiers;
+    match->soldiers += soldiers;
     health_sums[offset] += health;
     if (can_run) {
       match->can_run = true;
@@ -115,6 +121,8 @@ auto selection_groups_to_variant(const std::vector<SelectionGroup>& groups)
     entry[QStringLiteral("nation")] = group.nation;
     entry[QStringLiteral("count")] = group.count;
     entry[QStringLiteral("woundedCount")] = group.wounded_count;
+    entry[QStringLiteral("soldiers")] = group.soldiers;
+    entry[QStringLiteral("maxSoldiers")] = group.max_soldiers;
     entry[QStringLiteral("health")] = group.health;
     entry[QStringLiteral("stamina")] = group.stamina;
     entry[QStringLiteral("canRun")] = group.can_run;

--- a/app/world/focus_target.cpp
+++ b/app/world/focus_target.cpp
@@ -176,6 +176,8 @@ auto focus_target_to_variant(const FocusTargetInfo& info) -> QVariantMap {
   map[QStringLiteral("isOwn")] = info.is_own;
   map[QStringLiteral("health")] = info.health;
   map[QStringLiteral("maxHealth")] = info.max_health;
+  map[QStringLiteral("soldiers")] = info.soldiers;
+  map[QStringLiteral("maxSoldiers")] = info.max_soldiers;
   map[QStringLiteral("healthRatio")] = info.health_ratio;
   map[QStringLiteral("activity")] = info.activity;
   map[QStringLiteral("activityState")] = info.activity_state;

--- a/app/world/focus_target.h
+++ b/app/world/focus_target.h
@@ -27,6 +27,8 @@ struct FocusTargetInfo {
   bool is_own = false;
   int health = 0;
   int max_health = 0;
+  int soldiers = 0;
+  int max_soldiers = 0;
   double health_ratio = 0.0;
   QString activity = QStringLiteral("idle");
   QString activity_state = QStringLiteral("active");

--- a/app/world/unit_queries.cpp
+++ b/app/world/unit_queries.cpp
@@ -2,6 +2,7 @@
 
 #include "game/core/component.h"
 #include "game/core/world.h"
+#include "game/systems/formation_combat_geometry.h"
 #include "game/systems/nation_id.h"
 #include "game/systems/troop_profile_service.h"
 #include "game/units/spawn_type.h"
@@ -36,6 +37,8 @@ auto describe_unit(const Engine::Core::World* world,
     out.name = QStringLiteral("Entity");
     out.health = 0;
     out.max_health = 0;
+    out.soldiers = 0;
+    out.max_soldiers = 0;
     out.alive = true;
     out.nation.clear();
     return true;
@@ -54,6 +57,16 @@ auto describe_unit(const Engine::Core::World* world,
   out.health = unit->health;
   out.max_health = unit->max_health;
   out.alive = unit->health > 0;
+  if (out.is_building) {
+    out.max_soldiers = 0;
+    out.soldiers = 0;
+  } else {
+    out.max_soldiers =
+        Game::Systems::FormationCombat::resolve_definition(*unit).total_count;
+    out.soldiers = out.alive ? Game::Systems::FormationCombat::living_slot_count(
+                                   *entity, out.max_soldiers)
+                             : 0;
+  }
   out.nation = Game::Systems::nation_id_to_qstring(unit->nation_id);
   return true;
 }

--- a/app/world/unit_queries.h
+++ b/app/world/unit_queries.h
@@ -16,6 +16,8 @@ struct UnitDescription {
   QString nation;
   int health = 0;
   int max_health = 0;
+  int soldiers = 0;
+  int max_soldiers = 0;
   bool is_building = false;
   bool alive = false;
 };

--- a/game/systems/combat_system/damage_application.cpp
+++ b/game/systems/combat_system/damage_application.cpp
@@ -245,11 +245,12 @@ auto ensure_formation_roster(Engine::Core::Entity& target,
 
   int const current_live_count = static_cast<int>(std::count(
       roster->alive.begin(), roster->alive.end(), static_cast<std::uint8_t>(1U)));
-  bool const valid = roster->total_count == total_count &&
-                     roster->alive.size() == static_cast<std::size_t>(total_count) &&
-                     current_live_count == expected_live_count;
-  if (valid) {
-    roster->live_count = static_cast<std::uint16_t>(expected_live_count);
+  bool const shaped_for_this_unit =
+      roster->total_count == total_count &&
+      roster->alive.size() == static_cast<std::size_t>(total_count);
+  if (shaped_for_this_unit && current_live_count <= expected_live_count) {
+
+    roster->live_count = static_cast<std::uint16_t>(current_live_count);
     return roster;
   }
 
@@ -413,10 +414,13 @@ auto begin_soldier_casualties(Engine::Core::Entity* target,
     }
     if (roster != nullptr && slot >= 0 && slot < individuals_per_unit) {
       roster->alive[static_cast<std::size_t>(slot)] = 0U;
-      roster->live_count = static_cast<std::uint16_t>(std::max(0, new_survivors));
       ++roster->revision;
     }
     ++queued_casualties;
+  }
+  if (roster != nullptr && queued_casualties > 0) {
+    roster->live_count = static_cast<std::uint16_t>(std::count(
+        roster->alive.begin(), roster->alive.end(), static_cast<std::uint8_t>(1U)));
   }
   return queued_casualties;
 }

--- a/game/systems/commander_system.cpp
+++ b/game/systems/commander_system.cpp
@@ -11,6 +11,7 @@
 #include "../core/event_manager.h"
 #include "../core/world.h"
 #include "command_service.h"
+#include "healing_rules.h"
 #include "nation_collapse_service.h"
 #include "owner_registry.h"
 #include "troop_profile_service.h"
@@ -492,8 +493,10 @@ void CommanderSystem::update(Engine::Core::World* world, float delta_time) {
             const int restored =
                 static_cast<int>(std::floor(buff->health_regen_accumulator));
             if (restored > 0) {
-              candidate_unit->health = std::min(candidate_unit->max_health,
-                                                candidate_unit->health + restored);
+
+              candidate_unit->health =
+                  std::min(HealingRules::maximum_recoverable_health(*candidate),
+                           candidate_unit->health + restored);
               buff->health_regen_accumulator -= static_cast<float>(restored);
             }
           }

--- a/game/systems/formation_combat_geometry.cpp
+++ b/game/systems/formation_combat_geometry.cpp
@@ -294,15 +294,34 @@ auto living_slot_indices(const Engine::Core::Entity& entity,
     return living;
   }
 
-  auto const* unit = entity.get_component<Engine::Core::UnitComponent>();
-  int const live_count = unit != nullptr
-                             ? Engine::Core::resolve_surviving_individual_count(
-                                   unit->health, unit->max_health, total_count)
-                             : total_count;
+  int const live_count = living_slot_count(entity, total_count);
   for (int idx = std::max(0, total_count - live_count); idx < total_count; ++idx) {
     living.push_back(static_cast<std::uint16_t>(idx));
   }
   return living;
+}
+
+auto living_slot_count(const Engine::Core::Entity& entity, int total_count) -> int {
+  if (total_count <= 0) {
+    return 0;
+  }
+
+  auto const* roster =
+      entity.get_component<Engine::Core::FormationRosterPresentationComponent>();
+  if (roster != nullptr &&
+      roster->alive.size() == static_cast<std::size_t>(total_count)) {
+    return static_cast<int>(std::count_if(
+        roster->alive.begin(), roster->alive.end(), [](std::uint8_t alive) {
+          return alive != 0U;
+        }));
+  }
+
+  auto const* unit = entity.get_component<Engine::Core::UnitComponent>();
+  if (unit == nullptr) {
+    return total_count;
+  }
+  return Engine::Core::resolve_surviving_individual_count(
+      unit->health, unit->max_health, total_count);
 }
 
 namespace {

--- a/game/systems/formation_combat_geometry.h
+++ b/game/systems/formation_combat_geometry.h
@@ -108,6 +108,9 @@ resolve_layout(const Engine::Core::Entity& entity) -> FormationLayout;
 [[nodiscard]] auto living_slot_indices(const Engine::Core::Entity& entity,
                                        int total_count) -> std::vector<std::uint16_t>;
 
+[[nodiscard]] auto living_slot_count(const Engine::Core::Entity& entity,
+                                     int total_count) -> int;
+
 [[nodiscard]] auto formation_turn_radius(const Engine::Core::Entity& entity) -> float;
 
 [[nodiscard]] auto

--- a/render/entity/formation_instance_layout.cpp
+++ b/render/entity/formation_instance_layout.cpp
@@ -67,12 +67,14 @@ auto resolve_formation_instances(FormationLayoutCache* cache,
   result.instances = &scratch;
 
   if (cache != nullptr && cache->valid) {
-    result.preserve_state_prefix =
-        cache->seed == request.seed && cache->rows == request.rows &&
-        cache->cols == request.cols &&
+
+    result.preserve_locomotion_state =
+        cache->seed == request.seed &&
         cache->layout_version == request.layout_version &&
-        cache->formation.individuals_per_unit ==
-            request.formation.individuals_per_unit &&
+        cache->formation.individuals_per_unit == request.formation.individuals_per_unit;
+    result.preserve_state_prefix =
+        result.preserve_locomotion_state && cache->rows == request.rows &&
+        cache->cols == request.cols &&
         cache->formation.max_per_row == request.formation.max_per_row &&
         cache->formation.spacing == request.formation.spacing &&
         cache->unit_layout == request.unit_layout &&

--- a/render/entity/formation_instance_layout.h
+++ b/render/entity/formation_instance_layout.h
@@ -91,6 +91,8 @@ struct FormationLayoutResult {
   bool reused_cache{false};
 
   bool preserve_state_prefix{false};
+
+  bool preserve_locomotion_state{false};
 };
 
 auto resolve_formation_instances(FormationLayoutCache* cache,

--- a/render/humanoid/runtime/instance_prepare.cpp
+++ b/render/humanoid/runtime/instance_prepare.cpp
@@ -474,6 +474,7 @@ auto prepare_formation_runtime(const HumanoidUnitSnapshot& s,
   }
   auto* soldier_layout_storage = layout_result.instances;
   bool const preserve_soldier_state_prefix = layout_result.preserve_state_prefix;
+  bool const preserve_soldier_locomotion = layout_result.preserve_locomotion_state;
 
   auto& soldier_layouts = *soldier_layout_storage;
 
@@ -497,15 +498,18 @@ auto prepare_formation_runtime(const HumanoidUnitSnapshot& s,
     animation_states.resize(static_cast<std::size_t>(total_layout_count));
     combat_lanes.resize(static_cast<std::size_t>(total_layout_count));
     visibility_frames.resize(static_cast<std::size_t>(total_layout_count), 0U);
-    if (!preserve_soldier_state_prefix) {
+    if (!preserve_soldier_locomotion) {
       for (auto& state : animation_states) {
         reset_humanoid_locomotion_state(state);
       }
+    }
+    if (!preserve_soldier_state_prefix) {
       for (auto& lane_state : combat_lanes) {
         lane_state = {};
       }
       std::fill(visibility_frames.begin(), visibility_frames.end(), 0U);
-    } else if (state_count_changed) {
+    }
+    if (preserve_soldier_locomotion && state_count_changed) {
       for (std::size_t idx = previous_state_count;
            idx < static_cast<std::size_t>(total_layout_count);
            ++idx) {

--- a/scripts/beat-align.py
+++ b/scripts/beat-align.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Put a promo spec's cuts on a track's beat.
+
+A short-form reel is cut *to* the music: every cut, and every punch-in inside a
+shot, lands on a beat. A spec authored by eye does not do that, and the
+difference is the whole reason a reel reads as an edit rather than as a trailer
+with music over it.
+
+    python3 tools/audio_synth/reel_score.py --bpm 140 --bars 22 \
+        --out artifacts/promo/reel_beat.ogg
+    python3 scripts/beat-align.py tools/arena/promos/commander_rally.json \
+        --track artifacts/promo/reel_beat.ogg
+
+Each shot's *finished* length (``duration * slow_motion``) is quantised to a
+whole number of beats, so the joins land on the grid without the editor having
+to do arithmetic, and ``punch`` marks are written onto the beats inside each
+shot. Because the length changes, the clips have to be re-captured afterwards.
+
+The grid comes from the track's ``.grid.json`` sidecar when the track was
+synthesised here, and is detected from the audio otherwise. ``--detect`` reports
+what it found without touching the spec, which is also how the detector is
+checked against a track whose tempo is known by construction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+SAMPLE_RATE = 8000
+HOP = 128
+MIN_BPM, MAX_BPM = 70.0, 190.0
+
+MIN_CONFIDENCE = 2.0
+
+
+MIN_ONSET_STRENGTH = 0.002
+
+
+def fail(message: str) -> None:
+    print(f"beat-align: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def onset_flux(track: Path) -> list[float]:
+    """Half-wave rectified energy rise per frame: where a hit starts."""
+    result = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(track),
+            "-ac",
+            "1",
+            "-ar",
+            str(SAMPLE_RATE),
+            "-f",
+            "s16le",
+            "-",
+        ],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        fail(f"could not decode {track}")
+    raw = result.stdout
+    count = len(raw) // 2
+    samples = [
+        int.from_bytes(raw[i * 2 : i * 2 + 2], "little", signed=True) / 32768.0
+        for i in range(count)
+    ]
+    energies = []
+    for start in range(0, len(samples) - HOP, HOP):
+        window = samples[start : start + HOP]
+        energies.append(math.sqrt(sum(x * x for x in window) / HOP))
+    return [max(0.0, b - a) for a, b in zip(energies, energies[1:], strict=False)]
+
+
+def detect_grid(track: Path) -> dict:
+    """Tempo by autocorrelation of the onset flux, then the phase that fits it."""
+    flux = onset_flux(track)
+    if len(flux) < 200:
+        fail(f"{track} is too short to find a beat in")
+    frames_per_second = SAMPLE_RATE / HOP
+    mean = sum(flux) / len(flux)
+    centred = [value - mean for value in flux]
+
+    def prior(candidate: float) -> float:
+        octaves = math.log2(candidate / 120.0)
+        return math.exp(-0.5 * (octaves / 0.9) ** 2)
+
+    best_bpm, best_score = 0.0, -1.0
+    bpm = MIN_BPM
+    while bpm <= MAX_BPM:
+        lag = frames_per_second * 60.0 / bpm
+        whole = int(round(lag))
+        if whole >= len(centred) // 2:
+            bpm += 0.5
+            continue
+        score = sum(
+            centred[i] * centred[i + whole] for i in range(len(centred) - whole)
+        )
+        score = (score / (len(centred) - whole)) * prior(bpm)
+        if score > best_score:
+            best_bpm, best_score = bpm, score
+        bpm += 0.5
+
+    period = frames_per_second * 60.0 / best_bpm
+    best_phase, best_energy = 0.0, -1.0
+    steps = max(1, int(round(period)))
+    for step in range(steps):
+        hits = [
+            flux[int(round(step + k * period))]
+            for k in range(int((len(flux) - step) / period))
+        ]
+        energy = sum(hits) / max(1, len(hits))
+        if energy > best_energy:
+            best_phase, best_energy = step / frames_per_second, energy
+    floor = sum(flux) / len(flux)
+    confidence = round(best_energy / floor, 2) if floor > 0 else 0.0
+    if floor < MIN_ONSET_STRENGTH:
+        fail(
+            f"{track.name} has no onsets to find a beat in (mean onset strength "
+            f"{floor:.5f}, needs {MIN_ONSET_STRENGTH}). This is a held or ambient "
+            "sound rather than a track with hits in it."
+        )
+    if confidence < MIN_CONFIDENCE:
+        fail(
+            f"{track.name} has no steady beat to cut to (confidence {confidence}, "
+            f"needs {MIN_CONFIDENCE}). Orchestral score swells and rests instead of "
+            "landing on a grid; synthesise a bed with "
+            "tools/audio_synth/reel_score.py, or pass a track that has a pulse."
+        )
+    return {
+        "bpm": round(best_bpm, 2),
+        "first_beat": round(best_phase, 4),
+        "beat_seconds": round(60.0 / best_bpm, 6),
+        "confidence": confidence,
+        "detected": True,
+    }
+
+
+def load_grid(track: Path) -> dict:
+    sidecar = track.with_suffix(".grid.json")
+    if sidecar.is_file():
+        grid = json.loads(sidecar.read_text())
+        grid.setdefault("beat_seconds", 60.0 / grid["bpm"])
+        grid["detected"] = False
+        return grid
+    return detect_grid(track)
+
+
+def quantise(spec: dict, grid: dict, min_beats: int, punch_every: int) -> list[str]:
+    """Snap every shot's finished length to whole beats and mark the punches."""
+    beat = grid["beat_seconds"]
+    notes: list[str] = []
+    for shot in spec.get("shots", []):
+        if shot.get("flame_card"):
+            continue
+        slow = float(shot.get("slow_motion", 1.0))
+        clip = float(shot["duration"]) * slow
+
+        freeze = float(shot.get("freeze", 0.0) or 0.0)
+        if freeze > 0.0:
+            freeze = max(1, int(round(freeze / beat))) * beat
+            shot["freeze"] = round(freeze, 4)
+        beats = max(min_beats, int(round((clip + freeze) / beat)))
+        wanted = beats * beat - freeze
+        if wanted < beat:
+            beats += int(math.ceil((beat - wanted) / beat))
+            wanted = beats * beat - freeze
+        shot["duration"] = round(wanted / slow, 4)
+        held = f" + {freeze:.2f}s held" if freeze > 0.0 else ""
+        notes.append(
+            f"{shot.get('name', '?')}: {clip:.2f}s -> {wanted:.2f}s{held} "
+            f"({beats} beats)"
+        )
+        marks = []
+        step = max(1, punch_every)
+        for index in range(0, beats, step):
+            marks.append(
+                {
+                    "at": round(index * beat, 3),
+                    "amount": 0.11 if index == 0 else 0.07,
+                    "decay": round(beat * 0.55, 3),
+                }
+            )
+        shot["punch"] = marks
+
+        for key in shot.get("camera", []):
+            if float(key.get("time", 0.0)) > wanted:
+                key["time"] = round(wanted, 3)
+    return notes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("spec", type=Path, nargs="?")
+    parser.add_argument("--track", type=Path, required=True)
+    parser.add_argument(
+        "--detect",
+        action="store_true",
+        help="report the grid without touching the spec",
+    )
+    parser.add_argument("--min-beats", type=int, default=4)
+    parser.add_argument("--punch-every", type=int, default=2)
+    args = parser.parse_args()
+
+    if not args.track.is_file():
+        fail(f"track not found: {args.track}")
+
+    if args.detect:
+        found = detect_grid(args.track)
+        print(json.dumps(found, indent=2))
+        return 0
+
+    if args.spec is None or not args.spec.is_file():
+        fail("a promo spec is required unless --detect is given")
+
+    grid = load_grid(args.track)
+    spec = json.loads(args.spec.read_text())
+    spec["music"] = str(args.track)
+    spec["music_start"] = round(float(grid.get("drums_in", 0.0)), 3)
+    spec["beat"] = {"bpm": grid["bpm"], "beat_seconds": grid["beat_seconds"]}
+
+    notes = quantise(spec, grid, args.min_beats, args.punch_every)
+    args.spec.write_text(json.dumps(spec, indent=2) + "\n")
+
+    total = sum(
+        shot["duration"] * shot.get("slow_motion", 1.0) for shot in spec["shots"]
+    )
+    source = "detected" if grid.get("detected") else "from the track's grid sidecar"
+    print(
+        f"beat-align: {grid['bpm']} BPM {source}; "
+        f"{len(notes)} shot(s) snapped, {total:.2f}s of picture"
+    )
+    for note in notes:
+        print("   ", note)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/place-rally-cues.py
+++ b/scripts/place-rally-cues.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Place the commander-rally reel's sound cues on the moments that happen.
+
+    build/bin/arena_app --batch --scenario promo_commander_rally \
+      --artifact-dir artifacts/arena/rally
+    python3 scripts/place-rally-cues.py \
+      artifacts/arena/rally/promo_commander_rally/trace.jsonl \
+      tools/arena/promos/commander_rally.json
+
+Reads the scenario's own trace, finds the losses on each side, the commander's
+signature strikes and the moment the aura is called, maps every one through the
+shot that shows it (``start`` plus ``slow_motion``), and writes the cue list back
+into the spec. Hand-typed cue times rot the moment a shot is retimed -- see
+``scripts/place-promo-cues.py`` for what that looked like on the wolf reel -- so
+re-run this after any retime.
+"""
+import json
+import sys
+
+trace_path, spec_path = sys.argv[1], sys.argv[2]
+
+alive = {}
+losses = []
+signatures = []
+aura = None
+for line in open(trace_path):
+    frame = json.loads(line)
+    now = round(frame["time_seconds"], 2)
+    live = {}
+    for unit in frame.get("units", []):
+        group = unit["group"]
+        if unit["health"] > 0:
+            live[group] = live.get(group, 0) + 1
+        if group == "roman_consul":
+            if unit.get("combat_action_id", 0) >= 16:
+                signatures.append(now)
+            if aura is None and unit.get("commander_aura_active"):
+                aura = now
+    for group, was in alive.items():
+        if live.get(group, 0) < was:
+            losses.append((now, group))
+    alive = live
+
+spec = json.load(open(spec_path))
+DEFAULT = spec.get("transition", {"type": "cut", "duration": 0.0})
+
+shots = []
+finished = 0.0
+for index, shot in enumerate(spec["shots"]):
+    slow = shot.get("slow_motion", 1.0)
+    if index > 0:
+        join = shot.get("transition", DEFAULT)
+        if join.get("type") != "cut":
+            finished -= float(join.get("duration", 0.0))
+    shots.append((shot["name"], finished, shot["start"], shot["duration"], slow))
+    finished += shot["duration"] * slow
+total = finished
+
+
+QUIET = {"after"}
+
+
+def to_finished(scenario_seconds, name_filter=None):
+    """Scenario seconds -> finished seconds, or None when no shot shows it."""
+    for name, start, window_start, duration, slow in shots:
+        if window_start <= scenario_seconds < window_start + duration:
+            if name in QUIET:
+                return None
+            if name_filter and name != name_filter:
+                continue
+            return start + (scenario_seconds - window_start) * slow
+    return None
+
+
+def shot_start(name):
+    for shot_name, start, _ws, _d, _s in shots:
+        if shot_name == name:
+            return start
+    return None
+
+
+COMBAT = "assets/audio/sfx/combat/"
+ORDERS = "assets/audio/sfx/orders/"
+cues = []
+
+
+def add(path, at, gain):
+    if at is None or at < 0 or at > total:
+        return
+    cues.append({"file": path, "at": round(at, 2), "gain": gain})
+
+
+def after_shot(name, offset=0.0):
+    """A cue offset into a named shot, or None when the reel no longer has it."""
+    start = shot_start(name)
+    return None if start is None else start + offset
+
+
+add(COMBAT + "battlefield_distant_mass_01.ogg", 0.1, 1.20)
+add(COMBAT + "roman_shield_wall_impact.ogg", after_shot("the_field", 0.25), 1.80)
+add(COMBAT + "gladius_shield_impacts_close.ogg", after_shot("the_field", 0.9), 1.35)
+add(COMBAT + "battlefield_crowd_chaos.ogg", after_shot("the_field", 1.6), 1.10)
+
+
+add(ORDERS + "attack_horn_stab.ogg", to_finished(aura), 2.30)
+add(COMBAT + "roman_war_horns_orders.ogg", to_finished(aura), 1.70)
+add(COMBAT + "charge_roar.ogg", after_shot("behind_him", 0.1), 1.85)
+add(ORDERS + "run_kit_rattle.ogg", after_shot("behind_him", 0.5), 1.15)
+
+add(COMBAT + "roman_cavalry_charge.ogg", after_shot("the_charge", 0.05), 1.65)
+add(COMBAT + "horse_gallop_close_pass.ogg", after_shot("the_charge", 1.2), 1.45)
+add(COMBAT + "roman_shield_wall_impact.ogg", after_shot("the_charge", 2.3), 1.90)
+add(COMBAT + "vanguard_rush.ogg", after_shot("they_break", 0.2), 1.25)
+add(COMBAT + "soldiers_victory_cheer.ogg", after_shot("after", 0.7), 1.20)
+
+
+last = -9.0
+for index, at in enumerate(signatures):
+    finished_at = to_finished(at, "signature")
+    if finished_at is None or finished_at - last < 0.30:
+        continue
+    last = finished_at
+    add(COMBAT + f"blade_clash_0{(index % 4) + 1}.ogg", finished_at, 2.20)
+    add(COMBAT + f"sword_hit_0{(index % 4) + 1}.ogg", finished_at + 0.06, 1.60)
+
+
+last = -9.0
+for at, _group in losses:
+    finished_at = to_finished(at)
+    if finished_at is None:
+        continue
+    if finished_at - last < 0.5:
+        continue
+    last = finished_at
+    add(COMBAT + "human_death_cry.ogg", finished_at - 0.05, 2.40)
+
+cues.sort(key=lambda cue: cue["at"])
+spec["sfx"] = cues
+json.dump(spec, open(spec_path, "w"), indent=2)
+print(f"placed {len(cues)} cues across {total:.2f} s (aura at scenario {aura}s)")

--- a/scripts/promo-edit.py
+++ b/scripts/promo-edit.py
@@ -87,6 +87,7 @@ import tempfile
 from pathlib import Path
 
 CAPTION_Y_FRACTION = 0.70
+FREEZE_TEXT_Y_FRACTION = 0.44
 TITLE_Y_FRACTION = 0.42
 CAPTION_FADE = 0.25
 END_CARD_SECONDS = 2.2
@@ -95,9 +96,25 @@ FIRST_FRAME_MIN_PEAK = 8
 FIRST_FRAME_VISIBLE_LUMA = 32
 FIRST_FRAME_MIN_VISIBLE = 0.001
 
+PUNCH_MAX = 0.22
 FLASH_DELTA = 25
 FLASH_HARD_DELTA = 60
 FLASHES_PER_SECOND = 3
+
+
+MOTION_LIMITS = {
+    "yaw": 12.0,
+    "pitch": 6.0,
+    "fov": 6.0,
+    "roll_rate": 4.0,
+    "roll": 5.0,
+    "shake": 0.03,
+    "min_clip": 1.5,
+    "mean_clip": 2.0,
+}
+
+
+MOTION_P90_LIMIT = 6.0
 MASTER_TOOL_CANDIDATES = (
     "build/bin/audio_master_preview",
     "build-release/bin/audio_master_preview",
@@ -207,8 +224,14 @@ def master_music(track: Path, workdir: Path) -> Path | None:
     return rendered
 
 
-def luma_jumps(video: Path, fps: float) -> list[float]:
-    """Mean-luminance change per frame, 0-255, over the finished cut."""
+def frame_metrics(video: Path) -> tuple[list[float], list[float]]:
+    """Per-frame luminance jump and motion energy over the finished cut.
+
+    Both are read from one downscaled greyscale pass. The first is the mean
+    luminance change, which is what flashing looks like. The second is the mean
+    *absolute pixel* change, which is what a moving camera looks like -- a whip
+    pan barely moves mean luminance while replacing most of the frame.
+    """
     width, height = 64, 36
     result = subprocess.run(
         [
@@ -228,12 +251,111 @@ def luma_jumps(video: Path, fps: float) -> list[float]:
         check=False,
     )
     if result.returncode != 0 or not result.stdout:
-        return []
+        return [], []
     size = width * height
     raw = result.stdout
     frames = [raw[i * size : (i + 1) * size] for i in range(len(raw) // size)]
     means = [sum(frame) / size for frame in frames]
-    return [abs(b - a) for a, b in zip(means, means[1:], strict=False)]
+    jumps = [abs(b - a) for a, b in zip(means, means[1:], strict=False)]
+    motion = [
+        sum(abs(x - y) for x, y in zip(a, b, strict=False)) / size
+        for a, b in zip(frames, frames[1:], strict=False)
+    ]
+    return jumps, motion
+
+
+def motion_offence(motion: list[float]) -> str | None:
+    """Refuse a cut whose frame is in constant violent movement."""
+    if not motion:
+        return None
+    ordered = sorted(motion)
+    p90 = ordered[int(0.9 * (len(ordered) - 1))]
+    if p90 > MOTION_P90_LIMIT:
+        return (
+            f"nine frames in ten change by {p90:.1f}/255 or more "
+            f"(limit {MOTION_P90_LIMIT}); the camera is moving through the whole cut"
+        )
+    return None
+
+
+def shorter_arc(from_degrees: float, to_degrees: float) -> float:
+    delta = (to_degrees - from_degrees) % 360.0
+    return delta - 360.0 if delta > 180.0 else delta
+
+
+def camera_offences(spec: dict) -> list[str]:
+    """Author-time camera limits, mirrored from `Arena::Promo::motion_violations`."""
+    offences: list[str] = []
+    clips: list[float] = []
+    for shot in spec.get("shots", []):
+        if shot.get("flame_card"):
+            continue
+        name = shot.get("name", "?")
+        clip = float(shot.get("duration", 0.0)) * float(shot.get("slow_motion", 1.0))
+        clips.append(clip)
+        if clip + 1e-3 < MOTION_LIMITS["min_clip"]:
+            offences.append(
+                f"{name}: is on screen for {clip:.2f}s, under the "
+                f"{MOTION_LIMITS['min_clip']:.2f}s a viewer needs to read a frame"
+            )
+        if float(shot.get("shake", 0.0)) > MOTION_LIMITS["shake"] + 1e-4:
+            offences.append(
+                f"{name}: shakes at {float(shot['shake']):.3f}, over the "
+                f"{MOTION_LIMITS['shake']:.3f} ceiling"
+            )
+        if shot.get("gameplay_camera"):
+            continue
+        keys = shot.get("camera", [])
+        for key in keys:
+            if abs(float(key.get("roll", 0.0))) > MOTION_LIMITS["roll"] + 1e-4:
+                offences.append(
+                    f"{name}: rolls the horizon {abs(float(key['roll'])):.1f} degrees, "
+                    f"over the {MOTION_LIMITS['roll']:.1f} ceiling"
+                )
+                break
+        for before, after in zip(keys, keys[1:], strict=False):
+            span = max(
+                0.001, float(after.get("time", 0.0)) - float(before.get("time", 0.0))
+            )
+            for axis, limit, delta in (
+                (
+                    "yaw",
+                    MOTION_LIMITS["yaw"],
+                    shorter_arc(
+                        float(before.get("yaw", 0.0)), float(after.get("yaw", 0.0))
+                    ),
+                ),
+                (
+                    "pitch",
+                    MOTION_LIMITS["pitch"],
+                    float(after.get("pitch", 0.0)) - float(before.get("pitch", 0.0)),
+                ),
+                (
+                    "fov",
+                    MOTION_LIMITS["fov"],
+                    float(after.get("fov", 40.0)) - float(before.get("fov", 40.0)),
+                ),
+                (
+                    "roll",
+                    MOTION_LIMITS["roll_rate"],
+                    float(after.get("roll", 0.0)) - float(before.get("roll", 0.0)),
+                ),
+            ):
+                rate = abs(delta) / span
+                if rate > limit + 1e-3:
+                    offences.append(
+                        f"{name}: swings {axis} at {rate:.1f} deg/s, over the "
+                        f"{limit:.1f} deg/s ceiling"
+                    )
+    if clips:
+        mean = sum(clips) / len(clips)
+        if mean + 1e-3 < MOTION_LIMITS["mean_clip"]:
+            offences.append(
+                f"the cut averages {mean:.2f}s a shot, under the "
+                f"{MOTION_LIMITS['mean_clip']:.2f}s that keeps a reel from reading "
+                "as strobing"
+            )
+    return offences
 
 
 def photosensitivity_offence(jumps: list[float], fps: float) -> str | None:
@@ -595,8 +717,50 @@ def plan_timeline(
     return spans, cursor
 
 
+def punch_expression(punches: list[dict]) -> str:
+    """A zoom that snaps in on a beat and settles back before the next one.
+
+    Written as one expression of `t` so the whole reel still encodes in a single
+    pass: each punch adds `amount * exp(-(t - at) / decay)` once its time has
+    passed, and the crop is scaled back up to the frame afterwards.
+    """
+    terms = ["1"]
+    for punch in punches:
+        at = float(punch.get("at", 0.0))
+        amount = max(0.0, min(PUNCH_MAX, float(punch.get("amount", 0.08))))
+        decay = max(0.05, float(punch.get("decay", 0.25)))
+        if amount <= 0.0:
+            continue
+        terms.append(
+            f"{amount:.4f}*if(gte(t,{at:.3f}),exp(-(t-{at:.3f})/{decay:.3f}),0)"
+        )
+    return "+".join(terms)
+
+
+def shot_filter(shot: dict, width: int, height: int) -> str:
+    """Per-clip effects: hold the last frame, and punch in on the beat."""
+    stages: list[str] = []
+    freeze = float(shot.get("freeze", 0.0) or 0.0)
+    if freeze > 0.0:
+        stages.append(f"tpad=stop_mode=clone:stop_duration={freeze:.3f}")
+    punches = shot.get("punch") or []
+    if punches:
+        zoom = punch_expression(punches)
+
+        stages.append(
+            f"crop=w='trunc(iw/({zoom})/2)*2':h='trunc(ih/({zoom})/2)*2'"
+            ":x='(iw-ow)/2':y='(ih-oh)/2'"
+        )
+        stages.append(f"scale={width}:{height}:flags=bicubic")
+        stages.append("setsar=1")
+    return ",".join(stages)
+
+
 def build_join_graph(
-    lengths: list[float], joins: list[Join], spans: list[tuple[float, float]]
+    lengths: list[float],
+    joins: list[Join],
+    spans: list[tuple[float, float]],
+    effects: list[str] | None = None,
 ) -> tuple[list[str], str]:
     """Join the clips into one stream, blending where a transition asks for it.
 
@@ -619,7 +783,9 @@ def build_join_graph(
 
     chain: list[str] = []
     for index in range(len(lengths)):
-        chain.append(f"[{index}:v]settb=AVTB,setpts=PTS-STARTPTS[n{index}]")
+        extra = (effects[index] if effects and index < len(effects) else "") or ""
+        prefix = f"{extra}," if extra else ""
+        chain.append(f"[{index}:v]{prefix}settb=AVTB,setpts=PTS-STARTPTS[n{index}]")
 
     labels: list[str] = []
     for position, members in enumerate(segments):
@@ -744,6 +910,13 @@ def main() -> int:
     output.parent.mkdir(parents=True, exist_ok=True)
     staged = output.with_suffix(f".staging{output.suffix}")
 
+    offences = camera_offences(spec)
+    if offences:
+        fail(
+            "this spec's camera work is unwatchable on a phone:\n  "
+            + "\n  ".join(offences)
+        )
+
     default_kind, default_seconds = read_transition(
         spec.get("transition"), DEFAULT_TRANSITION, DEFAULT_TRANSITION_SECONDS
     )
@@ -751,6 +924,7 @@ def main() -> int:
     inputs: list[str] = []
     names: list[str] = []
     lengths: list[float] = []
+    freezes: list[float] = []
     joins: list[Join] = []
     for index, shot in enumerate(shots):
         clip = args.clips / shot["clip"]
@@ -761,8 +935,10 @@ def main() -> int:
         if length <= 0:
             fail(f"clip {clip.name} reports no duration")
         name = shot.get("name", "")
+        freeze = float(authored.get(name, {}).get("freeze", 0.0) or 0.0)
         names.append(name)
-        lengths.append(length)
+        lengths.append(length + freeze)
+        freezes.append(freeze)
         if index == 0:
             joins.append(HARD_CUT)
             continue
@@ -780,7 +956,8 @@ def main() -> int:
     width = int(manifest.get("width", 1080))
     height = int(manifest.get("height", 1920))
 
-    chain, joined = build_join_graph(lengths, joins, spans)
+    effects = [shot_filter(authored.get(name, {}), width, height) for name in names]
+    chain, joined = build_join_graph(lengths, joins, spans, effects)
     chain.append(f"[{joined}]{build_grade(spec.get('grade', {}))}[graded]")
 
     timeline = [
@@ -840,6 +1017,28 @@ def main() -> int:
         has_card = bool(spec.get("title") or spec.get("subtitle"))
         step = 0
         for index, (name, start, end) in enumerate(timeline):
+
+            freeze = freezes[index] if index < len(freezes) else 0.0
+            punchline = authored.get(name, {}).get("freeze_text")
+            if punchline and freeze > 0.0:
+                chain.append(
+                    f"[{stage}]"
+                    + drawtext(
+                        text=tracked(punchline),
+                        font=font,
+                        size=fit_font_size(
+                            tracked(punchline), font, title_size, title_safe_width
+                        ),
+                        y_expr=f"h*{FREEZE_TEXT_Y_FRACTION}",
+                        start=max(start, end - freeze + 0.05),
+                        end=end - 0.03,
+                        fade=0.08,
+                    )
+                    + f"[punch{step}]"
+                )
+                stage = f"punch{step}"
+                step += 1
+
             caption = captions.get(name)
             if not caption:
                 continue
@@ -1098,7 +1297,7 @@ def main() -> int:
         )
 
     fps = float(manifest.get("fps", 60))
-    jumps = luma_jumps(staged, fps)
+    jumps, motion = frame_metrics(staged)
     offence = photosensitivity_offence(jumps, fps)
     if not jumps:
         print("promo-edit: warning: could not measure the cut for flashing")
@@ -1113,6 +1312,16 @@ def main() -> int:
         )
     elif offence is not None:
         print(f"promo-edit: warning: --allow-flashes set; {offence}")
+
+    moving = motion_offence(motion)
+    if moving is not None:
+        reject(
+            staged,
+            output,
+            f"the cut never holds still: {moving}. Hold shots longer, drop `shake`, "
+            "and let the camera push or drift rather than orbit -- a frame the eye "
+            "cannot settle on reads as chaos however good the footage is.",
+        )
 
     staged.replace(output)
     worst = max(jumps) if jumps else 0.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -403,6 +403,7 @@ add_executable(
     render/rig_dsl/barracks_rig_test.cpp
     render/bpat/bpat_format_test.cpp
     render/bpat/bpat_registry_test.cpp
+    render/formation_locomotion_state_test.cpp
     render/humanoid/skeleton_test.cpp
     render/humanoid/humanoid_spec_test.cpp
     render/horse/mounted_seat_frame_test.cpp

--- a/tests/promo_beat_test.sh
+++ b/tests/promo_beat_test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# The beat pipeline: a synthesised bed, the grid recovered from it, and a spec
+# quantised onto that grid.
+#
+# A reel is cut *to* the music, so the two failures that matter are silent: a
+# tempo read an octave out, and a track with no pulse at all quantising a spec
+# onto a grid that is not there. Both are asserted here. Needs python3 and
+# ffmpeg; no compiler.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+green() { printf '\033[0;32m%s\033[0m\n' "$1"; }
+die() {
+  printf '\033[0;31m%s\033[0m\n' "$1" >&2
+  exit 1
+}
+
+echo "Test 1: a synthesised bed carries its own grid..."
+python3 "${root}/tools/audio_synth/reel_score.py" --bpm 150 --bars 6 \
+  --out "${work}/bed.ogg" >/dev/null
+[ -f "${work}/bed.grid.json" ] || die "no grid sidecar was written"
+python3 - "${work}/bed.grid.json" <<'PY'
+import json, sys
+grid = json.load(open(sys.argv[1]))
+assert grid["bpm"] == 150.0, grid
+assert abs(grid["beat_seconds"] - 0.4) < 1e-6, grid
+PY
+green "✓ Test 1 passed: the bed states its own tempo"
+
+echo
+echo "Test 2: the detector recovers that tempo, or its octave, from the audio..."
+python3 "${root}/scripts/beat-align.py" --track "${work}/bed.ogg" --detect \
+  >"${work}/detected.json"
+python3 - "${work}/detected.json" <<'PY'
+import json, sys
+found = json.load(open(sys.argv[1]))
+bpm = found["bpm"]
+octaves = [75.0, 150.0, 300.0]
+assert any(abs(bpm - o) <= 2.5 for o in octaves), f"detected {bpm}, expected 150 or an octave of it"
+assert found["confidence"] >= 2.0, found
+PY
+green "✓ Test 2 passed: $(python3 -c "import json;print(json.load(open('${work}/detected.json'))['bpm'])") BPM detected"
+
+echo
+echo "Test 3: a track with no pulse is refused rather than quantised to nothing..."
+ffmpeg -v error -f lavfi -i "sine=frequency=220:duration=8" -c:a libvorbis \
+  "${work}/drone.ogg"
+if python3 "${root}/scripts/beat-align.py" --track "${work}/drone.ogg" --detect \
+  >"${work}/drone.json" 2>"${work}/drone.err"; then
+  die "a steady drone was accepted as a beat"
+fi
+grep -qE "no steady beat|no onsets" "${work}/drone.err" || die "refused for the wrong reason"
+green "✓ Test 3 passed: refused, with the reason"
+
+echo
+echo "Test 4: shot lengths land on whole beats, freeze included..."
+cat >"${work}/spec.json" <<'JSON'
+{
+  "id": "beat_test",
+  "width": 1080, "height": 1920, "fps": 60,
+  "shots": [
+    {"name": "a", "scenario": "s", "start": 0, "duration": 2.9, "slow_motion": 1.0,
+     "focus": {"mode": "all"},
+     "camera": [{"time": 0, "distance": 10, "pitch": 10, "yaw": 90, "fov": 40}]},
+    {"name": "b", "scenario": "s", "start": 5, "duration": 1.1, "slow_motion": 2.0,
+     "freeze": 0.3, "freeze_text": "HELD",
+     "focus": {"mode": "all"},
+     "camera": [{"time": 0, "distance": 10, "pitch": 10, "yaw": 90, "fov": 40}]}
+  ]
+}
+JSON
+python3 "${root}/scripts/beat-align.py" "${work}/spec.json" --track "${work}/bed.ogg" \
+  --punch-every 2 >/dev/null
+python3 - "${work}/spec.json" <<'PY'
+import json, sys
+spec = json.load(open(sys.argv[1]))
+beat = spec["beat"]["beat_seconds"]
+for shot in spec["shots"]:
+    clip = shot["duration"] * shot.get("slow_motion", 1.0) + shot.get("freeze", 0.0)
+    beats = clip / beat
+    assert abs(beats - round(beats)) < 1e-3, f"{shot['name']} is {beats} beats long"
+    assert shot["punch"], f"{shot['name']} was given no punch marks"
+    for mark in shot["punch"]:
+        on = mark["at"] / beat
+        assert abs(on - round(on)) < 1e-3, f"punch at {mark['at']}s is off the grid"
+held = next(s for s in spec["shots"] if s["name"] == "b")
+assert abs(held["freeze"] / beat - round(held["freeze"] / beat)) < 1e-3, held
+PY
+green "✓ Test 4 passed: every cut and punch is on the grid"
+
+echo
+echo "===================================="
+green "All tests passed!"

--- a/tests/render/formation_locomotion_state_test.cpp
+++ b/tests/render/formation_locomotion_state_test.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "render/entity/formation_instance_layout.h"
+
+namespace {
+
+using Render::Entity::FormationInstance;
+using Render::Entity::FormationLayoutCache;
+using Render::Entity::FormationLayoutRequest;
+using Render::Entity::resolve_formation_instances;
+
+auto request_for(float blend_ratio, int total_count = 12) -> FormationLayoutRequest {
+  FormationLayoutRequest request;
+  request.rows = 3;
+  request.cols = 4;
+  request.total_count = total_count;
+  request.seed = 4242U;
+  request.layout_version = 7;
+  request.formation.individuals_per_unit = total_count;
+  request.formation.max_per_row = 4;
+  request.formation.spacing = 1.1F;
+  request.blend_ratio = blend_ratio;
+  return request;
+}
+
+void prime(FormationLayoutCache& cache, const FormationLayoutRequest& request) {
+  std::vector<FormationInstance> scratch;
+  (void)resolve_formation_instances(&cache, scratch, request);
+}
+
+} // namespace
+
+TEST(FormationLocomotionStateTest, ABlendingLayoutKeepsItsSoldiersGait) {
+  FormationLayoutCache cache;
+  prime(cache, request_for(0.25F));
+
+  std::vector<FormationInstance> scratch;
+
+  auto const result = resolve_formation_instances(&cache, scratch, request_for(0.31F));
+
+  EXPECT_FALSE(result.preserve_state_prefix)
+      << "the cached instance geometry is stale once the blend has moved";
+  EXPECT_TRUE(result.preserve_locomotion_state)
+      << "a soldier mid-stride is the same soldier at a different blend ratio";
+}
+
+TEST(FormationLocomotionStateTest, AReshapedLayoutKeepsItsSoldiersGait) {
+  FormationLayoutCache cache;
+  prime(cache, request_for(0.0F));
+
+  auto reshaped = request_for(0.0F);
+  reshaped.rows = 4;
+  reshaped.cols = 3;
+  std::vector<FormationInstance> scratch;
+  auto const result = resolve_formation_instances(&cache, scratch, reshaped);
+
+  EXPECT_FALSE(result.preserve_state_prefix);
+  EXPECT_TRUE(result.preserve_locomotion_state)
+      << "changing rank and file moves a man, it does not replace him";
+}
+
+TEST(FormationLocomotionStateTest, ADifferentUnitDoesNotInheritAGait) {
+  FormationLayoutCache cache;
+  prime(cache, request_for(0.0F));
+
+  auto other = request_for(0.0F);
+  other.seed = 99U;
+  std::vector<FormationInstance> scratch;
+  EXPECT_FALSE(
+      resolve_formation_instances(&cache, scratch, other).preserve_locomotion_state)
+      << "a different seed is a different set of men";
+
+  auto resized = request_for(0.0F, 9);
+  resized.formation.individuals_per_unit = 9;
+  EXPECT_FALSE(
+      resolve_formation_instances(&cache, scratch, resized).preserve_locomotion_state)
+      << "a roster of a different size cannot map onto the cached one";
+}

--- a/tests/systems/combat_mode_test.cpp
+++ b/tests/systems/combat_mode_test.cpp
@@ -30,6 +30,7 @@
 #include "systems/combat_system/combat_status_effect_processor.h"
 #include "systems/combat_system/combat_types.h"
 #include "systems/combat_system/combat_utils.h"
+#include "systems/combat_system/damage_application.h"
 #include "systems/combat_system/damage_processor.h"
 #include "systems/combat_system/mounted_charge_processor.h"
 #include "systems/combat_system/spear_brace_processor.h"
@@ -2686,6 +2687,35 @@ TEST_F(CombatModeTest, HealingRestoresSurvivorsWithoutResurrectingFormationCasua
   healing_system.update(world.get(), 0.1F);
   EXPECT_EQ(formation_unit->health, 40);
   EXPECT_FALSE(healer->is_healing_active);
+}
+
+TEST_F(CombatModeTest, DamageTakenAfterHealthOutrunsTheRosterDoesNotRaiseTheDead) {
+  auto* formation = world->create_entity();
+  formation->add_component<TransformComponent>(0.0F, 0.0F, 0.0F);
+  auto* formation_unit = formation->add_component<UnitComponent>(100, 100, 1.0F, 12.0F);
+  formation_unit->owner_id = 1;
+  formation_unit->spawn_type = Game::Units::SpawnType::Archer;
+
+  const int total_count =
+      Game::Systems::FormationCombat::resolve_definition(*formation_unit).total_count;
+  ASSERT_GT(total_count, 4);
+
+  auto* roster = formation->add_component<FormationRosterPresentationComponent>();
+  roster->total_count = static_cast<std::uint16_t>(total_count);
+  roster->live_count = 4;
+  roster->alive.assign(static_cast<std::size_t>(total_count), 0U);
+  std::fill(roster->alive.end() - 4, roster->alive.end(), std::uint8_t{1U});
+
+  Game::Systems::Combat::apply_unit_damage(world.get(), formation, 10);
+
+  const auto living =
+      std::count(roster->alive.begin(), roster->alive.end(), std::uint8_t{1U});
+  EXPECT_LE(living, 4)
+      << "a unit whose health outran its roster must not refill its ranks when hit";
+  EXPECT_EQ(roster->live_count, living)
+      << "the published survivor count must match the slots that are actually alive";
+  EXPECT_EQ(Game::Systems::FormationCombat::living_slot_count(*formation, total_count),
+            static_cast<int>(living));
 }
 
 TEST_F(CombatModeTest, GravePriestSuppressesFireballWhileUndeadHealingIsAvailable) {

--- a/tests/systems/commander_system_test.cpp
+++ b/tests/systems/commander_system_test.cpp
@@ -430,6 +430,60 @@ TEST(CommanderSystemTest, AuraAppliesAttackAndProductionBonusesByType) {
   EXPECT_FLOAT_EQ(barracks_prod->time_remaining, expected_haste_time);
 }
 
+TEST(CommanderSystemTest, HealthRegenAuraCannotRefillADecimatedUnit) {
+  Engine::Core::World world;
+
+  auto* commander = world.create_entity();
+  auto* commander_unit = commander->add_component<Engine::Core::UnitComponent>();
+  auto* commander_transform =
+      commander->add_component<Engine::Core::TransformComponent>();
+  auto* commander_data = commander->add_component<Engine::Core::CommanderComponent>();
+  ASSERT_NE(commander_unit, nullptr);
+  ASSERT_NE(commander_transform, nullptr);
+  ASSERT_NE(commander_data, nullptr);
+  commander_unit->owner_id = 1;
+  commander_unit->health = 100;
+  commander_unit->nation_id = Game::Systems::NationID::RomanRepublic;
+  commander_transform->position = {0.0F, 0.0F, 0.0F};
+  commander_data->bonus_type = "health_regen";
+  commander_data->aura_bonus_value = 50.0F;
+  commander_data->aura_radius = 10.0F;
+  commander_data->aura_ability_active = true;
+  commander_data->aura_ability_remaining = 10.0F;
+
+  auto* ally = world.create_entity();
+  auto* ally_unit = ally->add_component<Engine::Core::UnitComponent>();
+  auto* ally_transform = ally->add_component<Engine::Core::TransformComponent>();
+  ASSERT_NE(ally_unit, nullptr);
+  ASSERT_NE(ally_transform, nullptr);
+  ally_unit->owner_id = 1;
+  ally_unit->health = 40;
+  ally_unit->max_health = 100;
+  ally_unit->spawn_type = Game::Units::SpawnType::Archer;
+  ally_unit->nation_id = Game::Systems::NationID::RomanRepublic;
+  ally_transform->position = {2.0F, 0.0F, 0.0F};
+
+  auto* roster =
+      ally->add_component<Engine::Core::FormationRosterPresentationComponent>();
+  ASSERT_NE(roster, nullptr);
+  roster->total_count = 30;
+  roster->live_count = 15;
+  roster->alive.assign(30, 0U);
+  for (std::size_t slot = 15; slot < roster->alive.size(); ++slot) {
+    roster->alive[slot] = 1U;
+  }
+
+  Game::Systems::CommanderSystem system;
+  for (int tick = 0; tick < 20; ++tick) {
+    system.update(&world, 1.0F);
+  }
+
+  EXPECT_EQ(ally_unit->health, 50)
+      << "a half-dead unit can only be mended up to what its survivors can hold";
+  EXPECT_LT(ally_unit->health, ally_unit->max_health)
+      << "the aura must never report a decimated unit as at full strength";
+}
+
 TEST(CommanderSystemTest, AttackBoostFallsOffOutsideAura) {
   Engine::Core::World world;
 

--- a/tests/tools/arena_promo_spec_test.cpp
+++ b/tests/tools/arena_promo_spec_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cmath>
 #include <gtest/gtest.h>
 #include <vector>
@@ -33,7 +34,88 @@ auto shot(const char* name,
   return result;
 }
 
+auto calm_shot(const char* name, float clip_seconds) -> Shot {
+  auto result = shot(name, "arena", 0.0F, clip_seconds);
+  CameraKey first;
+  first.time = 0.0F;
+  first.yaw = 90.0F;
+  first.pitch = 10.0F;
+  first.fov = 40.0F;
+  CameraKey last = first;
+  last.time = clip_seconds;
+  last.yaw = 96.0F;
+  result.keys = {first, last};
+  return result;
+}
+
+auto spec_of(std::vector<Shot> shots) -> Spec {
+  Spec result;
+  result.id = QStringLiteral("test");
+  result.shots = std::move(shots);
+  return result;
+}
+
+auto mentions(const std::vector<QString>& breaches, const char* needle) -> bool {
+  return std::any_of(breaches.begin(), breaches.end(), [needle](const QString& line) {
+    return line.contains(QString::fromLatin1(needle));
+  });
+}
+
 } // namespace
+
+TEST(ArenaPromoSpecMotionTest, CalmCameraWorkPasses) {
+  EXPECT_TRUE(Arena::Promo::motion_violations(
+                  spec_of({calm_shot("wide", 3.0F), calm_shot("close", 2.5F)}))
+                  .empty());
+}
+
+TEST(ArenaPromoSpecMotionTest, AWhippingOrbitIsRefused) {
+  auto whip = calm_shot("whip", 2.0F);
+  whip.keys.back().yaw = 150.0F;
+
+  const auto breaches = Arena::Promo::motion_violations(
+      spec_of({whip, calm_shot("hold", 3.0F), calm_shot("hold_two", 3.0F)}));
+
+  EXPECT_TRUE(mentions(breaches, "swings yaw"))
+      << "a 30 deg/s orbit is the shaky-chaos camera the limits exist to stop";
+}
+
+TEST(ArenaPromoSpecMotionTest, HandheldShakeIsRefused) {
+  auto shaky = calm_shot("shaky", 3.0F);
+  shaky.shake = 0.09F;
+
+  EXPECT_TRUE(mentions(Arena::Promo::motion_violations(spec_of({shaky})), "shakes at"));
+}
+
+TEST(ArenaPromoSpecMotionTest, ARollingHorizonIsRefused) {
+  auto rolled = calm_shot("rolled", 2.0F);
+  rolled.keys.front().roll = -6.0F;
+  rolled.keys.back().roll = 6.0F;
+
+  const auto breaches = Arena::Promo::motion_violations(spec_of({rolled}));
+
+  EXPECT_TRUE(mentions(breaches, "rolls the horizon"));
+  EXPECT_TRUE(mentions(breaches, "swings roll"))
+      << "a horizon that tips one way and back inside two seconds reads as a stumble";
+}
+
+TEST(ArenaPromoSpecMotionTest, FlashCuttingIsRefused) {
+  const auto breaches = Arena::Promo::motion_violations(
+      spec_of({calm_shot("a", 0.9F), calm_shot("b", 0.9F), calm_shot("c", 0.9F)}));
+
+  EXPECT_TRUE(mentions(breaches, "is on screen for"));
+  EXPECT_TRUE(mentions(breaches, "averages"));
+}
+
+TEST(ArenaPromoSpecMotionTest, ACrashZoomIsRefused) {
+  auto zoom = calm_shot("zoom", 1.6F);
+  zoom.keys.front().fov = 54.0F;
+  zoom.keys.back().fov = 36.0F;
+
+  EXPECT_TRUE(mentions(
+      Arena::Promo::motion_violations(spec_of({zoom, calm_shot("hold", 3.0F)})),
+      "swings fov"));
+}
 
 TEST(ArenaPromoSpecTest, YawBlendsAlongTheShorterArc) {
   const std::vector<CameraKey> keys{key(0.0F, 8.0F), key(1.0F, 352.0F)};

--- a/tests/ui/qml/tst_main_menu.qml
+++ b/tests/ui/qml/tst_main_menu.qml
@@ -1,0 +1,114 @@
+import QtQuick 2.15
+import QtTest 1.15
+import StandardOfIron 1.0
+import "../../../ui/qml"
+
+TestCase {
+    id: testCase
+
+    name: "MainMenu"
+    when: windowShown
+    width: 1280
+    height: 800
+    visible: true
+
+    function make_menu(game_started) {
+        var menu = menuComponent.createObject(testCase, {
+                "game_started": game_started
+            });
+        verify(menu !== null, "MainMenu failed to instantiate");
+        menu.forceActiveFocus();
+        verify(menu.activeFocus, "the menu never took the keyboard");
+        return menu;
+    }
+
+    function test_escape_asks_to_resume_the_battle() {
+        var menu = make_menu(true);
+        var spy = spyComponent.createObject(testCase, {
+                "target": menu,
+                "signalName": "resume_requested"
+            });
+        keyClick(Qt.Key_Escape);
+        compare(spy.count, 1, "Esc did not ask to resume the battle");
+        spy.destroy();
+        menu.destroy();
+    }
+
+    function test_escape_keeps_asking_every_time_the_menu_is_reopened() {
+        var menu = make_menu(true);
+        var spy = spyComponent.createObject(testCase, {
+                "target": menu,
+                "signalName": "resume_requested"
+            });
+        for (var round = 0; round < 3; ++round) {
+            menu.visible = false;
+            menu.visible = true;
+            menu.forceActiveFocus();
+            keyClick(Qt.Key_Escape);
+        }
+        compare(spy.count, 3, "Esc stopped resuming after the menu was reopened");
+        spy.destroy();
+        menu.destroy();
+    }
+
+    function test_escape_does_nothing_without_a_battle_to_return_to() {
+        var menu = make_menu(false);
+        var spy = spyComponent.createObject(testCase, {
+                "target": menu,
+                "signalName": "resume_requested"
+            });
+        keyClick(Qt.Key_Escape);
+        compare(spy.count, 0, "Esc resumed a battle that was never started");
+        spy.destroy();
+        menu.destroy();
+    }
+
+    function test_the_menu_swallows_clicks_meant_for_nothing_behind_it() {
+        var below = catcherComponent.createObject(testCase);
+        below.z = -1;
+        var menu = make_menu(true);
+        mouseClick(testCase, 6, 6);
+        compare(below.hits, 0, "a click on the menu reached the battlefield behind it");
+        menu.destroy();
+        below.destroy();
+    }
+
+    function test_a_click_on_the_menu_leaves_the_keyboard_with_the_menu() {
+        var below = catcherComponent.createObject(testCase);
+        below.z = -1;
+        var menu = make_menu(true);
+        mouseClick(testCase, 6, 6);
+        verify(menu.activeFocus, "clicking the menu handed the keyboard back to the battlefield");
+        menu.destroy();
+        below.destroy();
+    }
+
+    Component {
+        id: menuComponent
+
+        MainMenu {
+        }
+    }
+
+    Component {
+        id: catcherComponent
+
+        MouseArea {
+            property int hits: 0
+
+            anchors.fill: parent
+            acceptedButtons: Qt.AllButtons
+            onPressed: {
+                hits += 1;
+                forceActiveFocus();
+            }
+        }
+    }
+
+    Component {
+        id: spyComponent
+
+        SignalSpy {
+        }
+    }
+}

--- a/tests/ui/qml/tst_selection_summary.qml
+++ b/tests/ui/qml/tst_selection_summary.qml
@@ -20,6 +20,8 @@ TestCase {
                     "nation": specs[i].nation || "roman_republic",
                     "count": specs[i].count,
                     "woundedCount": specs[i].wounded || 0,
+                    "soldiers": specs[i].soldiers === undefined ? 0 : specs[i].soldiers,
+                    "maxSoldiers": specs[i].maxSoldiers === undefined ? 0 : specs[i].maxSoldiers,
                     "health": specs[i].health === undefined ? 1 : specs[i].health,
                     "stamina": specs[i].stamina === undefined ? 1 : specs[i].stamina,
                     "canRun": specs[i].canRun === undefined ? true : specs[i].canRun
@@ -337,6 +339,78 @@ TestCase {
         summary.destroy();
     }
 
+    function test_a_single_unit_reads_its_surviving_soldiers_out_of_its_roster() {
+        var summary = makeSummary(1, makeGroups([{
+                        "typeKey": "archer",
+                        "count": 1,
+                        "health": 0.5,
+                        "soldiers": 15,
+                        "maxSoldiers": 30
+                    }]));
+        compare(findChild(summary, "selectionHealthLabel").text, "SOLDIERS");
+        compare(findChild(summary, "selectionHealthValue").text, "15 / 30", "a mauled unit must say how many men it has left");
+        summary.groups = makeGroups([{
+                    "typeKey": "archer",
+                    "count": 1,
+                    "health": 0.2,
+                    "soldiers": 6,
+                    "maxSoldiers": 30
+                }]);
+        compare(findChild(summary, "selectionHealthValue").text, "6 / 30", "casualties must move the readout");
+        summary.destroy();
+    }
+
+    function test_a_one_body_unit_keeps_the_percentage_readout() {
+        var summary = makeSummary(1, makeGroups([{
+                        "typeKey": "catapult",
+                        "count": 1,
+                        "health": 0.65,
+                        "soldiers": 1,
+                        "maxSoldiers": 1,
+                        "canRun": false
+                    }]));
+        compare(findChild(summary, "selectionHealthLabel").text, "HEALTH");
+        compare(findChild(summary, "selectionHealthValue").text, "65%", "a single body has no roster to count out of");
+        summary.destroy();
+    }
+
+    function test_roster_cards_read_the_men_left_in_each_group() {
+        var summary = makeSummary(60, makeGroups([{
+                        "typeKey": "spearman",
+                        "count": 40,
+                        "health": 0.9,
+                        "wounded": 12,
+                        "soldiers": 648,
+                        "maxSoldiers": 720
+                    }, {
+                        "typeKey": "archer",
+                        "count": 20,
+                        "health": 0.4,
+                        "soldiers": 240,
+                        "maxSoldiers": 600
+                    }]));
+        verify(summary.army);
+        compare(findChild(summary, "selectionGroupStrength_spearman").text, "648/720");
+        compare(findChild(summary, "selectionGroupStrength_archer").text, "240/600");
+        compare(summary.soldierCount, 888);
+        compare(summary.soldierMax, 1320);
+        compare(findChild(summary, "selectionSubtitle").text, "888 soldiers ready", "the force header must count men, not unit cards");
+        summary.destroy();
+    }
+
+    function test_a_selection_without_soldier_counts_still_reads_cleanly() {
+        var summary = makeSummary(60, makeGroups([{
+                        "typeKey": "spearman",
+                        "count": 40,
+                        "health": 0.9,
+                        "wounded": 12
+                    }]));
+        var strength = findChild(summary, "selectionGroupStrength_spearman");
+        compare(strength.text, "12 wounded", "with no roster data the card falls back to the wounded line");
+        compare(findChild(summary, "selectionSubtitle").text, "60 soldiers ready");
+        summary.destroy();
+    }
+
     function test_icons_resolve_from_the_type_key_or_the_display_name() {
         var summary = makeSummary(1, []);
         var byKey = summary.iconFor("horse_archer", "roman_republic", "");
@@ -387,8 +461,24 @@ TestCase {
         fuzzyCompare(bar.value, 0.3, 0.001, "inspect health bar must show the enemy ratio");
         compare(bar.fillColor.toString(), Theme.danger.toString(), "enemy health reads in the danger colour regardless of ratio");
         compare(findChild(summary, "inspectHealthValue").text, "30 / 100");
+        verify(!findChild(summary, "inspectSoldiersValue").visible, "an enemy with no roster data must not print a soldier line");
         compare(summary.inspectHeader(), "ENEMY UNIT");
         verify(findChild(summary, "inspectAttackSummary").text.indexOf("3") >= 0, "the card says how many of your units are attacking it");
+        summary.destroy();
+    }
+
+    function test_inspecting_a_formation_shows_the_men_it_has_left() {
+        var summary = summaryComponent.createObject(testCase, {
+                "unitCount": 0,
+                "groups": [],
+                "inspected": makeFocus({
+                        "soldiers": 9,
+                        "maxSoldiers": 30
+                    })
+            });
+        var soldiers = findChild(summary, "inspectSoldiersValue");
+        verify(soldiers.visible);
+        compare(soldiers.text, "9 / 30 soldiers");
         summary.destroy();
     }
 

--- a/tests/ui/selected_units_model_test.cpp
+++ b/tests/ui/selected_units_model_test.cpp
@@ -48,6 +48,10 @@ struct SelectionFixture {
     return entity;
   }
 
+  [[nodiscard]] auto role_of(int row, int role) const -> QVariant {
+    return model->data(model->index(row, 0), role);
+  }
+
   [[nodiscard]] auto counted_in_groups() const -> int {
     int total = 0;
     for (const auto& group : model->grouped_by_type()) {
@@ -106,6 +110,40 @@ TEST(SelectedUnitsModel, KeepsARowPerSoldierWhenASelectedBuildingIsFilteredOut) 
   fixture.model->refresh();
   EXPECT_EQ(resets, 0) << "an unchanged selection must not rebuild the unit chips";
   EXPECT_EQ(fixture.model->rowCount(), 1);
+}
+
+TEST(SelectedUnitsModel, ReportsTheMenStillStandingInAFormationUnit) {
+  SelectionFixture fixture;
+  auto* archers = fixture.add_soldier(Game::Units::SpawnType::Archer);
+  fixture.model->refresh();
+  ASSERT_EQ(fixture.model->rowCount(), 1);
+
+  const int roster = fixture.role_of(0, SelectedUnitsModel::MaxSoldiersRole).toInt();
+  ASSERT_GT(roster, 1) << "archers fight as a formation, not as one body";
+  EXPECT_EQ(fixture.role_of(0, SelectedUnitsModel::SoldiersRole).toInt(), roster)
+      << "an undamaged unit must show a full roster";
+
+  archers->get_component<Engine::Core::UnitComponent>()->health = 50;
+  fixture.model->refresh();
+  const int survivors = fixture.role_of(0, SelectedUnitsModel::SoldiersRole).toInt();
+  EXPECT_LT(survivors, roster) << "half a unit's health is half its men";
+  EXPECT_GT(survivors, 0);
+  EXPECT_EQ(fixture.role_of(0, SelectedUnitsModel::MaxSoldiersRole).toInt(), roster)
+      << "casualties must not shrink the denominator";
+}
+
+TEST(SelectedUnitsModel, GroupsCarryTheSoldierCountsTheHudPrints) {
+  SelectionFixture fixture;
+  fixture.add_soldier(Game::Units::SpawnType::Archer);
+  fixture.add_soldier(Game::Units::SpawnType::Archer);
+  fixture.model->refresh();
+
+  const auto groups = fixture.model->grouped_by_type();
+  ASSERT_EQ(groups.size(), 1);
+  const QVariantMap group = groups.first().toMap();
+  const int roster = fixture.role_of(0, SelectedUnitsModel::MaxSoldiersRole).toInt();
+  EXPECT_EQ(group.value(QStringLiteral("maxSoldiers")).toInt(), roster * 2);
+  EXPECT_EQ(group.value(QStringLiteral("soldiers")).toInt(), roster * 2);
 }
 
 } // namespace

--- a/tests/ui/selection_grouping_test.cpp
+++ b/tests/ui/selection_grouping_test.cpp
@@ -26,6 +26,17 @@ auto unit(const QString& type,
   return entry;
 }
 
+auto formation(const QString& type,
+               const QString& name,
+               double health,
+               int soldiers,
+               int max_soldiers) -> QVariant {
+  QVariantMap entry = unit(type, name, health).toMap();
+  entry[QStringLiteral("soldiers")] = soldiers;
+  entry[QStringLiteral("max_soldiers")] = max_soldiers;
+  return entry;
+}
+
 TEST(SelectionGroupingTest, EmptySelectionProducesNoRows) {
   EXPECT_TRUE(group_selection_by_type({}).empty());
 }
@@ -187,12 +198,47 @@ TEST(SelectionGroupingTest, VariantConversionExposesTheKeysTheHudBindsTo) {
   EXPECT_EQ(row.value(QStringLiteral("nation")).toString(), QStringLiteral("carthage"));
   EXPECT_EQ(row.value(QStringLiteral("count")).toInt(), 1);
   EXPECT_EQ(row.value(QStringLiteral("woundedCount")).toInt(), 1);
+  EXPECT_TRUE(row.contains(QStringLiteral("soldiers")));
+  EXPECT_TRUE(row.contains(QStringLiteral("maxSoldiers")));
   EXPECT_NEAR(row.value(QStringLiteral("health")).toDouble(), 0.5, 1e-9);
   EXPECT_DOUBLE_EQ(row.value(QStringLiteral("stamina")).toDouble(), 1.0);
   EXPECT_TRUE(row.value(QStringLiteral("canRun")).toBool());
   EXPECT_EQ(row.value(QStringLiteral("activity")).toString(), QStringLiteral("idle"));
   EXPECT_EQ(row.value(QStringLiteral("activityState")).toString(),
             QStringLiteral("active"));
+}
+
+TEST(SelectionGroupingTest, AGroupAddsUpTheSoldiersStillStandingInIt) {
+  const QVariantList units{formation("archer", "Archer", 0.5, 15, 30),
+                           formation("archer", "Archer", 1.0, 30, 30),
+                           formation("archer", "Archer", 0.2, 6, 30)};
+
+  const auto groups = group_selection_by_type(units);
+
+  ASSERT_EQ(groups.size(), 1U);
+  EXPECT_EQ(groups[0].soldiers, 51);
+  EXPECT_EQ(groups[0].max_soldiers, 90)
+      << "the HUD reads a group as its living men out of the men it can hold";
+}
+
+TEST(SelectionGroupingTest, SoldierCountsNeverExceedTheUnitRoster) {
+  const QVariantList units{formation("archer", "Archer", 1.0, 99, 30),
+                           formation("archer", "Archer", 0.0, -4, 30)};
+
+  const auto groups = group_selection_by_type(units);
+
+  ASSERT_EQ(groups.size(), 1U);
+  EXPECT_EQ(groups[0].soldiers, 30);
+  EXPECT_EQ(groups[0].max_soldiers, 60);
+}
+
+TEST(SelectionGroupingTest, UnitsWithoutSoldierCountsReportNone) {
+  const auto groups = group_selection_by_type({unit("catapult", "Catapult", 1.0)});
+
+  ASSERT_EQ(groups.size(), 1U);
+  EXPECT_EQ(groups[0].soldiers, 0);
+  EXPECT_EQ(groups[0].max_soldiers, 0)
+      << "a selection built before soldier counts existed must not print 0 / 0";
 }
 
 TEST(SelectionGroupingTest, AGroupReportsTheActivityMostOfItIsDoing) {

--- a/tools/arena/arena_scenario_catalog.cpp
+++ b/tools/arena/arena_scenario_catalog.cpp
@@ -9635,6 +9635,195 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
 
   {
     auto s = definition(
+        QString::fromLatin1(k_promo_commander_rally_id),
+        QStringLiteral("Promo: The Consul Steps In"),
+        QStringLiteral("Afternoon capture scene. A thinned Roman line is being "
+                       "rolled up by twice its number until the consul walks up "
+                       "from the rear, calls the Consular Assault, and the legion "
+                       "turns the field with the horse coming round the flank."),
+        50.0F,
+        {30.0F, 26.0F, 0.0F});
+    s.camera_focus = QVector3D(0.0F, 1.0F, 0.0F);
+    s.select_spawned_units = false;
+    s.suppress_spawn_anchor = true;
+    s.suppress_ui_overlays = true;
+    s.force_full_creature_lod = true;
+    s.suppress_combat_dust = true;
+    s.graphics_quality = Render::GraphicsQuality::Ultra;
+    s.arena_floor_half_extent = 34.0F;
+    s.terrain_height_scale_override = 2.6F;
+
+    s.terrain_seed_override = 2024;
+    s.suppress_boundary_mountains = true;
+    {
+      constexpr int k_ring_mounds = 18;
+      constexpr float k_ring_radius = 44.0F;
+      for (int i = 0; i < k_ring_mounds; ++i) {
+        float const angle = 2.0F * std::numbers::pi_v<float> * static_cast<float>(i) /
+                            static_cast<float>(k_ring_mounds);
+        float const wobble = 0.5F * std::sin(static_cast<float>(i) * 2.3F);
+        s.elevation_patches.push_back(
+            {{k_ring_radius * std::sin(angle), 0.0F, k_ring_radius * std::cos(angle)},
+             20.0F,
+             14.5F + (2.5F * wobble)});
+      }
+    }
+    s.environment.start_time = 14.6F;
+    s.environment.time_mode = Game::Map::TimeMode::Locked;
+    s.environment.fog_density_override = 0.018F;
+    s.environment.exposure_override = 1.22F;
+
+    auto consul = group(QStringLiteral("roman_consul"),
+                        Troop::RomanVeteranConsul,
+                        1,
+                        1,
+                        {2.0F, 0.0F, -19.0F},
+                        1);
+    consul.health_override = consul.max_health_override = 12000;
+
+    auto roman_line = group(QStringLiteral("roman_line"),
+                            Troop::Swordsman,
+                            1,
+                            7,
+                            {-11.9F, 0.0F, -6.0F},
+                            12,
+                            {3.4F, 0.0F, 0.0F});
+    auto roman_spears = group(QStringLiteral("roman_spears"),
+                              Troop::Spearman,
+                              1,
+                              5,
+                              {-8.5F, 0.0F, -10.5F},
+                              12,
+                              {3.4F, 0.0F, 0.0F});
+
+    roman_line.max_health_override = 3200;
+    roman_line.health_override = 1400;
+    roman_spears.max_health_override = 3200;
+    roman_spears.health_override = 1500;
+
+    auto roman_horse = group(QStringLiteral("roman_horse"),
+                             Troop::MountedKnight,
+                             1,
+                             5,
+                             {24.0F, 0.0F, -10.0F},
+                             6,
+                             {3.6F, 0.0F, 0.0F});
+    roman_horse.max_health_override = roman_horse.health_override = 2400;
+
+    auto punic_horde = group(QStringLiteral("punic_horde"),
+                             Troop::Swordsman,
+                             2,
+                             9,
+                             {-15.3F, 0.0F, 7.0F},
+                             16,
+                             {3.4F, 0.0F, 0.0F});
+    auto punic_spears = group(QStringLiteral("punic_spears"),
+                              Troop::Spearman,
+                              2,
+                              6,
+                              {-10.2F, 0.0F, 11.5F},
+                              16,
+                              {3.4F, 0.0F, 0.0F});
+    auto punic_horse = group(QStringLiteral("punic_horse"),
+                             Troop::MountedKnight,
+                             2,
+                             4,
+                             {-26.0F, 0.0F, 12.0F},
+                             6,
+                             {3.6F, 0.0F, 0.0F});
+    punic_horde.max_health_override = punic_horde.health_override = 900;
+    punic_spears.max_health_override = punic_spears.health_override = 900;
+    punic_horse.max_health_override = punic_horse.health_override = 800;
+
+    s.groups = {consul,
+                roman_line,
+                roman_spears,
+                roman_horse,
+                punic_horde,
+                punic_spears,
+                punic_horse};
+
+    s.resource_patches = {
+        {QStringLiteral("pine"), 6, {-36.0F, 0.0F, -30.0F}, {4.0F, 0.0F, 2.5F}, 1.3F},
+        {QStringLiteral("pine"), 5, {-34.0F, 0.0F, 30.0F}, {4.2F, 0.0F, 2.0F}, 1.25F},
+        {QStringLiteral("pine"), 4, {8.0F, 0.0F, 34.0F}, {4.2F, 0.0F, 2.0F}, 1.2F},
+        {QStringLiteral("boulder"), 3, {-30.0F, 0.0F, 24.0F}, {3.4F, 0.0F, 2.0F}, 1.1F},
+        {QStringLiteral("boulder"),
+         2,
+         {-34.0F, 0.0F, -10.0F},
+         {3.6F, 0.0F, 2.0F},
+         1.0F},
+    };
+
+    auto consul_walk = at(8.0F, Command::Move, QStringLiteral("roman_consul"));
+    consul_walk.destination = {2.0F, 0.0F, -9.0F};
+
+    auto rally =
+        at(17.4F, Command::TriggerCommanderAura, QStringLiteral("roman_consul"));
+    rally.value = 18;
+
+    auto first_blood = at(6.0F, Command::ApplyDamage, QStringLiteral("roman_line"));
+    first_blood.value = 110;
+    auto second_blood = at(10.5F, Command::ApplyDamage, QStringLiteral("roman_spears"));
+    second_blood.value = 130;
+    auto third_blood = at(14.0F, Command::ApplyDamage, QStringLiteral("roman_line"));
+    third_blood.value = 120;
+
+    s.steps = {
+        at(0.2F, Command::Hold, QStringLiteral("roman_line")),
+        at(0.2F, Command::Hold, QStringLiteral("roman_spears")),
+        at(0.2F, Command::Hold, QStringLiteral("roman_horse")),
+        at(0.4F,
+           Command::AttackMove,
+           QStringLiteral("punic_horde"),
+           QStringLiteral("roman_line")),
+        at(0.6F,
+           Command::AttackMove,
+           QStringLiteral("punic_spears"),
+           QStringLiteral("roman_spears")),
+        first_blood,
+        at(6.5F,
+           Command::Charge,
+           QStringLiteral("punic_horse"),
+           QStringLiteral("roman_spears")),
+        second_blood,
+        consul_walk,
+        third_blood,
+        rally,
+        at(17.8F,
+           Command::AttackMove,
+           QStringLiteral("roman_line"),
+           QStringLiteral("punic_horde")),
+        at(18.0F,
+           Command::AttackMove,
+           QStringLiteral("roman_spears"),
+           QStringLiteral("punic_spears")),
+        at(18.2F,
+           Command::Charge,
+           QStringLiteral("roman_consul"),
+           QStringLiteral("punic_horde")),
+        at(18.6F,
+           Command::Charge,
+           QStringLiteral("roman_horse"),
+           QStringLiteral("punic_horde")),
+    };
+
+    s.expectations = {
+        expectation(Expect::GroupExists, QStringLiteral("roman_consul")),
+        expectation(Expect::GroupIsRendered, QStringLiteral("roman_line")),
+        expectation(Expect::GroupIsRendered, QStringLiteral("punic_horde")),
+        expectation(Expect::GroupIsRendered, QStringLiteral("roman_consul")),
+        expectation(Expect::GroupIsRendered, QStringLiteral("roman_horse")),
+        expectation(Expect::CommanderAuraActivated, QStringLiteral("roman_consul")),
+        expectation(Expect::CommanderAuraBuffObserved, QStringLiteral("roman_line")),
+        expectation(Expect::AttackAnimationObserved, QStringLiteral("punic_horde")),
+        expectation(Expect::DeathAnimationObserved, QStringLiteral("punic_horde")),
+    };
+    result.push_back(std::move(s));
+  }
+
+  {
+    auto s = definition(
         QString::fromLatin1(k_promo_wolf_attack_id),
         QStringLiteral("Promo: Wolves on the Fold"),
         QStringLiteral("Late-afternoon capture scene. A pack comes out of the east "

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -211,6 +211,7 @@ inline constexpr char k_promo_last_stand_id[] = "promo_last_stand";
 inline constexpr char k_promo_night_of_the_dead_id[] = "promo_night_of_the_dead";
 inline constexpr char k_promo_storm_charge_id[] = "promo_storm_charge";
 inline constexpr char k_promo_commander_duel_id[] = "promo_commander_duel";
+inline constexpr char k_promo_commander_rally_id[] = "promo_commander_rally";
 inline constexpr char k_promo_wolf_attack_id[] = "promo_wolf_attack";
 
 inline constexpr char k_ambience_night_watch_id[] = "ambience_night_watch";

--- a/tools/arena/promo_spec.cpp
+++ b/tools/arena/promo_spec.cpp
@@ -5,6 +5,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
+#include <QStringList>
 
 #include <algorithm>
 #include <cmath>
@@ -100,14 +101,18 @@ auto ease_value(Ease ease, float t) -> float {
   return clamped * clamped * (3.0F - (2.0F * clamped));
 }
 
-auto lerp_yaw(float from, float to, float blend) -> float {
+auto shorter_arc(float from, float to) -> float {
   float delta = std::fmod(to - from, 360.0F);
   if (delta > 180.0F) {
     delta -= 360.0F;
   } else if (delta < -180.0F) {
     delta += 360.0F;
   }
-  return from + (delta * blend);
+  return delta;
+}
+
+auto lerp_yaw(float from, float to, float blend) -> float {
+  return from + (shorter_arc(from, to) * blend);
 }
 
 auto hash_noise(int seed) -> float {
@@ -383,7 +388,107 @@ auto load(const QString& path, QString* error) -> std::optional<Spec> {
     spec.shots.push_back(std::move(shot));
   }
 
+  if (auto const breaches = motion_violations(spec); !breaches.empty()) {
+    if (error != nullptr) {
+      QStringList lines;
+      lines.reserve(static_cast<int>(breaches.size()));
+      for (const QString& breach : breaches) {
+        lines.push_back(breach);
+      }
+      *error = QStringLiteral("promo spec '%1' has camera work that is unwatchable "
+                              "on a phone:\n  %2")
+                   .arg(spec.id, lines.join(QStringLiteral("\n  ")));
+    }
+    return std::nullopt;
+  }
+
   return spec;
+}
+
+auto motion_violations(const Spec& spec,
+                       const MotionLimits& limits) -> std::vector<QString> {
+  std::vector<QString> breaches;
+  float total_clip_seconds = 0.0F;
+  int measured_shots = 0;
+
+  auto report = [&breaches](const QString& shot, const QString& what) {
+    breaches.push_back(QStringLiteral("%1: %2").arg(shot, what));
+  };
+
+  for (const Shot& shot : spec.shots) {
+    if (shot.flame_card) {
+      continue;
+    }
+    float const clip_seconds = shot.duration_seconds * shot.slow_motion;
+    total_clip_seconds += clip_seconds;
+    ++measured_shots;
+
+    if (clip_seconds + 1e-3F < limits.minimum_clip_seconds) {
+      report(shot.name,
+             QStringLiteral("is on screen for %1 s, under the %2 s a viewer needs to "
+                            "read a frame")
+                 .arg(clip_seconds, 0, 'f', 2)
+                 .arg(limits.minimum_clip_seconds, 0, 'f', 2));
+    }
+    if (shot.shake > limits.shake + 1e-4F) {
+      report(shot.name,
+             QStringLiteral("shakes at %1, over the %2 ceiling")
+                 .arg(shot.shake, 0, 'f', 3)
+                 .arg(limits.shake, 0, 'f', 3));
+    }
+    if (shot.gameplay_camera) {
+      continue;
+    }
+
+    for (const CameraKey& key : shot.keys) {
+      if (std::abs(key.roll) > limits.roll_magnitude_degrees + 1e-4F) {
+        report(shot.name,
+               QStringLiteral("rolls the horizon %1 degrees, over the %2 ceiling")
+                   .arg(std::abs(key.roll), 0, 'f', 1)
+                   .arg(limits.roll_magnitude_degrees, 0, 'f', 1));
+        break;
+      }
+    }
+
+    for (std::size_t index = 1; index < shot.keys.size(); ++index) {
+      const CameraKey& from = shot.keys[index - 1];
+      const CameraKey& to = shot.keys[index];
+      float const span = std::max(0.001F, to.time - from.time);
+
+      auto rate = [&](const QString& what, float delta, float limit) {
+        float const measured = std::abs(delta) / span;
+        if (measured > limit + 1e-3F) {
+          report(shot.name,
+                 QStringLiteral("swings %1 at %2 deg/s, over the %3 deg/s ceiling")
+                     .arg(what)
+                     .arg(measured, 0, 'f', 1)
+                     .arg(limit, 0, 'f', 1));
+        }
+      };
+
+      rate(QStringLiteral("yaw"),
+           shorter_arc(from.yaw, to.yaw),
+           limits.yaw_degrees_per_second);
+      rate(QStringLiteral("pitch"),
+           to.pitch - from.pitch,
+           limits.pitch_degrees_per_second);
+      rate(QStringLiteral("fov"), to.fov - from.fov, limits.fov_degrees_per_second);
+      rate(QStringLiteral("roll"), to.roll - from.roll, limits.roll_degrees_per_second);
+    }
+  }
+
+  if (measured_shots > 0) {
+    float const mean = total_clip_seconds / static_cast<float>(measured_shots);
+    if (mean + 1e-3F < limits.mean_clip_seconds) {
+      breaches.push_back(
+          QStringLiteral("the cut averages %1 s a shot, under the %2 s that keeps a "
+                         "reel from reading as strobing")
+              .arg(mean, 0, 'f', 2)
+              .arg(limits.mean_clip_seconds, 0, 'f', 2));
+    }
+  }
+
+  return breaches;
 }
 
 } // namespace Arena::Promo

--- a/tools/arena/promo_spec.h
+++ b/tools/arena/promo_spec.h
@@ -65,6 +65,17 @@ struct Shot {
   std::vector<CameraKey> keys;
 };
 
+struct MotionLimits {
+  float yaw_degrees_per_second{12.0F};
+  float pitch_degrees_per_second{6.0F};
+  float fov_degrees_per_second{6.0F};
+  float roll_degrees_per_second{4.0F};
+  float roll_magnitude_degrees{5.0F};
+  float shake{0.03F};
+  float minimum_clip_seconds{1.5F};
+  float mean_clip_seconds{2.0F};
+};
+
 struct Spec {
   QString id;
   QString title;
@@ -94,6 +105,9 @@ struct CapturePass {
 [[nodiscard]] auto plan_passes(const Spec& spec) -> std::vector<CapturePass>;
 
 [[nodiscard]] auto load(const QString& path, QString* error) -> std::optional<Spec>;
+
+[[nodiscard]] auto motion_violations(const Spec& spec, const MotionLimits& limits = {})
+    -> std::vector<QString>;
 
 [[nodiscard]] auto evaluate(const std::vector<CameraKey>& keys,
                             float shot_time) -> Pose;

--- a/tools/arena/promos/commander_duel.json
+++ b/tools/arena/promos/commander_duel.json
@@ -83,7 +83,7 @@
       "start": 6.45,
       "duration": 1.05,
       "slow_motion": 2.4,
-      "shake": 0.05,
+      "shake": 0.03,
       "focus": {
         "mode": "group_pair",
         "group": "scipio",
@@ -104,7 +104,7 @@
           "time": 2.52,
           "distance": 7.8,
           "pitch": 16,
-          "yaw": 14,
+          "yaw": 21.76,
           "fov": 38,
           "height": 1.5,
           "roll": 2,
@@ -156,7 +156,7 @@
       "start": 13.35,
       "duration": 1.05,
       "slow_motion": 2.2,
-      "shake": 0.04,
+      "shake": 0.03,
       "focus": {
         "mode": "group_pair",
         "group": "scipio",
@@ -176,7 +176,7 @@
           "time": 2.31,
           "distance": 7.2,
           "pitch": 15,
-          "yaw": 338,
+          "yaw": 338.28,
           "fov": 38,
           "height": 1.5,
           "ease": "linear"
@@ -228,7 +228,7 @@
       "start": 20.1,
       "duration": 1.1,
       "slow_motion": 2.2,
-      "shake": 0.045,
+      "shake": 0.03,
       "focus": {
         "mode": "group_pair",
         "group": "scipio",
@@ -249,7 +249,7 @@
           "time": 2.42,
           "distance": 7.4,
           "pitch": 15,
-          "yaw": 122,
+          "yaw": 87.04,
           "fov": 38,
           "height": 1.5,
           "roll": -2,
@@ -269,7 +269,7 @@
       "start": 31.85,
       "duration": 1.6,
       "slow_motion": 2.4,
-      "shake": 0.05,
+      "shake": 0.03,
       "focus": {
         "mode": "group_pair",
         "group": "scipio",

--- a/tools/arena/promos/commander_rally.json
+++ b/tools/arena/promos/commander_rally.json
@@ -1,0 +1,518 @@
+{
+  "id": "commander_rally",
+  "title": "AVERAGE ROMAN COMMANDER",
+  "subtitle": "STANDARD OF IRON",
+  "width": 1080,
+  "height": 1920,
+  "fps": 60,
+  "supersample": 1,
+  "transition": {
+    "type": "cut"
+  },
+  "shots": [
+    {
+      "name": "the_field",
+      "scenario": "promo_commander_rally",
+      "start": 12.0,
+      "duration": 3.4286,
+      "slow_motion": 1.0,
+      "focus": {
+        "mode": "group_pair",
+        "group": "roman_line",
+        "second_group": "punic_horde",
+        "smoothing": 0.6
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 18.0,
+          "pitch": 14,
+          "yaw": 96,
+          "fov": 44,
+          "height": 1.9
+        },
+        {
+          "time": 3.429,
+          "distance": 15.6,
+          "pitch": 13,
+          "yaw": 100,
+          "fov": 44,
+          "height": 1.85,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "ROME IS LOSING",
+      "punch": [
+        {
+          "at": 0.0,
+          "amount": 0.11,
+          "decay": 0.236
+        },
+        {
+          "at": 1.714,
+          "amount": 0.07,
+          "decay": 0.236
+        }
+      ]
+    },
+    {
+      "name": "walk_in",
+      "scenario": "promo_commander_rally",
+      "start": 15.5,
+      "duration": 1.7143,
+      "slow_motion": 3.0,
+      "focus": {
+        "mode": "group",
+        "group": "roman_consul",
+        "smoothing": 0.3
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 7.6,
+          "pitch": 7,
+          "yaw": 112,
+          "fov": 34,
+          "height": 1.72
+        },
+        {
+          "time": 5.143,
+          "distance": 6.0,
+          "pitch": 8,
+          "yaw": 116,
+          "fov": 34,
+          "height": 1.68,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "AVERAGE ROMAN COMMANDER",
+      "punch": [
+        {
+          "at": 0.0,
+          "amount": 0.11,
+          "decay": 0.236
+        },
+        {
+          "at": 1.714,
+          "amount": 0.07,
+          "decay": 0.236
+        },
+        {
+          "at": 3.429,
+          "amount": 0.07,
+          "decay": 0.236
+        }
+      ]
+    },
+    {
+      "name": "he_walks",
+      "scenario": "promo_commander_rally",
+      "start": 16.3,
+      "duration": 1.3187,
+      "slow_motion": 2.6,
+      "focus": {
+        "mode": "group",
+        "group": "roman_consul",
+        "smoothing": 0.25
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 6.2,
+          "pitch": 6,
+          "yaw": 16,
+          "fov": 32,
+          "height": 1.74
+        },
+        {
+          "time": 3.429,
+          "distance": 4.6,
+          "pitch": 6,
+          "yaw": 12,
+          "fov": 32,
+          "height": 1.7,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "HIM:",
+      "punch": [
+        {
+          "at": 0.0,
+          "amount": 0.11,
+          "decay": 0.236
+        },
+        {
+          "at": 1.714,
+          "amount": 0.07,
+          "decay": 0.236
+        }
+      ]
+    },
+    {
+      "name": "rally",
+      "scenario": "promo_commander_rally",
+      "start": 17.2,
+      "duration": 1.4286,
+      "slow_motion": 2.4,
+      "focus": {
+        "mode": "group",
+        "group": "roman_consul",
+        "smoothing": 0.2
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 8.4,
+          "pitch": 10,
+          "yaw": 124,
+          "fov": 42,
+          "height": 1.8
+        },
+        {
+          "time": 3.429,
+          "distance": 7.6,
+          "pitch": 11,
+          "yaw": 130,
+          "fov": 42,
+          "height": 1.78,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "CONSULAR ASSAULT",
+      "punch": [
+        {
+          "at": 0.0,
+          "amount": 0.11,
+          "decay": 0.236
+        },
+        {
+          "at": 1.714,
+          "amount": 0.07,
+          "decay": 0.236
+        }
+      ]
+    },
+    {
+      "name": "the_charge",
+      "scenario": "promo_commander_rally",
+      "start": 21.8,
+      "duration": 2.5714,
+      "slow_motion": 1.0,
+      "focus": {
+        "mode": "group",
+        "group": "roman_horse",
+        "smoothing": 0.4
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 11.5,
+          "pitch": 20,
+          "yaw": 24,
+          "fov": 46,
+          "height": 1.9
+        },
+        {
+          "time": 2.571,
+          "distance": 9.4,
+          "pitch": 16,
+          "yaw": 14,
+          "fov": 46,
+          "height": 1.75,
+          "ease": "smooth"
+        }
+      ],
+      "punch": [
+        {
+          "at": 0.0,
+          "amount": 0.11,
+          "decay": 0.236
+        },
+        {
+          "at": 1.714,
+          "amount": 0.07,
+          "decay": 0.236
+        }
+      ]
+    },
+    {
+      "name": "signature",
+      "scenario": "promo_commander_rally",
+      "start": 25.5,
+      "duration": 1.1688,
+      "slow_motion": 2.2,
+      "focus": {
+        "mode": "group",
+        "group": "roman_consul",
+        "smoothing": 0.18
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 5.6,
+          "pitch": 10,
+          "yaw": 140,
+          "fov": 36,
+          "height": 1.76
+        },
+        {
+          "time": 2.569,
+          "distance": 5.0,
+          "pitch": 11,
+          "yaw": 146,
+          "fov": 36,
+          "height": 1.72,
+          "ease": "smooth"
+        }
+      ],
+      "freeze": 0.8571,
+      "freeze_text": "SKILL ISSUE",
+      "punch": [
+        {
+          "at": 0.0,
+          "amount": 0.11,
+          "decay": 0.236
+        },
+        {
+          "at": 1.714,
+          "amount": 0.07,
+          "decay": 0.236
+        }
+      ]
+    },
+    {
+      "name": "they_break",
+      "scenario": "promo_commander_rally",
+      "start": 33.5,
+      "duration": 2.5714,
+      "slow_motion": 1.0,
+      "focus": {
+        "mode": "group_pair",
+        "group": "punic_horde",
+        "second_group": "roman_horse",
+        "smoothing": 0.45
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 8.4,
+          "pitch": 12,
+          "yaw": 150,
+          "fov": 42,
+          "height": 1.8
+        },
+        {
+          "time": 2.571,
+          "distance": 10.4,
+          "pitch": 14,
+          "yaw": 144,
+          "fov": 42,
+          "height": 1.85,
+          "ease": "smooth"
+        }
+      ],
+      "punch": [
+        {
+          "at": 0.0,
+          "amount": 0.11,
+          "decay": 0.236
+        },
+        {
+          "at": 1.714,
+          "amount": 0.07,
+          "decay": 0.236
+        }
+      ]
+    },
+    {
+      "name": "after",
+      "scenario": "promo_commander_rally",
+      "start": 44.6,
+      "duration": 4.0,
+      "slow_motion": 1.5,
+      "focus": {
+        "mode": "group_pair",
+        "group": "roman_consul",
+        "second_group": "roman_horse",
+        "smoothing": 0.6
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 6.5,
+          "pitch": 9,
+          "yaw": 116,
+          "fov": 42,
+          "height": 1.76
+        },
+        {
+          "time": 6.0,
+          "distance": 12.0,
+          "pitch": 18,
+          "yaw": 124,
+          "fov": 42,
+          "height": 1.92,
+          "ease": "smooth"
+        }
+      ],
+      "punch": [
+        {
+          "at": 0.0,
+          "amount": 0.11,
+          "decay": 0.236
+        },
+        {
+          "at": 1.714,
+          "amount": 0.07,
+          "decay": 0.236
+        },
+        {
+          "at": 3.429,
+          "amount": 0.07,
+          "decay": 0.236
+        },
+        {
+          "at": 5.143,
+          "amount": 0.07,
+          "decay": 0.236
+        }
+      ]
+    }
+  ],
+  "grade": {
+    "contrast": 1.16,
+    "saturation": 0.9,
+    "brightness": 0.0,
+    "gamma": 0.99,
+    "grain": 4,
+    "vignette": 0.22
+  },
+  "music": "artifacts/promo/reel_beat.ogg",
+  "music_start": 3.429,
+  "sfx": [
+    {
+      "file": "assets/audio/sfx/combat/battlefield_distant_mass_01.ogg",
+      "at": 0.1,
+      "gain": 1.2
+    },
+    {
+      "file": "assets/audio/sfx/combat/roman_shield_wall_impact.ogg",
+      "at": 0.25,
+      "gain": 1.8
+    },
+    {
+      "file": "assets/audio/sfx/combat/human_death_cry.ogg",
+      "at": 0.85,
+      "gain": 2.4
+    },
+    {
+      "file": "assets/audio/sfx/combat/gladius_shield_impacts_close.ogg",
+      "at": 0.9,
+      "gain": 1.35
+    },
+    {
+      "file": "assets/audio/sfx/combat/battlefield_crowd_chaos.ogg",
+      "at": 1.6,
+      "gain": 1.1
+    },
+    {
+      "file": "assets/audio/sfx/combat/human_death_cry.ogg",
+      "at": 1.68,
+      "gain": 2.4
+    },
+    {
+      "file": "assets/audio/sfx/orders/attack_horn_stab.ogg",
+      "at": 11.51,
+      "gain": 2.3
+    },
+    {
+      "file": "assets/audio/sfx/combat/roman_war_horns_orders.ogg",
+      "at": 11.51,
+      "gain": 1.7
+    },
+    {
+      "file": "assets/audio/sfx/combat/roman_cavalry_charge.ogg",
+      "at": 15.48,
+      "gain": 1.65
+    },
+    {
+      "file": "assets/audio/sfx/combat/horse_gallop_close_pass.ogg",
+      "at": 16.63,
+      "gain": 1.45
+    },
+    {
+      "file": "assets/audio/sfx/combat/human_death_cry.ogg",
+      "at": 17.4,
+      "gain": 2.4
+    },
+    {
+      "file": "assets/audio/sfx/combat/roman_shield_wall_impact.ogg",
+      "at": 17.73,
+      "gain": 1.9
+    },
+    {
+      "file": "assets/audio/sfx/combat/blade_clash_03.ogg",
+      "at": 18.0,
+      "gain": 2.2
+    },
+    {
+      "file": "assets/audio/sfx/combat/sword_hit_03.ogg",
+      "at": 18.06,
+      "gain": 1.6
+    },
+    {
+      "file": "assets/audio/sfx/combat/blade_clash_04.ogg",
+      "at": 18.33,
+      "gain": 2.2
+    },
+    {
+      "file": "assets/audio/sfx/combat/sword_hit_04.ogg",
+      "at": 18.39,
+      "gain": 1.6
+    },
+    {
+      "file": "assets/audio/sfx/combat/blade_clash_01.ogg",
+      "at": 18.66,
+      "gain": 2.2
+    },
+    {
+      "file": "assets/audio/sfx/combat/sword_hit_01.ogg",
+      "at": 18.72,
+      "gain": 1.6
+    },
+    {
+      "file": "assets/audio/sfx/combat/blade_clash_02.ogg",
+      "at": 18.99,
+      "gain": 2.2
+    },
+    {
+      "file": "assets/audio/sfx/combat/sword_hit_02.ogg",
+      "at": 19.05,
+      "gain": 1.6
+    },
+    {
+      "file": "assets/audio/sfx/combat/blade_clash_03.ogg",
+      "at": 19.32,
+      "gain": 2.2
+    },
+    {
+      "file": "assets/audio/sfx/combat/sword_hit_03.ogg",
+      "at": 19.38,
+      "gain": 1.6
+    },
+    {
+      "file": "assets/audio/sfx/combat/vanguard_rush.ogg",
+      "at": 20.77,
+      "gain": 1.25
+    },
+    {
+      "file": "assets/audio/sfx/combat/soldiers_victory_cheer.ogg",
+      "at": 23.84,
+      "gain": 1.2
+    }
+  ],
+  "beat": {
+    "bpm": 140.0,
+    "beat_seconds": 0.42857142857142855
+  }
+}

--- a/tools/arena/promos/last_stand.json
+++ b/tools/arena/promos/last_stand.json
@@ -42,7 +42,7 @@
       "name": "horde_advance",
       "scenario": "promo_last_stand",
       "start": 2.4,
-      "duration": 1.3,
+      "duration": 1.5,
       "slow_motion": 1.0,
       "focus": {
         "mode": "group",
@@ -77,7 +77,7 @@
       "start": 4.6,
       "duration": 1.1,
       "slow_motion": 2.5,
-      "shake": 0.06,
+      "shake": 0.03,
       "focus": {
         "mode": "group_pair",
         "group": "roman_line",
@@ -97,7 +97,7 @@
           "time": 1.1,
           "distance": 8.5,
           "pitch": 17,
-          "yaw": 104,
+          "yaw": 104.8,
           "fov": 52,
           "height": 1.6,
           "ease": "linear"
@@ -111,7 +111,7 @@
       "start": 6.2,
       "duration": 1.5,
       "slow_motion": 2.0,
-      "shake": 0.04,
+      "shake": 0.03,
       "focus": {
         "mode": "group",
         "group": "punic_cavalry",
@@ -131,10 +131,10 @@
           "time": 1.5,
           "distance": 9.0,
           "pitch": 13,
-          "yaw": 96,
+          "yaw": 92.0,
           "fov": 50,
           "height": 1.6,
-          "roll": -4,
+          "roll": -2.0,
           "ease": "linear"
         }
       ],
@@ -165,7 +165,7 @@
           "time": 2.3,
           "distance": 12,
           "pitch": 17.0,
-          "yaw": 196.0,
+          "yaw": 177.6,
           "fov": 46,
           "height": 1.4,
           "ease": "linear"
@@ -200,7 +200,7 @@
           "yaw": 138,
           "fov": 46,
           "height": 1.4,
-          "roll": 3,
+          "roll": 2.4,
           "ease": "out"
         }
       ]
@@ -227,7 +227,7 @@
         {
           "time": 3.0,
           "distance": 33,
-          "pitch": 35,
+          "pitch": 32.0,
           "yaw": 226.0,
           "fov": 44,
           "height": 1.0,

--- a/tools/arena/promos/night_of_the_dead.json
+++ b/tools/arena/promos/night_of_the_dead.json
@@ -108,7 +108,7 @@
       "start": 11.0,
       "duration": 1.2,
       "slow_motion": 2.2,
-      "shake": 0.05,
+      "shake": 0.03,
       "focus": {
         "mode": "group",
         "group": "roman_column",
@@ -159,10 +159,10 @@
           "time": 1.1,
           "distance": 6.0,
           "pitch": 8,
-          "yaw": 6,
+          "yaw": 8.8,
           "fov": 50,
           "height": 2.2,
-          "roll": -3,
+          "roll": -1.4,
           "ease": "linear"
         }
       ]
@@ -189,7 +189,7 @@
         {
           "time": 2.8,
           "distance": 28,
-          "pitch": 32,
+          "pitch": 28.8,
           "yaw": 238,
           "fov": 44,
           "height": 1.2,

--- a/tools/arena/promos/storm_charge.json
+++ b/tools/arena/promos/storm_charge.json
@@ -67,7 +67,7 @@
           "yaw": 78,
           "fov": 50,
           "height": 1.6,
-          "roll": 4,
+          "roll": 2.0,
           "ease": "linear"
         }
       ],
@@ -110,7 +110,7 @@
       "start": 6.6,
       "duration": 1.1,
       "slow_motion": 2.5,
-      "shake": 0.07,
+      "shake": 0.03,
       "focus": {
         "mode": "group_pair",
         "group": "roman_cavalry",
@@ -130,7 +130,7 @@
           "time": 1.1,
           "distance": 8.5,
           "pitch": 16,
-          "yaw": 112,
+          "yaw": 111.2,
           "fov": 52,
           "height": 1.6,
           "ease": "linear"
@@ -193,7 +193,7 @@
         {
           "time": 2.8,
           "distance": 34,
-          "pitch": 34,
+          "pitch": 31.8,
           "yaw": 176,
           "fov": 44,
           "height": 1.0,

--- a/tools/audio_synth/reel_score.py
+++ b/tools/audio_synth/reel_score.py
@@ -1,0 +1,223 @@
+"""A beat-driven bed for short-form reels, and the grid it was built on.
+
+The game's music is orchestral and through-composed: it swells, it rests, and
+nothing in it lands on a grid. A short-form reel is cut the other way round --
+the picture is cut *to* a beat, and every hit lands on one. Scoring a reel with
+a battle track means the cuts fall wherever the story falls, which is why a reel
+scored that way reads as a trailer rather than as an edit.
+
+So this synthesises its own bed, with the same standard-library toolkit the cue
+sounds use, and hands back the exact grid it laid: nothing has to be detected
+because nothing was guessed. `scripts/beat-align.py` quantises a promo spec's
+shot lengths onto that grid.
+
+    python3 tools/audio_synth/reel_score.py --bpm 140 --bars 22 \
+        --out artifacts/promo/reel_beat.ogg
+
+Half-time is the point: at 140 BPM the kick lands on beats 1 and 3, which reads
+as a 70 BPM stride under 140 BPM hats. That is the tempo a slow walk cuts to.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import dsp
+
+BEATS_PER_BAR = 4
+
+
+def kick(seed: int) -> list[float]:
+    """Sub-heavy 808: a pitch drop with a click on the front of it."""
+    body = dsp.sweep(96.0, 41.0, dsp.seconds(0.42), curve=0.35)
+    body = dsp.apply(body, dsp.env_ad(len(body), attack=0.002, decay=0.40, curve=2.2))
+    click = dsp.bandpass(dsp.noise(dsp.seconds(0.012), seed), 2200.0, 1.4)
+    click = dsp.apply(click, dsp.env_perc(len(click), attack=0.0005, curve=3.0))
+    return dsp.softclip(dsp.mix(body, dsp.gain_of(click, 0.35)), drive=1.6)
+
+
+def sub(note_hz: float, length: float, seed: int) -> list[float]:
+    """The long tail under a bar: one note, no movement, felt more than heard."""
+    tone = dsp.sine(note_hz, dsp.seconds(length))
+    tone = dsp.apply(tone, dsp.env_ad(len(tone), attack=0.01, decay=length, curve=1.4))
+    return dsp.lowpass(dsp.softclip(tone, drive=1.3), 180.0, 0.8)
+
+
+def snare(seed: int) -> list[float]:
+    """Clap-ish backbeat: two noise bursts a few milliseconds apart."""
+
+    def burst(offset: int, level: float) -> list[float]:
+        raw = dsp.bandpass(dsp.noise(dsp.seconds(0.19), seed + offset), 1750.0, 1.1)
+        raw = dsp.apply(raw, dsp.env_perc(len(raw), attack=0.001, curve=2.6))
+        return dsp.gain_of(raw, level)
+
+    out = burst(0, 1.0)
+    out = dsp.place(out, burst(7, 0.55), 0.011)
+    body = dsp.modal(dsp.seconds(0.12), [(190.0, 0.06, 0.5), (330.0, 0.04, 0.3)], seed)
+    return dsp.mix(out, dsp.gain_of(body, 0.4))
+
+
+def hat(seed: int, open_hat: bool = False) -> list[float]:
+    length = dsp.seconds(0.16 if open_hat else 0.035)
+    raw = dsp.highpass(dsp.noise(length, seed), 7200.0, 0.9)
+    return dsp.apply(raw, dsp.env_perc(len(raw), attack=0.0004, curve=3.2))
+
+
+def cowbell(freq: float, seed: int) -> list[float]:
+    """The phonk signature: two inharmonic partials, struck and dry."""
+    return dsp.modal(
+        dsp.seconds(0.30),
+        [(freq, 0.10, 1.0), (freq * 1.5, 0.07, 0.7), (freq * 2.42, 0.03, 0.25)],
+        seed,
+    )
+
+
+def drone(note_hz: float, length: float, seed: int) -> list[float]:
+    """A dark held chord: root, fifth and a detuned octave, filtered down."""
+    n = dsp.seconds(length)
+    voices = dsp.mix(
+        dsp.gain_of(dsp.sine(note_hz, n), 1.0),
+        dsp.gain_of(dsp.sine(note_hz * 1.4983, n), 0.55),
+        dsp.gain_of(dsp.sine(note_hz * 2.006, n), 0.32),
+        dsp.gain_of(dsp.pink(n, seed), 0.05),
+    )
+    swept = dsp.moving_bandpass(voices, 220.0, 900.0, 0.9)
+    return dsp.apply(swept, dsp.env_swell(n, peak=0.35, curve=1.5))
+
+
+def render(
+    bpm: float, bars: int, root_hz: float, seed: int
+) -> tuple[list[float], dict]:
+    """Lay the bed and return it with the grid, in seconds."""
+    beat = 60.0 / bpm
+    bar = beat * BEATS_PER_BAR
+    total = bar * bars
+    rng = random.Random(seed)
+
+    track = dsp.silence(dsp.seconds(total + 1.2))
+
+    intro_bars = 2
+    hole_bar = intro_bars + int((bars - intro_bars) * 0.62)
+
+    progression = [1.0, 1.0, 1.1892, 0.8909]
+    accents: list[float] = []
+
+    for bar_index in range(bars):
+        at = bar_index * bar
+        note = root_hz * progression[bar_index % len(progression)]
+        track = dsp.place(
+            track, dsp.gain_of(drone(note, bar, seed + bar_index), 0.16), at
+        )
+        if bar_index >= intro_bars:
+            accents.append(round(at, 4))
+
+        playing = bar_index >= intro_bars and bar_index != hole_bar
+        if not playing:
+            for eighth in range(BEATS_PER_BAR * 2):
+                if eighth % 2 == 0:
+                    track = dsp.place(
+                        track,
+                        dsp.gain_of(hat(seed + eighth + bar_index * 31), 0.10),
+                        at + eighth * beat / 2.0,
+                    )
+            continue
+
+        track = dsp.place(
+            track, dsp.gain_of(sub(note * 0.5, bar * 0.9, seed), 0.55), at
+        )
+        for kick_beat in (0.0, 2.0, 2.75):
+            track = dsp.place(
+                track, dsp.gain_of(kick(seed + bar_index), 0.95), at + kick_beat * beat
+            )
+        for snare_beat in (1.0, 3.0):
+            track = dsp.place(
+                track,
+                dsp.gain_of(snare(seed + bar_index * 7), 0.50),
+                at + snare_beat * beat,
+            )
+        for sixteenth in range(BEATS_PER_BAR * 4):
+            when = at + sixteenth * beat / 4.0
+            if sixteenth % 2 == 0:
+                level = 0.16 if sixteenth % 4 == 0 else 0.11
+                track = dsp.place(
+                    track, dsp.gain_of(hat(seed + sixteenth), level), when
+                )
+            elif rng.random() < 0.22:
+                track = dsp.place(
+                    track, dsp.gain_of(hat(seed + sixteenth + 3), 0.07), when
+                )
+        if bar_index % 2 == 1:
+            for bell_beat in (1.5, 3.5):
+                track = dsp.place(
+                    track,
+                    dsp.gain_of(cowbell(root_hz * 12.0, seed + bar_index), 0.13),
+                    at + bell_beat * beat,
+                )
+
+    track = dsp.softclip(track, drive=1.15)
+    track = dsp.fade_out(dsp.normalize(track, -1.2), 0.6)
+    grid = {
+        "bpm": bpm,
+        "first_beat": 0.0,
+        "beat_seconds": beat,
+        "bar_seconds": bar,
+        "beats_per_bar": BEATS_PER_BAR,
+        "duration_seconds": round(len(track) / dsp.SR, 3),
+        "drums_in": round(intro_bars * bar, 3),
+        "hole": round(hole_bar * bar, 3),
+        "bar_starts": accents,
+    }
+    return track, grid
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bpm", type=float, default=140.0)
+    parser.add_argument("--bars", type=int, default=22)
+    parser.add_argument(
+        "--root", type=float, default=43.65, help="root note in Hz (F1)"
+    )
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+
+    track, grid = render(args.bpm, args.bars, args.root, args.seed)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as work:
+        wav = Path(work) / "reel.wav"
+        dsp.write_wav(wav, track)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-v",
+                "error",
+                "-y",
+                "-i",
+                str(wav),
+                "-c:a",
+                "libvorbis",
+                "-q:a",
+                "5",
+                str(args.out),
+            ],
+            check=True,
+        )
+    grid_path = args.out.with_suffix(".grid.json")
+    grid_path.write_text(json.dumps(grid, indent=2) + "\n")
+    print(
+        f"wrote {args.out} ({grid['duration_seconds']}s at {args.bpm} BPM) "
+        f"and {grid_path.name}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ui/qml/CampaignScreen.qml
+++ b/ui/qml/CampaignScreen.qml
@@ -132,6 +132,13 @@ Item {
         target: (typeof game !== "undefined") ? game.setup : null
     }
 
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        onWheel: wheel => wheel.accepted = true
+    }
+
     Rectangle {
         anchors.fill: parent
         color: Theme.dim

--- a/ui/qml/GameView.qml
+++ b/ui/qml/GameView.qml
@@ -159,7 +159,9 @@ Item {
                 game.placement.on_formation_cancel();
             else if (game_view.is_rally_placement())
                 game_view.cancel_rally_placement();
-            else if (typeof mainWindow !== 'undefined' && !mainWindow.menu_visible)
+            else if (typeof mainWindow !== 'undefined' && mainWindow.menu_visible)
+                mainWindow.menu_visible = false;
+            else if (typeof mainWindow !== 'undefined' && !mainWindow.overlay_active)
                 mainWindow.menu_visible = true;
             return true;
         case "global.quicksave":

--- a/ui/qml/HelpPanel.qml
+++ b/ui/qml/HelpPanel.qml
@@ -148,6 +148,13 @@ Item {
         }
     }
 
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        onWheel: wheel => wheel.accepted = true
+    }
+
     Rectangle {
         anchors.fill: parent
         color: Design.Theme.scrim

--- a/ui/qml/LoadGamePanel.qml
+++ b/ui/qml/LoadGamePanel.qml
@@ -102,6 +102,13 @@ Item {
         target: typeof game !== 'undefined' ? game.saves : null
     }
 
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        onWheel: wheel => wheel.accepted = true
+    }
+
     Rectangle {
         anchors.fill: parent
         color: Theme.dim

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -16,6 +16,8 @@ ApplicationWindow {
 
     property bool suppress_modals: false
 
+    readonly property bool overlay_active: mainWindow.menu_visible || mapSelect.visible || campaign_screen.visible || save_game_panel.visible || load_game_panel.visible || settingsPanel.visible || objectivesPanel.visible || help_panel.visible || commander_preview.visible
+
     property bool capture_view_ready: false
     property bool capture_view_settled: false
     property bool capture_tutorial_requested: false
@@ -131,7 +133,7 @@ ApplicationWindow {
 
         anchors.fill: parent
         z: 0
-        focus: !mainWindow.menu_visible
+        focus: !mainWindow.overlay_active
         visible: game_started
     }
 
@@ -296,13 +298,15 @@ ApplicationWindow {
                 mainMenu.forceActiveFocus();
         }
         onVisibleChanged: {
-            if (visible) {
+            if (visible)
                 mainMenu.forceActiveFocus();
-                gameViewItem.focus = false;
-            } else if (mainMenu.game_started) {
+            else if (mainMenu.game_started && !mainWindow.overlay_active)
                 gameViewItem.forceActiveFocus();
-            }
             mainWindow.sync_audio_context();
+        }
+        onResume_requested: function () {
+            if (mainWindow.game_started)
+                mainWindow.menu_visible = false;
         }
         onOpen_skirmish: function () {
             mapSelect.visible = true;
@@ -352,7 +356,6 @@ ApplicationWindow {
         onVisibleChanged: {
             if (visible) {
                 mapSelect.forceActiveFocus();
-                gameViewItem.focus = false;
                 Design.UiSound.panelOpen();
             } else {
                 Design.UiSound.panelClose();
@@ -385,7 +388,6 @@ ApplicationWindow {
         onVisibleChanged: {
             if (visible) {
                 campaign_screen.forceActiveFocus();
-                gameViewItem.focus = false;
                 Design.UiSound.panelOpen();
             } else {
                 Design.UiSound.panelClose();
@@ -419,7 +421,6 @@ ApplicationWindow {
         onVisibleChanged: {
             if (visible) {
                 save_game_panel.forceActiveFocus();
-                gameViewItem.focus = false;
                 Design.UiSound.panelOpen();
             } else {
                 Design.UiSound.panelClose();
@@ -449,7 +450,6 @@ ApplicationWindow {
         onVisibleChanged: {
             if (visible) {
                 load_game_panel.forceActiveFocus();
-                gameViewItem.focus = false;
                 Design.UiSound.panelOpen();
             } else {
                 Design.UiSound.panelClose();
@@ -483,7 +483,6 @@ ApplicationWindow {
         onVisibleChanged: {
             if (visible) {
                 settingsPanel.forceActiveFocus();
-                gameViewItem.focus = false;
                 Design.UiSound.panelOpen();
             } else {
                 Design.UiSound.panelClose();
@@ -506,7 +505,6 @@ ApplicationWindow {
         onVisibleChanged: {
             if (visible) {
                 objectivesPanel.forceActiveFocus();
-                gameViewItem.focus = false;
                 Design.UiSound.panelOpen();
             } else {
                 Design.UiSound.panelClose();
@@ -537,7 +535,6 @@ ApplicationWindow {
         onVisibleChanged: {
             if (visible) {
                 help_panel.forceActiveFocus();
-                gameViewItem.focus = false;
                 Design.UiSound.panelOpen();
             } else {
                 Design.UiSound.panelClose();

--- a/ui/qml/MainMenu.qml
+++ b/ui/qml/MainMenu.qml
@@ -31,6 +31,7 @@ Item {
     signal load_save
     signal save_game
     signal exit_requested
+    signal resume_requested
 
     anchors.fill: parent
     z: 10
@@ -83,8 +84,8 @@ Item {
             trigger_selection(commandList.currentIndex);
             event.accepted = true;
         } else if (event.key === Qt.Key_Escape) {
-            if (typeof mainWindow !== "undefined" && mainWindow.menu_visible && mainWindow.game_started) {
-                mainWindow.menu_visible = false;
+            if (root.game_started) {
+                root.resume_requested();
                 event.accepted = true;
             }
         }
@@ -173,6 +174,13 @@ Item {
             requiresGame: false
             accent: "#6E2B25"
         }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        onWheel: wheel => wheel.accepted = true
     }
 
     Rectangle {

--- a/ui/qml/MapSelect.qml
+++ b/ui/qml/MapSelect.qml
@@ -548,6 +548,13 @@ Item {
         id: players_model
     }
 
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        onWheel: wheel => wheel.accepted = true
+    }
+
     Rectangle {
         anchors.fill: parent
         color: Theme.dim

--- a/ui/qml/ObjectivesPanel.qml
+++ b/ui/qml/ObjectivesPanel.qml
@@ -49,6 +49,13 @@ Item {
         target: root.game_ready() ? game.setup : null
     }
 
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        onWheel: wheel => wheel.accepted = true
+    }
+
     Rectangle {
         anchors.fill: parent
         color: Design.Theme.scrim

--- a/ui/qml/SaveGamePanel.qml
+++ b/ui/qml/SaveGamePanel.qml
@@ -41,6 +41,13 @@ Item {
         target: typeof game !== 'undefined' ? game.saves : null
     }
 
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        onWheel: wheel => wheel.accepted = true
+    }
+
     Rectangle {
         anchors.fill: parent
         color: Theme.dim

--- a/ui/qml/SettingsPanel.qml
+++ b/ui/qml/SettingsPanel.qml
@@ -84,6 +84,13 @@ Item {
             sync_audio_sliders();
     }
 
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        onWheel: wheel => wheel.accepted = true
+    }
+
     Rectangle {
         anchors.fill: parent
         color: Theme.dim

--- a/ui/qml/design/ComponentGallery.qml
+++ b/ui/qml/design/ComponentGallery.qml
@@ -393,6 +393,8 @@ ScrollView {
                                     "nation": "roman_republic",
                                     "count": 40,
                                     "woundedCount": 7,
+                                    "soldiers": 592,
+                                    "maxSoldiers": 720,
                                     "health": 0.82,
                                     "stamina": 0.65
                                 }, {
@@ -401,6 +403,8 @@ ScrollView {
                                     "nation": "roman_republic",
                                     "count": 24,
                                     "woundedCount": 0,
+                                    "soldiers": 360,
+                                    "maxSoldiers": 360,
                                     "health": 1,
                                     "stamina": 0.9
                                 }]

--- a/ui/qml/design/controls/IronSelectionSummary.qml
+++ b/ui/qml/design/controls/IronSelectionSummary.qml
@@ -41,8 +41,48 @@ Design.IronPanel {
 
     readonly property bool canShowProfile: !!root.focusProfile
 
+    readonly property int soldierCount: {
+        var total = 0;
+        for (var i = 0; i < root.groups.length; ++i)
+            total += root.soldiersOf(root.groups[i]);
+        return total;
+    }
+
+    readonly property int soldierMax: {
+        var total = 0;
+        for (var i = 0; i < root.groups.length; ++i)
+            total += root.maxSoldiersOf(root.groups[i]);
+        return total;
+    }
+
     accessibleName: qsTr("Selected units")
     Accessible.description: header.text
+
+    function soldiersOf(entry) {
+        if (!entry)
+            return 0;
+        var value = entry.soldiers;
+        return value === undefined || value === null ? 0 : value;
+    }
+
+    function maxSoldiersOf(entry) {
+        if (!entry)
+            return 0;
+        var value = entry.maxSoldiers !== undefined ? entry.maxSoldiers : entry.max_soldiers;
+        return value === undefined || value === null ? 0 : value;
+    }
+
+    function hasSoldierCount(entry) {
+        return root.maxSoldiersOf(entry) > 1;
+    }
+
+    function strengthText(entry) {
+        return qsTr("%1 / %2").arg(root.soldiersOf(entry)).arg(root.maxSoldiersOf(entry));
+    }
+
+    function strengthTextCompact(entry) {
+        return qsTr("%1/%2").arg(root.soldiersOf(entry)).arg(root.maxSoldiersOf(entry));
+    }
 
     function healthColor(ratio) {
         if (ratio > 0.6)
@@ -144,7 +184,8 @@ Design.IronPanel {
 
                 Text {
                     visible: !root.empty || root.inspecting
-                    text: root.inspecting ? root.inspected.name : root.singleUnit && root.groups.length > 0 ? root.groups[0].name : qsTr("%1 soldiers ready").arg(root.unitCount)
+                    objectName: "selectionSubtitle"
+                    text: root.inspecting ? root.inspected.name : root.singleUnit && root.groups.length > 0 ? root.groups[0].name : qsTr("%1 soldiers ready").arg(root.soldierMax > 0 ? root.soldierCount : root.unitCount)
                     color: Design.Theme.textPrimary
                     font.family: Design.Typography.displayFamily
                     font.pixelSize: Design.Typography.label
@@ -268,7 +309,7 @@ Design.IronPanel {
 
             objectName: "selectionInspectCard"
             width: parent.width
-            height: Design.Metrics.space24 * 4
+            height: Design.Metrics.space24 * 4 + (root.hasSoldierCount(root.inspected) ? Design.Metrics.space16 : 0)
             radius: Design.Metrics.radiusMedium
             color: Design.Theme.backgroundDeep
             border.width: Design.Metrics.borderThin
@@ -351,6 +392,17 @@ Design.IronPanel {
                         height: Design.Metrics.space12
                         value: root.inspected.healthRatio
                         fillColor: root.focusHealthColor(root.inspected)
+                    }
+
+                    Text {
+                        objectName: "inspectSoldiersValue"
+                        width: parent.width
+                        visible: root.hasSoldierCount(root.inspected)
+                        text: qsTr("%1 soldiers").arg(root.strengthText(root.inspected))
+                        color: Design.Theme.textSecondary
+                        font.family: Design.Typography.family
+                        font.pixelSize: Design.Typography.caption
+                        elide: Text.ElideRight
                     }
                 }
 
@@ -458,7 +510,7 @@ Design.IronPanel {
 
                             Text {
                                 objectName: "selectionHealthLabel"
-                                text: qsTr("HEALTH")
+                                text: root.hasSoldierCount(root.groups[0]) ? qsTr("SOLDIERS") : qsTr("HEALTH")
                                 color: Design.Theme.textPrimary
                                 font.family: Design.Typography.family
                                 font.pixelSize: Design.Typography.caption
@@ -471,7 +523,7 @@ Design.IronPanel {
 
                             Text {
                                 objectName: "selectionHealthValue"
-                                text: qsTr("%1%").arg(Math.round(root.groups[0].health * 100))
+                                text: root.hasSoldierCount(root.groups[0]) ? root.strengthText(root.groups[0]) : qsTr("%1%").arg(Math.round(root.groups[0].health * 100))
                                 color: root.healthColor(root.groups[0].health)
                                 font.family: Design.Typography.family
                                 font.pixelSize: Design.Typography.caption
@@ -563,9 +615,12 @@ Design.IronPanel {
                     width: Design.Metrics.space24 * 2
                     height: Design.Metrics.space24 * 2
 
+                    readonly property bool showsStrength: root.hasSoldierCount(chip.model)
+                    readonly property string strength: chip.showsStrength ? root.strengthTextCompact(chip.model) : ""
+
                     Accessible.role: Accessible.Button
                     Accessible.name: chip.model.name
-                    Accessible.description: Math.round(chip.model.health_ratio * 100) + "% — " + Design.ActivityIcons.summary(chip.model.activity, chip.model.activity_state)
+                    Accessible.description: (chip.showsStrength ? chip.strength + qsTr(" soldiers — ") : Math.round(chip.model.health_ratio * 100) + "% — ") + Design.ActivityIcons.summary(chip.model.activity, chip.model.activity_state)
 
                     Rectangle {
                         anchors.fill: parent
@@ -577,13 +632,27 @@ Design.IronPanel {
 
                     Image {
                         anchors.centerIn: parent
-                        anchors.verticalCenterOffset: -Design.Metrics.space2
+                        anchors.verticalCenterOffset: chip.showsStrength ? -Design.Metrics.space8 : -Design.Metrics.space2
                         width: Design.Metrics.iconMedium
                         height: width
                         fillMode: Image.PreserveAspectFit
                         source: root.iconFor(chip.model.unit_type, chip.model.nation, chip.model.name)
                         smooth: true
                         mipmap: true
+                    }
+
+                    Text {
+                        objectName: "selectionChipStrength_" + chip.model.unit_id
+
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: Design.Metrics.space8
+                        visible: chip.showsStrength
+                        text: chip.strength
+                        color: root.healthColor(chip.model.health_ratio)
+                        font.family: Design.Typography.family
+                        font.pixelSize: Design.Typography.caption
+                        font.weight: Design.Typography.bold
                     }
 
                     Item {
@@ -633,7 +702,7 @@ Design.IronPanel {
 
                     ToolTip.visible: chipMouse.containsMouse
                     ToolTip.delay: Design.Metrics.tooltipDelay
-                    ToolTip.text: chip.model.name + " — " + Math.round(chip.model.health_ratio * 100) + "%" + "\n" + Design.ActivityIcons.summary(chip.model.activity, chip.model.activity_state)
+                    ToolTip.text: chip.model.name + " — " + (chip.showsStrength ? qsTr("%1 soldiers").arg(chip.strength) : Math.round(chip.model.health_ratio * 100) + "%") + "\n" + Design.ActivityIcons.summary(chip.model.activity, chip.model.activity_state)
                 }
             }
         }
@@ -669,13 +738,16 @@ Design.IronPanel {
 
                     readonly property string activityText: Design.ActivityIcons.summary(root.groupActivity(groupCard.modelData), root.groupActivityState(groupCard.modelData)) + (groupCard.modelData.mixedActivity ? qsTr(" (mixed)") : "")
 
+                    readonly property bool showsStrength: root.hasSoldierCount(groupCard.modelData)
+                    readonly property string strength: groupCard.showsStrength ? root.strengthTextCompact(groupCard.modelData) : ""
+
                     Accessible.role: Accessible.Button
                     Accessible.name: groupCard.modelData.name + " ×" + groupCard.modelData.count
-                    Accessible.description: Math.round(groupCard.modelData.health * 100) + "% — " + groupCard.activityText
+                    Accessible.description: (groupCard.showsStrength ? groupCard.strength + qsTr(" soldiers — ") : Math.round(groupCard.modelData.health * 100) + "% — ") + groupCard.activityText
 
                     ToolTip.visible: groupMouse.containsMouse
                     ToolTip.delay: Design.Metrics.tooltipDelay
-                    ToolTip.text: groupCard.modelData.name + " ×" + groupCard.modelData.count + "\n" + groupCard.activityText
+                    ToolTip.text: groupCard.modelData.name + " ×" + groupCard.modelData.count + (groupCard.showsStrength ? " — " + qsTr("%1 soldiers").arg(groupCard.strength) : "") + "\n" + groupCard.activityText
 
                     Rectangle {
                         id: portraitFrame
@@ -769,15 +841,21 @@ Design.IronPanel {
                     }
 
                     Text {
+                        objectName: "selectionGroupStrength_" + groupCard.modelData.typeKey
+
                         anchors.left: portraitFrame.right
                         anchors.leftMargin: Design.Metrics.space8
+                        anchors.right: parent.right
+                        anchors.rightMargin: Design.Metrics.space8
                         anchors.bottom: groupHealth.top
                         anchors.bottomMargin: Design.Metrics.space2
-                        visible: groupCard.modelData.woundedCount > 0 && groupFlow.cardHeight >= Design.Metrics.space24 * 3
-                        text: qsTr("%1 wounded").arg(groupCard.modelData.woundedCount)
-                        color: Design.Theme.warning
+                        visible: groupFlow.cardHeight >= Design.Metrics.space24 * 3 && (groupCard.showsStrength || groupCard.modelData.woundedCount > 0)
+                        text: groupCard.showsStrength ? groupCard.strength : qsTr("%1 wounded").arg(groupCard.modelData.woundedCount)
+                        color: groupCard.showsStrength ? root.healthColor(groupCard.modelData.health) : Design.Theme.warning
                         font.family: Design.Typography.family
                         font.pixelSize: Design.Typography.caption
+                        font.weight: groupCard.showsStrength ? Design.Typography.bold : Design.Typography.regular
+                        elide: Text.ElideRight
                     }
 
                     MouseArea {


### PR DESCRIPTION
Selection: replace the bare health percentage with the men still standing out of the roster the unit holds -- SOLDIERS 15 / 30 on a single unit, on each squad chip, as the group total on a roster card, and as a soldiers line on the inspected enemy. Single-body units keep the percentage, and the force header counts men rather than unit cards. living_slot_count() prefers the per-soldier roster flags and falls back to the health formula, so the HUD cannot disagree with the field. Two paths could still drive them apart, both fixed here: the commander health_regen aura clamped to max_health instead of HealingRules::maximum_recoverable_health, refilling a decimated unit's bar, and ensure_formation_roster rebuilt alive flags whenever they disagreed with health, resurrecting the dead on the next hit -- it now only ever shrinks a roster. grouped_by_type() reads each unit once instead of re-walking data() role by role, so the panel costs less than it did before the feature.

Focus: derive one overlay_active flag in Main.qml from the pause menu and every panel, focus the game view only when nothing overlays it, let Escape close an open overlay before opening the pause menu, and make resume hide the menu directly. Panels take key focus without clearing the game view's, ending the frame-lock races around menu transitions. Covered by tst_main_menu.qml.

Render: split preserve_locomotion_state from preserve_state_prefix when a formation layout cache entry is reused, so changing rows, columns or spacing no longer resets every soldier's walk cycle mid-stride; combat lanes and visibility frames still reset with the state prefix. Covered by formation_locomotion_state_test.cpp.

Arena promos: add a beat-authoring pipeline. reel_score.py synthesises a half-time bed and hands back the exact grid it laid; beat-align.py quantises each shot's finished length onto whole beats and drops punch marks inside shots; place-rally-cues.py maps losses, signature strikes and the aura call from the scenario's own trace through the shots that show them and writes the cue list back into commander_rally.json, which joins the roster while the four existing promos are retimed and tamed to pass. promo_spec gains MotionLimits and motion_violations(), checking camera roll, shake and clip pacing against limits, with promo-edit.py growing spec-aware edits. arena_promo_spec_test.cpp and promo_beat_test.sh guard the pipeline.