### PR TITLE
fix: preserve walkable squad routes across crossings

### DIFF
--- a/game/systems/movement_orders.cpp
+++ b/game/systems/movement_orders.cpp
@@ -106,20 +106,59 @@ auto segment_traverses_navigation_portal(const QVector3D& from,
 }
 
 auto align_portal_waypoint(const QVector3D& waypoint,
-                           bool final_waypoint) -> QVector3D {
+                           bool final_waypoint,
+                           const std::optional<QVector3D>& previous) -> QVector3D {
   if (final_waypoint) {
     return waypoint;
   }
+
+  const auto* pathfinder = NavGrid::get_pathfinder();
+  auto usable = [pathfinder, &previous](const QVector3D& candidate) {
+    if (pathfinder == nullptr) {
+      return true;
+    }
+    Point const cell = NavGrid::world_to_grid(candidate.x(), candidate.z());
+    if (!pathfinder->is_walkable(cell.x, cell.y)) {
+      return false;
+    }
+
+    return !previous.has_value() ||
+           pathfinder->is_world_segment_walkable(
+               *previous, candidate, Pathfinding::Passability::Light, 0.0F);
+  };
+
   auto& terrain = Game::Map::TerrainService::instance();
   if (auto const aligned =
           terrain.get_bridge_traversal_position(waypoint.x(), waypoint.z())) {
-    return {aligned->x(), waypoint.y(), aligned->z()};
+    QVector3D const candidate(aligned->x(), waypoint.y(), aligned->z());
+    if (usable(candidate)) {
+      return candidate;
+    }
   }
   if (auto const aligned =
           terrain.get_hill_entrance_traversal_position(waypoint.x(), waypoint.z())) {
-    return {aligned->x(), waypoint.y(), aligned->z()};
+    QVector3D const candidate(aligned->x(), waypoint.y(), aligned->z());
+    if (usable(candidate)) {
+      return candidate;
+    }
   }
   return waypoint;
+}
+
+[[nodiscard]] auto
+path_legs_are_walkable(Pathfinding& pathfinder,
+                       const Engine::Core::TransformComponent& transform,
+                       Pathfinding::Passability passability,
+                       const std::vector<std::pair<float, float>>& path) -> bool {
+  QVector3D previous(transform.position.x, 0.0F, transform.position.z);
+  for (auto const& waypoint : path) {
+    QVector3D const point(waypoint.first, 0.0F, waypoint.second);
+    if (!pathfinder.is_world_segment_walkable(previous, point, passability, 0.0F)) {
+      return false;
+    }
+    previous = point;
+  }
+  return true;
 }
 
 void pull_path_taut(Pathfinding& pathfinder,
@@ -264,8 +303,11 @@ auto MovementSystem::assign_path_to_movement(
   for (std::size_t idx = first_waypoint_index; idx < path_points.size(); ++idx) {
     QVector3D const raw_waypoint =
         pathfinder.path_waypoint_world_position(path_points[idx]);
-    QVector3D const waypoint =
-        align_portal_waypoint(raw_waypoint, idx + 1U == path_points.size());
+    QVector3D const waypoint = align_portal_waypoint(
+        raw_waypoint,
+        idx + 1U == path_points.size(),
+        waypoints.empty() ? std::optional<QVector3D>{}
+                          : std::optional<QVector3D>{waypoints.back()});
     if (!waypoints.empty()) {
       QVector3D const delta = waypoint - waypoints.back();
       float const dx = delta.x();
@@ -304,9 +346,28 @@ auto MovementSystem::assign_waypoints_to_movement(
   movement.route_opening_waypoint_index = 0U;
   movement.route_reform_waypoint_index = 0U;
   movement.path.reserve(waypoints.size());
+
+  std::vector<std::pair<float, float>> plain;
+  plain.reserve(waypoints.size());
+  for (const auto& waypoint : waypoints) {
+    if (!plain.empty()) {
+      float const dx = waypoint.x() - plain.back().first;
+      float const dz = waypoint.z() - plain.back().second;
+      if ((dx * dx) + (dz * dz) <= 1.0e-6F) {
+        continue;
+      }
+    }
+    plain.emplace_back(waypoint.x(), waypoint.z());
+  }
+
   for (std::size_t index = 0; index < waypoints.size(); ++index) {
-    QVector3D const waypoint =
-        align_portal_waypoint(waypoints[index], index + 1U == waypoints.size());
+    QVector3D const waypoint = align_portal_waypoint(
+        waypoints[index],
+        index + 1U == waypoints.size(),
+        movement.path.empty()
+            ? std::optional<QVector3D>{}
+            : std::optional<QVector3D>{QVector3D(
+                  movement.path.back().first, 0.0F, movement.path.back().second)});
     if (!movement.path.empty()) {
       auto const& previous = movement.path.back();
       float const dx = waypoint.x() - previous.first;
@@ -318,11 +379,24 @@ auto MovementSystem::assign_waypoints_to_movement(
     movement.path.emplace_back(waypoint.x(), waypoint.z());
   }
 
-  pull_path_taut(pathfinder,
-                 transform,
-                 passability_for(movement),
-                 movement.get_navigation_clearance(),
-                 movement.path);
+  if (!path_legs_are_walkable(
+          pathfinder, transform, passability_for(movement), movement.path)) {
+    movement.path = plain;
+  }
+
+  {
+
+    auto const cornered = movement.path;
+    pull_path_taut(pathfinder,
+                   transform,
+                   passability_for(movement),
+                   movement.get_navigation_clearance(),
+                   movement.path);
+    if (!path_legs_are_walkable(
+            pathfinder, transform, passability_for(movement), movement.path)) {
+      movement.path = cornered;
+    }
+  }
 
   while (movement.has_waypoints()) {
     const auto& wp = movement.current_waypoint();

--- a/game/systems/pathfinding.cpp
+++ b/game/systems/pathfinding.cpp
@@ -296,7 +296,6 @@ auto Pathfinding::is_world_segment_walkable(const QVector3D& from,
         return false;
       }
     }
-    return true;
   }
 
   constexpr float k_boundary_epsilon = 1.0e-5F;

--- a/notes.txt
+++ b/notes.txt
@@ -61,4 +61,3 @@ Two god objects concentrate all architectural risk:
   input, camera, motor, abilities, lock-on, audio, diagnostics.
 Fix: extract collaborators incrementally — abilities and lock-on out of
 the controller first, following CommanderCameraRig/CommanderMotor precedent.
-

--- a/tests/map/map_crossing_traversal_test.cpp
+++ b/tests/map/map_crossing_traversal_test.cpp
@@ -188,26 +188,28 @@ TEST_F(MapCrossingTraversalTest, ASquadOrderedOverEveryShippedFordReachesTheFarB
       Game::Systems::CommandService::move_units(
           world, squad, std::vector<QVector3D>(squad.size(), *target));
 
-      if (qEnvironmentVariableIsSet("SOI_CROSSING_GRID")) {
-        const Game::Systems::BodyProfile probe{
-            .radius = 0.5F,
-            .passability = Game::Systems::Pathfinding::Passability::Light};
+      {
         auto* pathfinder = Game::Systems::NavGrid::get_pathfinder();
-        const auto centre = Game::Systems::NavGrid::world_to_grid(-14.0F, -25.5F);
-        for (int dz = -8; dz <= 8; ++dz) {
-          QString row;
-          for (int dx = -8; dx <= 12; ++dx) {
-            const int gx = centre.x + dx;
-            const int gz = centre.y + dz;
-            const QVector3D world_point(static_cast<float>(gx) - (176 * 0.5F - 0.5F),
-                                        0.0F,
-                                        static_cast<float>(gz) - (176 * 0.5F - 0.5F));
-            const bool grid_ok = pathfinder->is_walkable(gx, gz);
-            const bool stand_ok =
-                Game::Systems::Walkability::can_stand(world_point, probe);
-            row += grid_ok ? (stand_ok ? '.' : 'c') : '#';
-          }
-          qWarning("GRID z=%d %s", centre.y + dz, row.toLatin1().constData());
+        auto* leader = world.get_entity(squad.front());
+        const auto* movement = leader->get_component<Engine::Core::MovementComponent>();
+        const auto& path = movement->get_path();
+        const auto* transform =
+            leader->get_component<Engine::Core::TransformComponent>();
+        QVector3D previous(transform->position.x, 0.0F, transform->position.z);
+        for (std::size_t wp = 0; wp < path.size(); ++wp) {
+          const QVector3D point(path[wp].first, 0.0F, path[wp].second);
+          const auto cell = Game::Systems::NavGrid::world_to_grid(point.x(), point.z());
+          EXPECT_TRUE(pathfinder->is_walkable(cell.x, cell.y))
+              << file_name.toStdString() << " crossing " << index << ": waypoint " << wp
+              << " at (" << point.x() << "," << point.z()
+              << ") is inside a blocked cell";
+          EXPECT_TRUE(pathfinder->is_world_segment_walkable(
+              previous, point, Game::Systems::Pathfinding::Passability::Light, 0.0F))
+              << file_name.toStdString() << " crossing " << index << ": leg " << wp
+              << " from (" << previous.x() << "," << previous.z() << ") to ("
+              << point.x() << "," << point.z() << ") of " << path.size()
+              << " crosses blocked ground";
+          previous = point;
         }
       }
 
@@ -221,13 +223,12 @@ TEST_F(MapCrossingTraversalTest, ASquadOrderedOverEveryShippedFordReachesTheFarB
           const std::size_t wp = m->get_path_index();
           const float wp_x = wp < path.size() ? path[wp].first : 0.0F;
           const float wp_z = wp < path.size() ? path[wp].second : 0.0F;
-          const Game::Systems::BodyProfile probe{
-              .radius = 0.5F,
-              .passability = Game::Systems::Pathfinding::Passability::Light};
-          const bool wp_standable =
-              Game::Systems::Walkability::can_stand(QVector3D(wp_x, 0.0F, wp_z), probe);
-          const bool here_standable = Game::Systems::Walkability::can_stand(
-              QVector3D(t->position.x, 0.0F, t->position.z), probe);
+          auto* pf = Game::Systems::NavGrid::get_pathfinder();
+          const auto wp_cell = Game::Systems::NavGrid::world_to_grid(wp_x, wp_z);
+          const auto here_cell =
+              Game::Systems::NavGrid::world_to_grid(t->position.x, t->position.z);
+          const bool wp_standable = pf->is_walkable(wp_cell.x, wp_cell.y);
+          const bool here_standable = pf->is_walkable(here_cell.x, here_cell.y);
           qWarning("%s[%zu] t=%5.1fs pos=(%7.2f,%7.2f)%s goal=(%7.2f,%7.2f) "
                    "target=%d stuck=%5.2f wp=%zu/%zu v=(%5.2f,%5.2f) "
                    "next=(%7.2f,%7.2f)%s",

--- a/tests/systems/pathfinding_test.cpp
+++ b/tests/systems/pathfinding_test.cpp
@@ -565,6 +565,50 @@ TEST_F(PathfindingTest, BridgeApproachSegmentIsWalkableThroughGridCells) {
                                                     QVector3D(-1.5F, 0.0F, 0.0F)));
 }
 
+TEST_F(PathfindingTest, ASegmentWithClearanceStillWalksEveryCellItCrosses) {
+  Game::Map::MapDefinition map_def;
+  map_def.grid.width = 21;
+  map_def.grid.height = 21;
+  map_def.grid.tile_size = 1.0F;
+  Game::Map::TerrainService::instance().initialize(map_def);
+
+  Game::Systems::Pathfinding pathfinding(map_def.grid.width, map_def.grid.height);
+  pathfinding.set_grid_offset(-(static_cast<float>(map_def.grid.width) * 0.5F - 0.5F),
+                              -(static_cast<float>(map_def.grid.height) * 0.5F - 0.5F));
+  pathfinding.update_navigation_grid();
+
+  pathfinding.set_obstacle(10, 10, true);
+
+  const QVector3D from(-3.0F, 0.0F, -0.4F);
+  const QVector3D to(3.0F, 0.0F, 0.4F);
+
+  EXPECT_FALSE(pathfinding.is_world_segment_walkable(
+      from, to, Game::Systems::Pathfinding::Passability::Light, 0.0F))
+      << "the cell walk missed a blocked cell on the segment";
+  EXPECT_FALSE(pathfinding.is_world_segment_walkable(
+      from, to, Game::Systems::Pathfinding::Passability::Light, 0.4F))
+      << "a body with clearance was allowed through a blocked cell";
+}
+
+TEST_F(PathfindingTest, AnOpenSegmentIsStillWalkableWithClearance) {
+  Game::Map::MapDefinition map_def;
+  map_def.grid.width = 21;
+  map_def.grid.height = 21;
+  map_def.grid.tile_size = 1.0F;
+  Game::Map::TerrainService::instance().initialize(map_def);
+
+  Game::Systems::Pathfinding pathfinding(map_def.grid.width, map_def.grid.height);
+  pathfinding.set_grid_offset(-(static_cast<float>(map_def.grid.width) * 0.5F - 0.5F),
+                              -(static_cast<float>(map_def.grid.height) * 0.5F - 0.5F));
+  pathfinding.update_navigation_grid();
+
+  EXPECT_TRUE(pathfinding.is_world_segment_walkable(
+      QVector3D(-3.0F, 0.0F, -0.4F),
+      QVector3D(3.0F, 0.0F, 0.4F),
+      Game::Systems::Pathfinding::Passability::Light,
+      0.4F));
+}
+
 TEST_F(PathfindingTest, CrossingRhoneAuthoredBridgeRoutesAcrossRiver) {
   Game::Map::MapDefinition map_def;
   QString error;


### PR DESCRIPTION
Validate bridge and hill portal waypoint alignment against the navigation grid and the preceding route leg so squad paths do not snap onto blocked cells or cross impassable terrain. Deduplicate generated waypoints and retain a plain route whenever taut-path simplification would make any leg unsafe.

Strengthen the shipped-ford traversal diagnostics to inspect every waypoint and route segment, and add pathfinding regressions covering blocked-cell traversal with clearance and open-segment behavior. Remove obsolete crossing debug scaffolding and completed navigation notes while keeping the repository formatting consistent.