### PR TITLE
perf(sim): consolidate simulation hot-path optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,6 +658,7 @@ add_library(
     app/session/skirmish_runtime_coordinator.cpp
     app/session/world_bootstrap.cpp
     # app/commander -- the first-person control mode and its camera.
+    app/commander/commander_abilities.cpp
     app/commander/commander_camera_rig.cpp
     app/commander/commander_control_controller.cpp
     app/commander/commander_motor.cpp

--- a/app/commander/commander_abilities.cpp
+++ b/app/commander/commander_abilities.cpp
@@ -1,0 +1,348 @@
+#include "app/commander/commander_abilities.h"
+
+#include <QVector3D>
+
+#include <algorithm>
+#include <cmath>
+
+#include "app/commander/commander_motor.h"
+#include "game/audio/audio_cues.h"
+#include "game/core/component.h"
+#include "game/core/world.h"
+#include "game/session/session_context.h"
+#include "game/systems/building_collision_registry.h"
+#include "game/systems/building_line_of_sight.h"
+#include "game/systems/combat_system/mounted_charge_processor.h"
+#include "game/systems/owner_registry.h"
+#include "game/systems/rpg_combat_system/rpg_commander_damage.h"
+#include "game/units/spawn_type.h"
+
+namespace App::Core {
+namespace {
+
+constexpr float k_degrees_to_radians = 0.017453292519943295F;
+
+constexpr float k_bash_range = 2.5F;
+constexpr float k_bash_stagger_duration = 0.5F;
+constexpr float k_bash_cooldown = 3.0F;
+constexpr float k_bash_punish_window = 0.75F;
+
+constexpr float k_rush_cooldown = 4.5F;
+constexpr float k_rush_max_range = 8.0F;
+constexpr float k_rush_stop_distance = 1.35F;
+constexpr float k_rush_default_distance = 3.6F;
+constexpr int k_rush_damage = 18;
+constexpr float k_rush_stagger_duration = 0.35F;
+constexpr float k_rush_contact_range = 2.35F;
+constexpr float k_rush_punish_window = 0.85F;
+constexpr float k_rush_launch_speed = 8.0F;
+
+constexpr float k_second_wind_cooldown = 8.0F;
+constexpr float k_second_wind_posture_restore = 55.0F;
+constexpr float k_second_wind_stamina_restore = 35.0F;
+constexpr float k_second_wind_guard_window = 0.35F;
+
+auto buildings_of(const Engine::Core::World& world)
+    -> const Game::Systems::BuildingCollisionRegistry& {
+  return Game::Session::session_for(world).building_collision();
+}
+
+void apply_stagger(Engine::Core::Entity& entity, float duration) {
+  if (auto* existing = entity.get_component<Engine::Core::StaggerComponent>()) {
+    existing->remaining = std::max(existing->remaining, duration);
+    return;
+  }
+  entity.add_component<Engine::Core::StaggerComponent>(duration);
+}
+
+void open_punish_window(Engine::Core::Entity& entity, float duration) {
+  if (auto* commander = entity.get_component<Engine::Core::CommanderComponent>()) {
+    commander->punish_window_remaining =
+        std::max(commander->punish_window_remaining, duration);
+  }
+}
+
+auto is_idle_for_ability(const Engine::Core::Entity& commander) -> bool {
+  auto const* combat_state =
+      commander.get_component<Engine::Core::CombatStateComponent>();
+  return combat_state == nullptr ||
+         combat_state->animation_state == Engine::Core::CombatAnimationState::Idle;
+}
+
+void refuse() {
+  Game::Audio::play_cue(Game::Audio::Cue::k_combat_ability_refused);
+}
+
+} // namespace
+
+void CommanderAbilities::reset() {
+  m_shield_bash_cooldown = 0.0F;
+  m_vanguard_rush_cooldown = 0.0F;
+  m_second_wind_cooldown = 0.0F;
+}
+
+void CommanderAbilities::advance_cooldowns(Engine::Core::CommanderComponent* commander,
+                                           float dt) {
+  auto decay = [dt](float& cooldown) {
+    if (cooldown > 0.0F) {
+      cooldown = std::max(0.0F, cooldown - dt);
+    }
+  };
+  decay(m_shield_bash_cooldown);
+  decay(m_vanguard_rush_cooldown);
+  decay(m_second_wind_cooldown);
+
+  if (commander != nullptr) {
+    commander->shield_bash_cooldown_remaining = m_shield_bash_cooldown;
+    commander->vanguard_rush_cooldown_remaining = m_vanguard_rush_cooldown;
+    commander->second_wind_cooldown_remaining = m_second_wind_cooldown;
+  }
+}
+
+auto CommanderAbilities::activate(const CommanderAbilityRequest& request,
+                                  const CommanderAbilityContext& context)
+    -> CommanderAbilityOutcome {
+  CommanderAbilityOutcome outcome;
+  if (context.world == nullptr || context.commander == nullptr) {
+    return outcome;
+  }
+
+  if (request.shield_bash) {
+    static_cast<void>(try_shield_bash(context));
+  }
+  if (request.vanguard_rush) {
+    outcome.rescan_primary_target = try_vanguard_rush(context);
+  }
+  if (request.second_wind) {
+    static_cast<void>(try_second_wind(context));
+  }
+  return outcome;
+}
+
+auto CommanderAbilities::resolve_target(const CommanderAbilityContext& context,
+                                        float max_range) const
+    -> Engine::Core::EntityID {
+  auto& world = *context.world;
+  auto* transform =
+      context.commander->get_component<Engine::Core::TransformComponent>();
+  if (transform == nullptr) {
+    return 0;
+  }
+
+  const QVector3D origin(transform->position.x, 0.0F, transform->position.z);
+  const float max_range_sq = max_range * max_range;
+  auto& owners = Game::Session::session_for(world).owners();
+
+  auto qualifies = [&](Engine::Core::EntityID candidate_id) -> bool {
+    auto* candidate = world.get_entity(candidate_id);
+    auto* candidate_unit = (candidate != nullptr)
+                               ? candidate->get_component<Engine::Core::UnitComponent>()
+                               : nullptr;
+    auto* candidate_transform =
+        (candidate != nullptr)
+            ? candidate->get_component<Engine::Core::TransformComponent>()
+            : nullptr;
+    if (candidate_unit == nullptr || candidate_transform == nullptr ||
+        candidate_unit->health <= 0 ||
+        !owners.are_enemies(context.local_owner_id, candidate_unit->owner_id)) {
+      return false;
+    }
+
+    const QVector3D target(
+        candidate_transform->position.x, 0.0F, candidate_transform->position.z);
+    return (target - origin).lengthSquared() <= max_range_sq &&
+           Game::Systems::has_clear_building_los(buildings_of(world), origin, target);
+  };
+
+  if (context.locked_target_id != 0 && qualifies(context.locked_target_id)) {
+    return context.locked_target_id;
+  }
+  if (context.soft_target_id != 0 && qualifies(context.soft_target_id)) {
+    return context.soft_target_id;
+  }
+  return 0;
+}
+
+auto CommanderAbilities::try_shield_bash(const CommanderAbilityContext& context)
+    -> bool {
+  auto& world = *context.world;
+  auto& commander = *context.commander;
+
+  auto* guard = commander.get_component<Engine::Core::CommanderGuardComponent>();
+  auto* cmd_comp = commander.get_component<Engine::Core::CommanderComponent>();
+  if (guard == nullptr || !guard->active || m_shield_bash_cooldown > 0.0F ||
+      context.airborne) {
+    refuse();
+    return false;
+  }
+
+  auto* transform = commander.get_component<Engine::Core::TransformComponent>();
+  if (transform == nullptr) {
+    return false;
+  }
+
+  auto& owners = Game::Session::session_for(world).owners();
+  const QVector3D cmd_pos(
+      transform->position.x, transform->position.y, transform->position.z);
+  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
+    if (entity == nullptr || entity->get_id() == context.commander_id) {
+      continue;
+    }
+    auto* unit = entity->get_component<Engine::Core::UnitComponent>();
+    auto* ent_tf = entity->get_component<Engine::Core::TransformComponent>();
+    if (unit == nullptr || ent_tf == nullptr || unit->health <= 0 ||
+        !owners.are_enemies(context.local_owner_id, unit->owner_id)) {
+      continue;
+    }
+    const QVector3D epos(ent_tf->position.x, ent_tf->position.y, ent_tf->position.z);
+    if ((epos - cmd_pos).length() > k_bash_range) {
+      continue;
+    }
+    apply_stagger(*entity, k_bash_stagger_duration);
+    open_punish_window(*entity, k_bash_punish_window);
+  }
+
+  m_shield_bash_cooldown = k_bash_cooldown;
+  Game::Audio::play_cue(Game::Audio::Cue::k_combat_shield_bash);
+  if (cmd_comp != nullptr) {
+    cmd_comp->shield_bash_cooldown_remaining = m_shield_bash_cooldown;
+  }
+  return true;
+}
+
+auto CommanderAbilities::try_vanguard_rush(const CommanderAbilityContext& context)
+    -> bool {
+  auto& world = *context.world;
+  auto& commander = *context.commander;
+
+  if (m_vanguard_rush_cooldown > 0.0F || context.dodging || context.airborne) {
+    refuse();
+    return false;
+  }
+
+  auto* transform = commander.get_component<Engine::Core::TransformComponent>();
+  auto* unit = commander.get_component<Engine::Core::UnitComponent>();
+  auto* movement = commander.get_component<Engine::Core::MovementComponent>();
+  auto* cmd_comp = commander.get_component<Engine::Core::CommanderComponent>();
+  if (transform == nullptr || unit == nullptr || !is_idle_for_ability(commander)) {
+    return false;
+  }
+
+  const QVector3D start(
+      transform->position.x, transform->position.y, transform->position.z);
+  const float yaw_rad = context.view_yaw * k_degrees_to_radians;
+  QVector3D rush_direction(std::sin(yaw_rad), 0.0F, std::cos(yaw_rad));
+  float rush_distance = k_rush_default_distance;
+
+  if (Game::Units::is_cavalry(unit->spawn_type) && movement != nullptr) {
+    movement->set_manual_velocity(rush_direction.x() * k_rush_launch_speed,
+                                  rush_direction.z() * k_rush_launch_speed);
+    if (!Game::Systems::Combat::request_mounted_charge(
+            commander, Engine::Core::MountedChargeIntentSource::Player)) {
+      return false;
+    }
+    m_vanguard_rush_cooldown = k_rush_cooldown;
+    Game::Audio::play_cue(Game::Audio::Cue::k_combat_vanguard_rush);
+    if (cmd_comp != nullptr) {
+      cmd_comp->vanguard_rush_cooldown_remaining = m_vanguard_rush_cooldown;
+    }
+    return true;
+  }
+
+  Engine::Core::Entity* target = nullptr;
+  const auto target_id = resolve_target(context, k_rush_max_range);
+  if (target_id != 0) {
+    target = world.get_entity(target_id);
+    auto* target_transform =
+        (target != nullptr) ? target->get_component<Engine::Core::TransformComponent>()
+                            : nullptr;
+    if (target_transform != nullptr) {
+      QVector3D const to_target(target_transform->position.x - start.x(),
+                                0.0F,
+                                target_transform->position.z - start.z());
+      if (to_target.lengthSquared() > 0.0001F) {
+        const float target_distance = std::sqrt(to_target.lengthSquared());
+        rush_direction = to_target / target_distance;
+        rush_distance = std::clamp(target_distance - k_rush_stop_distance,
+                                   1.4F,
+                                   k_rush_default_distance + 0.4F);
+      }
+    }
+  }
+
+  const QVector3D desired = start + rush_direction * rush_distance;
+  const QVector3D resolved = CommanderMotor::reachable_ground_position(
+      Game::Session::session_for(world), start, desired, context.commander_id);
+  if (context.motor != nullptr) {
+    static_cast<void>(context.motor->teleport(
+        *transform, resolved, CommanderDisplacementSource::StrikeLunge));
+  }
+  if (movement != nullptr) {
+    movement->set_manual_velocity(rush_direction.x() * k_rush_launch_speed,
+                                  rush_direction.z() * k_rush_launch_speed);
+  }
+
+  if (target != nullptr) {
+    auto* target_unit = target->get_component<Engine::Core::UnitComponent>();
+    auto* target_transform = target->get_component<Engine::Core::TransformComponent>();
+    if (target_unit != nullptr && target_transform != nullptr &&
+        target_unit->health > 0) {
+      const QVector3D target_pos(target_transform->position.x,
+                                 target_transform->position.y,
+                                 target_transform->position.z);
+      if ((target_pos - resolved).length() <= k_rush_contact_range &&
+          Game::Systems::has_clear_building_los(
+              buildings_of(world), resolved, target_pos)) {
+        Game::Systems::RpgCombat::deal_commander_attack_damage(
+            &world, target, k_rush_damage, context.commander_id);
+        if (target_unit->health > 0) {
+          apply_stagger(*target, k_rush_stagger_duration);
+          open_punish_window(*target, k_rush_punish_window);
+        }
+      }
+    }
+  }
+
+  m_vanguard_rush_cooldown = k_rush_cooldown;
+  Game::Audio::play_cue(Game::Audio::Cue::k_combat_vanguard_rush);
+  if (cmd_comp != nullptr) {
+    cmd_comp->vanguard_rush_cooldown_remaining = m_vanguard_rush_cooldown;
+  }
+  return true;
+}
+
+auto CommanderAbilities::try_second_wind(const CommanderAbilityContext& context)
+    -> bool {
+  auto& commander = *context.commander;
+
+  if (m_second_wind_cooldown > 0.0F || context.dodging || context.airborne) {
+    refuse();
+    return false;
+  }
+
+  auto* cmd_comp = commander.get_component<Engine::Core::CommanderComponent>();
+  if (cmd_comp == nullptr || !is_idle_for_ability(commander)) {
+    return false;
+  }
+
+  cmd_comp->posture = std::max(0.0F, cmd_comp->posture - k_second_wind_posture_restore);
+  if (auto* stamina = commander.get_component<Engine::Core::StaminaComponent>()) {
+    stamina->stamina = std::min(stamina->max_stamina,
+                                stamina->stamina + k_second_wind_stamina_restore);
+  }
+  auto* guard = commander.get_component<Engine::Core::CommanderGuardComponent>();
+  if (guard == nullptr) {
+    guard = commander.add_component<Engine::Core::CommanderGuardComponent>();
+  }
+  if (guard != nullptr && guard->guard_break_remaining <= 0.0F) {
+    guard->perfect_guard_remaining =
+        std::max(guard->perfect_guard_remaining, k_second_wind_guard_window);
+  }
+
+  m_second_wind_cooldown = k_second_wind_cooldown;
+  Game::Audio::play_cue(Game::Audio::Cue::k_combat_second_wind);
+  cmd_comp->second_wind_cooldown_remaining = m_second_wind_cooldown;
+  return true;
+}
+
+} // namespace App::Core

--- a/app/commander/commander_abilities.h
+++ b/app/commander/commander_abilities.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Engine::Core {
+class World;
+class Entity;
+class CommanderComponent;
+using EntityID = std::uint64_t;
+} // namespace Engine::Core
+
+namespace App::Core {
+
+class CommanderMotor;
+
+struct CommanderAbilityRequest {
+  bool shield_bash{false};
+  bool vanguard_rush{false};
+  bool second_wind{false};
+
+  [[nodiscard]] auto any() const -> bool {
+    return shield_bash || vanguard_rush || second_wind;
+  }
+};
+
+struct CommanderAbilityContext {
+  Engine::Core::World* world{nullptr};
+  Engine::Core::Entity* commander{nullptr};
+  Engine::Core::EntityID commander_id{0};
+  int local_owner_id{0};
+  float view_yaw{0.0F};
+  bool dodging{false};
+  bool airborne{false};
+  Engine::Core::EntityID locked_target_id{0};
+  Engine::Core::EntityID soft_target_id{0};
+  CommanderMotor* motor{nullptr};
+};
+
+struct CommanderAbilityOutcome {
+  bool rescan_primary_target{false};
+};
+
+class CommanderAbilities {
+public:
+  void advance_cooldowns(Engine::Core::CommanderComponent* commander, float dt);
+
+  auto activate(const CommanderAbilityRequest& request,
+                const CommanderAbilityContext& context) -> CommanderAbilityOutcome;
+
+  [[nodiscard]] auto shield_bash_cooldown() const -> float {
+    return m_shield_bash_cooldown;
+  }
+  [[nodiscard]] auto vanguard_rush_cooldown() const -> float {
+    return m_vanguard_rush_cooldown;
+  }
+  [[nodiscard]] auto second_wind_cooldown() const -> float {
+    return m_second_wind_cooldown;
+  }
+
+  void reset();
+
+private:
+  [[nodiscard]] auto resolve_target(const CommanderAbilityContext& context,
+                                    float max_range) const -> Engine::Core::EntityID;
+
+  auto try_shield_bash(const CommanderAbilityContext& context) -> bool;
+  auto try_vanguard_rush(const CommanderAbilityContext& context) -> bool;
+  auto try_second_wind(const CommanderAbilityContext& context) -> bool;
+
+  float m_shield_bash_cooldown{0.0F};
+  float m_vanguard_rush_cooldown{0.0F};
+  float m_second_wind_cooldown{0.0F};
+};
+
+} // namespace App::Core

--- a/app/commander/commander_control_controller.cpp
+++ b/app/commander/commander_control_controller.cpp
@@ -12,6 +12,7 @@
 #include <numbers>
 #include <vector>
 
+#include "app/commander/commander_abilities.h"
 #include "app/commander/commander_motor.h"
 #include "game/accessibility/commander_input_settings.h"
 #include "game/accessibility/motion_settings.h"
@@ -43,6 +44,8 @@
 namespace {
 
 constexpr float k_degrees_to_radians = 0.017453292519943295F;
+
+constexpr float k_ability_rescan_cooldown = 0.18F;
 
 auto wrap_angle_degrees(float degrees) -> float {
   degrees = std::fmod(degrees, 360.0F);
@@ -379,9 +382,7 @@ void CommanderControlController::reset() {
   m_guard_was_active = false;
   m_combo_miss_timer = 0.0F;
   m_primary_held_duration = 0.0F;
-  m_shield_bash_cooldown = 0.0F;
-  m_vanguard_rush_cooldown = 0.0F;
-  m_second_wind_cooldown = 0.0F;
+  m_abilities.reset();
 }
 
 void CommanderControlController::set_view_yaw(float yaw) {
@@ -1343,255 +1344,6 @@ auto CommanderControlController::queued_intent_count(
   return intents != nullptr ? static_cast<int>(intents->count) : 0;
 }
 
-auto CommanderControlController::resolve_ability_target(Engine::Core::World& world,
-                                                        Engine::Core::Entity& commander,
-                                                        int local_owner_id,
-                                                        float max_range) const
-    -> Engine::Core::EntityID {
-  auto* transform = commander.get_component<Engine::Core::TransformComponent>();
-  if (transform == nullptr) {
-    return 0;
-  }
-
-  const QVector3D origin(transform->position.x, 0.0F, transform->position.z);
-  const float max_range_sq = max_range * max_range;
-  auto& owners = Game::Session::session_for(world).owners();
-
-  auto qualifies = [&](Engine::Core::EntityID candidate_id) -> bool {
-    auto* candidate = world.get_entity(candidate_id);
-    auto* candidate_unit = (candidate != nullptr)
-                               ? candidate->get_component<Engine::Core::UnitComponent>()
-                               : nullptr;
-    auto* candidate_transform =
-        (candidate != nullptr)
-            ? candidate->get_component<Engine::Core::TransformComponent>()
-            : nullptr;
-    if (candidate_unit == nullptr || candidate_transform == nullptr ||
-        candidate_unit->health <= 0 ||
-        !owners.are_enemies(local_owner_id, candidate_unit->owner_id)) {
-      return false;
-    }
-
-    const QVector3D target(
-        candidate_transform->position.x, 0.0F, candidate_transform->position.z);
-    return (target - origin).lengthSquared() <= max_range_sq &&
-           Game::Systems::has_clear_building_los(buildings_of(world), origin, target);
-  };
-
-  if (m_locked_target_id != 0 && qualifies(m_locked_target_id)) {
-    return m_locked_target_id;
-  }
-  if (m_soft_target_id != 0 && qualifies(m_soft_target_id)) {
-    return m_soft_target_id;
-  }
-  return 0;
-}
-
-void CommanderControlController::update_ability_cooldowns(
-    Engine::Core::CommanderComponent* commander, float dt) {
-  auto decay = [dt](float& cooldown) {
-    if (cooldown > 0.0F) {
-      cooldown = std::max(0.0F, cooldown - dt);
-    }
-  };
-  decay(m_shield_bash_cooldown);
-  decay(m_vanguard_rush_cooldown);
-  decay(m_second_wind_cooldown);
-
-  if (commander != nullptr) {
-    commander->shield_bash_cooldown_remaining = m_shield_bash_cooldown;
-    commander->vanguard_rush_cooldown_remaining = m_vanguard_rush_cooldown;
-    commander->second_wind_cooldown_remaining = m_second_wind_cooldown;
-  }
-}
-
-void CommanderControlController::try_activate_shield_bash(
-    Engine::Core::World& world,
-    Engine::Core::Entity& commander,
-    Engine::Core::EntityID commander_id,
-    int local_owner_id) {
-  const bool bash_requested = m_tick_input.shield_bash_pressed;
-  m_tick_input.shield_bash_pressed = false;
-  if (!bash_requested) {
-    return;
-  }
-
-  auto* guard = commander.get_component<Engine::Core::CommanderGuardComponent>();
-  auto* cmd_comp = commander.get_component<Engine::Core::CommanderComponent>();
-  constexpr float k_bash_range = 2.5F;
-  constexpr float k_bash_stagger_duration = 0.5F;
-  constexpr float k_bash_cooldown = 3.0F;
-  if (guard == nullptr || !guard->active || m_shield_bash_cooldown > 0.0F ||
-      m_jump_timer > 0.0F) {
-    Game::Audio::play_cue(Game::Audio::Cue::k_combat_ability_refused);
-    return;
-  }
-
-  auto* transform = commander.get_component<Engine::Core::TransformComponent>();
-  if (transform == nullptr) {
-    return;
-  }
-
-  auto& owners = Game::Session::session_for(world).owners();
-  const QVector3D cmd_pos(
-      transform->position.x, transform->position.y, transform->position.z);
-  for (auto* entity : world.collect_entities_with<Engine::Core::UnitComponent>()) {
-    if (entity == nullptr || entity->get_id() == commander_id) {
-      continue;
-    }
-    auto* unit = entity->get_component<Engine::Core::UnitComponent>();
-    auto* ent_tf = entity->get_component<Engine::Core::TransformComponent>();
-    if (unit == nullptr || ent_tf == nullptr || unit->health <= 0 ||
-        !owners.are_enemies(local_owner_id, unit->owner_id)) {
-      continue;
-    }
-    const QVector3D epos(ent_tf->position.x, ent_tf->position.y, ent_tf->position.z);
-    if ((epos - cmd_pos).length() > k_bash_range) {
-      continue;
-    }
-    if (auto* existing_stagger =
-            entity->get_component<Engine::Core::StaggerComponent>()) {
-      existing_stagger->remaining =
-          std::max(existing_stagger->remaining, k_bash_stagger_duration);
-    } else {
-      entity->add_component<Engine::Core::StaggerComponent>(k_bash_stagger_duration);
-    }
-    if (auto* enemy_cmd = entity->get_component<Engine::Core::CommanderComponent>()) {
-      enemy_cmd->punish_window_remaining =
-          std::max(enemy_cmd->punish_window_remaining, 0.75F);
-    }
-  }
-
-  m_shield_bash_cooldown = k_bash_cooldown;
-  Game::Audio::play_cue(Game::Audio::Cue::k_combat_shield_bash);
-  if (cmd_comp != nullptr) {
-    cmd_comp->shield_bash_cooldown_remaining = m_shield_bash_cooldown;
-  }
-}
-
-void CommanderControlController::try_activate_vanguard_rush(
-    Engine::Core::World& world,
-    Engine::Core::Entity& commander,
-    Engine::Core::EntityID commander_id,
-    int local_owner_id) {
-  const bool rush_requested = m_tick_input.vanguard_rush_pressed;
-  m_tick_input.vanguard_rush_pressed = false;
-  if (!rush_requested) {
-    return;
-  }
-  if (m_vanguard_rush_cooldown > 0.0F || m_dodge_state != DodgeState::None ||
-      m_jump_timer > 0.0F) {
-    Game::Audio::play_cue(Game::Audio::Cue::k_combat_ability_refused);
-    return;
-  }
-
-  auto* transform = commander.get_component<Engine::Core::TransformComponent>();
-  auto* unit = commander.get_component<Engine::Core::UnitComponent>();
-  auto* movement = commander.get_component<Engine::Core::MovementComponent>();
-  auto* combat_state = commander.get_component<Engine::Core::CombatStateComponent>();
-  auto* cmd_comp = commander.get_component<Engine::Core::CommanderComponent>();
-  if (transform == nullptr || unit == nullptr ||
-      (combat_state != nullptr &&
-       combat_state->animation_state != Engine::Core::CombatAnimationState::Idle)) {
-    return;
-  }
-
-  constexpr float k_rush_cooldown = 4.5F;
-  constexpr float k_rush_max_range = 8.0F;
-  constexpr float k_rush_stop_distance = 1.35F;
-  constexpr float k_rush_default_distance = 3.6F;
-  constexpr int k_rush_damage = 18;
-  constexpr float k_rush_stagger_duration = 0.35F;
-
-  const QVector3D start(
-      transform->position.x, transform->position.y, transform->position.z);
-  const float yaw_rad = m_view_yaw * k_degrees_to_radians;
-  QVector3D rush_direction(std::sin(yaw_rad), 0.0F, std::cos(yaw_rad));
-  float rush_distance = k_rush_default_distance;
-
-  if (Game::Units::is_cavalry(unit->spawn_type) && movement != nullptr) {
-    movement->set_manual_velocity(rush_direction.x() * 8.0F, rush_direction.z() * 8.0F);
-    if (Game::Systems::Combat::request_mounted_charge(
-            commander, Engine::Core::MountedChargeIntentSource::Player)) {
-      m_vanguard_rush_cooldown = k_rush_cooldown;
-      Game::Audio::play_cue(Game::Audio::Cue::k_combat_vanguard_rush);
-      m_primary_scan_cooldown = 0.18F;
-      if (cmd_comp != nullptr) {
-        cmd_comp->vanguard_rush_cooldown_remaining = m_vanguard_rush_cooldown;
-      }
-    }
-    return;
-  }
-
-  Engine::Core::Entity* target = nullptr;
-  const auto target_id =
-      resolve_ability_target(world, commander, local_owner_id, k_rush_max_range);
-  if (target_id != 0) {
-    target = world.get_entity(target_id);
-    auto* target_transform =
-        (target != nullptr) ? target->get_component<Engine::Core::TransformComponent>()
-                            : nullptr;
-    if (target_transform != nullptr) {
-      QVector3D const to_target(target_transform->position.x - start.x(),
-                                0.0F,
-                                target_transform->position.z - start.z());
-      if (to_target.lengthSquared() > 0.0001F) {
-        const float target_distance = std::sqrt(to_target.lengthSquared());
-        rush_direction = to_target / target_distance;
-        rush_distance = std::clamp(target_distance - k_rush_stop_distance,
-                                   1.4F,
-                                   k_rush_default_distance + 0.4F);
-      }
-    }
-  }
-
-  const QVector3D desired = start + rush_direction * rush_distance;
-  const QVector3D resolved = App::Core::CommanderMotor::reachable_ground_position(
-      Game::Session::session_for(world), start, desired, commander_id);
-  static_cast<void>(m_motor.teleport(
-      *transform, resolved, App::Core::CommanderDisplacementSource::StrikeLunge));
-  if (movement != nullptr) {
-    movement->set_manual_velocity(rush_direction.x() * 8.0F, rush_direction.z() * 8.0F);
-  }
-  m_primary_scan_cooldown = 0.18F;
-
-  if (target != nullptr) {
-    auto* target_unit = target->get_component<Engine::Core::UnitComponent>();
-    auto* target_transform = target->get_component<Engine::Core::TransformComponent>();
-    if (target_unit != nullptr && target_transform != nullptr &&
-        target_unit->health > 0) {
-      const QVector3D target_pos(target_transform->position.x,
-                                 target_transform->position.y,
-                                 target_transform->position.z);
-      if ((target_pos - resolved).length() <= 2.35F &&
-          Game::Systems::has_clear_building_los(
-              buildings_of(world), resolved, target_pos)) {
-        Game::Systems::RpgCombat::deal_commander_attack_damage(
-            &world, target, k_rush_damage, commander_id);
-        if (target_unit->health > 0) {
-          if (auto* stagger = target->get_component<Engine::Core::StaggerComponent>()) {
-            stagger->remaining = std::max(stagger->remaining, k_rush_stagger_duration);
-          } else {
-            target->add_component<Engine::Core::StaggerComponent>(
-                k_rush_stagger_duration);
-          }
-          if (auto* target_cmd =
-                  target->get_component<Engine::Core::CommanderComponent>()) {
-            target_cmd->punish_window_remaining =
-                std::max(target_cmd->punish_window_remaining, 0.85F);
-          }
-        }
-      }
-    }
-  }
-
-  m_vanguard_rush_cooldown = k_rush_cooldown;
-  Game::Audio::play_cue(Game::Audio::Cue::k_combat_vanguard_rush);
-  if (cmd_comp != nullptr) {
-    cmd_comp->vanguard_rush_cooldown_remaining = m_vanguard_rush_cooldown;
-  }
-}
-
 void CommanderControlController::publish_resolved_defense_feedback(
     Engine::Core::Entity& commander,
     Engine::Core::EntityID commander_id,
@@ -1631,51 +1383,6 @@ void CommanderControlController::publish_resolved_defense_feedback(
     m_observed_guard_broken_contacts = rpg->guard_broken_contacts;
     publish(App::Core::PlayerFeedbackType::GuardBroken, "guard_break");
   }
-}
-
-void CommanderControlController::try_activate_second_wind(
-    Engine::Core::Entity& commander) {
-  const bool second_wind_requested = m_tick_input.second_wind_pressed;
-  m_tick_input.second_wind_pressed = false;
-  if (!second_wind_requested) {
-    return;
-  }
-  if (m_second_wind_cooldown > 0.0F || m_dodge_state != DodgeState::None ||
-      m_jump_timer > 0.0F) {
-    Game::Audio::play_cue(Game::Audio::Cue::k_combat_ability_refused);
-    return;
-  }
-
-  auto* cmd_comp = commander.get_component<Engine::Core::CommanderComponent>();
-  auto* combat_state = commander.get_component<Engine::Core::CombatStateComponent>();
-  if (cmd_comp == nullptr ||
-      (combat_state != nullptr &&
-       combat_state->animation_state != Engine::Core::CombatAnimationState::Idle)) {
-    return;
-  }
-
-  constexpr float k_second_wind_cooldown = 8.0F;
-  constexpr float k_second_wind_posture_restore = 55.0F;
-  constexpr float k_second_wind_stamina_restore = 35.0F;
-  constexpr float k_second_wind_guard_window = 0.35F;
-
-  cmd_comp->posture = std::max(0.0F, cmd_comp->posture - k_second_wind_posture_restore);
-  if (auto* stamina = commander.get_component<Engine::Core::StaminaComponent>()) {
-    stamina->stamina = std::min(stamina->max_stamina,
-                                stamina->stamina + k_second_wind_stamina_restore);
-  }
-  auto* guard = commander.get_component<Engine::Core::CommanderGuardComponent>();
-  if (guard == nullptr) {
-    guard = commander.add_component<Engine::Core::CommanderGuardComponent>();
-  }
-  if (guard != nullptr && guard->guard_break_remaining <= 0.0F) {
-    guard->perfect_guard_remaining =
-        std::max(guard->perfect_guard_remaining, k_second_wind_guard_window);
-  }
-
-  m_second_wind_cooldown = k_second_wind_cooldown;
-  Game::Audio::play_cue(Game::Audio::Cue::k_combat_second_wind);
-  cmd_comp->second_wind_cooldown_remaining = m_second_wind_cooldown;
 }
 
 auto CommanderControlController::update(Engine::Core::World& world,
@@ -1745,7 +1452,7 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
 
   if (cmd_comp != nullptr && cmd_comp->flag_rally_in_progress &&
       !cmd_comp->fpv_controlled) {
-    update_ability_cooldowns(cmd_comp, dt);
+    m_abilities.advance_cooldowns(cmd_comp, dt);
     cmd_comp->fpv_motion_vx = 0.0F;
     cmd_comp->fpv_motion_vz = 0.0F;
     cmd_comp->fpv_motion_requested = false;
@@ -2331,10 +2038,31 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
     }
   }
 
-  update_ability_cooldowns(cmd_comp, dt);
-  try_activate_shield_bash(world, *commander, commander_id, local_owner_id);
-  try_activate_vanguard_rush(world, *commander, commander_id, local_owner_id);
-  try_activate_second_wind(*commander);
+  App::Core::CommanderAbilityRequest ability_request;
+  ability_request.shield_bash = m_tick_input.shield_bash_pressed;
+  ability_request.vanguard_rush = m_tick_input.vanguard_rush_pressed;
+  ability_request.second_wind = m_tick_input.second_wind_pressed;
+  m_tick_input.shield_bash_pressed = false;
+  m_tick_input.vanguard_rush_pressed = false;
+  m_tick_input.second_wind_pressed = false;
+
+  m_abilities.advance_cooldowns(cmd_comp, dt);
+  if (ability_request.any()) {
+    App::Core::CommanderAbilityContext ability_context;
+    ability_context.world = &world;
+    ability_context.commander = commander;
+    ability_context.commander_id = commander_id;
+    ability_context.local_owner_id = local_owner_id;
+    ability_context.view_yaw = m_view_yaw;
+    ability_context.dodging = m_dodge_state != DodgeState::None;
+    ability_context.airborne = m_jump_timer > 0.0F;
+    ability_context.locked_target_id = m_locked_target_id;
+    ability_context.soft_target_id = m_soft_target_id;
+    ability_context.motor = &m_motor;
+    if (m_abilities.activate(ability_request, ability_context).rescan_primary_target) {
+      m_primary_scan_cooldown = k_ability_rescan_cooldown;
+    }
+  }
 
   if (m_tick_input.primary_held) {
     m_combo_miss_timer = 0.0F;

--- a/app/commander/commander_control_controller.h
+++ b/app/commander/commander_control_controller.h
@@ -8,6 +8,7 @@
 #include <limits>
 #include <mutex>
 
+#include "app/commander/commander_abilities.h"
 #include "app/commander/commander_camera_rig.h"
 #include "app/commander/commander_frame_intent.h"
 #include "app/commander/commander_input_snapshot.h"
@@ -176,21 +177,6 @@ private:
                                  int local_owner_id,
                                  Render::GL::Camera* camera,
                                  float dt);
-  [[nodiscard]] Engine::Core::EntityID
-  resolve_ability_target(Engine::Core::World& world,
-                         Engine::Core::Entity& commander,
-                         int local_owner_id,
-                         float max_range) const;
-  void update_ability_cooldowns(Engine::Core::CommanderComponent* commander, float dt);
-  void try_activate_shield_bash(Engine::Core::World& world,
-                                Engine::Core::Entity& commander,
-                                Engine::Core::EntityID commander_id,
-                                int local_owner_id);
-  void try_activate_vanguard_rush(Engine::Core::World& world,
-                                  Engine::Core::Entity& commander,
-                                  Engine::Core::EntityID commander_id,
-                                  int local_owner_id);
-  void try_activate_second_wind(Engine::Core::Entity& commander);
   void
   publish_resolved_defense_feedback(Engine::Core::Entity& commander,
                                     Engine::Core::EntityID commander_id,
@@ -270,9 +256,7 @@ private:
   CommanderInputSnapshot m_tick_input;
   std::uint64_t m_input_snapshot_sequence = 0;
   mutable std::mutex m_input_mutex;
-  float m_shield_bash_cooldown = 0.0F;
-  float m_vanguard_rush_cooldown = 0.0F;
-  float m_second_wind_cooldown = 0.0F;
+  App::Core::CommanderAbilities m_abilities;
 
   Engine::Core::EntityID m_locked_target_id = 0;
   std::uint16_t m_locked_target_slot{std::numeric_limits<std::uint16_t>::max()};

--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -919,22 +919,31 @@ void GameEngine::render(int pixel_width, int pixel_height) {
     std::unique_lock<std::recursive_mutex> frame_lock(m_frame_mutex, std::defer_lock);
     {
       const FrameLockWaiter waiter(m_frame_lock_waiters);
-      frame_lock.lock();
+      auto const deadline =
+          std::chrono::steady_clock::now() + k_render_effects_lock_budget;
+      while (!frame_lock.try_lock()) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+          break;
+        }
+        std::this_thread::yield();
+      }
     }
-    App::Core::FrameUiCoordinator::render_effects(
-        {.renderer = m_renderer.get(),
-         .world = m_world,
-         .command_controller = m_command_controller.get(),
-         .local_owner_id = m_runtime.local_owner_id,
-         .commander_rally_preview_pos =
-             m_commander_view_model->rally_preview_position(),
-         .attack_targeting = &m_attack_targeting,
-         .attack_range_rings = &m_attack_range_rings,
-         .order_markers = &m_order_markers.markers(),
-         .target_focus = &m_target_focus,
-         .interaction_targeting = &m_interaction_targeting,
-         .objective_marker = m_mission_stage_tracker.active_target()},
-        [this]() { m_commander_view_model->render_effects(); });
+    if (frame_lock.owns_lock()) {
+      App::Core::FrameUiCoordinator::render_effects(
+          {.renderer = m_renderer.get(),
+           .world = m_world,
+           .command_controller = m_command_controller.get(),
+           .local_owner_id = m_runtime.local_owner_id,
+           .commander_rally_preview_pos =
+               m_commander_view_model->rally_preview_position(),
+           .attack_targeting = &m_attack_targeting,
+           .attack_range_rings = &m_attack_range_rings,
+           .order_markers = &m_order_markers.markers(),
+           .target_focus = &m_target_focus,
+           .interaction_targeting = &m_interaction_targeting,
+           .objective_marker = m_mission_stage_tracker.active_target()},
+          [this]() { m_commander_view_model->render_effects(); });
+    }
   }
   m_renderer->end_frame();
 

--- a/app/core/game_engine.h
+++ b/app/core/game_engine.h
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -573,6 +574,8 @@ private:
   float m_deferred_presentation_dt = 0.0F;
 
   static constexpr int k_frame_lock_handoff_yields = 64;
+
+  static constexpr std::chrono::milliseconds k_render_effects_lock_budget{8};
   std::atomic<int> m_frame_lock_waiters{0};
 
   int m_loading_overlay_frames_remaining = 0;

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -1943,6 +1943,7 @@ public:
   std::uint32_t target_files{1U};
   std::vector<std::uint16_t> stable_slot_mapping;
   std::vector<UnitTraversalSlotState> slot_states;
+  std::uint32_t slot_states_revision{0U};
 
   float entry_progress{0.0F};
   float exit_progress{1.0F};

--- a/game/systems/building_collision_registry.cpp
+++ b/game/systems/building_collision_registry.cpp
@@ -49,7 +49,8 @@ namespace {
 
 BuildingCollisionRegistry::RegionDirtyHook g_region_dirty_hook = nullptr;
 BuildingCollisionRegistry::GridDirtyHook g_grid_dirty_hook = nullptr;
-BuildingCollisionRegistry::GridDirtyHook g_obstruction_released_hook = nullptr;
+BuildingCollisionRegistry::ObstructionReleasedHook g_obstruction_released_hook =
+    nullptr;
 
 void announce_region_dirty(float center_x, float center_z, float width, float depth) {
   if (g_region_dirty_hook != nullptr) {
@@ -63,10 +64,20 @@ void announce_grid_dirty() {
   }
 }
 
-void announce_obstruction_released() {
+void announce_obstruction_released(
+    const BuildingCollisionRegistry::ObstructionRelease& release) {
   if (g_obstruction_released_hook != nullptr) {
-    g_obstruction_released_hook();
+    g_obstruction_released_hook(release);
   }
+}
+
+void announce_obstruction_released_at(float center_x, float center_z) {
+  announce_obstruction_released(
+      {.center_x = center_x, .center_z = center_z, .located = true});
+}
+
+void announce_obstruction_released_everywhere() {
+  announce_obstruction_released({});
 }
 
 } // namespace
@@ -79,7 +90,8 @@ void BuildingCollisionRegistry::set_grid_dirty_hook(GridDirtyHook hook) {
   g_grid_dirty_hook = hook;
 }
 
-void BuildingCollisionRegistry::set_obstruction_released_hook(GridDirtyHook hook) {
+void BuildingCollisionRegistry::set_obstruction_released_hook(
+    ObstructionReleasedHook hook) {
   g_obstruction_released_hook = hook;
 }
 
@@ -270,7 +282,7 @@ void BuildingCollisionRegistry::unregister_building(Engine::Core::EntityID entit
   release_authored_obstacles_within(center_x, center_z, width, depth);
 
   announce_region_dirty(center_x, center_z, width, depth);
-  announce_obstruction_released();
+  announce_obstruction_released_at(center_x, center_z);
 }
 
 void BuildingCollisionRegistry::release_authored_obstacles_within(float center_x,
@@ -676,7 +688,7 @@ void BuildingCollisionRegistry::clear() {
   m_max_half_extent = 0.0F;
 
   announce_grid_dirty();
-  announce_obstruction_released();
+  announce_obstruction_released_everywhere();
 }
 
 void BuildingCollisionRegistry::set_grid_padding(float padding) {

--- a/game/systems/building_collision_registry.h
+++ b/game/systems/building_collision_registry.h
@@ -82,9 +82,17 @@ public:
                                    float width,
                                    float depth);
   using GridDirtyHook = void (*)();
+
+  struct ObstructionRelease {
+    float center_x{0.0F};
+    float center_z{0.0F};
+    bool located{false};
+  };
+
+  using ObstructionReleasedHook = void (*)(const ObstructionRelease& release);
   static void set_region_dirty_hook(RegionDirtyHook hook);
   static void set_grid_dirty_hook(GridDirtyHook hook);
-  static void set_obstruction_released_hook(GridDirtyHook hook);
+  static void set_obstruction_released_hook(ObstructionReleasedHook hook);
 
   static auto get_building_size(const std::string& building_type) -> BuildingSize;
 

--- a/game/systems/command_service.cpp
+++ b/game/systems/command_service.cpp
@@ -29,6 +29,8 @@
 namespace Game::Systems {
 
 namespace {
+constexpr int k_stranded_start_recovery_cells = 8;
+
 auto resolve_walkable_target(const QVector3D& target) -> QVector3D {
   return NavGrid::snap_to_walkable_ground(target, 8);
 }
@@ -49,12 +51,13 @@ auto slot_is_reachable(Engine::Core::World& world,
   auto const passability = movement == nullptr || movement->get_can_enter_forest()
                                ? Pathfinding::Passability::Light
                                : Pathfinding::Passability::Heavy;
-  float const clearance = FormationCombat::formation_navigation_clearance(*entity);
-  Point const start =
-      NavGrid::world_to_grid(transform->position.x, transform->position.z);
   Point const target = NavGrid::world_to_grid(destination.x(), destination.z());
-  auto const route = pathfinder->find_path(start, target, passability, clearance);
-  return !route.empty() && route.back() == target;
+  Point const start = Pathfinding::find_nearest_walkable_point(
+      NavGrid::world_to_grid(transform->position.x, transform->position.z),
+      k_stranded_start_recovery_cells,
+      *pathfinder,
+      passability);
+  return pathfinder->can_reach(start, target, passability);
 }
 
 auto rescued_slot_position(Engine::Core::World& world,

--- a/game/systems/formation_combat_geometry.cpp
+++ b/game/systems/formation_combat_geometry.cpp
@@ -7,6 +7,8 @@
 #include <limits>
 #include <numbers>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "../core/component.h"
 #include "../formation/traversal_layout_policy.h"
@@ -533,10 +535,10 @@ auto resolve_layout(const Engine::Core::Entity& entity) -> FormationLayout {
   return entry != nullptr ? entry->layout : FormationLayout{};
 }
 
-auto soldier_spatial_anchors(const Engine::Core::Entity& entity,
-                             const FormationLayout& base_layout)
-    -> std::vector<SoldierSpatialAnchor> {
-  std::vector<SoldierSpatialAnchor> result;
+void soldier_spatial_anchors_into(const Engine::Core::Entity& entity,
+                                  const FormationLayout& base_layout,
+                                  std::vector<SoldierSpatialAnchor>& result) {
+  result.clear();
   result.reserve(base_layout.live_slots.size());
   auto const* transform = entity.get_component<Engine::Core::TransformComponent>();
   auto const* traversal =
@@ -551,7 +553,8 @@ auto soldier_spatial_anchors(const Engine::Core::Entity& entity,
   float const sin_yaw = std::sin(yaw);
   float const cos_yaw = std::cos(yaw);
   constexpr std::size_t k_missing_soldier = std::numeric_limits<std::size_t>::max();
-  std::vector<std::size_t> presentation_by_slot;
+  thread_local std::vector<std::size_t> presentation_by_slot;
+  presentation_by_slot.clear();
   if (presentation != nullptr) {
     std::uint16_t max_slot = 0U;
     for (auto const& base : base_layout.live_slots) {
@@ -567,6 +570,34 @@ auto soldier_spatial_anchors(const Engine::Core::Entity& entity,
     }
   }
 
+  thread_local std::vector<const Engine::Core::UnitTraversalSlotState*>
+      traversal_by_slot;
+  traversal_by_slot.clear();
+  if (traversal != nullptr) {
+    for (auto const& slot : traversal->slot_states) {
+      if (slot.slot_index >= traversal_by_slot.size()) {
+        traversal_by_slot.resize(static_cast<std::size_t>(slot.slot_index) + 1U,
+                                 nullptr);
+      }
+      if (traversal_by_slot[slot.slot_index] == nullptr) {
+        traversal_by_slot[slot.slot_index] = &slot;
+      }
+    }
+  }
+
+  auto traversal_slot_for =
+      [&](std::uint16_t slot_index) -> const Engine::Core::UnitTraversalSlotState* {
+    if (traversal == nullptr) {
+      return nullptr;
+    }
+    if (slot_index < traversal->slot_states.size() &&
+        traversal->slot_states[slot_index].slot_index == slot_index) {
+      return &traversal->slot_states[slot_index];
+    }
+    return slot_index < traversal_by_slot.size() ? traversal_by_slot[slot_index]
+                                                 : nullptr;
+  };
+
   for (auto const& base : base_layout.live_slots) {
     SoldierSpatialAnchor anchor{
         .slot_index = base.index,
@@ -578,7 +609,7 @@ auto soldier_spatial_anchors(const Engine::Core::Entity& entity,
         .source = SoldierAnchorSource::BaseLayout,
     };
     if (traversal != nullptr) {
-      if (auto const* slot = traversal->slot_for(base.index);
+      if (auto const* slot = traversal_slot_for(base.index);
           slot != nullptr && slot->alive) {
         anchor.row = slot->row;
         anchor.col = slot->col;
@@ -603,6 +634,13 @@ auto soldier_spatial_anchors(const Engine::Core::Entity& entity,
     anchor.world_z = root_z - sin_yaw * anchor.local_x + cos_yaw * anchor.local_z;
     result.push_back(anchor);
   }
+}
+
+auto soldier_spatial_anchors(const Engine::Core::Entity& entity,
+                             const FormationLayout& base_layout)
+    -> std::vector<SoldierSpatialAnchor> {
+  std::vector<SoldierSpatialAnchor> result;
+  soldier_spatial_anchors_into(entity, base_layout, result);
   return result;
 }
 
@@ -658,18 +696,21 @@ auto has_formation_slots(const Engine::Core::Entity& entity) -> bool {
 
 namespace {
 
-auto spatialized_layout(const Engine::Core::Entity& entity,
-                        const FormationLayout& base_layout) -> FormationLayout {
-  FormationLayout result = base_layout;
-  auto const anchors = soldier_spatial_anchors(entity, base_layout);
-  std::vector<const SoldierSpatialAnchor*> anchor_by_slot;
+void spatialize_layout_into(const Engine::Core::Entity& entity,
+                            const FormationLayout& base_layout,
+                            FormationLayout& result) {
+  result = base_layout;
+  thread_local std::vector<SoldierSpatialAnchor> anchors;
+  soldier_spatial_anchors_into(entity, base_layout, anchors);
+  thread_local std::vector<const SoldierSpatialAnchor*> anchor_by_slot;
+  anchor_by_slot.clear();
   for (auto const& anchor : anchors) {
     if (anchor.slot_index >= anchor_by_slot.size()) {
       anchor_by_slot.resize(static_cast<std::size_t>(anchor.slot_index) + 1U, nullptr);
     }
     anchor_by_slot[anchor.slot_index] = &anchor;
   }
-  auto apply = [&anchor_by_slot](std::vector<SoldierSlot>& slot_list) {
+  auto apply = [](std::vector<SoldierSlot>& slot_list) {
     for (auto& slot : slot_list) {
       if (slot.index >= anchor_by_slot.size() ||
           anchor_by_slot[slot.index] == nullptr) {
@@ -688,13 +729,83 @@ auto spatialized_layout(const Engine::Core::Entity& entity,
   apply(result.all_slots);
   apply(result.live_slots);
   apply(result.occupied_slots);
-  return result;
+}
+
+struct SpatialLayoutCacheEntry {
+  std::uint64_t base_signature{0};
+  float world_x{0.0F};
+  float world_z{0.0F};
+  float yaw{0.0F};
+  std::uint32_t traversal_revision{0U};
+  std::uint32_t presentation_revision{0U};
+  bool has_traversal{false};
+  bool has_presentation{false};
+  bool valid{false};
+  FormationLayout layout;
+};
+
+thread_local std::unordered_map<const Engine::Core::Entity*, SpatialLayoutCacheEntry>
+    g_spatial_layout_cache;
+
+constexpr std::size_t k_max_cached_spatial_layouts = 8192U;
+
+void prune_spatial_layout_cache() {
+  if (g_spatial_layout_cache.size() > k_max_cached_spatial_layouts) {
+    g_spatial_layout_cache.clear();
+  }
+}
+
+auto spatialized_layout_for(const Engine::Core::Entity& entity,
+                            const FormationLayout& base_layout,
+                            std::uint64_t base_signature) -> const FormationLayout& {
+  auto const* transform = entity.get_component<Engine::Core::TransformComponent>();
+  auto const* traversal =
+      entity.get_component<Engine::Core::UnitTraversalLayoutStateComponent>();
+  auto const* presentation =
+      entity.get_component<Engine::Core::FormationPresentationComponent>();
+
+  float const world_x = transform != nullptr ? transform->position.x : 0.0F;
+  float const world_z = transform != nullptr ? transform->position.z : 0.0F;
+  float const yaw = transform != nullptr ? transform->rotation.y : 0.0F;
+  std::uint32_t const traversal_revision =
+      traversal != nullptr ? traversal->slot_states_revision : 0U;
+  std::uint32_t const presentation_revision =
+      presentation != nullptr ? presentation->revision : 0U;
+
+  SpatialLayoutCacheEntry& entry = g_spatial_layout_cache[&entity];
+  if (entry.valid && entry.base_signature == base_signature &&
+      entry.world_x == world_x && entry.world_z == world_z && entry.yaw == yaw &&
+      entry.has_traversal == (traversal != nullptr) &&
+      entry.has_presentation == (presentation != nullptr) &&
+      entry.traversal_revision == traversal_revision &&
+      entry.presentation_revision == presentation_revision) {
+    return entry.layout;
+  }
+
+  spatialize_layout_into(entity, base_layout, entry.layout);
+  entry.base_signature = base_signature;
+  entry.world_x = world_x;
+  entry.world_z = world_z;
+  entry.yaw = yaw;
+  entry.has_traversal = traversal != nullptr;
+  entry.has_presentation = presentation != nullptr;
+  entry.traversal_revision = traversal_revision;
+  entry.presentation_revision = presentation_revision;
+  entry.valid = true;
+  return entry.layout;
 }
 
 struct ResolvedContact {
-  FormationLayout attacker_layout;
-  FormationLayout target_layout;
+  const FormationLayout* attacker_layout{nullptr};
+  const FormationLayout* target_layout{nullptr};
   ContactGeometry geometry;
+};
+
+struct SlotOffset {
+  float world_x{0.0F};
+  float world_z{0.0F};
+  float offset_x{0.0F};
+  float offset_z{0.0F};
 };
 
 void accumulate_slot_contact(const Engine::Core::TransformComponent& attacker_transform,
@@ -707,25 +818,72 @@ void accumulate_slot_contact(const Engine::Core::TransformComponent& attacker_tr
                              ContactGeometry& result) {
   const float contact_radius = attacker_layout.body_radius + target_layout.body_radius;
   const float contact_radius_sq = contact_radius * contact_radius;
+  constexpr float k_infinity = std::numeric_limits<float>::infinity();
 
-  float nearest = std::numeric_limits<float>::infinity();
+  thread_local std::vector<SlotOffset> target_offsets;
+  target_offsets.clear();
+  target_offsets.reserve(target_layout.occupied_slots.size());
+
+  float target_min_x = k_infinity;
+  float target_max_x = -k_infinity;
+  float target_min_z = k_infinity;
+  float target_max_z = -k_infinity;
+  float nearest_target_parallel = k_infinity;
+  for (auto const& target_slot : target_layout.occupied_slots) {
+    const float offset_x = target_slot.world_x - target_transform.position.x;
+    const float offset_z = target_slot.world_z - target_transform.position.z;
+    target_offsets.push_back({.world_x = target_slot.world_x,
+                              .world_z = target_slot.world_z,
+                              .offset_x = offset_x,
+                              .offset_z = offset_z});
+    target_min_x = std::min(target_min_x, target_slot.world_x);
+    target_max_x = std::max(target_max_x, target_slot.world_x);
+    target_min_z = std::min(target_min_z, target_slot.world_z);
+    target_max_z = std::max(target_max_z, target_slot.world_z);
+    nearest_target_parallel =
+        std::min(nearest_target_parallel, (offset_x * dir_x) + (offset_z * dir_z));
+  }
+
+  float nearest_sq = k_infinity;
   for (auto const& attacker_slot : attacker_layout.occupied_slots) {
+    const float gap_x = std::max({0.0F,
+                                  target_min_x - attacker_slot.world_x,
+                                  attacker_slot.world_x - target_max_x});
+    const float gap_z = std::max({0.0F,
+                                  target_min_z - attacker_slot.world_z,
+                                  attacker_slot.world_z - target_max_z});
+    const bool may_shorten = ((gap_x * gap_x) + (gap_z * gap_z)) < nearest_sq;
+
     const float attacker_offset_x =
         attacker_slot.world_x - attacker_transform.position.x;
     const float attacker_offset_z =
         attacker_slot.world_z - attacker_transform.position.z;
+    const float attacker_parallel =
+        (attacker_offset_x * dir_x) + (attacker_offset_z * dir_z);
+    const bool may_deepen =
+        has_direction && (contact_radius - nearest_target_parallel +
+                          attacker_parallel) > result.contact_center_distance;
 
-    for (auto const& target_slot : target_layout.occupied_slots) {
-      nearest = std::min(nearest, slot_distance(attacker_slot, target_slot));
+    if (!may_shorten && !may_deepen) {
+      continue;
+    }
 
-      if (!has_direction) {
+    for (auto const& target_slot : target_offsets) {
+      if (may_shorten) {
+        const float span_x = target_slot.world_x - attacker_slot.world_x;
+        const float span_z = target_slot.world_z - attacker_slot.world_z;
+        nearest_sq = std::min(nearest_sq, (span_x * span_x) + (span_z * span_z));
+      }
+      if (!may_deepen) {
         continue;
       }
-      const float relative_x =
-          (target_slot.world_x - target_transform.position.x) - attacker_offset_x;
-      const float relative_z =
-          (target_slot.world_z - target_transform.position.z) - attacker_offset_z;
+
+      const float relative_x = target_slot.offset_x - attacker_offset_x;
+      const float relative_z = target_slot.offset_z - attacker_offset_z;
       const float parallel = (relative_x * dir_x) + (relative_z * dir_z);
+      if (contact_radius - parallel <= result.contact_center_distance) {
+        continue;
+      }
       const float relative_sq = (relative_x * relative_x) + (relative_z * relative_z);
       const float lateral_sq = std::max(0.0F, relative_sq - (parallel * parallel));
       if (lateral_sq > contact_radius_sq) {
@@ -737,13 +895,17 @@ void accumulate_slot_contact(const Engine::Core::TransformComponent& attacker_tr
     }
   }
 
+  const float nearest = std::isinf(nearest_sq) ? nearest_sq : std::sqrt(nearest_sq);
   result.surface_gap =
       nearest - attacker_layout.body_radius - target_layout.body_radius;
 }
 
-auto resolve_contact(const Engine::Core::Entity& attacker,
-                     const Engine::Core::Entity& target) -> ResolvedContact {
-  ResolvedContact resolved;
+void resolve_contact(const Engine::Core::Entity& attacker,
+                     const Engine::Core::Entity& target,
+                     ResolvedContact& resolved) {
+  resolved.geometry = ContactGeometry{};
+  resolved.attacker_layout = nullptr;
+  resolved.target_layout = nullptr;
   ContactGeometry& result = resolved.geometry;
   auto const* attacker_transform =
       attacker.get_component<Engine::Core::TransformComponent>();
@@ -751,7 +913,7 @@ auto resolve_contact(const Engine::Core::Entity& attacker,
       target.get_component<Engine::Core::TransformComponent>();
   if (attacker_transform == nullptr || target_transform == nullptr) {
     result.surface_gap = std::numeric_limits<float>::infinity();
-    return resolved;
+    return;
   }
 
   float const dx = target_transform->position.x - attacker_transform->position.x;
@@ -769,7 +931,7 @@ auto resolve_contact(const Engine::Core::Entity& attacker,
     result.contact_center_distance = body_contact;
     result.engagement_center_distance =
         body_contact + std::max(0.0F, reach - body_contact) * k_single_body_reach_share;
-    return resolved;
+    return;
   }
 
   const std::uint64_t generation_before = g_layout_cache_generation;
@@ -786,10 +948,17 @@ auto resolve_contact(const Engine::Core::Entity& attacker,
       attacker_entry != nullptr ? attacker_entry->layout : k_absent_layout;
   auto const& target_layout =
       target_entry != nullptr ? target_entry->layout : k_absent_layout;
-  resolved.attacker_layout = spatialized_layout(attacker, attacker_layout);
-  resolved.target_layout = spatialized_layout(target, target_layout);
-  auto const& spatial_attacker_layout = resolved.attacker_layout;
-  auto const& spatial_target_layout = resolved.target_layout;
+  prune_spatial_layout_cache();
+  resolved.attacker_layout = &spatialized_layout_for(
+      attacker,
+      attacker_layout,
+      attacker_entry != nullptr ? attacker_entry->local_signature : 0U);
+  resolved.target_layout = &spatialized_layout_for(
+      target,
+      target_layout,
+      target_entry != nullptr ? target_entry->local_signature : 0U);
+  auto const& spatial_attacker_layout = *resolved.attacker_layout;
+  auto const& spatial_target_layout = *resolved.target_layout;
 
   result.formation_overlap_required =
       has_formation_slots(attacker) && has_formation_slots(target);
@@ -831,8 +1000,6 @@ auto resolve_contact(const Engine::Core::Entity& attacker,
                  result.center_distance - result.surface_gap +
                      melee_reach(attacker) * k_mixed_body_approach_margin);
   }
-
-  return resolved;
 }
 
 } // namespace
@@ -840,18 +1007,24 @@ auto resolve_contact(const Engine::Core::Entity& attacker,
 auto resolve_contact_context(const Engine::Core::Entity& attacker,
                              const Engine::Core::Entity& target)
     -> FormationContactContext {
-  const ResolvedContact resolved = resolve_contact(attacker, target);
+  ResolvedContact resolved;
+  resolve_contact(attacker, target, resolved);
   FormationContactContext context;
   context.geometry = resolved.geometry;
-  context.attacker_layout = resolved.attacker_layout;
-  context.target_layout = resolved.target_layout;
+  if (resolved.attacker_layout != nullptr) {
+    context.attacker_layout = *resolved.attacker_layout;
+  }
+  if (resolved.target_layout != nullptr) {
+    context.target_layout = *resolved.target_layout;
+  }
   return context;
 }
 
 auto contact_geometry(const Engine::Core::Entity& attacker,
                       const Engine::Core::Entity& target) -> ContactGeometry {
-
-  return resolve_contact(attacker, target).geometry;
+  thread_local ResolvedContact scratch;
+  resolve_contact(attacker, target, scratch);
+  return scratch.geometry;
 }
 
 auto single_combat_strike_distance(const Engine::Core::Entity& attacker,
@@ -941,8 +1114,10 @@ auto engagement_pairs(const Engine::Core::Entity& attacker,
     return result;
   }
 
-  auto const spatial_attacker_layout = spatialized_layout(attacker, attacker_layout);
-  auto const spatial_target_layout = spatialized_layout(target, target_layout);
+  FormationLayout spatial_attacker_layout;
+  FormationLayout spatial_target_layout;
+  spatialize_layout_into(attacker, attacker_layout, spatial_attacker_layout);
+  spatialize_layout_into(target, target_layout, spatial_target_layout);
   float const contact_distance =
       spatial_attacker_layout.body_radius + spatial_target_layout.body_radius;
   for (auto const& attacker_slot : spatial_attacker_layout.live_slots) {

--- a/game/systems/formation_combat_geometry.h
+++ b/game/systems/formation_combat_geometry.h
@@ -105,6 +105,10 @@ resolve_layout(const Engine::Core::Entity& entity) -> FormationLayout;
                                            const FormationLayout& base_layout)
     -> std::vector<SoldierSpatialAnchor>;
 
+void soldier_spatial_anchors_into(const Engine::Core::Entity& entity,
+                                  const FormationLayout& base_layout,
+                                  std::vector<SoldierSpatialAnchor>& result);
+
 [[nodiscard]] auto living_slot_indices(const Engine::Core::Entity& entity,
                                        int total_count) -> std::vector<std::uint16_t>;
 

--- a/game/systems/local_avoidance_system.cpp
+++ b/game/systems/local_avoidance_system.cpp
@@ -207,9 +207,19 @@ void LocalAvoidanceSystem::build_index(Engine::Core::SystemContext& context) {
 auto LocalAvoidanceSystem::gather_neighbors(std::size_t self,
                                             float horizon) -> std::size_t {
   m_neighbors.clear();
+  m_neighbors.reserve(k_max_neighbors + 1U);
   auto const& me = m_circles[self];
   float const inv_cell_size = 1.0F / k_default_cell_size;
   CellKey const center = to_cell(me.x, me.z, inv_cell_size);
+
+  auto const sorts_before = [this](const Neighbor& lhs, const Neighbor& rhs) {
+    float const left = lhs.time_to_collision < 0.0F ? 1.0e9F : lhs.time_to_collision;
+    float const right = rhs.time_to_collision < 0.0F ? 1.0e9F : rhs.time_to_collision;
+    if (left != right) {
+      return left < right;
+    }
+    return m_circles[lhs.index].id < m_circles[rhs.index].id;
+  };
 
   std::uint32_t examined = 0;
   for (int dx = -1; dx <= 1; ++dx) {
@@ -237,54 +247,52 @@ auto LocalAvoidanceSystem::gather_neighbors(std::size_t self,
           continue;
         }
 
-        float response = 0.5F;
-        if (!them.avoids || !them.is_moving) {
-          response = 1.0F;
-        } else if (them.priority > me.priority) {
-          response = 0.75F;
-        } else if (them.priority < me.priority) {
-          response = 0.25F;
-        } else {
-
-          float const speed = std::hypot(me.desired_vx, me.desired_vz);
-          if (speed > 1.0e-4F) {
-            float const cross = (me.desired_vx * pz - me.desired_vz * px) / speed;
-            response = cross < 0.0F ? 0.8F : 0.2F;
-          }
-        }
-
-        if (them.formation_id != 0U && them.formation_id == me.formation_id) {
-          response *= 0.6F;
-        }
-
         float const ttc = time_to_collision(px,
                                             pz,
                                             them.predicted_vx - me.desired_vx,
                                             them.predicted_vz - me.desired_vz,
                                             combined,
                                             horizon);
-        m_neighbors.push_back({other, ttc, response});
+
+        m_neighbors.push_back({other, ttc, 0.5F});
+        std::push_heap(m_neighbors.begin(), m_neighbors.end(), sorts_before);
+        if (m_neighbors.size() > k_max_neighbors) {
+          std::pop_heap(m_neighbors.begin(), m_neighbors.end(), sorts_before);
+          m_neighbors.pop_back();
+        }
       }
     }
   }
 
-  std::sort(m_neighbors.begin(),
-            m_neighbors.end(),
-            [this](const Neighbor& lhs, const Neighbor& rhs) {
-              return m_circles[lhs.index].id < m_circles[rhs.index].id;
-            });
-  std::stable_sort(m_neighbors.begin(),
-                   m_neighbors.end(),
-                   [](const Neighbor& lhs, const Neighbor& rhs) {
-                     float const left =
-                         lhs.time_to_collision < 0.0F ? 1.0e9F : lhs.time_to_collision;
-                     float const right =
-                         rhs.time_to_collision < 0.0F ? 1.0e9F : rhs.time_to_collision;
-                     return left < right;
-                   });
-  if (m_neighbors.size() > k_max_neighbors) {
-    m_neighbors.resize(k_max_neighbors);
+  std::sort_heap(m_neighbors.begin(), m_neighbors.end(), sorts_before);
+
+  for (auto& neighbor : m_neighbors) {
+    auto const& them = m_circles[neighbor.index];
+    float const px = them.x - me.x;
+    float const pz = them.z - me.z;
+
+    float response = 0.5F;
+    if (!them.avoids || !them.is_moving) {
+      response = 1.0F;
+    } else if (them.priority > me.priority) {
+      response = 0.75F;
+    } else if (them.priority < me.priority) {
+      response = 0.25F;
+    } else {
+
+      float const speed = std::hypot(me.desired_vx, me.desired_vz);
+      if (speed > 1.0e-4F) {
+        float const cross = (me.desired_vx * pz - me.desired_vz * px) / speed;
+        response = cross < 0.0F ? 0.8F : 0.2F;
+      }
+    }
+
+    if (them.formation_id != 0U && them.formation_id == me.formation_id) {
+      response *= 0.6F;
+    }
+    neighbor.response = response;
   }
+
   return examined;
 }
 

--- a/game/systems/movement_system.cpp
+++ b/game/systems/movement_system.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <numbers>
 #include <vector>
@@ -285,8 +286,14 @@ void MovementSystem::process_pending_path_requests(Engine::Core::World& world) {
         ++processed;
         continue;
       }
-      float const goal_dx = movement->get_goal_x() - request.target.x();
-      float const goal_dz = movement->get_goal_y() - request.target.z();
+      float const current_goal_x = movement->get_has_requested_goal()
+                                       ? movement->get_requested_goal_x()
+                                       : movement->get_goal_x();
+      float const current_goal_z = movement->get_has_requested_goal()
+                                       ? movement->get_requested_goal_z()
+                                       : movement->get_goal_y();
+      float const goal_dx = current_goal_x - request.target.x();
+      float const goal_dz = current_goal_z - request.target.z();
       if (goal_dx * goal_dx + goal_dz * goal_dz > 0.01F) {
         ++processed;
         continue;
@@ -322,6 +329,19 @@ void MovementSystem::cancel_pending_path_request(Engine::Core::EntityID entity_i
 
 void MovementSystem::repath_after_obstruction_release(
     Engine::Core::World& world, const std::vector<Engine::Core::Entity*>& movers) {
+  auto* pathfinder = NavGrid::get_pathfinder();
+  auto const release = pathfinder != nullptr ? pathfinder->last_obstruction_release()
+                                             : Pathfinding::ObstructionRelease{};
+
+  struct RepathCandidate {
+    Engine::Core::EntityID entity_id{0};
+    QVector3D goal;
+    float distance_to_release_sq{0.0F};
+  };
+
+  std::vector<RepathCandidate> candidates;
+  candidates.reserve(movers.size());
+
   for (auto* entity : movers) {
     if (entity == nullptr ||
         entity->has_component<Engine::Core::PendingRemovalComponent>()) {
@@ -338,14 +358,58 @@ void MovementSystem::repath_after_obstruction_release(
       continue;
     }
 
-    QVector3D const goal =
+    RepathCandidate candidate;
+    candidate.entity_id = entity->get_id();
+    candidate.goal =
         movement->get_has_requested_goal()
             ? QVector3D(movement->get_requested_goal_x(),
                         0.0F,
                         movement->get_requested_goal_z())
             : QVector3D(movement->get_goal_x(), 0.0F, movement->get_goal_y());
 
-    if (!retarget_unit(world, entity->get_id(), goal)) {
+    auto const* transform = entity->get_component<Engine::Core::TransformComponent>();
+    if (release.located && transform != nullptr) {
+      float const dx = transform->position.x - release.center.x();
+      float const dz = transform->position.z - release.center.z();
+      candidate.distance_to_release_sq = (dx * dx) + (dz * dz);
+    }
+    candidates.push_back(candidate);
+  }
+
+  if (release.located && candidates.size() > k_path_requests_per_tick) {
+    std::partial_sort(candidates.begin(),
+                      candidates.begin() +
+                          static_cast<std::ptrdiff_t>(k_path_requests_per_tick),
+                      candidates.end(),
+                      [](const RepathCandidate& lhs, const RepathCandidate& rhs) {
+                        return lhs.distance_to_release_sq < rhs.distance_to_release_sq;
+                      });
+  }
+
+  std::uint64_t const navigation_revision =
+      pathfinder != nullptr ? pathfinder->navigation_revision() : 0U;
+  std::size_t repathed_now = 0;
+
+  for (auto const& candidate : candidates) {
+    auto* entity = world.get_entity(candidate.entity_id);
+    if (entity == nullptr) {
+      continue;
+    }
+    auto* movement = entity->get_component<Engine::Core::MovementComponent>();
+    if (movement == nullptr) {
+      continue;
+    }
+
+    if (repathed_now < k_path_requests_per_tick) {
+      if (!retarget_unit(world, candidate.entity_id, candidate.goal)) {
+        continue;
+      }
+      ++repathed_now;
+    } else if (!enqueue_pending_path_request(candidate.entity_id,
+                                             candidate.goal,
+                                             movement->get_precise_arrival(),
+                                             navigation_revision,
+                                             movement->get_order_sequence())) {
       continue;
     }
 

--- a/game/systems/nav_grid.cpp
+++ b/game/systems/nav_grid.cpp
@@ -34,11 +34,18 @@ void NavGrid::initialize(int world_width, int world_height) {
       s_pathfinder->mark_navigation_grid_dirty();
     }
   });
-  BuildingCollisionRegistry::set_obstruction_released_hook([]() {
-    if (s_pathfinder != nullptr) {
-      s_pathfinder->mark_obstruction_released();
-    }
-  });
+  BuildingCollisionRegistry::set_obstruction_released_hook(
+      [](const BuildingCollisionRegistry::ObstructionRelease& release) {
+        if (s_pathfinder == nullptr) {
+          return;
+        }
+        if (release.located) {
+          s_pathfinder->mark_obstruction_released_at(release.center_x,
+                                                     release.center_z);
+        } else {
+          s_pathfinder->mark_obstruction_released();
+        }
+      });
 }
 
 auto NavGrid::get_pathfinder() -> Pathfinding* {

--- a/game/systems/pathfinding.cpp
+++ b/game/systems/pathfinding.cpp
@@ -417,7 +417,25 @@ void Pathfinding::mark_building_region_dirty(float center_x,
 }
 
 void Pathfinding::mark_obstruction_released() {
+  m_obstruction_center_located.store(false, std::memory_order_relaxed);
   m_obstruction_revision.fetch_add(1, std::memory_order_acq_rel);
+}
+
+void Pathfinding::mark_obstruction_released_at(float center_x, float center_z) {
+  m_obstruction_center_x.store(center_x, std::memory_order_relaxed);
+  m_obstruction_center_z.store(center_z, std::memory_order_relaxed);
+  m_obstruction_center_located.store(true, std::memory_order_relaxed);
+  m_obstruction_revision.fetch_add(1, std::memory_order_acq_rel);
+}
+
+auto Pathfinding::last_obstruction_release() const -> ObstructionRelease {
+  if (!m_obstruction_center_located.load(std::memory_order_relaxed)) {
+    return {};
+  }
+  return {.center = QVector3D(m_obstruction_center_x.load(std::memory_order_relaxed),
+                              0.0F,
+                              m_obstruction_center_z.load(std::memory_order_relaxed)),
+          .located = true};
 }
 
 auto Pathfinding::obstruction_revision() const -> std::uint64_t {
@@ -909,6 +927,103 @@ auto Pathfinding::find_path(const Point& start,
   }
   m_path_cache.emplace(key, path);
   return path;
+}
+
+auto Pathfinding::label_at(const RegionMap& map,
+                           const Point& cell) const -> std::uint32_t {
+  if (cell.x < 0 || cell.x >= m_width || cell.y < 0 || cell.y >= m_height) {
+    return k_unreachable_region;
+  }
+  auto const index = static_cast<std::size_t>(to_index(cell));
+  return index < map.labels.size() ? map.labels[index] : k_unreachable_region;
+}
+
+void Pathfinding::rebuild_region_map(RegionMap& map, Passability passability) const {
+  auto const cell_count = static_cast<std::size_t>(std::max(m_width, 0)) *
+                          static_cast<std::size_t>(std::max(m_height, 0));
+  map.labels.assign(cell_count, k_unreachable_region);
+  if (cell_count == 0U) {
+    return;
+  }
+
+  std::vector<int> frontier;
+  std::uint32_t next_label = k_unreachable_region;
+  for (int seed_y = 0; seed_y < m_height; ++seed_y) {
+    for (int seed_x = 0; seed_x < m_width; ++seed_x) {
+      int const seed_index = to_index(seed_x, seed_y);
+      if (map.labels[static_cast<std::size_t>(seed_index)] != k_unreachable_region ||
+          !is_walkable(seed_x, seed_y, passability)) {
+        continue;
+      }
+
+      ++next_label;
+      map.labels[static_cast<std::size_t>(seed_index)] = next_label;
+      frontier.clear();
+      frontier.push_back(seed_index);
+
+      while (!frontier.empty()) {
+        Point const current = to_point(frontier.back());
+        frontier.pop_back();
+
+        std::array<Point, 8> neighbors{};
+        std::size_t const neighbor_count =
+            collect_neighbors(current, neighbors, passability);
+        for (std::size_t i = 0; i < neighbor_count; ++i) {
+          Point const& neighbor = neighbors[i];
+          if (!is_walkable(neighbor.x, neighbor.y, passability)) {
+            continue;
+          }
+          auto const neighbor_index = static_cast<std::size_t>(to_index(neighbor));
+          if (map.labels[neighbor_index] != k_unreachable_region) {
+            continue;
+          }
+          map.labels[neighbor_index] = next_label;
+          frontier.push_back(static_cast<int>(neighbor_index));
+        }
+      }
+    }
+  }
+}
+
+void Pathfinding::region_labels(const Point& first,
+                                const Point& second,
+                                Passability passability,
+                                std::uint32_t& first_label,
+                                std::uint32_t& second_label) {
+  if (m_navigation_grid_dirty.load(std::memory_order_acquire)) {
+    update_navigation_grid();
+  }
+
+  std::uint64_t const revision = navigation_revision();
+  std::shared_lock<std::shared_mutex> const navigation_lock(m_navigation_mutex);
+  std::lock_guard<std::mutex> const region_lock(m_region_mutex);
+
+  auto& map = m_region_maps[static_cast<std::size_t>(passability)];
+  if (!map.built || map.revision != revision) {
+    rebuild_region_map(map, passability);
+    map.revision = revision;
+    map.built = true;
+  }
+
+  first_label = label_at(map, first);
+  second_label = label_at(map, second);
+}
+
+auto Pathfinding::region_of(const Point& cell,
+                            Passability passability) -> std::uint32_t {
+  std::uint32_t label = k_unreachable_region;
+  std::uint32_t ignored = k_unreachable_region;
+  region_labels(cell, cell, passability, label, ignored);
+  return label;
+}
+
+auto Pathfinding::can_reach(const Point& start,
+                            const Point& end,
+                            Passability passability) -> bool {
+  std::uint32_t start_label = k_unreachable_region;
+  std::uint32_t end_label = k_unreachable_region;
+  region_labels(start, end, passability, start_label, end_label);
+  return start_label != k_unreachable_region && start_label == end_label;
 }
 
 auto Pathfinding::PathCacheKeyHash::operator()(const PathCacheKey& key) const noexcept

--- a/game/systems/pathfinding.h
+++ b/game/systems/pathfinding.h
@@ -109,12 +109,30 @@ public:
 
   void mark_obstruction_released();
 
+  void mark_obstruction_released_at(float center_x, float center_z);
+
   [[nodiscard]] auto obstruction_revision() const -> std::uint64_t;
+
+  struct ObstructionRelease {
+    QVector3D center;
+    bool located{false};
+  };
+
+  [[nodiscard]] auto last_obstruction_release() const -> ObstructionRelease;
 
   auto find_path(const Point& start,
                  const Point& end,
                  Passability passability = Passability::Light,
                  float clearance_radius = 0.0F) -> std::vector<Point>;
+
+  static constexpr std::uint32_t k_unreachable_region = 0U;
+
+  [[nodiscard]] auto region_of(const Point& cell,
+                               Passability passability) -> std::uint32_t;
+
+  [[nodiscard]] auto can_reach(const Point& start,
+                               const Point& end,
+                               Passability passability = Passability::Light) -> bool;
 
   [[nodiscard]] auto navigation_revision() const -> std::uint64_t {
     return m_navigation_revision.load(std::memory_order_acquire);
@@ -233,6 +251,23 @@ private:
   static void push_open_node(SearchBuffers& buffers, const QueueNode& node);
   static auto pop_open_node(SearchBuffers& buffers) -> QueueNode;
 
+  struct RegionMap {
+    std::vector<std::uint32_t> labels;
+    std::uint64_t revision{0};
+    bool built{false};
+  };
+
+  static constexpr std::size_t k_passability_count = 2U;
+
+  void region_labels(const Point& first,
+                     const Point& second,
+                     Passability passability,
+                     std::uint32_t& first_label,
+                     std::uint32_t& second_label);
+  void rebuild_region_map(RegionMap& map, Passability passability) const;
+  [[nodiscard]] auto label_at(const RegionMap& map,
+                              const Point& cell) const -> std::uint32_t;
+
   void process_dirty_regions();
 
   void update_region(int min_x, int max_x, int min_z, int max_z);
@@ -254,6 +289,9 @@ private:
   bool m_full_update_required{true};
   std::atomic<std::uint64_t> m_applied_world_props_revision{0};
   std::atomic<std::uint64_t> m_obstruction_revision{0};
+  std::atomic<float> m_obstruction_center_x{0.0F};
+  std::atomic<float> m_obstruction_center_z{0.0F};
+  std::atomic<bool> m_obstruction_center_located{false};
   std::atomic<std::uint64_t> m_applied_terrain_topology_revision{0};
   std::unordered_map<int, CellValue> m_world_prop_cells;
   std::vector<bool> m_forest_cells;
@@ -261,6 +299,8 @@ private:
   std::atomic<std::uint64_t> m_navigation_revision{1};
   std::uint64_t m_path_cache_revision{0};
   std::unordered_map<PathCacheKey, std::vector<Point>, PathCacheKeyHash> m_path_cache;
+  mutable std::mutex m_region_mutex;
+  std::array<RegionMap, k_passability_count> m_region_maps;
 };
 
 } // namespace Game::Systems

--- a/game/systems/unit_traversal_layout_system.cpp
+++ b/game/systems/unit_traversal_layout_system.cpp
@@ -483,6 +483,7 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
   }
 
   state.slot_states = std::move(next);
+  ++state.slot_states_revision;
   float max_remaining_ratio = 0.0F;
   state.transition_total_distance = 0.0F;
   state.transition_remaining_distance = 0.0F;

--- a/notes.txt
+++ b/notes.txt
@@ -62,14 +62,3 @@ Two god objects concentrate all architectural risk:
 Fix: extract collaborators incrementally — abilities and lock-on out of
 the controller first, following CommanderCameraRig/CommanderMotor precedent.
 
-Priority 4: startup cost
-------------------------
-- 194 .ogg files zlib-compressed inside QRC (pointless; they are already
-  compressed). Wastes binary size and first-touch decompression time.
-- Fix: move to loose files or rcc -no-compress; keep existing lazy/
-  streaming audio load policies.
-
-Starting point
---------------
-Priority 1.2 (melee raycast caching): highest ratio of measured impact to
-contained blast radius.

--- a/scripts/ambient_instance_budget.json
+++ b/scripts/ambient_instance_budget.json
@@ -1,7 +1,8 @@
 {
+  "app/world": 2,
   "game/core": 1,
   "game/formation": 4,
-  "game/map": 13,
+  "game/map": 14,
   "game/systems": 27,
   "game/units": 8,
   "game/visuals": 1,

--- a/tests/systems/pathfinding_test.cpp
+++ b/tests/systems/pathfinding_test.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <gtest/gtest.h>
 #include <optional>
 #include <vector>
@@ -735,6 +736,97 @@ TEST_F(PathfindingTest, HeavyUnitsRouteAroundAWoodThatLightUnitsWalkThrough) {
     return widest;
   };
   EXPECT_GT(widest_deviation(heavy_path), widest_deviation(light_path));
+}
+
+TEST_F(PathfindingTest, ReachableRegionsAgreeWithPathSearch) {
+  using Passability = Game::Systems::Pathfinding::Passability;
+  constexpr int k_extent = 24;
+  constexpr float k_origin = -((static_cast<float>(k_extent) * 0.5F) - 0.5F);
+
+  Game::Systems::Pathfinding pathfinding(k_extent, k_extent);
+  pathfinding.set_grid_offset(k_origin, k_origin);
+  pathfinding.update_navigation_grid();
+
+  std::uint32_t seed = 0x5EED1234U;
+  auto next_random = [&seed]() {
+    seed = (seed * 1664525U) + 1013904223U;
+    return seed >> 16U;
+  };
+  for (int y = 0; y < k_extent; ++y) {
+    for (int x = 0; x < k_extent; ++x) {
+      if (next_random() % 100U < 22U) {
+        pathfinding.set_obstacle(x, y, true);
+      }
+    }
+  }
+
+  for (int offset = 2; offset <= 6; ++offset) {
+    pathfinding.set_obstacle(offset, 2, true);
+    pathfinding.set_obstacle(offset, 6, true);
+    pathfinding.set_obstacle(2, offset, true);
+    pathfinding.set_obstacle(6, offset, true);
+  }
+  for (int y = 3; y <= 5; ++y) {
+    for (int x = 3; x <= 5; ++x) {
+      pathfinding.set_obstacle(x, y, false);
+    }
+  }
+
+  int compared = 0;
+  int unreachable = 0;
+  for (int start_y = 0; start_y < k_extent; start_y += 3) {
+    for (int start_x = 0; start_x < k_extent; start_x += 3) {
+      Game::Systems::Point const start{start_x, start_y};
+      if (!pathfinding.is_walkable(start.x, start.y)) {
+        continue;
+      }
+      for (int end_y = 0; end_y < k_extent; end_y += 5) {
+        for (int end_x = 0; end_x < k_extent; end_x += 5) {
+          Game::Systems::Point const end{end_x, end_y};
+          auto const route =
+              pathfinding.find_path(start, end, Passability::Light, 0.35F);
+          bool const path_arrives = !route.empty() && route.back() == end;
+          bool const reachable = pathfinding.can_reach(start, end, Passability::Light);
+          EXPECT_EQ(reachable, path_arrives)
+              << "(" << start.x << "," << start.y << ") -> (" << end.x << "," << end.y
+              << ")";
+          ++compared;
+          if (!reachable) {
+            ++unreachable;
+          }
+        }
+      }
+    }
+  }
+
+  EXPECT_GT(compared, 100);
+  EXPECT_GT(unreachable, 0) << "the sealed chamber must make some pairs unreachable";
+}
+
+TEST_F(PathfindingTest, ReachableRegionsFollowGridEdits) {
+  using Passability = Game::Systems::Pathfinding::Passability;
+  constexpr int k_extent = 9;
+  Game::Systems::Pathfinding pathfinding(k_extent, k_extent);
+  pathfinding.set_grid_offset(-4.0F, -4.0F);
+  pathfinding.update_navigation_grid();
+
+  Game::Systems::Point const left{1, 4};
+  Game::Systems::Point const right{7, 4};
+  EXPECT_TRUE(pathfinding.can_reach(left, right, Passability::Light));
+
+  for (int y = 0; y < k_extent; ++y) {
+    pathfinding.set_obstacle(4, y, true);
+  }
+  EXPECT_FALSE(pathfinding.can_reach(left, right, Passability::Light));
+  EXPECT_NE(pathfinding.region_of(left, Passability::Light),
+            Game::Systems::Pathfinding::k_unreachable_region);
+  EXPECT_NE(pathfinding.region_of(left, Passability::Light),
+            pathfinding.region_of(right, Passability::Light));
+
+  pathfinding.set_obstacle(4, 4, false);
+  EXPECT_TRUE(pathfinding.can_reach(left, right, Passability::Light));
+  EXPECT_EQ(pathfinding.region_of({4, 0}, Passability::Light),
+            Game::Systems::Pathfinding::k_unreachable_region);
 }
 
 } // namespace

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -244,7 +244,7 @@ public:
   };
   [[nodiscard]] auto rpg_bow_hud_state() const -> RpgBowHudState;
 
-public slots:
+public:
   [[nodiscard]] auto
   attack_range_rings() const -> const std::vector<Game::Systems::AttackRangeRing>& {
     return m_attack_range_rings;


### PR DESCRIPTION
Reduce per-tick simulation work across contact resolution, movement, avoidance, and frame handoff while preserving the existing gameplay interfaces.

- Prune formation contact slot-pair scans with exact distance and reachability bounds, reuse scratch storage, and avoid unnecessary layout copies.\n- Cache each entity's spatialised formation layout using traversal and presentation revisions together with transform and layout identity, so repeated contact queries reuse stable results.\n- Replace per-member A* reachability checks for formation movement with navigation connected-component queries that rebuild only after navigation changes, and add coverage for sealed regions and invalidation.\n- Prioritise obstruction-release repaths by distance and feed them through the throttled request queue while retaining goal-aware staleness checks.\n- Bound local-avoidance neighbour selection during collection instead of sorting and truncating the complete candidate set.\n- Bound the render thread's simulation-lock wait and skip only the effects pass when a tick exceeds the frame budget.\n- Extract commander ability rules and target resolution into CommanderAbilities, leaving the controller focused on orchestration.\n- Record ambient singleton lookup counts introduced by main, update the related build metadata, and remove completed performance notes.\n- Keep ArenaViewport warning cleanup and the pathfinding regression tests aligned with the refactor.