### PR TITLE
feat(ai): add deterministic commander duel match coverage

### DIFF
--- a/assets/data/ai/doctrines.json
+++ b/assets/data/ai/doctrines.json
@@ -32,12 +32,12 @@
       "town_plan": "roman_bulwark",
       "recruitment": { "ranged_share": 0.45 },
       "wave": {
-        "size": 10,
+        "size": 8,
         "regroup_seconds": 45.0,
         "spent_fraction": 0.5,
         "target_priority": ["army", "any"]
       },
-      "garrison": { "minimum_units": 6, "fraction": 0.6 }
+      "garrison": { "minimum_units": 4, "fraction": 0.6 }
     },
     "roman_veteran_consul": {
       "_name": "Publius Cornelius Scipio",
@@ -77,12 +77,12 @@
       "town_plan": "punic_trade_town",
       "recruitment": { "ranged_share": 0.4 },
       "wave": {
-        "size": 9,
+        "size": 7,
         "regroup_seconds": 40.0,
         "spent_fraction": 0.45,
         "target_priority": ["army", "any"]
       },
-      "garrison": { "minimum_units": 5, "fraction": 0.5 }
+      "garrison": { "minimum_units": 4, "fraction": 0.5 }
     },
     "carthage_bow_commander": {
       "_name": "Hasdrubal Barca",
@@ -107,7 +107,7 @@
       "town_plan": "punic_grand_camp",
       "recruitment": { "ranged_share": 0.4 },
       "wave": {
-        "size": 8,
+        "size": 6,
         "regroup_seconds": 22.0,
         "spent_fraction": 0.3,
         "target_priority": ["army", "barracks", "economy", "any"]

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -221,6 +221,25 @@ Commanders are handled separately:
 - they reposition behind the army centroid
 - they periodically trigger the rally ability
 
+The lord is also the single most valuable thing the AI owns: `NationCollapse`
+turns his death into the loss of the whole nation, barracks, workers and all.
+`CommanderBehavior` therefore treats his station as a safety question rather
+than a flavour one.
+
+- **Every station is behind the line.** The doctrines differ in how close behind
+  he rides -- three metres for the aggressive tempers, eight for the defensive
+  ones -- not in whether he stands in front of his own soldiers.
+- He only leaves home ground **at the head of a committed wave that is still at
+  full strength**, and only for a doctrine that leads its attacks at all. A
+  defensive or economic lord stays at the rally point.
+- He needs a **real escort**: with fewer than two soldiers on the field he holds
+  station at home rather than following a lone scout across the map.
+- He **turns for home** as soon as he drops below sixty percent health.
+
+Without those rules an aggressive doctrine walks its lord after the first pair
+of scouts, straight into the enemy town, and loses the match in four minutes to
+an opponent that never attacked.
+
 ## Macro and building logic
 
 The AI now uses shared macro targets instead of scattered hardcoded thresholds.
@@ -239,6 +258,55 @@ The AI now uses shared macro targets instead of scattered hardcoded thresholds.
 `BuilderBehavior` then builds toward the largest deficit while preserving important early priorities like homes and the first barracks.
 
 `ProductionBehavior` also reads from the same config, so unit production and structure growth are at least pulling in the same strategic direction.
+
+### The manpower chain
+
+Recruitment manpower is the one resource a settlement cannot cut out of the
+landscape, and every macro target above is ultimately in service of it:
+
+```text
+farm ripens (60s) -> worker cuts it for 60 food
+                  -> home spends 20 food to raise a family (3 per home, ever)
+                  -> family walks to a barracks and grants 18 manpower
+                  -> barracks spends 52+ manpower on one soldier
+```
+
+The opening barracks is seeded with the map's population cap in manpower and
+that is the only bulk the AI ever gets for free. Three consequences shape the
+macro layer:
+
+- **Housing is sized off the army the doctrine means to field**, not the army it
+  happens to have (`wave.size + garrison.minimum_units`, plus a couple). Sizing
+  it off the current army leaves a town that can only ever replace its losses
+  one at a time.
+- **Fields are a macro target of their own.** Without them the granary empties
+  around the ten-minute mark, no family is ever raised again, and the town stops
+  recruiting while its wood and stone piles look perfectly healthy. Fields are
+  broken when the store runs low and worked whenever the granary has room, so
+  the crop is cut before the cupboard is bare rather than after.
+- **A builder past a working minimum is only raised if the town could still pay
+  for a soldier afterwards.** A work crew that eats the manpower pool leaves a
+  settlement that can build anything and field nothing.
+
+When the barracks cannot afford a single recruit and no home has a family left
+to send it, `raise_homes_first` puts housing ahead of everything else --
+including the authored town plan, which yields its ordering (never its
+placement) until the town can recruit again.
+
+### Placing what it builds
+
+Two rules keep the settlement from stalling on a site it can never use:
+
+- The **layout frame is fixed by the enemy town**, not by whoever is currently
+  in sight. Every authored slot is expressed in that frame, so a facing that
+  swung whenever a scout wandered past would rotate the whole plan and no slot
+  would ever be recognised as already filled.
+- A slot counts as taken by **footprint**, not by a blanket radius. The plans
+  author wall runs four metres apart and homes five; anything wider than the two
+  buildings' own footprints swallows most of the blueprint and the settlement
+  stops halfway through it. The fallback ring placement applies the same test,
+  so a site that is already occupied is skipped rather than re-ordered every
+  cycle forever.
 
 ## Expansion logic
 
@@ -590,12 +658,35 @@ too few are left to be worth the name.
 
 Two rules are load-bearing:
 
-- A wave is made of **soldiers**. `is_combat_role_unit` only rules out buildings
-  and builders, which leaves civilians walking manpower to the barracks and
-  healers tending the line. Marching those off to war quietly stops the town
-  being able to recruit at all.
+- A wave is made of **soldiers**. `is_combat_role_unit` rules out buildings,
+  builders and civilians; healers still follow the line to tend it. Marching a
+  civilian off to war strands the eighteen manpower it was carrying to the
+  barracks, and a town that does that a few times quietly stops being able to
+  recruit at all.
 - The **garrison is taken out first**, nearest the base, and never leaves. That
   is how a doctrine splits what it holds from what it sends.
+- A wave targets what it **knows**, not only what it can see. `visible_enemies`
+  is vision-gated, so on a map where the two towns sit in opposite corners
+  nothing is ever in sight at the moment a wave is ready; the selector falls
+  back to `strategic_objectives`, which carries every enemy building and
+  commander regardless of vision, the way a player knows where the enemy castle
+  is. Without that fallback a wave never forms and no AI ever attacks.
+- A wave **disbands at or below** its spent threshold, rounded up and never
+  below two. One survivor still walking into a town is a casualty, not an
+  attack.
+- An AI with a doctrine **only marches in waves**. `AttackBehavior` has an older
+  path that walks whatever is ready toward the nearest strategic objective as
+  soon as the state machine says `Attacking`; left enabled alongside the wave
+  system it feeds soldiers to the enemy one at a time and the army never
+  accumulates to wave size at all. With a doctrine present that path is limited
+  to answering enemies already close to the group, and crossing the map is the
+  committed wave's job.
+
+Wave sizes are authored against what the economy can actually field. A doctrine
+needs `wave.size + garrison.minimum_units` soldiers alive before a single wave
+commits, and every one of those is a home that had to be built first -- so a
+wave of ten reads as "this commander never attacks", not "this commander
+attacks hard."
 
 Without authored data, wave size falls back to the strategy's own
 `proactive_attack_size` and the garrison to its `reserve_units`, so an AI with no

--- a/game/systems/ai_system/ai_attack_wave.cpp
+++ b/game/systems/ai_system/ai_attack_wave.cpp
@@ -1,6 +1,7 @@
 #include "ai_attack_wave.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <unordered_set>
 #include <utility>
@@ -64,26 +65,56 @@ auto spent_fraction_for(const AIContext& context) -> float {
   return doctrine != nullptr ? doctrine->wave.spent_fraction : 0.35F;
 }
 
+auto nearest_matching(const std::vector<ContactSnapshot>& contacts,
+                      DoctrineTarget target_kind,
+                      float from_x,
+                      float from_z) -> const ContactSnapshot* {
+  const ContactSnapshot* best = nullptr;
+  float best_distance_sq = std::numeric_limits<float>::infinity();
+  for (const auto& contact : contacts) {
+    if (contact.health <= 0 || !matches_target(contact, target_kind)) {
+      continue;
+    }
+    const float distance_sq =
+        distance_squared(contact.pos_x, 0.0F, contact.pos_z, from_x, 0.0F, from_z);
+    if (distance_sq < best_distance_sq) {
+      best_distance_sq = distance_sq;
+      best = &contact;
+    }
+  }
+  return best;
+}
+
 auto select_wave_target(const AISnapshot& snapshot,
                         const AIContext& context,
                         float from_x,
                         float from_z) -> const ContactSnapshot* {
   for (const auto target_kind : target_priority_for(context)) {
-    const ContactSnapshot* best = nullptr;
-    float best_distance_sq = std::numeric_limits<float>::infinity();
-    for (const auto& contact : snapshot.visible_enemies) {
-      if (contact.health <= 0 || !matches_target(contact, target_kind)) {
-        continue;
-      }
-      const float distance_sq =
-          distance_squared(contact.pos_x, 0.0F, contact.pos_z, from_x, 0.0F, from_z);
-      if (distance_sq < best_distance_sq) {
-        best_distance_sq = distance_sq;
-        best = &contact;
-      }
+    if (const auto* seen =
+            nearest_matching(snapshot.visible_enemies, target_kind, from_x, from_z)) {
+      return seen;
     }
-    if (best != nullptr) {
-      return best;
+  }
+
+  for (const auto target_kind : target_priority_for(context)) {
+    if (const auto* known = nearest_matching(
+            snapshot.strategic_objectives, target_kind, from_x, from_z)) {
+      return known;
+    }
+  }
+  return nullptr;
+}
+
+auto find_contact(const AISnapshot& snapshot,
+                  Engine::Core::EntityID id) -> const ContactSnapshot* {
+  for (const auto& contact : snapshot.visible_enemies) {
+    if (contact.id == id && contact.health > 0) {
+      return &contact;
+    }
+  }
+  for (const auto& objective : snapshot.strategic_objectives) {
+    if (objective.id == id && objective.health > 0) {
+      return &objective;
     }
   }
   return nullptr;
@@ -199,11 +230,13 @@ void update_attack_wave(const AISnapshot& snapshot, AIContext& context) {
     wave.members = std::move(survivors);
 
     const int remaining = static_cast<int>(wave.members.size());
+
     const int spent_threshold =
-        std::max(1,
-                 static_cast<int>(spent_fraction_for(context) *
-                                  static_cast<float>(std::max(1, wave.initial_size))));
-    if (remaining < spent_threshold) {
+        std::max(2,
+                 static_cast<int>(
+                     std::ceil(spent_fraction_for(context) *
+                               static_cast<float>(std::max(1, wave.initial_size)))));
+    if (remaining <= spent_threshold) {
       wave.committed = false;
       wave.members.clear();
       wave.target_id = 0;
@@ -214,13 +247,7 @@ void update_attack_wave(const AISnapshot& snapshot, AIContext& context) {
     centre_x /= static_cast<float>(remaining);
     centre_z /= static_cast<float>(remaining);
 
-    const ContactSnapshot* target = nullptr;
-    for (const auto& contact : snapshot.visible_enemies) {
-      if (contact.id == wave.target_id && contact.health > 0) {
-        target = &contact;
-        break;
-      }
-    }
+    const ContactSnapshot* target = find_contact(snapshot, wave.target_id);
     if (target == nullptr) {
       target = select_wave_target(snapshot, context, centre_x, centre_z);
       if (target == nullptr) {

--- a/game/systems/ai_system/ai_reasoner.cpp
+++ b/game/systems/ai_system/ai_reasoner.cpp
@@ -11,6 +11,7 @@
 #include "../production_service.h"
 #include "ai_attack_wave.h"
 #include "ai_base_manager.h"
+#include "ai_doctrine_catalog.h"
 #include "ai_utils.h"
 #include "systems/ai_system/ai_types.h"
 #include "units/spawn_type.h"
@@ -325,7 +326,11 @@ auto wants_expansion(const Game::Systems::AI::AIContext& ctx) -> bool {
   return can_capture_neutral_expansion(ctx) || can_build_outpost_expansion(ctx);
 }
 
-auto compute_macro_targets(const Game::Systems::AI::AIContext& ctx, int catapult_count)
+constexpr int k_food_reserve = 60;
+
+auto compute_macro_targets(const Game::Systems::AI::AISnapshot& snapshot,
+                           const Game::Systems::AI::AIContext& ctx,
+                           int catapult_count)
     -> Game::Systems::AI::AIContext::MacroTargets {
   Game::Systems::AI::AIContext::MacroTargets targets;
   if (is_no_economy_nation(ctx)) {
@@ -345,6 +350,8 @@ auto compute_macro_targets(const Game::Systems::AI::AIContext& ctx, int catapult
   targets.builder_count = ctx.strategy_config.target_builder_count;
   targets.barracks_count = ctx.strategy_config.desired_barracks_count;
   targets.marketplace_count = 1;
+
+  targets.farm_count = std::clamp(1 + (ctx.home_count / 2), 1, 6);
   targets.defense_tower_count = ctx.strategy_config.desired_defense_tower_count;
   targets.wall_segment_count = ctx.strategy_config.desired_wall_segment_count;
   targets.catapult_count = ctx.strategy_config.desired_catapult_count;
@@ -361,9 +368,22 @@ auto compute_macro_targets(const Game::Systems::AI::AIContext& ctx, int catapult
   targets.home_count = std::max(ctx.strategy_config.base_home_target,
                                 2 + home_growth + std::min(2, extra_barracks));
 
-  if (ctx.home_civilians_remaining == 0 &&
+  const auto* doctrine = ctx.strategy_config.doctrine;
+  const int army_the_doctrine_wants =
+      doctrine != nullptr ? doctrine->wave.size + doctrine->garrison.minimum_units
+                          : proactive_attack_size(ctx.strategy_config) +
+                                std::max(0, ctx.strategy_config.reserve_units);
+  targets.home_count = std::max(targets.home_count, 2 + army_the_doctrine_wants);
+
+  if (snapshot.has_resource_snapshot &&
+      snapshot.resources.get(Game::Systems::ResourceType::Food) < k_food_reserve) {
+    targets.farm_count = std::max(targets.farm_count, ctx.farm_count + 1);
+  }
+
+  if (ctx.home_civilians_remaining == 0 && ctx.civilian_count == 0 &&
       ctx.recruitment_manpower_available < cheapest_recruit_cost(ctx)) {
     targets.home_count = std::max(targets.home_count, ctx.home_count + 2);
+    targets.raise_homes_first = true;
   }
   targets.barracks_count = std::max(targets.barracks_count, 1 + extra_barracks);
   targets.defense_tower_count =
@@ -722,6 +742,7 @@ void AIReasoner::update_context(const AISnapshot& snapshot, AIContext& ctx) {
   ctx.melee_count = 0;
   ctx.ranged_count = 0;
   ctx.builder_count = 0;
+  ctx.civilian_count = 0;
   ctx.damaged_units_count = 0;
   ctx.average_health = 1.0F;
   ctx.rally_x = 0.0F;
@@ -739,6 +760,7 @@ void AIReasoner::update_context(const AISnapshot& snapshot, AIContext& ctx) {
   ctx.visible_enemy_count = 0;
   ctx.neutral_barracks_count = 0;
   ctx.home_count = 0;
+  ctx.farm_count = 0;
   ctx.defense_tower_count = 0;
   ctx.wall_segment_count = 0;
   ctx.barracks_count = 0;
@@ -793,6 +815,8 @@ void AIReasoner::update_context(const AISnapshot& snapshot, AIContext& ctx) {
         ctx.barracks_count++;
       } else if (entity.spawn_type == Game::Units::SpawnType::Marketplace) {
         ctx.marketplace_count++;
+      } else if (entity.spawn_type == Game::Units::SpawnType::Farm) {
+        ctx.farm_count++;
       }
 
       if (entity.spawn_type == Game::Units::SpawnType::Barracks) {
@@ -818,6 +842,10 @@ void AIReasoner::update_context(const AISnapshot& snapshot, AIContext& ctx) {
 
     if (entity.spawn_type == Game::Units::SpawnType::Builder) {
       ctx.builder_count++;
+    }
+
+    if (entity.spawn_type == Game::Units::SpawnType::Civilian) {
+      ctx.civilian_count++;
     }
 
     if (ctx.nation != nullptr) {
@@ -909,7 +937,7 @@ void AIReasoner::update_context(const AISnapshot& snapshot, AIContext& ctx) {
     }
   }
 
-  ctx.macro_targets = compute_macro_targets(ctx, catapult_count);
+  ctx.macro_targets = compute_macro_targets(snapshot, ctx, catapult_count);
   update_assault_unit_ids(snapshot, ctx);
   update_reserve_unit_ids(snapshot, ctx);
   update_harass_unit_ids(snapshot, ctx);

--- a/game/systems/ai_system/ai_snapshot_builder.cpp
+++ b/game/systems/ai_system/ai_snapshot_builder.cpp
@@ -197,6 +197,13 @@ auto AISnapshotBuilder::build(const Engine::Core::World& world,
     data.is_building = entity->has_component<Engine::Core::BuildingComponent>();
     data.is_commander = entity->has_component<Engine::Core::CommanderComponent>();
     data.is_assault = is_assault;
+    data.has_delivery_order =
+        world.has<Engine::Core::CivilianDeliveryComponent>(data.id);
+    if (const auto* crop = world.try_get<Engine::Core::FarmComponent>(data.id);
+        crop != nullptr) {
+      data.crop_is_ripe =
+          crop->ripe() && !world.has<Engine::Core::DismantleSiteComponent>(data.id);
+    }
     if (is_assault) {
       data.has_march_target = assault_wave->has_march_target;
       data.march_target_x = assault_wave->march_target_x;
@@ -236,6 +243,19 @@ auto AISnapshotBuilder::build(const Engine::Core::World& world,
           builder_prod->has_construction_site;
       data.builder_production.in_progress = builder_prod->in_progress;
       data.builder_production.at_construction_site = builder_prod->at_construction_site;
+      data.builder_production.has_task_target =
+          builder_prod->has_task_target || builder_prod->structure_task_entity_id != 0;
+
+      if (builder_prod->structure_task_entity_id != 0) {
+        data.builder_production.task_target_id = builder_prod->structure_task_entity_id;
+      } else if (builder_prod->has_task_target) {
+        data.builder_production.task_target_id = builder_prod->task_target_id;
+      }
+      if (const auto* carry =
+              world.try_get<Engine::Core::ResourceCarryComponent>(data.id);
+          carry != nullptr && !carry->empty()) {
+        data.builder_production.carrying_load = true;
+      }
       data.builder_production.construction_site_x = builder_prod->construction_site_x;
       data.builder_production.construction_site_z = builder_prod->construction_site_z;
     }

--- a/game/systems/ai_system/ai_types.h
+++ b/game/systems/ai_system/ai_types.h
@@ -110,6 +110,11 @@ struct BuilderProductionSnapshot {
   bool has_construction_site = false;
   bool in_progress = false;
   bool at_construction_site = false;
+  bool has_task_target = false;
+
+  Engine::Core::EntityID task_target_id = 0;
+
+  bool carrying_load = false;
   float construction_site_x = 0.0F;
   float construction_site_z = 0.0F;
 };
@@ -133,6 +138,10 @@ struct EntitySnapshot {
   bool has_march_target = false;
   float march_target_x = 0.0F;
   float march_target_z = 0.0F;
+
+  bool has_delivery_order = false;
+
+  bool crop_is_ripe = false;
 
   MovementSnapshot movement;
   ProductionSnapshot production;
@@ -252,6 +261,7 @@ struct AIBase {
 
   int barracks_count = 0;
   int home_count = 0;
+  int farm_count = 0;
   int defense_tower_count = 0;
   int queued_production = 0;
   int production_capacity = 0;
@@ -329,12 +339,15 @@ struct AIContext {
   int melee_count = 0;
   int ranged_count = 0;
   int builder_count = 0;
+
+  int civilian_count = 0;
   int damaged_units_count = 0;
 
   int visible_enemy_count = 0;
   int neutral_barracks_count = 0;
 
   int home_count = 0;
+  int farm_count = 0;
   int defense_tower_count = 0;
   int wall_segment_count = 0;
   int barracks_count = 0;
@@ -365,12 +378,15 @@ struct AIContext {
     int home_count = 2;
     int barracks_count = 1;
     int marketplace_count = 0;
+    int farm_count = 0;
     int defense_tower_count = 1;
     int wall_segment_count = 0;
     int catapult_count = 0;
     int assembly_size = 4;
     float assembly_radius = 10.0F;
     float gather_spacing = 1.4F;
+
+    bool raise_homes_first = false;
   };
   MacroTargets macro_targets;
 

--- a/game/systems/ai_system/ai_utils.h
+++ b/game/systems/ai_system/ai_utils.h
@@ -73,7 +73,9 @@ inline auto is_entity_engaged(const EntitySnapshot& entity,
 }
 
 inline auto is_combat_role_unit(const EntitySnapshot& entity) -> bool {
-  return !entity.is_building && entity.spawn_type != Game::Units::SpawnType::Builder;
+
+  return !entity.is_building && entity.spawn_type != Game::Units::SpawnType::Builder &&
+         entity.spawn_type != Game::Units::SpawnType::Civilian;
 }
 
 inline auto is_threatening_contact(const ContactSnapshot& contact) -> bool {

--- a/game/systems/ai_system/behaviors/attack_behavior.cpp
+++ b/game/systems/ai_system/behaviors/attack_behavior.cpp
@@ -19,7 +19,14 @@ namespace Game::Systems::AI {
 namespace {
 constexpr float k_gathering_advance_aggression_threshold = 0.70F;
 
+auto marches_only_in_waves(const AIContext& context) -> bool {
+  return context.strategy_config.doctrine != nullptr && !context.wave.committed;
+}
+
 auto can_advance_from_gathering(const AIContext& context, int ready_units) -> bool {
+  if (marches_only_in_waves(context)) {
+    return false;
+  }
   return context.state == AIState::Attacking ||
          (context.state == AIState::Gathering &&
           ready_units >= context.strategy_config.reactive_attack_size &&
@@ -103,7 +110,7 @@ void AttackBehavior::execute(const AISnapshot& snapshot,
   if (snapshot.visible_enemies.empty()) {
 
     constexpr int MIN_UNITS_FOR_SCOUTING = 3;
-    if (context.state == AIState::Attacking &&
+    if (context.state == AIState::Attacking && !marches_only_in_waves(context) &&
         static_cast<int>(ready_units.size()) >=
             std::max(MIN_UNITS_FOR_SCOUTING,
                      context.strategy_config.reactive_attack_size)) {

--- a/game/systems/ai_system/behaviors/builder_behavior.cpp
+++ b/game/systems/ai_system/behaviors/builder_behavior.cpp
@@ -8,10 +8,12 @@
 #include <cmath>
 #include <initializer_list>
 #include <limits>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "../../../map/terrain_service.h"
+#include "../../building_collision_registry.h"
 #include "../../construction_cost_catalog.h"
 #include "../../nation_registry.h"
 #include "../ai_base_manager.h"
@@ -30,14 +32,17 @@ constexpr const char* BUILDING_TYPE_WALL_SEGMENT = "wall_segment";
 constexpr const char* BUILDING_TYPE_BARRACKS = "barracks";
 constexpr const char* BUILDING_TYPE_MARKETPLACE = "marketplace";
 constexpr const char* BUILDING_TYPE_CATAPULT = "catapult";
+constexpr const char* BUILDING_TYPE_FARM = "farm";
 constexpr const char* HARVEST_TREE = "cut_tree";
 constexpr const char* HARVEST_STONE = "collect_stone";
 constexpr const char* HARVEST_IRON = "collect_iron_ore";
+constexpr const char* HARVEST_GRAIN = "harvest_grain";
 
 constexpr int MAX_HOMES = 20;
 constexpr int MAX_DEFENSE_TOWERS = 10;
 constexpr int MAX_WALL_SEGMENTS = 12;
 constexpr int MAX_BARRACKS = 6;
+constexpr int MAX_FARMS = 6;
 constexpr int MAX_MARKETPLACES = 2;
 constexpr int MAX_CATAPULTS = 5;
 
@@ -157,6 +162,31 @@ auto harvest_type_for_resource(ResourceType resource) -> const char* {
   }
 }
 
+constexpr int k_ai_food_reserve = 60;
+
+constexpr int k_ai_granary_target = 240;
+
+auto starved_of_food(const AISnapshot& snapshot) -> bool {
+  return snapshot.has_resource_snapshot &&
+         snapshot.resources.get(ResourceType::Food) < k_ai_food_reserve;
+}
+
+auto field_is_worked(const AISnapshot& snapshot,
+                     Engine::Core::EntityID field_id) -> bool {
+  for (const auto& entity : snapshot.friendly_units) {
+    if (entity.builder_production.has_component &&
+        entity.builder_production.task_target_id == field_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto granary_has_room(const AISnapshot& snapshot) -> bool {
+  return snapshot.has_resource_snapshot &&
+         snapshot.resources.get(ResourceType::Food) < k_ai_granary_target;
+}
+
 auto recruit_reserve_shortfall(const AISnapshot& snapshot) -> ResourceType {
   if (!snapshot.has_resource_snapshot) {
     return ResourceType::Count;
@@ -204,6 +234,9 @@ auto building_type_name(const std::string& name) -> const char* {
   if (name == BUILDING_TYPE_CATAPULT) {
     return BUILDING_TYPE_CATAPULT;
   }
+  if (name == BUILDING_TYPE_FARM) {
+    return BUILDING_TYPE_FARM;
+  }
   return nullptr;
 }
 
@@ -212,15 +245,24 @@ auto settlement_facing(const AIContext& context,
   float sum_x = 0.0F;
   float sum_z = 0.0F;
   int count = 0;
-  for (const auto& contact : snapshot.visible_enemies) {
-    if (contact.health <= 0) {
+  for (const auto& objective : snapshot.strategic_objectives) {
+    if (objective.health <= 0 || !objective.is_building) {
       continue;
     }
-
-    const float weight = contact.is_building ? 4.0F : 1.0F;
-    sum_x += contact.pos_x * weight;
-    sum_z += contact.pos_z * weight;
-    count += static_cast<int>(weight);
+    sum_x += objective.pos_x;
+    sum_z += objective.pos_z;
+    count++;
+  }
+  if (count == 0) {
+    for (const auto& contact : snapshot.visible_enemies) {
+      if (contact.health <= 0) {
+        continue;
+      }
+      const float weight = contact.is_building ? 4.0F : 1.0F;
+      sum_x += contact.pos_x * weight;
+      sum_z += contact.pos_z * weight;
+      count += static_cast<int>(weight);
+    }
   }
   if (count == 0) {
     return {0.0F, -1.0F};
@@ -246,8 +288,20 @@ auto plan_offset_to_world(const QVector2D& facing,
                    local_z * forward.y() + local_x * right.y());
 }
 
+auto slot_clearance(const char* building_type,
+                    Game::Units::SpawnType standing) -> float {
+  const auto half_extent = [](const std::string& type) {
+    const auto size = BuildingCollisionRegistry::get_building_size(type);
+    return 0.5F * std::max(size.width, size.depth);
+  };
+  constexpr float k_slot_gap = 0.2F;
+  return half_extent(std::string(building_type)) +
+         half_extent(Game::Units::spawn_typeToString(standing)) + k_slot_gap;
+}
+
 auto authored_plan_step(const AIContext& context,
                         const AISnapshot& snapshot,
+                        const char* preferred,
                         const char*& out_building,
                         QVector3D& out_offset) -> bool {
   const auto* doctrine = context.strategy_config.doctrine;
@@ -255,15 +309,17 @@ auto authored_plan_step(const AIContext& context,
     return false;
   }
 
-  constexpr float k_slot_taken_radius = 8.0F;
-  constexpr float k_slot_taken_radius_sq = k_slot_taken_radius * k_slot_taken_radius;
-
   constexpr float k_anchor_clearance = 9.0F;
   constexpr float k_anchor_clearance_sq = k_anchor_clearance * k_anchor_clearance;
 
   const QVector2D facing = settlement_facing(context, snapshot);
 
   for (const auto& step : doctrine->town_plan->steps) {
+    const char* resolved = building_type_name(step.building);
+    if (resolved == nullptr) {
+      continue;
+    }
+
     const QVector3D offset = plan_offset_to_world(facing, step.x, step.z);
     const float world_x = context.base_pos_x + offset.x();
     const float world_z = context.base_pos_z + offset.z();
@@ -277,8 +333,9 @@ auto authored_plan_step(const AIContext& context,
       if (!entity.is_building) {
         continue;
       }
+      const float clearance = slot_clearance(resolved, entity.spawn_type);
       if (distance_squared(entity.pos_x, 0.0F, entity.pos_z, world_x, 0.0F, world_z) <=
-          k_slot_taken_radius_sq) {
+          clearance * clearance) {
         occupied = true;
         break;
       }
@@ -287,15 +344,46 @@ auto authored_plan_step(const AIContext& context,
       continue;
     }
 
-    const char* resolved = building_type_name(step.building);
-    if (resolved == nullptr) {
+    if (preferred != nullptr && resolved != preferred) {
       continue;
     }
+
     out_building = resolved;
     out_offset = offset;
     return true;
   }
+
   return false;
+}
+
+auto site_is_free(const AISnapshot& snapshot,
+                  const char* building_type,
+                  float world_x,
+                  float world_z) -> bool {
+  for (const auto& entity : snapshot.friendly_units) {
+    if (!entity.is_building) {
+      continue;
+    }
+    const float clearance = slot_clearance(building_type, entity.spawn_type);
+    if (distance_squared(entity.pos_x, 0.0F, entity.pos_z, world_x, 0.0F, world_z) <=
+        clearance * clearance) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto expanding_ring_offset(int index,
+                           int per_ring,
+                           float first_radius,
+                           float radius_step) -> QVector3D {
+  const int ring = index / std::max(1, per_ring);
+  const int step = index % std::max(1, per_ring);
+  const float radius = first_radius + static_cast<float>(ring) * radius_step;
+  const float angle = (6.2831853F * static_cast<float>(step) /
+                       static_cast<float>(std::max(1, per_ring))) +
+                      (static_cast<float>(ring) * 0.4F);
+  return {radius * std::cos(angle), 0.0F, radius * std::sin(angle)};
 }
 
 auto planned_settlement_offset(const AIContext& context,
@@ -329,10 +417,29 @@ auto planned_settlement_offset(const AIContext& context,
                                                    QVector3D{-5.0F, 0.0F, -5.0F},
                                                    QVector3D{5.0F, 0.0F, -5.0F}};
     const auto& offsets = carthaginian ? punic : roman;
-    return offsets[static_cast<std::size_t>(construction_index) % offsets.size()];
+    if (construction_index < static_cast<int>(offsets.size())) {
+      return offsets[static_cast<std::size_t>(construction_index)];
+    }
+    return expanding_ring_offset(
+        construction_index - static_cast<int>(offsets.size()), 7, 12.0F, 4.0F);
+  }
+  if (building_type == BUILDING_TYPE_FARM) {
+
+    static const std::array<QVector3D, 6> fields = {QVector3D{-18.0F, 0.0F, 14.0F},
+                                                    QVector3D{18.0F, 0.0F, 14.0F},
+                                                    QVector3D{-24.0F, 0.0F, 2.0F},
+                                                    QVector3D{24.0F, 0.0F, 2.0F},
+                                                    QVector3D{-14.0F, 0.0F, 20.0F},
+                                                    QVector3D{14.0F, 0.0F, 20.0F}};
+    if (construction_index < static_cast<int>(fields.size())) {
+      return fields[static_cast<std::size_t>(construction_index)];
+    }
+    return expanding_ring_offset(
+        construction_index - static_cast<int>(fields.size()), 6, 28.0F, 8.0F);
   }
   if (building_type == BUILDING_TYPE_MARKETPLACE) {
-    return carthaginian ? QVector3D{0.0F, 0.0F, 2.0F} : QVector3D{};
+
+    return carthaginian ? QVector3D{-3.0F, 0.0F, 9.0F} : QVector3D{3.0F, 0.0F, 9.0F};
   }
   if (building_type == BUILDING_TYPE_BARRACKS) {
     return QVector3D{0.0F, 0.0F, carthaginian ? -7.0F : -8.0F};
@@ -369,7 +476,9 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
     }
 
     if (entity.builder_production.has_component &&
-        entity.builder_production.has_construction_site) {
+        (entity.builder_production.has_construction_site ||
+         entity.builder_production.has_task_target ||
+         entity.builder_production.carrying_load)) {
       continue;
     }
 
@@ -400,6 +509,7 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
       std::clamp(targets.defense_tower_count, 0, MAX_DEFENSE_TOWERS);
   const int target_walls = std::clamp(targets.wall_segment_count, 0, MAX_WALL_SEGMENTS);
   const int target_catapults = std::clamp(targets.catapult_count, 0, MAX_CATAPULTS);
+  const int target_farms = std::clamp(targets.farm_count, 0, MAX_FARMS);
 
   const char* building_to_construct = nullptr;
   float construction_x = context.base_pos_x;
@@ -436,9 +546,19 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
 
     const char* planned_building = nullptr;
     QVector3D planned_offset;
+
+    const bool wants_a_field =
+        context.farm_count < target_farms && starved_of_food(snapshot);
+    const char* preferred = nullptr;
+    if (wants_a_field) {
+      preferred = BUILDING_TYPE_FARM;
+    } else if (targets.raise_homes_first) {
+      preferred = BUILDING_TYPE_HOME;
+    }
     const bool has_plan_step =
         context.primary_barracks != 0 &&
-        authored_plan_step(context, snapshot, planned_building, planned_offset);
+        authored_plan_step(
+            context, snapshot, preferred, planned_building, planned_offset);
 
     if (has_plan_step) {
       building_to_construct = planned_building;
@@ -449,7 +569,12 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
     } else if (context.barracks_under_threat &&
                context.defense_tower_count < target_towers) {
       building_to_construct = BUILDING_TYPE_DEFENSE_TOWER;
+    } else if (targets.raise_homes_first && context.home_count < MAX_HOMES) {
+      building_to_construct = BUILDING_TYPE_HOME;
+    } else if (wants_a_field) {
+      building_to_construct = BUILDING_TYPE_FARM;
     } else if (const char* candidate = best_candidate({
+                   {BUILDING_TYPE_FARM, context.farm_count, target_farms},
                    {BUILDING_TYPE_BARRACKS, context.barracks_count, target_barracks},
                    {BUILDING_TYPE_DEFENSE_TOWER,
                     context.defense_tower_count,
@@ -485,6 +610,35 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
 
       if (missing_resource == ResourceType::Count && context.builder_count > 1) {
         missing_resource = recruit_reserve_shortfall(snapshot);
+      }
+    }
+
+    if (granary_has_room(snapshot)) {
+      const EntitySnapshot* ripest = nullptr;
+      float ripest_distance_sq = std::numeric_limits<float>::infinity();
+      for (const auto& entity : snapshot.friendly_units) {
+        if (!entity.crop_is_ripe || field_is_worked(snapshot, entity.id)) {
+          continue;
+        }
+        const float dx = entity.pos_x - context.base_pos_x;
+        const float dz = entity.pos_z - context.base_pos_z;
+        const float distance_sq = dx * dx + dz * dz;
+        if (distance_sq < ripest_distance_sq) {
+          ripest_distance_sq = distance_sq;
+          ripest = &entity;
+        }
+      }
+      if (ripest != nullptr) {
+        AICommand command;
+        command.type = AICommandType::StartBuilderHarvest;
+        command.units.push_back(select_best_builder(
+            snapshot, available_builders, ripest->pos_x, ripest->pos_z));
+        command.construction_type = HARVEST_GRAIN;
+        command.construction_site_x = ripest->pos_x;
+        command.construction_site_z = ripest->pos_z;
+        command.resource_target_id = ripest->id;
+        out_commands.push_back(std::move(command));
+        return;
       }
     }
 
@@ -524,10 +678,26 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
       construction_z = context.base_pos_z + planned_offset.z();
     } else if (context.has_base_anchor) {
 
-      const QVector3D offset = planned_settlement_offset(
-          context, building_to_construct, m_construction_counter);
-      construction_x += offset.x();
-      construction_z += offset.z();
+      constexpr int k_site_search_attempts = 24;
+      bool found_site = false;
+      for (int attempt = 0; attempt < k_site_search_attempts; ++attempt) {
+        const QVector3D offset = planned_settlement_offset(
+            context, building_to_construct, m_construction_counter + attempt);
+        const float candidate_x = context.base_pos_x + offset.x();
+        const float candidate_z = context.base_pos_z + offset.z();
+        if (!site_is_free(snapshot, building_to_construct, candidate_x, candidate_z)) {
+          continue;
+        }
+        construction_x = candidate_x;
+        construction_z = candidate_z;
+        m_construction_counter += attempt;
+        found_site = true;
+        break;
+      }
+      if (!found_site) {
+        m_construction_counter += k_site_search_attempts;
+        return;
+      }
     }
   }
 
@@ -588,11 +758,24 @@ auto BuilderBehavior::should_execute(const AISnapshot& snapshot,
     return true;
   }
 
+  if (granary_has_room(snapshot)) {
+    for (const auto& entity : snapshot.friendly_units) {
+      if (entity.crop_is_ripe) {
+        return true;
+      }
+    }
+  }
+
+  if (context.macro_targets.raise_homes_first && context.home_count < MAX_HOMES) {
+    return true;
+  }
+
   {
     const char* planned_building = nullptr;
     QVector3D planned_offset;
     if (context.primary_barracks != 0 &&
-        authored_plan_step(context, snapshot, planned_building, planned_offset)) {
+        authored_plan_step(
+            context, snapshot, nullptr, planned_building, planned_offset)) {
       return true;
     }
   }
@@ -610,7 +793,9 @@ auto BuilderBehavior::should_execute(const AISnapshot& snapshot,
              std::clamp(
                  context.macro_targets.wall_segment_count, 0, MAX_WALL_SEGMENTS) ||
          catapult_count <
-             std::clamp(context.macro_targets.catapult_count, 0, MAX_CATAPULTS);
+             std::clamp(context.macro_targets.catapult_count, 0, MAX_CATAPULTS) ||
+         context.farm_count <
+             std::clamp(context.macro_targets.farm_count, 0, MAX_FARMS);
 }
 
 } // namespace Game::Systems::AI

--- a/game/systems/ai_system/behaviors/commander_behavior.cpp
+++ b/game/systems/ai_system/behaviors/commander_behavior.cpp
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include "../ai_attack_wave.h"
+#include "../ai_base_manager.h"
 #include "../ai_utils.h"
 #include "systems/ai_system/ai_types.h"
 #include "units/spawn_type.h"
@@ -74,9 +76,9 @@ void nearest_enemy_direction(const AISnapshot& snapshot,
 constexpr float k_rally_interval = 5.0F;
 constexpr float k_aura_interval = 20.0F;
 
-constexpr float k_shielded_offset = -6.0F;
-constexpr float k_protected_offset = -4.0F;
-constexpr float k_leading_offset = 3.0F;
+constexpr float k_shielded_offset = -8.0F;
+constexpr float k_protected_offset = -5.0F;
+constexpr float k_leading_offset = -3.0F;
 
 constexpr float k_flanking_lateral_offset = 7.0F;
 
@@ -114,6 +116,58 @@ auto aura_interval_for(const AIStrategyConfig& config) -> float {
 }
 
 constexpr float k_aura_engagement_radius = 16.0F;
+
+constexpr float k_commander_march_health = 0.6F;
+constexpr float k_home_ground_radius = AIBaseManager::k_base_defend_radius;
+constexpr float k_home_ground_radius_sq = k_home_ground_radius * k_home_ground_radius;
+
+auto leads_from_the_front(const AIStrategyConfig& config) -> bool {
+  switch (config.strategy) {
+  case AIStrategy::Aggressive:
+  case AIStrategy::Rusher:
+  case AIStrategy::Harasser:
+    return true;
+  default:
+    return false;
+  }
+}
+
+constexpr int k_minimum_escort = 2;
+
+auto commander_marches_with_army(const AIContext& context,
+                                 const EntitySnapshot& commander,
+                                 const ArmyCentre& army) -> bool {
+  if (army.count < k_minimum_escort) {
+    return false;
+  }
+
+  const float health_fraction = commander.max_health > 0
+                                    ? static_cast<float>(commander.health) /
+                                          static_cast<float>(commander.max_health)
+                                    : 1.0F;
+  if (health_fraction < k_commander_march_health) {
+    return false;
+  }
+
+  if (!context.has_base_anchor) {
+    return true;
+  }
+
+  const float dx = army.x - context.base_pos_x;
+  const float dz = army.z - context.base_pos_z;
+  if ((dx * dx + dz * dz) <= k_home_ground_radius_sq) {
+    return true;
+  }
+
+  if (!leads_from_the_front(context.strategy_config) || !context.wave.committed) {
+    return false;
+  }
+  const int escort = static_cast<int>(context.wave.members.size());
+  if (escort < std::max(k_minimum_escort, wave_size_for(context) - 1)) {
+    return false;
+  }
+  return context.combat_units >= escort + k_minimum_escort;
+}
 
 auto enemies_are_within(const AISnapshot& snapshot,
                         float centre_x,
@@ -194,7 +248,7 @@ void CommanderBehavior::execute(const AISnapshot& snapshot,
     float target_x;
     float target_z;
 
-    if (army.count > 0) {
+    if (commander_marches_with_army(context, *snap, army)) {
       const CommanderStation station = station_for(config);
       target_x =
           army.x + enemy_dir_x * station.along_axis - enemy_dir_z * station.lateral;

--- a/game/systems/ai_system/behaviors/production_behavior.cpp
+++ b/game/systems/ai_system/behaviors/production_behavior.cpp
@@ -56,6 +56,20 @@ constexpr float k_rally_tolerance_sq = 4.0F;
   return candidates;
 }
 
+[[nodiscard]] auto cheapest_fighting_cost(const Game::Systems::Nation& nation) -> int {
+  int cheapest = std::numeric_limits<int>::max();
+  for (const auto& troop : nation.available_troops) {
+    if (Game::Units::is_commander_troop(troop.unit_type) ||
+        troop.unit_type == Game::Units::TroopType::Builder ||
+        troop.unit_type == Game::Units::TroopType::Civilian ||
+        !is_recruitable_from(troop, Game::Units::SpawnType::Barracks)) {
+      continue;
+    }
+    cheapest = std::min(cheapest, troop.cost);
+  }
+  return cheapest == std::numeric_limits<int>::max() ? 0 : cheapest;
+}
+
 [[nodiscard]] auto affordable(const Game::Systems::TroopType& troop,
                               const ProductionSnapshot& production,
                               const Game::Systems::ResourceAmounts& stock) -> bool {
@@ -110,6 +124,16 @@ void ProductionBehavior::execute(const AISnapshot& snapshot,
   else if (context.builder_count < desired_builders &&
            (m_production_counter % BUILDER_PRODUCTION_INTERVAL == 0)) {
     should_produce_builder = true;
+  }
+
+  constexpr int k_bootstrap_builders = 2;
+  if (should_produce_builder && context.builder_count >= k_bootstrap_builders) {
+    const auto* builder_troop = nation->get_troop(Game::Units::TroopType::Builder);
+    const int soldier_cost = cheapest_fighting_cost(*nation);
+    if (builder_troop != nullptr && soldier_cost > 0 &&
+        context.recruitment_manpower_available - builder_troop->cost < soldier_cost) {
+      should_produce_builder = false;
+    }
   }
 
   const Game::Systems::TroopType* troop_type = nullptr;
@@ -317,7 +341,7 @@ void ProductionBehavior::deliver_idle_civilians(
       continue;
     }
 
-    if (entity.movement.has_component && entity.movement.has_target) {
+    if (entity.has_delivery_order) {
       continue;
     }
 

--- a/game/systems/civilian_delivery_system.cpp
+++ b/game/systems/civilian_delivery_system.cpp
@@ -22,6 +22,8 @@ auto barracks_delivery_clearance() -> float {
   return BuildingCollisionRegistry::get_grid_padding() + unit_radius + 0.75F;
 }
 
+constexpr float k_delivery_settle_radius = 9.0F;
+
 auto is_at_barracks_delivery_edge(
     const Engine::Core::TransformComponent& civilian_transform,
     const Engine::Core::TransformComponent& barracks_transform) -> bool {
@@ -81,7 +83,21 @@ void CivilianDeliverySystem::update(Engine::Core::World* world, float) {
       continue;
     }
 
-    if (!is_at_barracks_delivery_edge(*civilian_transform, *barracks_transform)) {
+    const auto* civilian_movement =
+        world->try_get<Engine::Core::MovementComponent>(civilian_id);
+    const bool walk_is_over =
+        civilian_movement == nullptr || !civilian_movement->get_has_target();
+    const float to_barracks_x =
+        civilian_transform->position.x - barracks_transform->position.x;
+    const float to_barracks_z =
+        civilian_transform->position.z - barracks_transform->position.z;
+    const bool settled_beside_it =
+        walk_is_over &&
+        ((to_barracks_x * to_barracks_x) + (to_barracks_z * to_barracks_z)) <=
+            (k_delivery_settle_radius * k_delivery_settle_radius);
+
+    if (!is_at_barracks_delivery_edge(*civilian_transform, *barracks_transform) &&
+        !settled_beside_it) {
       continue;
     }
 

--- a/game/systems/production_system.cpp
+++ b/game/systems/production_system.cpp
@@ -162,6 +162,35 @@ void activate_bypass_movement(Engine::Core::BuilderProductionComponent* builder,
   builder->bypass_target_z = target_z;
 }
 
+auto walking_to_site(const Engine::Core::BuilderProductionComponent& builder,
+                     const Engine::Core::MovementComponent& movement) -> bool {
+  if (!movement.get_has_target()) {
+    return false;
+  }
+  const float goal_x = movement.get_has_requested_goal()
+                           ? movement.get_requested_goal_x()
+                           : movement.get_goal_x();
+  const float goal_z = movement.get_has_requested_goal()
+                           ? movement.get_requested_goal_z()
+                           : movement.get_goal_y();
+  const float dx = goal_x - builder.construction_site_x;
+  const float dz = goal_z - builder.construction_site_z;
+  constexpr float k_route_goal_tolerance_sq = 0.25F;
+  return (dx * dx + dz * dz) <= k_route_goal_tolerance_sq;
+}
+
+void abandon_site_route(const Engine::Core::BuilderProductionComponent& builder,
+                        Engine::Core::MovementComponent* movement) {
+  if (movement != nullptr && walking_to_site(builder, *movement)) {
+    movement->stop();
+  }
+}
+
+auto needs_site_route(const Engine::Core::BuilderProductionComponent& builder,
+                      const Engine::Core::MovementComponent* movement) -> bool {
+  return movement != nullptr && !walking_to_site(builder, *movement);
+}
+
 void load_onto_hauler(
     Engine::Core::Entity* worker,
     ResourceType resource_type,
@@ -594,6 +623,8 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
   constexpr float k_site_approach_limit_seconds = 30.0F;
   constexpr float MAX_CONSTRUCTION_DISTANCE_SQ = 9.0F;
 
+  constexpr float k_site_bypass_radius_sq = 6.25F;
+
   for (auto [entity_ref, builder_prod_ref] :
        world->entity_view<Engine::Core::BuilderProductionComponent>()) {
     Engine::Core::Entity* e = &entity_ref;
@@ -703,13 +734,26 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
         } else {
           builder_prod->site_approach_seconds += delta_time;
 
-          if (!builder_prod->bypass_movement_active) {
+          if (dist_sq > k_site_bypass_radius_sq) {
+            builder_prod->bypass_movement_active = false;
+            if (needs_site_route(*builder_prod, movement)) {
+              CommandService::move_unit(
+                  *world,
+                  e->get_id(),
+                  QVector3D(builder_prod->construction_site_x,
+                            0.0F,
+                            builder_prod->construction_site_z),
+                  CommandService::MoveOptions{.kind = MoveOrderKind::RecoveryMove,
+                                              .preserve_formation_mode = true});
+            }
+          } else if (!builder_prod->bypass_movement_active) {
             activate_bypass_movement(builder_prod,
                                      builder_prod->construction_site_x,
                                      builder_prod->construction_site_z);
           }
 
           if (builder_prod->site_approach_seconds > k_site_approach_limit_seconds) {
+            abandon_site_route(*builder_prod, movement);
             builder_prod->has_construction_site = false;
             builder_prod->at_construction_site = false;
             builder_prod->in_progress = false;
@@ -904,6 +948,8 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
               sp.spawn_type = Game::Units::SpawnType::Home;
             } else if (builder_prod->product_type == "marketplace") {
               sp.spawn_type = Game::Units::SpawnType::Marketplace;
+            } else if (builder_prod->product_type == "farm") {
+              sp.spawn_type = Game::Units::SpawnType::Farm;
             } else if (builder_prod->product_type == "temple") {
               sp.spawn_type = Game::Units::SpawnType::Temple;
             } else {

--- a/game/systems/resource_delivery_system.cpp
+++ b/game/systems/resource_delivery_system.cpp
@@ -131,6 +131,23 @@ void sync_stockpile_displays(Engine::Core::World* world, float delta_time) {
   }
 }
 
+auto delivery_stand_position(const Engine::Core::TransformComponent& depot,
+                             const StockpilePoint& drop,
+                             const Engine::Core::TransformComponent& hauler)
+    -> QVector3D {
+  QVector3D const wanted(drop.x, hauler.position.y, drop.z);
+  QVector3D stand = NavGrid::snap_to_walkable_ground(wanted);
+
+  float const snap_dx = stand.x() - drop.x;
+  float const snap_dz = stand.z() - drop.z;
+  if (((snap_dx * snap_dx) + (snap_dz * snap_dz)) >
+      (k_stockpile_depot_arrival_radius * k_stockpile_depot_arrival_radius)) {
+    stand = NavGrid::snap_to_walkable_ground(
+        QVector3D(depot.position.x, hauler.position.y, depot.position.z));
+  }
+  return stand;
+}
+
 auto hauler_is_free_to_walk(const Engine::Core::Entity& hauler) -> bool {
   const auto* builder =
       hauler.get_component<Engine::Core::BuilderProductionComponent>();
@@ -191,9 +208,15 @@ void ResourceDeliverySystem::update(Engine::Core::World* world, float delta_time
     carry->depot_x = drop.x;
     carry->depot_z = drop.z;
 
+    QVector3D const stand = delivery_stand_position(*depot_transform, drop, *transform);
+
     float const dx = drop.x - transform->position.x;
     float const dz = drop.z - transform->position.z;
     float const dist_sq = (dx * dx) + (dz * dz);
+
+    float const stand_dx = stand.x() - transform->position.x;
+    float const stand_dz = stand.z() - transform->position.z;
+    float const stand_dist_sq = (stand_dx * stand_dx) + (stand_dz * stand_dz);
 
     float const depot_dx = depot_transform->position.x - transform->position.x;
     float const depot_dz = depot_transform->position.z - transform->position.z;
@@ -204,6 +227,7 @@ void ResourceDeliverySystem::update(Engine::Core::World* world, float delta_time
         carry->haul_seconds >= k_stockpile_haul_patience_seconds;
 
     if (dist_sq <= k_stockpile_drop_radius * k_stockpile_drop_radius ||
+        stand_dist_sq <= k_stockpile_drop_radius * k_stockpile_drop_radius ||
         (out_of_patience && depot_dist_sq <= k_stockpile_depot_arrival_radius *
                                                  k_stockpile_depot_arrival_radius)) {
       credit_load(*world, unit->owner_id, *carry);
@@ -222,19 +246,8 @@ void ResourceDeliverySystem::update(Engine::Core::World* world, float delta_time
       continue;
     }
 
-    QVector3D target = NavGrid::snap_to_walkable_ground(
-        QVector3D(drop.x, transform->position.y, drop.z));
-
-    float const snap_dx = target.x() - drop.x;
-    float const snap_dz = target.z() - drop.z;
-    if (((snap_dx * snap_dx) + (snap_dz * snap_dz)) >
-        (k_stockpile_drop_radius * k_stockpile_drop_radius)) {
-      target = NavGrid::snap_to_walkable_ground(QVector3D(depot_transform->position.x,
-                                                          transform->position.y,
-                                                          depot_transform->position.z));
-    }
     CommandService::move_unit(
-        *world, hauler->get_id(), target, {.kind = MoveOrderKind::ScriptedMove});
+        *world, hauler->get_id(), stand, {.kind = MoveOrderKind::ScriptedMove});
     carry->haul_repath_cooldown = k_haul_repath_interval;
   }
 

--- a/game/systems/route_follow_system.cpp
+++ b/game/systems/route_follow_system.cpp
@@ -36,6 +36,8 @@ constexpr float k_repath_settle_seconds = 0.60F;
 constexpr float k_recovery_budget_seconds = 1.50F;
 constexpr std::uint32_t k_max_repath_attempts = 3U;
 
+constexpr std::uint32_t k_max_order_repaths = 24U;
+
 constexpr float k_lookahead_speed_seconds = 0.35F;
 constexpr float k_lookahead_min = 0.45F;
 constexpr float k_lookahead_max = 2.0F;
@@ -530,6 +532,7 @@ auto RouteFollowSystem::update_progress(Engine::Core::Entity& entity,
     progress.no_progress_seconds = 0.0F;
     progress.no_progress_advance = 0.0F;
     progress.repath_attempts = 0;
+    progress.repath_count = 0;
   }
   progress.order_seconds += delta_time;
 
@@ -612,7 +615,8 @@ auto RouteFollowSystem::update_progress(Engine::Core::Entity& entity,
       break;
     }
 
-    if (goal_is_reachable_from(movement, current, goal)) {
+    if (progress.repath_count < k_max_order_repaths &&
+        goal_is_reachable_from(movement, current, goal)) {
       progress.state = MovementOrderState::LocallyBlocked;
       progress.repath_attempts = 0;
       progress.no_progress_seconds = 0.0F;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,6 +241,7 @@ add_executable(
     systems/wall_system_test.cpp
     headless/mission_wave_assault_test.cpp
     headless/ai_skirmish_opening_test.cpp
+    headless/ai_duel_match_test.cpp
     headless/movement_quality_gate_test.cpp
     simulation_main.cpp
 )

--- a/tests/headless/ai_duel_match_test.cpp
+++ b/tests/headless/ai_duel_match_test.cpp
@@ -1,0 +1,490 @@
+#include <QtGlobal>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <gtest/gtest.h>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "game/core/component.h"
+#include "game/core/world.h"
+#include "game/map/map_definition.h"
+#include "game/map/map_transformer.h"
+#include "game/map/terrain_service.h"
+#include "game/session/session_context.h"
+#include "game/session/simulation_clock.h"
+#include "game/systems/ai_system.h"
+#include "game/systems/ai_system/ai_commander_doctrine.h"
+#include "game/systems/ai_system/ai_strategy.h"
+#include "game/systems/default_content.h"
+#include "game/systems/nation_registry.h"
+#include "game/systems/nav_grid.h"
+#include "game/systems/owner_registry.h"
+#include "game/systems/player_resource_registry.h"
+#include "game/systems/runtime_system_registry.h"
+#include "game/systems/troop_count_registry.h"
+#include "game/units/factory.h"
+#include "game/units/spawn_type.h"
+#include "game/units/troop_type.h"
+
+namespace {
+
+using Engine::Core::EntityID;
+using Engine::Core::UnitComponent;
+using Game::Session::SessionContext;
+
+constexpr int k_map_size = 128;
+constexpr int k_north = 2;
+constexpr int k_south = 3;
+constexpr int k_north_grid = 26;
+constexpr int k_south_grid = k_map_size - 26;
+constexpr int k_opening_builders = 4;
+
+struct SideReport {
+  int buildings = 0;
+  int barracks = 0;
+  int homes = 0;
+  int farms = 0;
+  int towers = 0;
+  int walls = 0;
+  int builders = 0;
+  int civilians = 0;
+  int fighters = 0;
+  bool commander_alive = false;
+};
+
+struct SideHistory {
+  int most_buildings = 0;
+  int most_homes = 0;
+  int most_farms = 0;
+  int most_fighters = 0;
+  int biggest_wave = 0;
+  int harvested = 0;
+  float commander_lost_at = -1.0F;
+  float commander_last_distance_from_home = 0.0F;
+};
+
+class AiDuelMatchTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Game::Systems::NavGrid::initialize(k_map_size, k_map_size);
+    m_factory = std::make_shared<Game::Units::UnitFactoryRegistry>();
+    Game::Units::register_built_in_units(*m_factory);
+    Game::Map::MapTransformer::setFactoryRegistry(m_factory);
+  }
+
+  void TearDown() override {
+    m_scope.reset();
+    m_session.reset();
+    Game::Map::MapTransformer::setFactoryRegistry(nullptr);
+    Game::Map::TerrainService::instance().clear();
+  }
+
+  auto make_duel(Game::Units::SpawnType north_commander,
+                 Game::Systems::NationID north_nation,
+                 Game::Units::SpawnType south_commander,
+                 Game::Systems::NationID south_nation) -> SessionContext& {
+    m_session = std::make_unique<SessionContext>();
+    auto& session = *m_session;
+    session.world().set_presentation_enabled(false);
+    m_scope = std::make_unique<Game::Session::ScopedSession>(session);
+
+    auto& owners = session.owners();
+    owners.register_owner_with_id(k_north, Game::Systems::OwnerType::AI, "north");
+    owners.register_owner_with_id(k_south, Game::Systems::OwnerType::AI, "south");
+    owners.set_owner_team(k_north, 1);
+    owners.set_owner_team(k_south, 2);
+
+    Game::Systems::initialize_default_content(session.nations());
+    session.nations().set_player_nation(k_north, north_nation);
+    session.nations().set_player_nation(k_south, south_nation);
+
+    Game::Map::MapDefinition map_definition;
+    map_definition.grid.width = k_map_size;
+    map_definition.grid.height = k_map_size;
+    map_definition.grid.tile_size = 1.0F;
+    scatter_resources(map_definition, k_north_grid, k_north_grid);
+    scatter_resources(map_definition, k_south_grid, k_south_grid);
+    session.terrain().initialize(map_definition);
+
+    Game::Systems::register_runtime_systems(session.world());
+    session.troop_counts().initialize();
+
+    for (const int owner : {k_north, k_south}) {
+      auto& economy = session.economy();
+      economy.ensure_owner(owner);
+      economy.set(owner, Game::Systems::ResourceType::Gold, 250);
+      economy.set(owner, Game::Systems::ResourceType::Food, 200);
+      economy.set(owner, Game::Systems::ResourceType::Wood, 250);
+      economy.set(owner, Game::Systems::ResourceType::Stone, 120);
+      economy.set(owner, Game::Systems::ResourceType::Iron, 80);
+    }
+
+    seat_town(session, k_north, k_north_grid, north_commander);
+    seat_town(session, k_south, k_south_grid, south_commander);
+
+    if (auto* ai = session.world().get_system<Game::Systems::AISystem>()) {
+      ai->reinitialize();
+      for (const int owner : {k_north, k_south}) {
+        auto profile =
+            Game::Systems::AI::doctrine_profile_for_owner(session.world(), owner);
+        EXPECT_TRUE(profile.has_value())
+            << "owner " << owner << " has no authored commander doctrine";
+        if (profile.has_value()) {
+          ai->set_ai_profile(owner, *profile);
+        }
+      }
+    }
+    return session;
+  }
+
+  static void scatter_resources(Game::Map::MapDefinition& map, int grid_x, int grid_z) {
+    const auto add = [&map](Game::Map::WorldProp::Type type, int x, int z) {
+      if (x < 2 || z < 2 || x >= k_map_size - 2 || z >= k_map_size - 2) {
+        return;
+      }
+      Game::Map::WorldProp prop;
+      prop.type = type;
+      prop.x = static_cast<float>(x);
+      prop.z = static_cast<float>(z);
+      map.world_props.push_back(prop);
+    };
+    for (int ring = 0; ring < 8; ++ring) {
+      const int offset = 10 + ring * 2;
+      add(Game::Map::WorldProp::Type::OliveTree, grid_x + offset, grid_z);
+      add(Game::Map::WorldProp::Type::OliveTree, grid_x - offset, grid_z);
+      add(Game::Map::WorldProp::Type::PineTree, grid_x, grid_z + offset);
+      add(Game::Map::WorldProp::Type::PineTree, grid_x, grid_z - offset);
+      add(Game::Map::WorldProp::Type::Boulder, grid_x + offset, grid_z + 6);
+      add(Game::Map::WorldProp::Type::IronOre, grid_x - offset, grid_z - 6);
+    }
+  }
+
+  void seat_town(SessionContext& session,
+                 int owner,
+                 int grid,
+                 Game::Units::SpawnType commander) {
+    spawn(session, Game::Units::SpawnType::Barracks, owner, world_of(grid, grid));
+    spawn(session, commander, owner, world_of(grid + 2, grid + 2));
+    for (int index = 0; index < k_opening_builders; ++index) {
+      spawn(session,
+            Game::Units::SpawnType::Builder,
+            owner,
+            world_of(grid + 4, grid - 3 + index * 2));
+    }
+  }
+
+  auto spawn(SessionContext& session,
+             Game::Units::SpawnType type,
+             int owner_id,
+             QVector3D position) -> EntityID {
+    Game::Units::SpawnParams params;
+    params.position = position;
+    params.player_id = owner_id;
+    params.spawn_type = type;
+    params.ai_controlled = true;
+    params.is_initial_spawn = true;
+    params.max_population = 280;
+    params.enables_production = true;
+    const auto* nation = session.nations().get_nation_for_player(owner_id);
+    params.nation_id =
+        nation != nullptr ? nation->id : Game::Systems::NationID::RomanRepublic;
+    auto unit = m_factory->create(type, session.world(), params);
+    return unit ? unit->id() : 0;
+  }
+
+  static auto world_of(int grid_x, int grid_z) -> QVector3D {
+    return Game::Systems::NavGrid::grid_to_world(Game::Systems::Point(grid_x, grid_z));
+  }
+
+  static void run_for(SessionContext& session, double seconds) {
+    const double step = session.clock().tick_seconds();
+    for (double elapsed = 0.0; elapsed < seconds; elapsed += step) {
+      session.clock().advance(step);
+      while (session.clock().consume_tick()) {
+        session.world().update(static_cast<float>(step));
+      }
+    }
+  }
+
+  static auto survey(SessionContext& session, int owner) -> SideReport {
+    SideReport report;
+    for (auto [id, unit] : session.world().view<UnitComponent>()) {
+      if (unit.owner_id != owner || unit.health <= 0) {
+        continue;
+      }
+      if (Game::Units::is_building_spawn(unit.spawn_type)) {
+        ++report.buildings;
+        switch (unit.spawn_type) {
+        case Game::Units::SpawnType::Barracks:
+          ++report.barracks;
+          break;
+        case Game::Units::SpawnType::Home:
+          ++report.homes;
+          break;
+        case Game::Units::SpawnType::Farm:
+          ++report.farms;
+          break;
+        case Game::Units::SpawnType::DefenseTower:
+          ++report.towers;
+          break;
+        case Game::Units::SpawnType::WallSegment:
+          ++report.walls;
+          break;
+        default:
+          break;
+        }
+        continue;
+      }
+      switch (unit.spawn_type) {
+      case Game::Units::SpawnType::Builder:
+        ++report.builders;
+        break;
+      case Game::Units::SpawnType::Civilian:
+        ++report.civilians;
+        break;
+      default:
+        if (const auto troop = Game::Units::spawn_typeToTroopType(unit.spawn_type);
+            troop.has_value() && Game::Units::is_commander_troop(*troop)) {
+          report.commander_alive = true;
+        } else {
+          ++report.fighters;
+        }
+        break;
+      }
+    }
+    return report;
+  }
+
+  static auto harvested_total(SessionContext& session, int owner) -> int {
+    const auto carried = session.economy().get_harvested_all(owner);
+    int total = 0;
+    for (const auto type : Game::Systems::k_all_resource_types) {
+      total += carried.get(type);
+    }
+    return total;
+  }
+
+  static auto barracks_manpower(SessionContext& session, int owner) -> int {
+    int manpower = 0;
+    for (auto [id, prod] : session.world().view<Engine::Core::ProductionComponent>()) {
+      const auto* unit = session.world().try_get<UnitComponent>(id);
+      if (unit != nullptr && unit->owner_id == owner &&
+          unit->spawn_type == Game::Units::SpawnType::Barracks) {
+        manpower += prod.manpower_available;
+      }
+    }
+    return manpower;
+  }
+
+  static auto commander_distance_from_home(SessionContext& session,
+                                           int owner) -> float {
+    auto* ai = session.world().get_system<Game::Systems::AISystem>();
+    const auto* plan = ai != nullptr ? ai->plan_for(owner) : nullptr;
+    if (plan == nullptr || !plan->has_base_anchor) {
+      return 0.0F;
+    }
+    for (auto [id, unit] : session.world().view<UnitComponent>()) {
+      if (unit.owner_id != owner || unit.health <= 0) {
+        continue;
+      }
+      const auto troop = Game::Units::spawn_typeToTroopType(unit.spawn_type);
+      if (!troop.has_value() || !Game::Units::is_commander_troop(*troop)) {
+        continue;
+      }
+      const auto* transform =
+          session.world().try_get<Engine::Core::TransformComponent>(id);
+      if (transform == nullptr) {
+        continue;
+      }
+      const float dx = transform->position.x - plan->base_pos_x;
+      const float dz = transform->position.z - plan->base_pos_z;
+      return std::sqrt((dx * dx) + (dz * dz));
+    }
+    return 0.0F;
+  }
+
+  static void
+  observe(SessionContext& session, int owner, float minute, SideHistory& history) {
+    const auto report = survey(session, owner);
+    auto* ai = session.world().get_system<Game::Systems::AISystem>();
+    const auto* plan = ai != nullptr ? ai->plan_for(owner) : nullptr;
+    if (report.commander_alive) {
+      history.commander_last_distance_from_home =
+          commander_distance_from_home(session, owner);
+    }
+
+    history.most_buildings = std::max(history.most_buildings, report.buildings);
+    history.most_homes = std::max(history.most_homes, report.homes);
+    history.most_farms = std::max(history.most_farms, report.farms);
+    history.most_fighters = std::max(history.most_fighters, report.fighters);
+    history.harvested = harvested_total(session, owner);
+
+    if (plan != nullptr && plan->wave.committed) {
+      history.biggest_wave =
+          std::max(history.biggest_wave, static_cast<int>(plan->wave.members.size()));
+    }
+
+    if (!report.commander_alive && history.commander_lost_at < 0.0F) {
+      history.commander_lost_at = minute;
+    }
+  }
+
+  static void narrate(SessionContext& session,
+                      float minute,
+                      const char* north_name,
+                      const char* south_name) {
+    if (!qEnvironmentVariableIsSet("SOI_DUEL_NARRATE")) {
+      return;
+    }
+    auto* ai = session.world().get_system<Game::Systems::AISystem>();
+    auto& economy = session.economy();
+    std::printf("t=%5.1f min\n", static_cast<double>(minute));
+    const std::pair<int, const char*> sides[] = {{k_north, north_name},
+                                                 {k_south, south_name}};
+    for (const auto& side : sides) {
+      const auto report = survey(session, side.first);
+      const auto* plan = ai != nullptr ? ai->plan_for(side.first) : nullptr;
+      std::printf(
+          "  %-10s bar %d home %d farm %d tow %d wall %d | work %d/%d "
+          "fight %d | food %d manpower %d | left %d homesfirst %d | "
+          "wave %s(%d) %s\n",
+          side.second,
+          report.barracks,
+          report.homes,
+          report.farms,
+          report.towers,
+          report.walls,
+          report.builders,
+          report.civilians,
+          report.fighters,
+          economy.get(side.first, Game::Systems::ResourceType::Food),
+          barracks_manpower(session, side.first),
+          plan != nullptr ? plan->home_civilians_remaining : -1,
+          plan != nullptr && plan->macro_targets.raise_homes_first ? 1 : 0,
+          (plan != nullptr && plan->wave.committed) ? "yes" : "no",
+          plan != nullptr ? static_cast<int>(plan->wave.members.size()) : 0,
+          plan != nullptr
+              ? Game::Systems::AI::AIStrategyFactory::state_to_string(plan->state)
+                    .toUtf8()
+                    .constData()
+              : "?");
+    }
+  }
+
+  struct DuelOutcome {
+    SideHistory north;
+    SideHistory south;
+  };
+
+  auto play(Game::Units::SpawnType north_commander,
+            Game::Systems::NationID north_nation,
+            const char* north_name,
+            Game::Units::SpawnType south_commander,
+            Game::Systems::NationID south_nation,
+            const char* south_name,
+            int minutes) -> DuelOutcome {
+    make_duel(north_commander, north_nation, south_commander, south_nation);
+    auto& session = *m_session;
+    DuelOutcome outcome;
+    for (int minute = 1; minute <= minutes; ++minute) {
+      run_for(session, 60.0);
+      const auto now = static_cast<float>(minute);
+      observe(session, k_north, now, outcome.north);
+      observe(session, k_south, now, outcome.south);
+      narrate(session, now, north_name, south_name);
+    }
+    return outcome;
+  }
+
+  static void expect_one_of_them_fought_a_war(const SideHistory& north,
+                                              const SideHistory& south) {
+    const int best_army = std::max(north.most_fighters, south.most_fighters);
+    const int best_wave = std::max(north.biggest_wave, south.biggest_wave);
+    EXPECT_GE(best_army, 5) << "neither side ever fielded more than " << best_army
+                            << " soldiers; nobody built an army";
+    EXPECT_GE(best_wave, 3) << "neither side ever gathered a wave bigger than "
+                            << best_wave << "; nobody attacked";
+  }
+
+  static void expect_a_commander_played_the_match(const SideHistory& side,
+                                                  const char* name) {
+    EXPECT_GE(side.most_buildings, 5)
+        << name << " raised only " << side.most_buildings << " buildings";
+    EXPECT_GE(side.most_homes, 3)
+        << name << " raised only " << side.most_homes
+        << " homes, so its barracks was always short of manpower";
+    EXPECT_GE(side.most_farms, 1)
+        << name << " never broke ground on a field, so it ran out of food";
+    EXPECT_GE(side.most_fighters, 2)
+        << name << " fielded at most " << side.most_fighters
+        << " soldiers, so its barracks never really opened";
+    EXPECT_GT(side.harvested, 400)
+        << name << " carried in only " << side.harvested << " of everything";
+
+    constexpr float k_home_ground = 45.0F;
+    EXPECT_TRUE(side.commander_lost_at < 0.0F ||
+                side.commander_last_distance_from_home <= k_home_ground)
+        << name << " lost its commander at minute " << side.commander_lost_at << ", "
+        << side.commander_last_distance_from_home
+        << "m from its own base, and its whole nation with him: a lord that far "
+           "out was thrown away rather than beaten";
+  }
+
+  std::shared_ptr<Game::Units::UnitFactoryRegistry> m_factory;
+  std::unique_ptr<SessionContext> m_session;
+  std::unique_ptr<Game::Session::ScopedSession> m_scope;
+};
+
+} // namespace
+
+TEST_F(AiDuelMatchTest, ScipioAndFabiusBothPlayTheirDoctrine) {
+  const auto outcome = play(Game::Units::SpawnType::RomanVeteranConsul,
+                            Game::Systems::NationID::RomanRepublic,
+                            "scipio",
+                            Game::Units::SpawnType::RomanLegionOrganizer,
+                            Game::Systems::NationID::RomanRepublic,
+                            "fabius",
+                            30);
+
+  expect_a_commander_played_the_match(outcome.north, "Scipio");
+  expect_a_commander_played_the_match(outcome.south, "Fabius");
+  expect_one_of_them_fought_a_war(outcome.north, outcome.south);
+
+  EXPECT_GE(outcome.north.biggest_wave, 4)
+      << "Scipio's aggressive doctrine never gathered a wave bigger than "
+      << outcome.north.biggest_wave;
+}
+
+TEST_F(AiDuelMatchTest, MarcellusAndHannoBothPlayTheirDoctrine) {
+  const auto outcome = play(Game::Units::SpawnType::RomanFieldCommander,
+                            Game::Systems::NationID::RomanRepublic,
+                            "marcellus",
+                            Game::Units::SpawnType::CarthageSpearCommander,
+                            Game::Systems::NationID::Carthage,
+                            "hanno",
+                            30);
+
+  expect_a_commander_played_the_match(outcome.north, "Marcellus");
+  expect_a_commander_played_the_match(outcome.south, "Hanno");
+  expect_one_of_them_fought_a_war(outcome.north, outcome.south);
+
+  EXPECT_GE(outcome.north.biggest_wave, 3)
+      << "Marcellus' rushing doctrine never gathered a wave";
+}
+
+TEST_F(AiDuelMatchTest, HannibalAndHasdrubalBothPlayTheirDoctrine) {
+  const auto outcome = play(Game::Units::SpawnType::CarthageSwordCommander,
+                            Game::Systems::NationID::Carthage,
+                            "hannibal",
+                            Game::Units::SpawnType::CarthageBowCommander,
+                            Game::Systems::NationID::Carthage,
+                            "hasdrubal",
+                            30);
+
+  expect_a_commander_played_the_match(outcome.north, "Hannibal");
+  expect_a_commander_played_the_match(outcome.south, "Hasdrubal");
+  expect_one_of_them_fought_a_war(outcome.north, outcome.south);
+}

--- a/tests/headless/ai_skirmish_opening_test.cpp
+++ b/tests/headless/ai_skirmish_opening_test.cpp
@@ -503,10 +503,12 @@ TEST_F(AiSkirmishOpeningTest, AWorkerThatCannotReachItsSiteGivesUpInsteadOfHangi
 TEST_F(AiSkirmishOpeningTest, TheComputerKeepsGatheringAfterItsOpeningStockIsGone) {
   auto& session = make_match();
   auto& economy = session.economy();
+
   const auto gathered = [&economy]() {
-    return economy.get(k_left, Game::Systems::ResourceType::Wood) +
-           economy.get(k_left, Game::Systems::ResourceType::Stone) +
-           economy.get(k_left, Game::Systems::ResourceType::Iron);
+    const auto harvested = economy.get_harvested_all(k_left);
+    return harvested.get(Game::Systems::ResourceType::Wood) +
+           harvested.get(Game::Systems::ResourceType::Stone) +
+           harvested.get(Game::Systems::ResourceType::Iron);
   };
 
   run_for(session, 100.0);
@@ -515,6 +517,7 @@ TEST_F(AiSkirmishOpeningTest, TheComputerKeepsGatheringAfterItsOpeningStockIsGon
   const int later = gathered();
 
   EXPECT_GT(later, after_the_opening)
-      << "the stockpile went from " << after_the_opening << " to " << later
-      << " over three minutes; the workers are not bringing anything in";
+      << "the work parties had carried in " << after_the_opening
+      << " and three minutes later still only " << later
+      << "; nobody is bringing anything home";
 }

--- a/tools/arena/README.md
+++ b/tools/arena/README.md
@@ -94,13 +94,22 @@ build/bin/arena_app --batch --scenario ai_duel_scipio_vs_fabius \
 ```
 
 `ai_duel_*` is the scenario family that verifies commander doctrines are
-actually reaching the computer opponent. Each side starts with a commander and
-four builders in opposite corners of the map, facing each other down the
-diagonal, with wood, stone and iron in reach -- and nothing else. No starting
-army, no starting barracks: the lord anchors the settlement, the builders raise
-homes and a barracks, and every soldier either side fields has to be recruited
+actually reaching the computer opponent. Each side starts with a commander, one
+barracks and four builders in opposite corners of the map, facing each other
+down the diagonal, with wood, stone and iron in reach -- and nothing else. No
+starting army and no homes: the builders have to raise the housing, break the
+fields that feed it, and every soldier either side fields has to be recruited
 out of that. They play until one side has no units and no buildings left, and
 the run stops at the decision rather than burning the rest of its duration.
+
+The duel runs for thirty simulated minutes because that is roughly what the
+manpower chain needs: a home raises three families, a family is worth about one
+soldier at the barracks, and a doctrine that gathers waves of six or eight has
+to build the housing for them first. Watching one of these at the renderer's
+pace costs the better part of an hour, so iterate on
+`build/bin/ai_tests --gtest_filter='AiDuelMatchTest.*'` -- the same match
+headless in seconds, with `SOI_DUEL_NARRATE=1` for a per-minute commentary --
+and come here to see it.
 
 Between the two camps runs a river with a single bridge, and hills of several
 shapes -- crowned, ridge, elbow, arc -- sit on both approaches. An attack has to

--- a/tools/arena/arena_ai_duel_scenarios.cpp
+++ b/tools/arena/arena_ai_duel_scenarios.cpp
@@ -135,8 +135,9 @@ void add_side(ArenaScenarioDefinition& scenario, const DuelSide& side) {
   scenario.groups.push_back(duel_group(side,
                                        prefix + QStringLiteral("_builder"),
                                        Troop::Builder,
-                                       1,
-                                       {-4.0F, 0.0F, -4.0F}));
+                                       4,
+                                       {-6.0F, 0.0F, -4.0F},
+                                       {2.4F, 0.0F, 0.0F}));
 
   ArenaScenarioBattleSide battle_side;
   battle_side.owner_id = side.owner_id;
@@ -187,7 +188,8 @@ auto duel_definition(const char* id,
   scenario.suppress_ui_overlays = true;
   scenario.force_full_creature_lod = false;
   scenario.collect_animation_diagnostics = false;
-  scenario.suppress_terrain_scatter = true;
+
+  scenario.suppress_terrain_scatter = false;
   scenario.terrain_grid_extent = 128;
 
   scenario.ai_starting_resources = {
@@ -262,7 +264,7 @@ auto build_ai_duel_definitions() -> std::vector<ArenaScenarioDefinition> {
                        "fight to elimination. Scipio's aggressive doctrine must "
                        "carry the attack while Fabius' delaying doctrine holds "
                        "its own ground."),
-        1200.0F,
+        1800.0F,
         scipio,
         fabius);
     s.expectations.push_back(
@@ -297,7 +299,7 @@ auto build_ai_duel_definitions() -> std::vector<ArenaScenarioDefinition> {
         QStringLiteral("A Roman rushing doctrine against a Carthaginian economic "
                        "garrison, each developing its own corner town until one "
                        "is destroyed."),
-        1200.0F,
+        1800.0F,
         marcellus,
         hanno);
     s.expectations.push_back(
@@ -331,7 +333,7 @@ auto build_ai_duel_definitions() -> std::vector<ArenaScenarioDefinition> {
         QStringLiteral("AI Duel: Hannibal vs Hasdrubal"),
         QStringLiteral("Two Barcid doctrines, one decisive and one harassing, "
                        "fight the same battle from opposite temperaments."),
-        1200.0F,
+        1800.0F,
         hannibal,
         hasdrubal);
     s.expectations.push_back(


### PR DESCRIPTION
Expand the data-driven commander AI beyond isolated opening scenarios so duel matches exercise the complete decision loop across snapshots, doctrine selection, attack waves, construction, production, delivery, and route following.

Add the headless AI duel match fixture and register it with the test suite, while extending the existing skirmish coverage and arena scenarios with deterministic duel setup and progression checks.

Refine AI snapshot and reasoning data, commander and attack behavior coordination, builder and production priorities, civilian and resource delivery handling, and route-follow integration. Update doctrine data and the AI architecture documentation to describe the new responsibilities and match flow.

Keep the gameplay systems resilient to incomplete delivery routes and evolving production state, and preserve the arena documentation and scenario contracts needed to reproduce commander-versus-commander behavior.