### PR TITLE
fix: stabilize fog rendering and selection feedback

### DIFF
--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -1498,7 +1498,10 @@ void GameEngine::start_skirmish_internal(const QString& map_path,
   if (m_victory_service) {
     m_victory_service->reset();
   }
-  m_enemy_troops_defeated = 0;
+  if (m_enemy_troops_defeated != 0) {
+    m_enemy_troops_defeated = 0;
+    emit enemy_troops_defeated_changed();
+  }
 
   if (!m_runtime.initialized) {
     ensure_initialized();

--- a/assets/shaders/include/visibility_mask.glsl
+++ b/assets/shaders/include/visibility_mask.glsl
@@ -7,6 +7,7 @@ uniform float u_explored_alpha;
 uniform int u_has_visibility;
 
 const float k_visibility_known_cutoff = 0.30;
+const float k_visibility_unseen_cutoff = 0.06;
 
 struct VisibilityMask {
   float seen_now;
@@ -34,6 +35,19 @@ VisibilityMask sample_visibility_mask(sampler2D mask_tex,
 
 bool visibility_is_unknown(VisibilityMask mask) {
   return mask.known < k_visibility_known_cutoff;
+}
+
+bool visibility_is_unseen(VisibilityMask mask) {
+  return mask.known < k_visibility_unseen_cutoff;
+}
+
+float visibility_known_weight(VisibilityMask mask) {
+  return smoothstep(k_visibility_unseen_cutoff, k_visibility_known_cutoff, mask.known);
+}
+
+vec3 unseen_surface_color(vec3 base_color) {
+  float luminance = dot(base_color, vec3(0.2126, 0.7152, 0.0722));
+  return mix(vec3(luminance), base_color, 0.25) * 0.13;
 }
 
 float visibility_live_weight(VisibilityMask mask) {
@@ -73,7 +87,8 @@ vec3 apply_visibility_memory_mask(vec3 lit_color, VisibilityMask mask) {
   }
   vec3 memory = remembered_surface_color(lit_color, u_explored_alpha) *
                 visibility_memory_falloff(mask);
-  return mix(memory, lit_color, visibility_live_weight(mask));
+  vec3 charted = mix(memory, lit_color, visibility_live_weight(mask));
+  return mix(unseen_surface_color(lit_color), charted, visibility_known_weight(mask));
 }
 
 vec3 apply_visibility_memory(vec3 lit_color, vec2 world_xz) {

--- a/assets/shaders/terrain_chunk.frag
+++ b/assets/shaders/terrain_chunk.frag
@@ -229,8 +229,11 @@ const float k_soi_tactical_far = 115.0;
 void main() {
 
   VisibilityMask visibility = visibility_mask_fetch(v_world_pos.xz);
-  if (visibility_is_unknown(visibility)) {
-    discard;
+  if (visibility_is_unseen(visibility)) {
+    frag_color = vec4(unseen_surface_color(u_soil_color) * u_ambient_boost *
+                          environment_exposure(),
+                      1.0);
+    return;
   }
 
   vec3 to_camera = u_camera_pos - v_world_pos;

--- a/render/ground/terrain_renderer.h
+++ b/render/ground/terrain_renderer.h
@@ -160,8 +160,6 @@ private:
   };
 
   struct ChunkVisibilityCacheEntry {
-    std::uint64_t visibility_version = std::numeric_limits<std::uint64_t>::max();
-    bool any_revealed = true;
     bool was_submitted = false;
   };
 

--- a/render/ground/terrain_renderer_submission.cpp
+++ b/render/ground/terrain_renderer_submission.cpp
@@ -8,7 +8,6 @@
 #include <cmath>
 #include <cstddef>
 
-#include "game/map/render_visibility_rules.h"
 #include "game/map/visibility_service.h"
 #include "render/gl/shader.h"
 #include "render/gl/texture.h"
@@ -505,28 +504,6 @@ void TerrainRenderer::submit(Renderer& renderer, ResourceManager* resources) {
       continue;
     }
     submission_cache.was_submitted = true;
-
-    if (visibility_snapshot != nullptr) {
-      auto& cache = m_chunk_visibility_cache[chunk_index];
-      if (cache.visibility_version != visibility_snapshot->version) {
-        bool any_revealed = false;
-        for (int gz = chunk.min_z; gz <= chunk.max_z && !any_revealed; ++gz) {
-          for (int gx = chunk.min_x; gx <= chunk.max_x; ++gx) {
-            if (Game::Map::classify_static_world_cell_visibility(
-                    *visibility_snapshot, gx, gz) !=
-                Game::Map::RenderVisibilityState::Hidden) {
-              any_revealed = true;
-              break;
-            }
-          }
-        }
-        cache.any_revealed = any_revealed;
-        cache.visibility_version = visibility_snapshot->version;
-      }
-      if (!cache.any_revealed) {
-        continue;
-      }
-    }
 
     TerrainSurfaceCmd cmd;
     cmd.mesh = chunk.mesh.get();

--- a/render/scene_walk.cpp
+++ b/render/scene_walk.cpp
@@ -895,10 +895,26 @@ void Renderer::submit_unit_entry(
                         return soldier.cull_reason !=
                                Render::Profiling::SoldierCullReason::None;
                       });
+      std::size_t prepared_requests = 0;
+      std::size_t prepared_visible_requests = 0;
+      if (prepared != nullptr) {
+        auto const requests = prepared->bodies.requests();
+        prepared_requests = requests.size();
+        prepared_visible_requests = static_cast<std::size_t>(
+            std::count_if(requests.begin(), requests.end(), [](const auto& request) {
+              return request.pass !=
+                     Render::Creature::Pipeline::RenderPassIntent::Shadow;
+            }));
+      }
+
+      const bool prepared_only_casts_shadows = prepared != nullptr &&
+                                               prepared_requests > 0 &&
+                                               prepared_visible_requests == 0;
+
       if (entry.unit != nullptr && entry.unit->health > 0 &&
           probe.rigged_body_count() == 0U &&
           unit_should_emit_rigged_body(entry.unit->spawn_type) && !tier_is_minimal &&
-          !all_published_soldiers_culled) {
+          !all_published_soldiers_culled && !prepared_only_casts_shadows) {
         static std::mutex warning_mutex;
         static std::unordered_set<std::string> warned_units;
         const std::string warning_key =
@@ -913,7 +929,8 @@ void Renderer::submit_unit_entry(
               << QStringLiteral(
                      "Renderer: unit renderer emitted no rigged body; "
                      "entity=%1 renderer='%2' spawn='%3' selected=%4 hovered=%5 "
-                     "combat=%6 distance_sq=%7 batching=%8 lod_tier=%9")
+                     "combat=%6 distance_sq=%7 batching=%8 lod_tier=%9 "
+                     "prepared=%10 requests=%11 visible_requests=%12")
                      .arg(entry.entity_id)
                      .arg(QString::fromStdString(entry.renderer_key))
                      .arg(Game::Units::spawn_typeToQString(entry.unit->spawn_type))
@@ -922,7 +939,10 @@ void Renderer::submit_unit_entry(
                      .arg(static_cast<int>(entry.combat_active))
                      .arg(entry.distance_sq)
                      .arg(static_cast<int>(use_batching))
-                     .arg(plan.lod_tier);
+                     .arg(plan.lod_tier)
+                     .arg(static_cast<int>(prepared != nullptr))
+                     .arg(prepared_requests)
+                     .arg(prepared_visible_requests);
         }
       }
 

--- a/tests/ui/design_system_qml_test.cpp
+++ b/tests/ui/design_system_qml_test.cpp
@@ -2,6 +2,8 @@
 
 #include <QFont>
 #include <QFontMetrics>
+#include <QMutex>
+#include <QMutexLocker>
 #include <QQmlEngine>
 #include <QQuickItem>
 #include <QQuickWindow>
@@ -80,6 +82,76 @@ public:
     return &probe;
   }
 };
+
+class WarningProbe : public QObject {
+  Q_OBJECT
+
+public:
+  explicit WarningProbe(QObject* parent = nullptr)
+      : QObject(parent) {}
+
+  Q_INVOKABLE void start() {
+    QMutexLocker const lock(&s_mutex);
+    s_messages.clear();
+    if (!s_recording) {
+      s_previous = qInstallMessageHandler(&WarningProbe::handle);
+      s_recording = true;
+    }
+  }
+
+  Q_INVOKABLE void stop() {
+    QMutexLocker const lock(&s_mutex);
+    if (!s_recording) {
+      return;
+    }
+    qInstallMessageHandler(s_previous);
+    s_previous = nullptr;
+    s_recording = false;
+  }
+
+  Q_INVOKABLE static QStringList messages() {
+    QMutexLocker const lock(&s_mutex);
+    return s_messages;
+  }
+
+  Q_INVOKABLE static int count() {
+    QMutexLocker const lock(&s_mutex);
+    return static_cast<int>(s_messages.size());
+  }
+
+  static void
+  handle(QtMsgType type, const QMessageLogContext& context, const QString& message) {
+    {
+      QMutexLocker const lock(&s_mutex);
+      if (s_recording && (type == QtWarningMsg || type == QtCriticalMsg)) {
+        s_messages.append(message);
+      }
+    }
+    if (s_previous != nullptr) {
+      s_previous(type, context, message);
+    }
+  }
+
+  static WarningProbe* create(QQmlEngine* engine, QJSEngine* scriptEngine) {
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+
+    static WarningProbe probe;
+    QQmlEngine::setObjectOwnership(&probe, QQmlEngine::CppOwnership);
+    return &probe;
+  }
+
+private:
+  static QMutex s_mutex;
+  static QStringList s_messages;
+  static bool s_recording;
+  static QtMessageHandler s_previous;
+};
+
+QMutex WarningProbe::s_mutex;
+QStringList WarningProbe::s_messages;
+bool WarningProbe::s_recording = false;
+QtMessageHandler WarningProbe::s_previous = nullptr;
 
 class CommanderPortraitStub : public QQuickItem {
   Q_OBJECT
@@ -172,6 +244,8 @@ public slots:
         "StandardOfIron", 1, 0, "CommanderPortraitView");
     qmlRegisterSingletonType<GlyphProbe>(
         "StandardOfIron.TestSupport", 1, 0, "GlyphProbe", &GlyphProbe::create);
+    qmlRegisterSingletonType<WarningProbe>(
+        "StandardOfIron.TestSupport", 1, 0, "WarningProbe", &WarningProbe::create);
   }
 
   void qmlEngineAvailable(QQmlEngine* engine) {

--- a/tests/ui/qml/tst_selection_summary_churn.qml
+++ b/tests/ui/qml/tst_selection_summary_churn.qml
@@ -1,0 +1,100 @@
+import QtQuick 2.15
+import QtTest 1.0
+import StandardOfIron.Design 1.0 as Design
+import StandardOfIron.TestSupport 1.0
+
+TestCase {
+    id: root
+
+    name: "SelectionSummaryChurn"
+    when: windowShown
+    width: 420
+    height: 320
+    visible: true
+
+    function unitRows(count) {
+        var out = [];
+        for (var i = 0; i < count; ++i)
+            out.push({
+                    "name": "Archer",
+                    "unit_type": "archer",
+                    "nation": "carthage",
+                    "unit_id": "u" + i,
+                    "health_ratio": 0.8,
+                    "activity": "idle",
+                    "activity_state": "",
+                    "soldiers": 20,
+                    "maxSoldiers": 22
+                });
+        return out;
+    }
+
+    function groupRows(count) {
+        var out = [];
+        for (var i = 0; i < count; ++i)
+            out.push({
+                    "typeKey": "archer",
+                    "name": "Archer",
+                    "nation": "carthage",
+                    "health": 0.8,
+                    "woundedCount": 0,
+                    "count": 2,
+                    "mixedActivity": false,
+                    "soldiers": 20,
+                    "maxSoldiers": 22
+                });
+        return out;
+    }
+
+    function applySelection(units, groups) {
+        summary.model = root.unitRows(units);
+        summary.unitCount = units;
+        summary.groups = root.groupRows(groups);
+    }
+
+    function noise() {
+        var out = [];
+        var all = WarningProbe.messages();
+        for (var i = 0; i < all.length; ++i) {
+            if (all[i].indexOf("IronSelectionSummary") >= 0 || all[i].indexOf("invalid context") >= 0)
+                out.push(all[i]);
+        }
+        return out;
+    }
+
+    Design.IronSelectionSummary {
+        id: summary
+
+        anchors.fill: parent
+        unitCount: 0
+        model: []
+        groups: []
+    }
+
+    function test_the_summary_is_quiet_while_the_selection_churns() {
+        WarningProbe.start();
+        root.applySelection(6, 6);
+        wait(80);
+        root.applySelection(0, 0);
+        wait(80);
+        root.applySelection(1, 1);
+        wait(80);
+        summary.groups = [];
+        wait(80);
+        root.applySelection(3, 3);
+        wait(80);
+        root.applySelection(6, 6);
+        wait(120);
+        WarningProbe.stop();
+        var noisy = root.noise();
+        compare(noisy.length, 0, "a churning selection must not evaluate bindings against a row that has gone away — " + noisy.slice(0, 3).join(" | "));
+    }
+
+    function test_the_group_cards_rebuild_with_real_values() {
+        root.applySelection(6, 6);
+        wait(120);
+        var groupBar = findChild(summary, "selectionGroupHealthBar_archer");
+        verify(groupBar !== null, "the group cards should carry their type keys");
+        compare(groupBar.value, 0.8);
+    }
+}

--- a/ui/qml/HUD.qml
+++ b/ui/qml/HUD.qml
@@ -15,6 +15,8 @@ Item {
     property int bottom_panel_height: bottomPanel.height
 
     readonly property int left_stack_bottom: waveTracker.visible ? waveTracker.y + waveTracker.height : topPanel.height
+
+    readonly property int right_stack_bottom: topPanel.height + Design.Metrics.space8 + (Design.Metrics.space24 * 8) + Design.Metrics.space8 + hudTop.minimapLegendHeight
     property int selection_tick: 0
     property bool has_movable_units: false
     property bool commander_rpg_mode: typeof game !== 'undefined' && game.commander.mode_state === "active"
@@ -260,7 +262,7 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: Design.Metrics.hudZoneMargin
         anchors.top: topPanel.bottom
-        anchors.topMargin: Design.Metrics.space8 + (Design.Metrics.space24 * 8) + Design.Metrics.space8 + hudTop.minimapLegendHeight
+        anchors.topMargin: hud.right_stack_bottom - topPanel.height
 
         visible: hud.camera_legend_visible && !hud.commander_rpg_mode && !commanderMessage.showing
         onDismissed: hud.camera_legend_visible = false
@@ -375,7 +377,7 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: Design.Metrics.hudZoneMargin
         anchors.top: topPanel.bottom
-        anchors.topMargin: Design.Metrics.space8 + (Design.Metrics.space24 * 8) + Design.Metrics.space8 + hudTop.minimapLegendHeight
+        anchors.topMargin: hud.right_stack_bottom - topPanel.height
 
         z: 200
     }

--- a/ui/qml/HUDTop.qml
+++ b/ui/qml/HUDTop.qml
@@ -348,9 +348,10 @@ Item {
                     hoverEnabled: enabled
                     cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
 
-                    ToolTip.visible: containsMouse
-                    ToolTip.delay: Design.Metrics.tooltipDelay
-                    ToolTip.text: topRoot.missionStaged ? (game.mission.active_hint !== "" ? game.mission.active_hint + "\n" + qsTr("Click to look at the objective.") : qsTr("Click to look at the objective.")) : ""
+                    Design.IronTooltip {
+                        visible: objectiveFocusArea.containsMouse
+                        text: topRoot.missionStaged ? (game.mission.active_hint !== "" ? game.mission.active_hint + "\n" + qsTr("Click to look at the objective.") : qsTr("Click to look at the objective.")) : ""
+                    }
 
                     onClicked: game.mission.focus_active_stage()
                 }
@@ -367,9 +368,10 @@ Item {
                     tone: Design.Theme.warning
                     text: Design.Icons.spectator + " " + qsTr("SPECTATOR")
 
-                    ToolTip.visible: spectatorHover.hovered
-                    ToolTip.delay: Design.Metrics.tooltipDelay
-                    ToolTip.text: qsTr("Watching a CPU-only match. You cannot issue commands.")
+                    Design.IronTooltip {
+                        visible: spectatorHover.hovered
+                        text: qsTr("Watching a CPU-only match. You cannot issue commands.")
+                    }
 
                     HoverHandler {
                         id: spectatorHover
@@ -443,9 +445,10 @@ Item {
                         compact: true
                     }
 
-                    ToolTip.visible: ownersHover.hovered
-                    ToolTip.delay: Design.Metrics.tooltipDelay
-                    ToolTip.text: topRoot.owners_tooltip()
+                    Design.IronTooltip {
+                        visible: ownersHover.hovered
+                        text: topRoot.owners_tooltip()
+                    }
 
                     HoverHandler {
                         id: ownersHover
@@ -768,9 +771,10 @@ Item {
             MouseArea {
                 id: minimapMouse
 
-                ToolTip.visible: containsMouse
-                ToolTip.delay: Design.Metrics.tooltipDelay
-                ToolTip.text: qsTr("Left click moves the camera, right click orders selected troops.\nVisible: currently scouted, enemies shown.\nExplored: seen before, terrain only.\nUnseen: never scouted.")
+                Design.IronTooltip {
+                    visible: minimapMouse.containsMouse
+                    text: qsTr("Left click moves the camera, right click orders selected troops.\nVisible: currently scouted, enemies shown.\nExplored: seen before, terrain only.\nUnseen: never scouted.")
+                }
 
                 function dispatch(button, x, y) {
                     if (!topRoot.game_ready())

--- a/ui/qml/LoadGamePanel.qml
+++ b/ui/qml/LoadGamePanel.qml
@@ -185,7 +185,7 @@ Item {
                                     append({
                                             "slot_name": qsTr("No saves found"),
                                             "title": "",
-                                            "timestamp": 0,
+                                            "timestamp": "",
                                             "map_name": "",
                                             "mode": "",
                                             "kind": "",
@@ -213,7 +213,7 @@ Item {
                                     append({
                                             "slot_name": qsTr("No saves found"),
                                             "title": "",
-                                            "timestamp": 0,
+                                            "timestamp": "",
                                             "map_name": "",
                                             "mode": "",
                                             "kind": "",
@@ -450,7 +450,7 @@ Item {
                         loadListModel.append({
                                 "slot_name": qsTr("No saves found"),
                                 "title": "",
-                                "timestamp": 0,
+                                "timestamp": "",
                                 "map_name": "",
                                 "mode": "",
                                 "kind": "",

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -230,7 +230,7 @@ ApplicationWindow {
 
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.topMargin: Design.Metrics.space24 * 3
+        anchors.topMargin: hud.visible ? hud.right_stack_bottom + Design.Metrics.space8 : Design.Metrics.space24 * 3
         anchors.rightMargin: Design.Metrics.space16
         z: 12
         visible: mainWindow.game_started && !mainWindow.menu_visible

--- a/ui/qml/design/controls/IronSelectionSummary.qml
+++ b/ui/qml/design/controls/IronSelectionSummary.qml
@@ -537,7 +537,7 @@ Design.IronPanel {
                             objectName: "selectionHealthBar"
                             width: parent.width
                             height: Design.Metrics.space12
-                            value: root.groups[0].health
+                            value: root.groups.length > 0 && root.groups[0].health !== undefined ? root.groups[0].health : 0
                             fillColor: root.healthColor(value)
                         }
                     }
@@ -615,12 +615,21 @@ Design.IronPanel {
                     width: Design.Metrics.space24 * 2
                     height: Design.Metrics.space24 * 2
 
-                    readonly property bool showsStrength: root.hasSoldierCount(chip.model)
-                    readonly property string strength: chip.showsStrength ? root.strengthTextCompact(chip.model) : ""
+                    readonly property var row: (chip.model !== undefined && chip.model !== null && chip.model.name !== undefined) ? chip.model : ({
+                            "name": "",
+                            "unit_type": "",
+                            "nation": "",
+                            "unit_id": "",
+                            "health_ratio": 0,
+                            "activity": "idle",
+                            "activity_state": ""
+                        })
+                    readonly property bool showsStrength: root.hasSoldierCount(chip.row)
+                    readonly property string strength: chip.showsStrength ? root.strengthTextCompact(chip.row) : ""
 
                     Accessible.role: Accessible.Button
-                    Accessible.name: chip.model.name
-                    Accessible.description: (chip.showsStrength ? chip.strength + qsTr(" soldiers — ") : Math.round(chip.model.health_ratio * 100) + "% — ") + Design.ActivityIcons.summary(chip.model.activity, chip.model.activity_state)
+                    Accessible.name: chip.row.name
+                    Accessible.description: (chip.showsStrength ? chip.strength + qsTr(" soldiers — ") : Math.round(chip.row.health_ratio * 100) + "% — ") + Design.ActivityIcons.summary(chip.row.activity, chip.row.activity_state)
 
                     Rectangle {
                         anchors.fill: parent
@@ -636,20 +645,20 @@ Design.IronPanel {
                         width: Design.Metrics.iconMedium
                         height: width
                         fillMode: Image.PreserveAspectFit
-                        source: root.iconFor(chip.model.unit_type, chip.model.nation, chip.model.name)
+                        source: root.iconFor(chip.row.unit_type, chip.row.nation, chip.row.name)
                         smooth: true
                         mipmap: true
                     }
 
                     Text {
-                        objectName: "selectionChipStrength_" + chip.model.unit_id
+                        objectName: "selectionChipStrength_" + chip.row.unit_id
 
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.bottom: parent.bottom
                         anchors.bottomMargin: Design.Metrics.space8
                         visible: chip.showsStrength
                         text: chip.strength
-                        color: root.healthColor(chip.model.health_ratio)
+                        color: root.healthColor(chip.row.health_ratio)
                         font.family: Design.Typography.family
                         font.pixelSize: Design.Typography.caption
                         font.weight: Design.Typography.bold
@@ -663,12 +672,12 @@ Design.IronPanel {
                         height: Design.Metrics.space4
 
                         Rectangle {
-                            objectName: "selectionChipHealth_" + chip.model.unit_id
+                            objectName: "selectionChipHealth_" + chip.row.unit_id
 
-                            width: parent.width * chip.model.health_ratio
+                            width: parent.width * chip.row.health_ratio
                             height: parent.height
                             radius: height / 2
-                            color: root.healthColor(chip.model.health_ratio)
+                            color: root.healthColor(chip.row.health_ratio)
                         }
                     }
 
@@ -678,10 +687,10 @@ Design.IronPanel {
                         anchors.margins: Design.Metrics.space2
                         width: Design.Metrics.iconSmall
                         height: width
-                        visible: chip.model.activity !== undefined && chip.model.activity !== "idle"
-                        iconId: Design.ActivityIcons.iconFor(chip.model.activity)
+                        visible: chip.row.activity !== undefined && chip.row.activity !== "idle"
+                        iconId: Design.ActivityIcons.iconFor(chip.row.activity)
                         monochrome: true
-                        tint: chip.model.activity_state === "unavailable" ? Design.Theme.danger : chip.model.activity_state === "interrupted" ? Design.Theme.warning : Design.Theme.accent
+                        tint: chip.row.activity_state === "unavailable" ? Design.Theme.danger : chip.row.activity_state === "interrupted" ? Design.Theme.warning : Design.Theme.accent
                     }
 
                     MouseArea {
@@ -692,7 +701,7 @@ Design.IronPanel {
                         cursorShape: Qt.PointingHandCursor
                         onClicked: {
                             Design.UiSound.activate();
-                            root.unitActivated(chip.model.unit_id);
+                            root.unitActivated(chip.row.unit_id);
                         }
                         onContainsMouseChanged: {
                             if (containsMouse)
@@ -702,7 +711,7 @@ Design.IronPanel {
 
                     ToolTip.visible: chipMouse.containsMouse
                     ToolTip.delay: Design.Metrics.tooltipDelay
-                    ToolTip.text: chip.model.name + " — " + (chip.showsStrength ? qsTr("%1 soldiers").arg(chip.strength) : Math.round(chip.model.health_ratio * 100) + "%") + "\n" + Design.ActivityIcons.summary(chip.model.activity, chip.model.activity_state)
+                    ToolTip.text: chip.row.name + " — " + (chip.showsStrength ? qsTr("%1 soldiers").arg(chip.strength) : Math.round(chip.row.health_ratio * 100) + "%") + "\n" + Design.ActivityIcons.summary(chip.row.activity, chip.row.activity_state)
                 }
             }
         }
@@ -729,25 +738,35 @@ Design.IronPanel {
 
                     required property var modelData
 
+                    readonly property var row: (groupCard.modelData !== undefined && groupCard.modelData !== null && groupCard.modelData.typeKey !== undefined) ? groupCard.modelData : ({
+                            "typeKey": "",
+                            "name": "",
+                            "nation": "",
+                            "health": 0,
+                            "woundedCount": 0,
+                            "count": 0,
+                            "mixedActivity": false
+                        })
+
                     width: groupFlow.cardWidth
                     height: groupFlow.cardHeight
                     radius: Design.Metrics.radiusMedium
                     color: groupMouse.containsMouse ? Design.Theme.panelLeather : Design.Theme.backgroundDeep
                     border.width: groupMouse.containsMouse ? Design.Metrics.borderFocus : Design.Metrics.borderThin
-                    border.color: groupMouse.containsMouse ? Design.Theme.selection : groupCard.modelData.woundedCount > 0 ? root.healthColor(groupCard.modelData.health) : Design.Theme.borderSubtle
+                    border.color: groupMouse.containsMouse ? Design.Theme.selection : groupCard.row.woundedCount > 0 ? root.healthColor(groupCard.row.health) : Design.Theme.borderSubtle
 
-                    readonly property string activityText: Design.ActivityIcons.summary(root.groupActivity(groupCard.modelData), root.groupActivityState(groupCard.modelData)) + (groupCard.modelData.mixedActivity ? qsTr(" (mixed)") : "")
+                    readonly property string activityText: Design.ActivityIcons.summary(root.groupActivity(groupCard.row), root.groupActivityState(groupCard.row)) + (groupCard.row.mixedActivity ? qsTr(" (mixed)") : "")
 
-                    readonly property bool showsStrength: root.hasSoldierCount(groupCard.modelData)
-                    readonly property string strength: groupCard.showsStrength ? root.strengthTextCompact(groupCard.modelData) : ""
+                    readonly property bool showsStrength: root.hasSoldierCount(groupCard.row)
+                    readonly property string strength: groupCard.showsStrength ? root.strengthTextCompact(groupCard.row) : ""
 
                     Accessible.role: Accessible.Button
-                    Accessible.name: groupCard.modelData.name + " ×" + groupCard.modelData.count
-                    Accessible.description: (groupCard.showsStrength ? groupCard.strength + qsTr(" soldiers — ") : Math.round(groupCard.modelData.health * 100) + "% — ") + groupCard.activityText
+                    Accessible.name: groupCard.row.name + " ×" + groupCard.row.count
+                    Accessible.description: (groupCard.showsStrength ? groupCard.strength + qsTr(" soldiers — ") : Math.round(groupCard.row.health * 100) + "% — ") + groupCard.activityText
 
                     ToolTip.visible: groupMouse.containsMouse
                     ToolTip.delay: Design.Metrics.tooltipDelay
-                    ToolTip.text: groupCard.modelData.name + " ×" + groupCard.modelData.count + (groupCard.showsStrength ? " — " + qsTr("%1 soldiers").arg(groupCard.strength) : "") + "\n" + groupCard.activityText
+                    ToolTip.text: groupCard.row.name + " ×" + groupCard.row.count + (groupCard.showsStrength ? " — " + qsTr("%1 soldiers").arg(groupCard.strength) : "") + "\n" + groupCard.activityText
 
                     Rectangle {
                         id: portraitFrame
@@ -766,7 +785,7 @@ Design.IronPanel {
                             anchors.fill: parent
                             anchors.margins: Design.Metrics.space4
                             fillMode: Image.PreserveAspectFit
-                            source: root.iconFor(groupCard.modelData.typeKey, groupCard.modelData.nation, groupCard.modelData.name)
+                            source: root.iconFor(groupCard.row.typeKey, groupCard.row.nation, groupCard.row.name)
                             smooth: true
                             mipmap: true
                         }
@@ -787,7 +806,7 @@ Design.IronPanel {
                                 id: groupCount
 
                                 anchors.centerIn: parent
-                                text: "×" + groupCard.modelData.count
+                                text: "×" + groupCard.row.count
                                 color: Design.Theme.accent
                                 font.family: Design.Typography.family
                                 font.pixelSize: Design.Typography.caption
@@ -801,10 +820,10 @@ Design.IronPanel {
                             anchors.margins: -Design.Metrics.space2
                             width: Design.Metrics.iconSmall
                             height: width
-                            visible: root.groupActivity(groupCard.modelData) !== "idle"
-                            iconId: Design.ActivityIcons.iconFor(root.groupActivity(groupCard.modelData))
+                            visible: root.groupActivity(groupCard.row) !== "idle"
+                            iconId: Design.ActivityIcons.iconFor(root.groupActivity(groupCard.row))
                             monochrome: true
-                            tint: root.groupActivityState(groupCard.modelData) === "unavailable" ? Design.Theme.danger : root.groupActivityState(groupCard.modelData) === "interrupted" ? Design.Theme.warning : Design.Theme.accent
+                            tint: root.groupActivityState(groupCard.row) === "unavailable" ? Design.Theme.danger : root.groupActivityState(groupCard.row) === "interrupted" ? Design.Theme.warning : Design.Theme.accent
                         }
                     }
 
@@ -817,7 +836,7 @@ Design.IronPanel {
                         anchors.rightMargin: Design.Metrics.space8
                         anchors.top: parent.top
                         anchors.topMargin: Design.Metrics.space8
-                        text: groupCard.modelData.name
+                        text: groupCard.row.name
                         color: Design.Theme.textPrimary
                         font.family: Design.Typography.family
                         font.pixelSize: Design.Typography.caption
@@ -828,7 +847,7 @@ Design.IronPanel {
                     Design.IronProgressBar {
                         id: groupHealth
 
-                        objectName: "selectionGroupHealthBar_" + groupCard.modelData.typeKey
+                        objectName: "selectionGroupHealthBar_" + groupCard.row.typeKey
 
                         anchors.left: portraitFrame.right
                         anchors.leftMargin: Design.Metrics.space8
@@ -836,12 +855,12 @@ Design.IronPanel {
                         anchors.rightMargin: Design.Metrics.space8
                         anchors.bottom: parent.bottom
                         anchors.bottomMargin: Design.Metrics.space8
-                        value: groupCard.modelData.health
+                        value: groupCard.row.health
                         fillColor: root.healthColor(value)
                     }
 
                     Text {
-                        objectName: "selectionGroupStrength_" + groupCard.modelData.typeKey
+                        objectName: "selectionGroupStrength_" + groupCard.row.typeKey
 
                         anchors.left: portraitFrame.right
                         anchors.leftMargin: Design.Metrics.space8
@@ -849,9 +868,9 @@ Design.IronPanel {
                         anchors.rightMargin: Design.Metrics.space8
                         anchors.bottom: groupHealth.top
                         anchors.bottomMargin: Design.Metrics.space2
-                        visible: groupFlow.cardHeight >= Design.Metrics.space24 * 3 && (groupCard.showsStrength || groupCard.modelData.woundedCount > 0)
-                        text: groupCard.showsStrength ? groupCard.strength : qsTr("%1 wounded").arg(groupCard.modelData.woundedCount)
-                        color: groupCard.showsStrength ? root.healthColor(groupCard.modelData.health) : Design.Theme.warning
+                        visible: groupFlow.cardHeight >= Design.Metrics.space24 * 3 && (groupCard.showsStrength || groupCard.row.woundedCount > 0)
+                        text: groupCard.showsStrength ? groupCard.strength : qsTr("%1 wounded").arg(groupCard.row.woundedCount)
+                        color: groupCard.showsStrength ? root.healthColor(groupCard.row.health) : Design.Theme.warning
                         font.family: Design.Typography.family
                         font.pixelSize: Design.Typography.caption
                         font.weight: groupCard.showsStrength ? Design.Typography.bold : Design.Typography.regular
@@ -866,7 +885,7 @@ Design.IronPanel {
                         cursorShape: Qt.PointingHandCursor
                         onClicked: function (mouse) {
                             Design.UiSound.activate();
-                            root.groupActivated(groupCard.modelData.typeKey);
+                            root.groupActivated(groupCard.row.typeKey);
                             mouse.accepted = true;
                         }
                         onContainsMouseChanged: {

--- a/ui/qml/design/controls/IronTooltip.qml
+++ b/ui/qml/design/controls/IronTooltip.qml
@@ -8,13 +8,17 @@ ToolTip {
     delay: Design.Metrics.tooltipDelay
     timeout: 8000
     padding: Design.Metrics.space8
+    implicitWidth: Math.min(tipText.implicitWidth + control.leftPadding + control.rightPadding, Design.Metrics.tooltipWidth)
+    implicitHeight: tipText.contentHeight + control.topPadding + control.bottomPadding
     contentItem: Text {
+        id: tipText
+
         text: control.text
         color: Design.Theme.textPrimary
         font.family: Design.Typography.family
         font.pixelSize: Design.Typography.caption
         wrapMode: Text.WordWrap
-        width: Math.min(implicitWidth, Design.Metrics.tooltipWidth)
+        width: control.availableWidth
     }
     background: Rectangle {
         color: Design.Theme.panelLeather


### PR DESCRIPTION
Preserve terrain visibility continuity by rendering unseen surfaces with a subdued material instead of discarding hidden terrain, and let shader-side visibility weighting distinguish unseen cells from previously explored ground. Remove redundant CPU chunk visibility rejection so the GPU mask remains authoritative.

Make the selection summary resilient while unit and group models churn by providing safe fallback rows for transient delegate state, reset empty selection health cleanly, and add QML warning coverage for repeated selection rebuilds. Improve HUD stack positioning, replace top-level status tooltips with the themed tooltip control, and keep empty save placeholders type-safe.

Emit the troop-defeated reset notification when starting a new skirmish and enrich the renderer diagnostic with prepared-request visibility details so legitimate shadow-only submissions do not produce false missing-body warnings.