### PR TITLE
feat: give commanders authored combat chains and battlefield VFX

### DIFF
--- a/assets/shaders/combat_dust.frag
+++ b/assets/shaders/combat_dust.frag
@@ -17,6 +17,7 @@ uniform vec3 u_center;
 uniform float u_radius;
 uniform int u_effect_type;
 uniform vec3 u_camera_pos;
+uniform float u_span;
 
 float inv_smoothstep(float edge0, float edge1, float x) {
   float lower_edge = min(edge0, edge1);
@@ -291,6 +292,35 @@ void main() {
     float tip_fade = 1.0 - smoothstep(0.72, 1.0, along);
     float spark_alpha = v_alpha * edge_fade * (0.72 + 0.28 * tip_fade);
     frag_color = vec4(color, clamp(spark_alpha, 0.0, 1.0));
+  } else if (u_effect_type == 6) {
+    float t = clamp(u_time, 0.0, 1.0);
+    float across = clamp(v_texcoord.y, 0.0, 1.0);
+    bool ring = abs(u_span) >= 0.999;
+
+    vec3 accent = max(u_dust_color, vec3(0.03));
+    vec3 white_hot = vec3(2.6, 2.4, 2.0);
+    vec3 hot_accent = accent * 2.2;
+    vec3 cool_accent = accent * 0.7;
+
+    float blade_band =
+        ring ? smoothstep(0.58, 0.74, across) * (1.0 - smoothstep(0.80, 0.94, across))
+             : smoothstep(0.58, 0.86, across) * (1.0 - smoothstep(0.92, 1.0, across));
+    float body = ring ? 0.0 : 1.0 - smoothstep(0.0, 0.75, across);
+
+    float heat = 1.0 - smoothstep(0.0, 0.7, t);
+    color = mix(hot_accent, white_hot, blade_band * heat * (ring ? 0.0 : 0.25));
+    color = mix(color, cool_accent, (1.0 - heat) * 0.5);
+
+    float grain = 0.90 + 0.10 * combined_noise;
+    color *= v_intensity * 1.6 * grain;
+    color = clamp(color, 0.0, 5.0);
+
+    float arc_alpha = v_alpha * (0.14 * body + 1.0 * blade_band) * grain;
+    if (ring) {
+      arc_alpha = v_alpha * 0.85 * blade_band * grain;
+    }
+    arc_alpha = clamp(arc_alpha, 0.0, 1.0);
+    frag_color = vec4(color * arc_alpha, arc_alpha * 0.30);
   } else {
 
     color = u_dust_color;

--- a/assets/shaders/combat_dust.vert
+++ b/assets/shaders/combat_dust.vert
@@ -12,6 +12,7 @@ uniform vec3 u_center;
 uniform float u_radius;
 uniform float u_intensity;
 uniform int u_effect_type;
+uniform float u_span;
 
 out vec3 v_world_pos;
 out vec3 v_normal;
@@ -198,6 +199,38 @@ void main() {
     float spark_fade = smoothstep(0.0, 0.05, t) * life;
     float flicker = 0.82 + 0.18 * sin(t * 45.0 + along * 11.0);
     v_alpha = clamp(spark_fade * flicker * u_intensity, 0.0, 1.0);
+  } else if (u_effect_type == 6) {
+    float t = clamp(u_time, 0.0, 1.0);
+    float span = clamp(abs(u_span), 0.02, 1.0);
+    bool ring = abs(u_span) >= 0.999;
+    float centered = (a_texcoord.x - 0.5) * 2.0;
+    float inside = step(abs(centered), span);
+    float along = clamp(centered / span * 0.5 + 0.5, 0.0, 1.0);
+    if (u_span < 0.0) {
+      along = 1.0 - along;
+    }
+    float across = a_texcoord.y;
+
+    float head = ring ? 1.0 : smoothstep(0.0, 0.42, t);
+    float tail = ring ? 0.0 : smoothstep(0.30, 1.0, t) * 0.85;
+    float head_mask = 1.0 - smoothstep(head - 0.07, head + 0.01, along);
+    float head_soft = 1.0 - smoothstep(head - 0.16, head, along);
+    float tail_soft = smoothstep(tail, tail + 0.22, along);
+    float wipe = ring ? 1.0 : head_mask * (0.35 + 0.65 * head_soft) * tail_soft;
+
+    float grow = ring ? mix(0.40, 1.0, smoothstep(0.0, 0.6, t)) : 1.0;
+    pos *= grow;
+    pos.y += ring ? 0.0 : (across - 0.5) * 0.04;
+
+    float life =
+        ring ? 1.0 - smoothstep(0.25, 0.80, t) : 1.0 - smoothstep(0.55, 1.0, t);
+    float edge =
+        ring ? (1.0 - smoothstep(0.55, 1.0, across)) * smoothstep(0.0, 0.25, across)
+             : smoothstep(0.0, 0.35, across);
+    v_alpha = clamp(inside * wipe * life * edge * u_intensity, 0.0, 1.0);
+    if (inside < 0.5) {
+      pos = vec3(0.0);
+    }
   } else {
     vec3 normal_dir = normalize(a_normal);
 

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -771,6 +771,13 @@ enum class CommanderSignatureForm : std::uint8_t {
   Thrust = 0,
   Cut,
   Shot,
+  Sweep,
+  Slam,
+};
+
+enum class CommanderStrikeCue : std::uint8_t {
+  Impact = 0,
+  Swing,
 };
 
 class CommanderSignaturePresentationComponent {
@@ -785,10 +792,14 @@ public:
     float age{0.0F};
     float lifetime{0.34F};
     float intensity{1.0F};
+    float reach{1.8F};
+    float span{0.55F};
     CommanderSignatureForm form{CommanderSignatureForm::Cut};
+    CommanderStrikeCue cue{CommanderStrikeCue::Impact};
   };
 
-  static constexpr std::size_t k_max_entries = 4U;
+  static constexpr std::size_t k_max_entries = 6U;
+  static constexpr float k_swing_lifetime = 0.46F;
   std::vector<Entry> entries;
 };
 

--- a/game/systems/arrow_visual_profile.cpp
+++ b/game/systems/arrow_visual_profile.cpp
@@ -65,6 +65,26 @@ auto make_arrow_visual_profile(ArrowVisualStyle style,
     profile.trail_length = 0.20F;
     profile.brightness = 1.30F;
     break;
+  case ArrowVisualStyle::Commander:
+    profile.scale = 1.42F;
+    profile.length_scale = 1.34F;
+    profile.roll_deg = remap_unit(unit_float(sequence ^ 0x3c6ef372U), -5.0F, 5.0F);
+    profile.spin_rate_deg =
+        remap_unit(unit_float(sequence ^ 0xa54ff53aU), 90.0F, 150.0F);
+    profile.trail_alpha = 0.34F;
+    profile.trail_length = 0.16F;
+    profile.brightness = 1.18F;
+    break;
+  case ArrowVisualStyle::CommanderSignature:
+    profile.scale = 1.85F;
+    profile.length_scale = 1.70F;
+    profile.roll_deg = remap_unit(unit_float(sequence ^ 0x510e527fU), -4.0F, 4.0F);
+    profile.spin_rate_deg =
+        remap_unit(unit_float(sequence ^ 0x9b05688cU), 160.0F, 240.0F);
+    profile.trail_alpha = 0.58F;
+    profile.trail_length = 0.26F;
+    profile.brightness = 1.40F;
+    break;
   case ArrowVisualStyle::Focused:
   default:
     profile.initial_progress =

--- a/game/systems/arrow_visual_profile.h
+++ b/game/systems/arrow_visual_profile.h
@@ -11,6 +11,9 @@ enum class ArrowVisualStyle : std::uint8_t {
   Javelin,
 
   Aimed,
+
+  Commander,
+  CommanderSignature,
 };
 
 struct ArrowVisualProfile {

--- a/game/systems/combat_system/attack_processor.cpp
+++ b/game/systems/combat_system/attack_processor.cpp
@@ -878,6 +878,23 @@ void spawn_rts_arrow_volley(Engine::Core::Entity* attacker,
   }
   arrow_count = std::min(arrow_count, Constants::k_max_visual_arrows_per_volley);
 
+  auto arrow_style = ArrowVisualStyle::Volley;
+  float lateral_scale = 1.0F;
+  if (auto const* commander =
+          attacker->get_component<Engine::Core::CommanderComponent>();
+      commander != nullptr && !commander->fpv_controlled) {
+    bool const signature_shot = commander->signature_strike_active;
+    bool const volley_signature =
+        signature_shot &&
+        commander->signature_move ==
+            static_cast<std::uint8_t>(
+                Game::Units::CommanderSignatureMove::PointBlankVolley);
+    arrow_style = signature_shot ? ArrowVisualStyle::CommanderSignature
+                                 : ArrowVisualStyle::Commander;
+    arrow_count = volley_signature ? 3 : 1;
+    lateral_scale = 0.55F;
+  }
+
   QVector3D const perpendicular(-dir.z(), 0.0F, dir.x());
   QVector3D const up_vector(0.0F, 1.0F, 0.0F);
   int const wave_count = std::max(1, Constants::k_arrow_volley_wave_count);
@@ -902,8 +919,9 @@ void spawn_rts_arrow_volley(Engine::Core::Entity* attacker,
         static_cast<float>(rank_index) - (static_cast<float>(rank_count - 1) * 0.5F);
 
     float const base_lateral = centered_rank * Constants::k_arrow_volley_rank_spacing;
-    float const launch_lateral = base_lateral + spread_a * 0.60F;
-    float const target_lateral = (base_lateral * 0.95F) + spread_b * 0.45F;
+    float const launch_lateral = (base_lateral + spread_a * 0.60F) * lateral_scale;
+    float const target_lateral =
+        ((base_lateral * 0.95F) + spread_b * 0.45F) * lateral_scale;
     float const wave_height = (1.0F - 0.18F * std::abs(centered_wave)) *
                               Constants::k_arrow_volley_wave_height;
     float const launch_height =
@@ -948,7 +966,7 @@ void spawn_rts_arrow_volley(Engine::Core::Entity* attacker,
                                 0.0F,
                                 0.0F,
                                 false,
-                                ArrowVisualStyle::Volley,
+                                arrow_style,
                                 t_pos);
   }
 }
@@ -1215,6 +1233,28 @@ auto rts_commander_action(Engine::Core::World& world,
       distance > normal_reach * 1.05F);
 }
 
+auto commander_link_still_swinging(Engine::Core::Entity* attacker) -> bool {
+  auto const* commander = attacker->get_component<Engine::Core::CommanderComponent>();
+  auto const* action =
+      attacker->get_component<Engine::Core::RpgCommanderActionComponent>();
+  if (commander == nullptr || commander->fpv_controlled ||
+      !commander->advanced_combat_enabled || action == nullptr ||
+      !action->action_running || action->combat_action_id == 0U) {
+    return false;
+  }
+  auto const* definition = Game::Systems::CombatActions::find_combat_action_definition(
+      static_cast<Game::Systems::CombatActions::CombatActionId>(
+          action->combat_action_id));
+  if (definition == nullptr || !definition->commander_only) {
+    return false;
+  }
+  float const exit_safe = Game::Systems::CombatActions::action_event_normalized_time(
+      *definition,
+      Game::Systems::CombatActions::CombatActionEventType::ExitSafe,
+      0.92F);
+  return action->normalized_action_time < exit_safe;
+}
+
 void begin_rts_melee_action(Engine::Core::World& world,
                             Engine::Core::Entity* attacker,
                             Engine::Core::Entity* target,
@@ -1228,6 +1268,14 @@ void begin_rts_melee_action(Engine::Core::World& world,
   }
   auto const family = Engine::Core::resolve_combat_attack_family(
       unit->spawn_type, Engine::Core::AttackComponent::CombatMode::Melee);
+  bool const chaining_from_link =
+      action->action_running && action->combat_action_id != 0U && [&] {
+        auto const* running =
+            Game::Systems::CombatActions::find_combat_action_definition(
+                static_cast<Game::Systems::CombatActions::CombatActionId>(
+                    action->combat_action_id));
+        return running != nullptr && running->commander_only;
+      }();
   auto const signature = claim_commander_signature(attacker, damage);
   auto const routine_id =
       attacker->has_component<Engine::Core::ElephantComponent>()
@@ -1283,7 +1331,14 @@ void begin_rts_melee_action(Engine::Core::World& world,
                                         melee_target_can_defend(attacker, target))
           : MeleeExchangeBeat{};
   action->exchange_outcome = static_cast<std::uint8_t>(beat.outcome);
-  Game::Systems::CombatActions::reset_combat_action_event_runtime(*action);
+  float entry_time = 0.0F;
+  if (chaining_from_link && definition != nullptr && definition->commander_only) {
+    entry_time = Game::Systems::CombatActions::action_event_normalized_time(
+        *definition,
+        Game::Systems::CombatActions::CombatActionEventType::WindupStart,
+        0.0F);
+  }
+  Game::Systems::CombatActions::reset_combat_action_event_runtime(*action, entry_time);
 }
 
 auto resolve_melee_swing_cadence(Engine::Core::Entity* attacker,
@@ -1296,6 +1351,21 @@ auto resolve_melee_swing_cadence(Engine::Core::Entity* attacker,
   if (action == nullptr || attacker->has_component<Engine::Core::ElephantComponent>() ||
       !melee_target_can_defend(attacker, target)) {
     return -base_delay;
+  }
+
+  auto const* commander = attacker->get_component<Engine::Core::CommanderComponent>();
+  auto const* definition = Game::Systems::CombatActions::find_combat_action_definition(
+      static_cast<Game::Systems::CombatActions::CombatActionId>(
+          action->combat_action_id));
+  if (commander != nullptr && !commander->fpv_controlled &&
+      commander->advanced_combat_enabled && definition != nullptr &&
+      definition->commander_only) {
+    float const exit_safe = Game::Systems::CombatActions::action_event_normalized_time(
+        *definition,
+        Game::Systems::CombatActions::CombatActionEventType::ExitSafe,
+        0.92F);
+    float const link_length = std::max(0.05F, action->action_duration * exit_safe);
+    return cooldown - std::max(cooldown, link_length);
   }
 
   auto const next_beat = resolve_melee_exchange_beat(
@@ -1440,7 +1510,10 @@ void process_attacks(Engine::Core::World* world,
       t_accum = &tmp_accum;
     }
 
-    bool const attack_ready = *t_accum >= cooldown;
+    bool attack_ready = *t_accum >= cooldown;
+    if (attack_ready && commander_link_still_swinging(attacker)) {
+      attack_ready = false;
+    }
 
     if (attack_ready && should_prioritize_healing(attacker, world)) {
       continue;

--- a/game/systems/combat_system/combat_action_processor.cpp
+++ b/game/systems/combat_system/combat_action_processor.cpp
@@ -16,9 +16,11 @@
 #include "../combat_actions/projectile_release.h"
 #include "../combat_actions/weapon_trace.h"
 #include "../combat_rules.h"
+#include "../pathfinding.h"
 #include "../rpg_combat_system/rpg_bow_draw.h"
 #include "../rpg_combat_system/rpg_bow_shot.h"
 #include "../rpg_combat_system/rpg_targeting.h"
+#include "../walkability.h"
 #include "attack_processor.h"
 #include "combat_hit_resolver.h"
 #include "combat_utils.h"
@@ -312,11 +314,90 @@ auto melee_contact_comes_from_the_sweep(
   return !target_is_a_structure(world, action.active_target_id);
 }
 
-void record_signature_contact(
+auto commander_strike_form(
+    const Game::Systems::CombatActions::CombatActionDefinition& definition,
+    const Engine::Core::CommanderComponent* commander)
+    -> Engine::Core::CommanderSignatureForm {
+  using Game::Systems::CombatActions::CombatActionId;
+  using Game::Systems::CombatActions::CommanderActionRole;
+  using Game::Systems::CombatActions::WeaponFamily;
+  if (definition.weapon_family == WeaponFamily::Bow) {
+    return Engine::Core::CommanderSignatureForm::Shot;
+  }
+  if (definition.id == CombatActionId::CommanderSwordSpin ||
+      definition.id == CombatActionId::RpgSpearSweep) {
+    return Engine::Core::CommanderSignatureForm::Sweep;
+  }
+  if (definition.id == CombatActionId::RtsCommanderThrust) {
+    return commander != nullptr && commander->signature_max_targets > 1
+               ? Engine::Core::CommanderSignatureForm::Sweep
+               : Engine::Core::CommanderSignatureForm::Thrust;
+  }
+  if (definition.attack_direction == Engine::Core::AttackDirection::Thrust) {
+    return Engine::Core::CommanderSignatureForm::Thrust;
+  }
+  if (definition.role == CommanderActionRole::Finisher ||
+      definition.role == CommanderActionRole::Dive ||
+      definition.role == CommanderActionRole::Launcher ||
+      definition.attack_direction == Engine::Core::AttackDirection::Overhead ||
+      definition.attack_direction == Engine::Core::AttackDirection::HeavyOverhead) {
+    return Engine::Core::CommanderSignatureForm::Slam;
+  }
+  return Engine::Core::CommanderSignatureForm::Cut;
+}
+
+auto commander_strike_span(
+    const Game::Systems::CombatActions::CombatActionDefinition& definition,
+    Engine::Core::CommanderSignatureForm form) -> float {
+  float span = 0.42F;
+  switch (form) {
+  case Engine::Core::CommanderSignatureForm::Sweep:
+    span = 0.86F;
+    break;
+  case Engine::Core::CommanderSignatureForm::Slam:
+    span = 0.50F;
+    break;
+  case Engine::Core::CommanderSignatureForm::Thrust:
+  case Engine::Core::CommanderSignatureForm::Shot:
+    span = 0.10F;
+    break;
+  case Engine::Core::CommanderSignatureForm::Cut:
+    span = 0.46F;
+    break;
+  }
+  if (definition.attack_direction == Engine::Core::AttackDirection::LeftSlash) {
+    span = -span;
+  }
+  return span;
+}
+
+auto commander_strike_intensity(
+    const Game::Systems::CombatActions::CombatActionDefinition& definition,
+    bool signature_strike) -> float {
+  using Game::Systems::CombatActions::CommanderActionRole;
+  if (signature_strike ||
+      definition.id == Game::Systems::CombatActions::CombatActionId::RtsCommanderCut ||
+      definition.id ==
+          Game::Systems::CombatActions::CombatActionId::RtsCommanderThrust) {
+    return 1.0F;
+  }
+  switch (definition.role) {
+  case CommanderActionRole::Finisher:
+  case CommanderActionRole::Dive:
+    return 1.0F;
+  case CommanderActionRole::Launcher:
+  case CommanderActionRole::GapCloser:
+  case CommanderActionRole::Aerial:
+    return 0.85F;
+  case CommanderActionRole::Routine:
+    return 0.70F;
+  }
+  return 0.70F;
+}
+
+void push_commander_cue(
     Engine::Core::Entity& attacker,
-    const Engine::Core::TransformComponent& attacker_transform,
-    const Engine::Core::TransformComponent& target_transform,
-    Engine::Core::CommanderSignatureForm form) {
+    const Engine::Core::CommanderSignaturePresentationComponent::Entry& entry) {
   auto* presentation = Engine::Core::get_or_add_component<
       Engine::Core::CommanderSignaturePresentationComponent>(&attacker);
   if (presentation == nullptr) {
@@ -326,20 +407,60 @@ void record_signature_contact(
       Engine::Core::CommanderSignaturePresentationComponent::k_max_entries) {
     presentation->entries.erase(presentation->entries.begin());
   }
+  presentation->entries.push_back(entry);
+}
 
+void record_signature_contact(
+    Engine::Core::Entity& attacker,
+    const Engine::Core::TransformComponent& attacker_transform,
+    const Engine::Core::TransformComponent& target_transform,
+    Engine::Core::CommanderSignatureForm form,
+    float intensity = 1.0F,
+    float reach = 1.8F) {
   float const dx = target_transform.position.x - attacker_transform.position.x;
   float const dz = target_transform.position.z - attacker_transform.position.z;
   float const length = std::max(0.0001F, std::hypot(dx, dz));
 
   Engine::Core::CommanderSignaturePresentationComponent::Entry entry;
-
   entry.x = attacker_transform.position.x + dx * 0.72F;
   entry.y = attacker_transform.position.y + 0.58F;
   entry.z = attacker_transform.position.z + dz * 0.72F;
   entry.dir_x = dx / length;
   entry.dir_z = dz / length;
   entry.form = form;
-  presentation->entries.push_back(entry);
+  entry.cue = Engine::Core::CommanderStrikeCue::Impact;
+  entry.intensity = intensity;
+  entry.reach = reach;
+  push_commander_cue(attacker, entry);
+}
+
+void record_commander_swing(
+    Engine::Core::Entity& attacker,
+    const Engine::Core::TransformComponent& attacker_transform,
+    const Game::Systems::CombatActions::CombatActionDefinition& definition,
+    const Engine::Core::CommanderComponent* commander,
+    float reach) {
+  bool const signature_strike =
+      commander != nullptr && commander->signature_strike_active;
+  auto const form = commander_strike_form(definition, commander);
+  float const yaw = attacker_transform.rotation.y * std::numbers::pi_v<float> / 180.0F;
+  float const forward_x = std::sin(yaw);
+  float const forward_z = std::cos(yaw);
+
+  Engine::Core::CommanderSignaturePresentationComponent::Entry entry;
+  entry.x = attacker_transform.position.x + forward_x * reach * 0.30F;
+  entry.y = attacker_transform.position.y + 0.95F;
+  entry.z = attacker_transform.position.z + forward_z * reach * 0.30F;
+  entry.dir_x = forward_x;
+  entry.dir_z = forward_z;
+  entry.form = form;
+  entry.cue = Engine::Core::CommanderStrikeCue::Swing;
+  entry.lifetime =
+      Engine::Core::CommanderSignaturePresentationComponent::k_swing_lifetime;
+  entry.intensity = commander_strike_intensity(definition, signature_strike);
+  entry.reach = reach;
+  entry.span = commander_strike_span(definition, form);
+  push_commander_cue(attacker, entry);
 }
 
 auto signature_form_for_action(Game::Systems::CombatActions::CombatActionId id)
@@ -367,13 +488,21 @@ void apply_commander_signature_effects(
   auto const* action =
       attacker.get_component<Engine::Core::RpgCommanderActionComponent>();
   if (target_transform != nullptr && action != nullptr) {
+    auto const* definition =
+        Game::Systems::CombatActions::find_combat_action_definition(
+            static_cast<Game::Systems::CombatActions::CombatActionId>(
+                action->combat_action_id));
     record_signature_contact(
         attacker,
         attacker_transform,
         *target_transform,
-        signature_form_for_action(
-            static_cast<Game::Systems::CombatActions::CombatActionId>(
-                action->combat_action_id)));
+        definition != nullptr
+            ? commander_strike_form(*definition, &commander)
+            : signature_form_for_action(
+                  static_cast<Game::Systems::CombatActions::CombatActionId>(
+                      action->combat_action_id)),
+        1.0F,
+        reach);
   }
 
   if (commander.signature_stagger_seconds > 0.0F) {
@@ -530,6 +659,14 @@ void resolve_rts_melee_contact(
     QVector3D const impact_point(attacker_transform->position.x + dx * 0.62F,
                                  attacker_transform->position.y + 1.0F,
                                  attacker_transform->position.z + dz * 0.62F);
+    if (!signature_strike) {
+      record_signature_contact(attacker,
+                               *attacker_transform,
+                               *target_transform,
+                               commander_strike_form(definition, commander),
+                               commander_strike_intensity(definition, false),
+                               reach);
+    }
     CombatHitResult authored_result;
     authored_result.attempted = true;
     authored_result.applied = true;
@@ -827,6 +964,109 @@ void deal_mount_body_impact(
   }
 }
 
+auto authored_drive(float s) -> float {
+  s = std::clamp(s, 0.0F, 1.0F);
+  return s * (2.0F - s);
+}
+
+constexpr float k_rts_commander_root_motion_max_speed = 5.5F;
+
+void apply_rts_commander_root_motion(
+    Engine::Core::World& world,
+    Engine::Core::Entity& entity,
+    const Engine::Core::RpgCommanderActionComponent& action,
+    const Game::Systems::CombatActions::CombatActionDefinition& definition) {
+  auto const& profile = definition.movement;
+  if (!action.action_running || profile.distance <= 0.0F ||
+      profile.end_normalized <= profile.start_normalized) {
+    return;
+  }
+  auto const* commander = entity.get_component<Engine::Core::CommanderComponent>();
+  if (commander == nullptr || commander->fpv_controlled ||
+      !commander->advanced_combat_enabled || !definition.commander_only ||
+      entity.has_component<Engine::Core::StaggerComponent>()) {
+    return;
+  }
+  auto* transform = entity.get_component<Engine::Core::TransformComponent>();
+  auto const* movement = entity.get_component<Engine::Core::MovementComponent>();
+  if (transform == nullptr) {
+    return;
+  }
+
+  float const window = profile.end_normalized - profile.start_normalized;
+  float const s_prev =
+      (action.previous_normalized_action_time - profile.start_normalized) / window;
+  float const s_now =
+      (action.normalized_action_time - profile.start_normalized) / window;
+  float const elapsed = std::max(
+      0.0F,
+      (action.normalized_action_time - action.previous_normalized_action_time) *
+          std::max(0.001F, action.action_duration));
+  float const step =
+      std::min(profile.distance * (authored_drive(s_now) - authored_drive(s_prev)),
+               k_rts_commander_root_motion_max_speed * elapsed);
+  if (step <= 1.0e-4F) {
+    return;
+  }
+
+  float const yaw = transform->rotation.y * std::numbers::pi_v<float> / 180.0F;
+  float forward_x = std::sin(yaw);
+  float forward_z = std::cos(yaw);
+  float own_radius = movement != nullptr ? movement->get_navigation_clearance() : 0.45F;
+  float allowed = step;
+
+  auto* target = world.get_entity(action.active_target_id);
+  if (target != nullptr && !target->has_component<Engine::Core::BuildingComponent>()) {
+    std::optional<Game::Systems::RpgCombat::SoldierTarget> nearest;
+    float nearest_distance = 0.0F;
+    for (auto const& soldier :
+         Game::Systems::RpgCombat::live_soldier_targets(*target)) {
+      float const distance = std::hypot(soldier.position.x() - transform->position.x,
+                                        soldier.position.z() - transform->position.z);
+      if (!nearest.has_value() || distance < nearest_distance) {
+        nearest = soldier;
+        nearest_distance = distance;
+      }
+    }
+    if (nearest.has_value() && nearest_distance > 0.001F) {
+      float const to_x =
+          (nearest->position.x() - transform->position.x) / nearest_distance;
+      float const to_z =
+          (nearest->position.z() - transform->position.z) / nearest_distance;
+      float const facing = forward_x * to_x + forward_z * to_z;
+      float const cone = std::cos(definition.target_assist.cone_degrees * 0.5F *
+                                  std::numbers::pi_v<float> / 180.0F);
+      if (facing >= cone) {
+        forward_x = to_x;
+        forward_z = to_z;
+        transform->rotation.y =
+            std::atan2(to_x, to_z) * 180.0F / std::numbers::pi_v<float>;
+        transform->desired_yaw = transform->rotation.y;
+      }
+      float const contact_gap =
+          nearest_distance - (nearest->body_radius + own_radius + 0.16F);
+      allowed = std::clamp(step, 0.0F, std::max(0.0F, contact_gap));
+    }
+  }
+  if (allowed <= 1.0e-4F) {
+    return;
+  }
+
+  Game::Systems::BodyProfile body;
+  body.radius = own_radius;
+  body.passability = movement != nullptr && movement->get_can_enter_forest()
+                         ? Pathfinding::Passability::Light
+                         : Pathfinding::Passability::Heavy;
+  QVector3D const destination(transform->position.x + forward_x * allowed,
+                              transform->position.y,
+                              transform->position.z + forward_z * allowed);
+  if (!Game::Systems::Walkability::can_stand(destination, body)) {
+    return;
+  }
+  transform->position.x = destination.x();
+  transform->position.z = destination.z();
+}
+
 void cancel_authored_action(Engine::Core::RpgCommanderActionComponent& action,
                             Engine::Core::CombatStateComponent* presentation_state) {
   action.action_running = false;
@@ -915,6 +1155,24 @@ void handle_action_events(
     auto const action_id = static_cast<Game::Systems::CombatActions::CombatActionId>(
         action.combat_action_id);
     bool const advanced_rts_melee = is_advanced_rts_commander_melee(entity, definition);
+    if (event.type ==
+            Game::Systems::CombatActions::CombatActionEventType::WeaponTraceStart &&
+        (advanced_rts_melee ||
+         action_id == Game::Systems::CombatActions::CombatActionId::RtsCommanderCut ||
+         action_id ==
+             Game::Systems::CombatActions::CombatActionId::RtsCommanderThrust)) {
+      auto const* commander = entity.get_component<Engine::Core::CommanderComponent>();
+      auto const* transform = entity.get_component<Engine::Core::TransformComponent>();
+      auto const* attack = entity.get_component<Engine::Core::AttackComponent>();
+      if (commander != nullptr && !commander->fpv_controlled && transform != nullptr) {
+        float const reach = std::max(attack != nullptr ? attack->melee_range : 0.0F,
+                                     definition.hit_shape.reach) +
+                            (commander->signature_strike_active
+                                 ? std::max(0.0F, commander->signature_bonus_reach)
+                                 : 0.0F);
+        record_commander_swing(entity, *transform, definition, commander, reach);
+      }
+    }
     if (event.type == contact_event &&
         (is_rts_melee_action(action_id) || advanced_rts_melee) &&
         action.hit_target_count == 0U) {
@@ -1053,7 +1311,9 @@ void process_authored_combat_action(
 
     auto const* attack = entity.get_component<Engine::Core::AttackComponent>();
     bool const shooting_from_a_melee =
-        !is_rts_melee_action(action_id) && attack != nullptr && attack->in_melee_lock &&
+        !is_rts_melee_action(action_id) &&
+        action_id != Game::Systems::CombatActions::CombatActionId::RtsCommanderShot &&
+        attack != nullptr && attack->in_melee_lock &&
         Game::Systems::CombatRules::participates_in_rts_melee_lock(&entity);
 
     bool const interrupted = unit == nullptr || unit->health <= 0 ||
@@ -1083,6 +1343,7 @@ void process_authored_combat_action(
 
   auto const events = Game::Systems::CombatActions::advance_combat_action_events(
       *action, action_delta, *definition);
+  apply_rts_commander_root_motion(*world, entity, *action, *definition);
   handle_action_events(*world, entity, *action, *definition, events);
 
   auto const* commander = entity.get_component<Engine::Core::CommanderComponent>();

--- a/game/systems/combat_system/hit_feedback_processor.cpp
+++ b/game/systems/combat_system/hit_feedback_processor.cpp
@@ -12,7 +12,28 @@ namespace Game::Systems::Combat {
 
 namespace {
 
-[[nodiscard]] auto knockback_moves_body(const Engine::Core::Entity& unit) -> bool {
+[[nodiscard]] auto locked_commander_holds_ground(
+    const Engine::Core::Entity& unit,
+    const Engine::Core::HitFeedbackComponent& feedback) -> bool {
+  auto const* commander = unit.get_component<Engine::Core::CommanderComponent>();
+  if (commander == nullptr || commander->fpv_controlled ||
+      !commander->advanced_combat_enabled) {
+    return false;
+  }
+  auto const* attack = unit.get_component<Engine::Core::AttackComponent>();
+  if (attack == nullptr || !attack->in_melee_lock) {
+    return false;
+  }
+  if (feedback.stagger_tier != Engine::Core::StaggerTier::LightFlinch) {
+    return false;
+  }
+  auto const* stagger = unit.get_component<Engine::Core::StaggerComponent>();
+  return stagger == nullptr || stagger->tier == Engine::Core::StaggerTier::LightFlinch;
+}
+
+[[nodiscard]] auto
+knockback_moves_body(const Engine::Core::Entity& unit,
+                     const Engine::Core::HitFeedbackComponent& feedback) -> bool {
   if (unit.has_component<Engine::Core::BuildingComponent>() ||
       unit.has_component<Engine::Core::ElephantComponent>()) {
     return false;
@@ -21,6 +42,9 @@ namespace {
     return false;
   }
   if (FormationCombat::has_formation_slots(unit)) {
+    return false;
+  }
+  if (locked_commander_holds_ground(unit, feedback)) {
     return false;
   }
   auto const* movement = unit.get_component<Engine::Core::MovementComponent>();
@@ -55,7 +79,7 @@ void apply_knockback_step(Engine::Core::Entity& unit,
   float const total_z =
       feedback.knockback_z * knockback_travel_scale(feedback.reaction_kind);
   float const total = std::hypot(total_x, total_z);
-  if (total <= 0.0005F || !knockback_moves_body(unit)) {
+  if (total <= 0.0005F || !knockback_moves_body(unit, feedback)) {
     return;
   }
   auto* transform = unit.get_component<Engine::Core::TransformComponent>();

--- a/game/systems/projectile_system.cpp
+++ b/game/systems/projectile_system.cpp
@@ -33,8 +33,10 @@ auto launch_cue_for_kind(ProjectileKind kind,
     return "combat.siege_launch";
   default:
 
-    return style == ArrowVisualStyle::Aimed ? "combat.bow_loose_heavy"
-                                            : "combat.arrow_launch";
+    return style == ArrowVisualStyle::Aimed ||
+                   style == ArrowVisualStyle::CommanderSignature
+               ? "combat.bow_loose_heavy"
+               : "combat.arrow_launch";
   }
 }
 

--- a/render/draw_commands.h
+++ b/render/draw_commands.h
@@ -236,7 +236,8 @@ struct EffectBatchCmd {
     Fireball,
     BloodPool,
     StoneImpact,
-    MetalSpark
+    MetalSpark,
+    WeaponArc
   };
 
   Kind kind = Kind::HealerAura;
@@ -257,6 +258,8 @@ struct EffectBatchCmd {
   float beam_width = 0.15F;
 
   QVector3D direction{0.0F, 0.0F, 0.0F};
+  float span = 0.0F;
+  float tilt = 0.0F;
 
   CommandPriority priority{CommandPriority::Normal};
 };

--- a/render/effects_submitter.cpp
+++ b/render/effects_submitter.cpp
@@ -184,6 +184,31 @@ void EffectsSubmitter::metal_spark(DrawQueue* queue,
   }
 }
 
+void EffectsSubmitter::weapon_arc(DrawQueue* queue,
+                                  const QVector3D& position,
+                                  const QVector3D& color,
+                                  float radius,
+                                  float intensity,
+                                  float time,
+                                  const QVector3D& direction,
+                                  float span,
+                                  float tilt) const {
+  EffectBatchCmd cmd;
+  cmd.kind = EffectBatchCmd::Kind::WeaponArc;
+  cmd.position = position;
+  cmd.color = color;
+  cmd.radius = radius;
+  cmd.intensity = intensity;
+  cmd.time = time;
+  cmd.direction = direction;
+  cmd.span = span;
+  cmd.tilt = tilt;
+  cmd.priority = CommandPriority::High;
+  if (queue != nullptr) {
+    queue->submit(std::move(cmd));
+  }
+}
+
 void Renderer::healing_beam(const QVector3D& start,
                             const QVector3D& end,
                             const QVector3D& color,
@@ -303,6 +328,22 @@ void Renderer::metal_spark(const QVector3D& position,
   }
   m_effects_submitter->metal_spark(
       m_active_queue, position, color, radius, intensity, time, direction);
+}
+
+void Renderer::weapon_arc(const QVector3D& position,
+                          const QVector3D& color,
+                          float radius,
+                          float intensity,
+                          float time,
+                          const QVector3D& direction,
+                          float span,
+                          float tilt) {
+  if (!m_submission_visibility.accepts_sphere(
+          position, radius, SubmissionFogMode::VisibleOnly, FogExtent::Anchor)) {
+    return;
+  }
+  m_effects_submitter->weapon_arc(
+      m_active_queue, position, color, radius, intensity, time, direction, span, tilt);
 }
 
 } // namespace Render::GL

--- a/render/effects_submitter.h
+++ b/render/effects_submitter.h
@@ -66,6 +66,15 @@ public:
                    float intensity,
                    float time,
                    const QVector3D& direction = {}) const;
+  void weapon_arc(DrawQueue* queue,
+                  const QVector3D& position,
+                  const QVector3D& color,
+                  float radius,
+                  float intensity,
+                  float time,
+                  const QVector3D& direction,
+                  float span,
+                  float tilt) const;
 };
 
 } // namespace Render::GL

--- a/render/entity/combat_dust_renderer.cpp
+++ b/render/entity/combat_dust_renderer.cpp
@@ -23,6 +23,116 @@
 namespace Render::GL {
 
 namespace {
+
+auto commander_strike_accent(Engine::Core::Entity* commander) -> QVector3D {
+  auto const* unit = commander->get_component<Engine::Core::UnitComponent>();
+  if (unit == nullptr) {
+    return {1.0F, 0.78F, 0.32F};
+  }
+  switch (unit->nation_id) {
+  case Game::Systems::NationID::RomanRepublic:
+    return {1.0F, 0.80F, 0.30F};
+  case Game::Systems::NationID::Carthage:
+    return {0.86F, 0.46F, 1.0F};
+  default:
+    return {1.0F, 0.72F, 0.24F};
+  }
+}
+
+void draw_commander_swing(
+    Render::GL::Renderer* renderer,
+    const Engine::Core::CommanderSignaturePresentationComponent::Entry& entry,
+    const QVector3D& contact,
+    const QVector3D& forward,
+    const QVector3D& across,
+    const QVector3D& accent,
+    float progress) {
+  constexpr float k_cut_tilt = 0.62F;
+  constexpr float k_slam_tilt = 1.02F;
+  float const reach = std::max(1.2F, entry.reach);
+  float const arc_alpha = entry.intensity * 1.4F;
+  QVector3D const hot = accent * 0.8F + QVector3D(0.2F, 0.2F, 0.2F);
+
+  switch (entry.form) {
+  case Engine::Core::CommanderSignatureForm::Cut: {
+    float const tilt = entry.span < 0.0F ? -k_cut_tilt : k_cut_tilt;
+    renderer->weapon_arc(contact,
+                         hot,
+                         reach * 1.05F,
+                         1.15F * arc_alpha,
+                         progress,
+                         forward,
+                         entry.span,
+                         tilt);
+    break;
+  }
+  case Engine::Core::CommanderSignatureForm::Sweep: {
+    renderer->weapon_arc(contact - QVector3D(0.0F, 0.22F, 0.0F),
+                         hot,
+                         reach * 0.92F,
+                         1.0F * arc_alpha,
+                         progress,
+                         forward,
+                         entry.span,
+                         0.0F);
+    break;
+  }
+  case Engine::Core::CommanderSignatureForm::Slam: {
+    renderer->weapon_arc(contact - forward * (reach * 0.12F),
+                         hot,
+                         reach * 0.95F,
+                         1.2F * arc_alpha,
+                         progress,
+                         forward,
+                         std::abs(entry.span) * 0.8F,
+                         k_slam_tilt);
+    constexpr float k_shock_start = 0.34F;
+    if (progress >= k_shock_start) {
+      float const shock =
+          std::clamp((progress - k_shock_start) / (1.0F - k_shock_start), 0.0F, 1.0F);
+      QVector3D const ground(contact.x(), contact.y() - 0.90F, contact.z());
+      renderer->weapon_arc(ground + forward * (reach * 0.40F),
+                           accent,
+                           reach * 0.80F,
+                           0.55F * arc_alpha,
+                           shock,
+                           forward,
+                           1.0F,
+                           0.0F);
+      renderer->combat_dust(ground + forward * (reach * 0.40F),
+                            QVector3D(0.55F, 0.47F, 0.36F),
+                            0.7F + 0.8F * shock,
+                            0.5F * (1.0F - shock) * arc_alpha,
+                            renderer->get_animation_time());
+    }
+    break;
+  }
+  case Engine::Core::CommanderSignatureForm::Thrust: {
+    float const drive = std::clamp(progress * 1.6F, 0.0F, 1.0F);
+    QVector3D const tip = contact + forward * (reach * (0.15F + 0.55F * drive));
+    renderer->metal_spark(
+        tip, hot, 0.26F, 2.6F * arc_alpha, std::max(0.0F, entry.age), forward);
+    renderer->metal_spark(contact + forward * (reach * 0.25F * drive),
+                          accent,
+                          0.20F,
+                          1.8F * arc_alpha,
+                          std::max(0.0F, entry.age - 0.04F),
+                          forward);
+    break;
+  }
+  case Engine::Core::CommanderSignatureForm::Shot:
+    break;
+  }
+
+  Render::LocalLight swing_light;
+  swing_light.position = contact + forward * (reach * 0.3F);
+  swing_light.color = accent * 0.6F + QVector3D(0.4F, 0.35F, 0.25F);
+  swing_light.radius = 2.2F + reach * 0.6F;
+  swing_light.intensity =
+      0.55F * arc_alpha * (1.0F - progress) * std::clamp(progress * 4.0F, 0.0F, 1.0F);
+  renderer->local_light(swing_light);
+}
+
 constexpr float k_degrees_to_radians = 0.017453292519943295F;
 constexpr float k_dust_y_offset = 0.05F;
 constexpr float k_dust_color_r = 0.6F;
@@ -523,12 +633,13 @@ void render_combat_dust(Renderer* renderer,
     if (presentation == nullptr) {
       continue;
     }
+    QVector3D const accent = commander_strike_accent(commander);
 
     for (auto const& entry : presentation->entries) {
       float const progress =
           std::clamp(entry.age / std::max(0.01F, entry.lifetime), 0.0F, 1.0F);
       float const fade = (1.0F - progress) * (1.0F - progress) * entry.intensity;
-      if (fade <= 0.01F) {
+      if (fade <= 0.01F && entry.cue == Engine::Core::CommanderStrikeCue::Impact) {
         continue;
       }
 
@@ -541,9 +652,16 @@ void render_combat_dust(Renderer* renderer,
       QVector3D const forward(entry.dir_x, 0.0F, entry.dir_z);
       QVector3D const across(-entry.dir_z, 0.0F, entry.dir_x);
 
+      if (entry.cue == Engine::Core::CommanderStrikeCue::Swing) {
+        draw_commander_swing(
+            renderer, entry, contact, forward, across, accent, progress);
+        continue;
+      }
+
       auto spark_age = [&entry](float delay) {
         return std::max(0.0F, entry.age - delay);
       };
+      QVector3D const spark_tint = accent * 0.35F + QVector3D(0.65F, 0.62F, 0.55F);
 
       switch (entry.form) {
       case Engine::Core::CommanderSignatureForm::Thrust: {
@@ -554,15 +672,15 @@ void render_combat_dust(Renderer* renderer,
               contact + forward * (along + progress * 0.22F) +
                   QVector3D(0.0F, 0.05F * static_cast<float>(step % 2) - 0.03F, 0.0F),
               QVector3D(0.86F, 0.92F, 1.0F),
-              0.135F,
-              2.8F,
+              0.135F * (0.8F + 0.2F * entry.intensity),
+              2.8F * entry.intensity,
               spark_age(0.025F * static_cast<float>(step)),
               forward);
         }
         renderer->metal_spark(contact + forward * 0.06F,
                               QVector3D(1.0F, 0.95F, 0.82F),
                               0.175F,
-                              3.2F,
+                              3.2F * entry.intensity,
                               spark_age(0.0F),
                               forward);
         break;
@@ -575,9 +693,9 @@ void render_combat_dust(Renderer* renderer,
           renderer->metal_spark(contact + across * offset * (1.0F + progress * 0.4F) +
                                     forward * arc +
                                     QVector3D(0.0F, 0.20F * offset, 0.0F),
-                                QVector3D(1.0F, 0.72F, 0.30F),
-                                0.115F,
-                                2.4F,
+                                spark_tint,
+                                0.115F * (0.8F + 0.2F * entry.intensity),
+                                2.4F * entry.intensity,
                                 spark_age(0.035F * static_cast<float>(step)),
                                 across);
         }
@@ -586,6 +704,46 @@ void render_combat_dust(Renderer* renderer,
                               0.8F + 0.6F * progress,
                               0.45F * fade,
                               animation_time);
+        break;
+      }
+      case Engine::Core::CommanderSignatureForm::Sweep: {
+
+        for (int step = 0; step < 7; ++step) {
+          float const angle =
+              (-0.9F + 0.3F * static_cast<float>(step)) * (1.0F + progress * 0.35F);
+          QVector3D const ray = forward * std::cos(angle) + across * std::sin(angle);
+          renderer->metal_spark(contact + ray * (0.25F + 0.30F * progress) +
+                                    QVector3D(0.0F, -0.15F, 0.0F),
+                                spark_tint,
+                                0.125F,
+                                2.3F * entry.intensity,
+                                spark_age(0.02F * static_cast<float>(step)),
+                                ray);
+        }
+        renderer->combat_dust(QVector3D(entry.x, entry.y - 0.55F, entry.z),
+                              QVector3D(0.50F, 0.43F, 0.34F),
+                              1.1F + 0.9F * progress,
+                              0.55F * fade,
+                              animation_time);
+        break;
+      }
+      case Engine::Core::CommanderSignatureForm::Slam: {
+
+        for (int step = 0; step < 6; ++step) {
+          float const angle = static_cast<float>(step) * 1.047F + progress * 0.6F;
+          QVector3D const ray = forward * std::cos(angle) + across * std::sin(angle);
+          renderer->metal_spark(contact + ray * 0.18F + QVector3D(0.0F, -0.35F, 0.0F),
+                                QVector3D(1.0F, 0.90F, 0.70F),
+                                0.145F,
+                                2.6F * entry.intensity,
+                                spark_age(0.02F * static_cast<float>(step)),
+                                ray + QVector3D(0.0F, 0.35F, 0.0F));
+        }
+        renderer->stone_impact(QVector3D(entry.x, entry.y - 0.58F, entry.z),
+                               QVector3D(0.55F, 0.47F, 0.36F),
+                               0.95F * entry.intensity,
+                               1.1F * entry.intensity,
+                               entry.age);
         break;
       }
       case Engine::Core::CommanderSignatureForm::Shot: {
@@ -614,8 +772,8 @@ void render_combat_dust(Renderer* renderer,
       strike_light.position = contact;
       strike_light.color = entry.form == Engine::Core::CommanderSignatureForm::Thrust
                                ? QVector3D(0.72F, 0.84F, 1.0F)
-                               : QVector3D(1.0F, 0.72F, 0.34F);
-      strike_light.radius = 2.6F;
+                               : accent * 0.55F + QVector3D(0.45F, 0.35F, 0.20F);
+      strike_light.radius = 2.6F + 0.8F * entry.intensity;
       strike_light.intensity = 0.7F * fade;
       renderer->local_light(strike_light);
     }

--- a/render/geom/projectile_renderer.cpp
+++ b/render/geom/projectile_renderer.cpp
@@ -625,8 +625,13 @@ void render_arrow_projectile(Renderer* renderer,
                      0.34F - (0.12F * static_cast<float>(trail_idx)));
     }
   } else {
-    bool const aimed = arrow.visual_style() == Game::Systems::ArrowVisualStyle::Aimed;
-    int const trail_segments = aimed ? 6 : 2;
+    bool const commander_shot =
+        arrow.visual_style() == Game::Systems::ArrowVisualStyle::Commander;
+    bool const signature_shot =
+        arrow.visual_style() == Game::Systems::ArrowVisualStyle::CommanderSignature;
+    bool const aimed = arrow.visual_style() == Game::Systems::ArrowVisualStyle::Aimed ||
+                       commander_shot || signature_shot;
+    int const trail_segments = signature_shot ? 8 : (aimed ? 6 : 2);
     float const trail_step = aimed ? 0.17F : 0.38F;
     if (arrow.trail_alpha() > 0.001F && arrow.trail_length() > 0.0F) {
       for (int segment = 1; segment <= trail_segments; ++segment) {
@@ -676,20 +681,45 @@ void render_arrow_projectile(Renderer* renderer,
       float const flight = std::clamp(arrow.get_progress(), 0.0F, 1.0F);
       float const settle = std::clamp(flight * 6.0F, 0.0F, 1.0F);
       QVector3D const glow_color = Geom::Arrow::glow_color(arrow.get_color());
+      QVector3D const head_color = signature_shot ? QVector3D(1.0F, 0.72F, 0.38F)
+                                                  : QVector3D(1.0F, 0.92F, 0.72F);
 
       renderer->metal_spark(pos,
-                            QVector3D(1.0F, 0.92F, 0.72F),
-                            0.055F * arrow.get_scale(),
-                            1.35F * settle,
+                            head_color,
+                            (signature_shot ? 0.085F : 0.055F) * arrow.get_scale(),
+                            (signature_shot ? 2.1F : 1.35F) * settle,
                             arrow.get_progress() * 0.24F,
                             delta.normalized());
+      if (signature_shot) {
+        for (int ember = 1; ember <= 3; ++ember) {
+          float const ember_t =
+              arrow.get_progress() - 0.045F * static_cast<float>(ember);
+          if (ember_t <= 0.0F) {
+            continue;
+          }
+          QVector3D ember_pos = arrow.get_start() + delta * ember_t;
+          ember_pos.setY(ember_pos.y() +
+                         arrow.get_arc_height() * 4.0F * ember_t * (1.0F - ember_t));
+          renderer->metal_spark(
+              ember_pos,
+              QVector3D(1.0F, 0.55F, 0.22F),
+              0.05F * arrow.get_scale(),
+              1.2F * settle,
+              std::fmod(arrow.get_progress() * 0.6F + static_cast<float>(ember) * 0.07F,
+                        0.26F),
+              delta.normalized());
+        }
+      }
 
       Render::LocalLight flight_light;
       flight_light.position = pos;
       flight_light.color =
-          (glow_color * 0.45F) + (QVector3D(1.0F, 0.90F, 0.66F) * 0.55F);
-      flight_light.radius = 2.6F;
-      flight_light.intensity = 0.65F * settle * arrow.brightness();
+          signature_shot
+              ? (glow_color * 0.35F) + (QVector3D(1.0F, 0.62F, 0.30F) * 0.65F)
+              : (glow_color * 0.45F) + (QVector3D(1.0F, 0.90F, 0.66F) * 0.55F);
+      flight_light.radius = signature_shot ? 3.4F : 2.6F;
+      flight_light.intensity =
+          (signature_shot ? 0.95F : 0.65F) * settle * arrow.brightness();
       renderer->local_light(flight_light);
     }
     model.rotate(arrow.roll_deg() + arrow.get_progress() * arrow.spin_rate_deg(),
@@ -713,6 +743,15 @@ void render_arrow_projectile(Renderer* renderer,
       shaft_color = QVector3D(0.42F, 0.18F, 0.58F);
       tip_color = QVector3D(0.72F, 0.32F, 0.92F);
       fletch_color = QVector3D(0.58F, 0.22F, 0.82F);
+    } else if (signature_shot) {
+      shaft_color = scaled_color(QVector3D(0.62F, 0.44F, 0.22F), brightness);
+      tip_color = scaled_color(QVector3D(1.0F, 0.86F, 0.55F), brightness);
+      fletch_color = scaled_color(QVector3D(0.92F, 0.20F, 0.16F), brightness);
+    } else if (commander_shot) {
+      shaft_color = scaled_color(QVector3D(0.58F, 0.46F, 0.30F), brightness);
+      tip_color = scaled_color(QVector3D(0.96F, 0.90F, 0.72F), brightness);
+      fletch_color =
+          scaled_color(fletch_color * 0.55F + QVector3D(0.45F, 0.38F, 0.18F), 1.0F);
     }
     renderer->mesh(arrow_shaft_mesh, model, shaft_color, nullptr, 1.0F);
     renderer->mesh(arrow_tip_mesh, model, tip_color, nullptr, 1.0F);
@@ -720,7 +759,9 @@ void render_arrow_projectile(Renderer* renderer,
     QVector3D const glow =
         arrow.get_kind() == Game::Systems::ProjectileKind::CursedArrow
             ? QVector3D(0.78F, 0.35F, 1.0F)
-            : relation_glow(Geom::Arrow::glow_color(team_color), relation);
+            : (signature_shot
+                   ? QVector3D(1.0F, 0.62F, 0.28F)
+                   : relation_glow(Geom::Arrow::glow_color(team_color), relation));
     draw_arrow_glow(renderer,
                     arrow_shaft_mesh,
                     arrow_tip_mesh,

--- a/render/gl/backend/combat_dust_pipeline.cpp
+++ b/render/gl/backend/combat_dust_pipeline.cpp
@@ -144,6 +144,11 @@ auto CombatDustPipeline::initialize() -> bool {
     return false;
   }
 
+  if (!create_weapon_arc_geometry()) {
+    qWarning() << "CombatDustPipeline: Failed to create weapon arc geometry";
+    return false;
+  }
+
   if (m_blood_shader != nullptr && !create_blood_geometry()) {
     qWarning() << "CombatDustPipeline: Blood pools disabled; failed to create "
                   "blood geometry";
@@ -167,8 +172,11 @@ void CombatDustPipeline::release_geometry() {
     initializeOpenGLFunctions();
     clear_gl_errors();
   }
-  for (StaticMeshBuffers* mesh :
-       {&m_dust_mesh, &m_fireball_mesh, &m_metal_spark_mesh, &m_blood_mesh}) {
+  for (StaticMeshBuffers* mesh : {&m_dust_mesh,
+                                  &m_fireball_mesh,
+                                  &m_metal_spark_mesh,
+                                  &m_weapon_arc_mesh,
+                                  &m_blood_mesh}) {
     release_mesh_buffers(*this, *mesh);
   }
 }
@@ -187,6 +195,7 @@ void CombatDustPipeline::cache_uniforms() {
     m_uniforms.dust_color = m_dust_shader->uniform_handle("u_dust_color");
     m_uniforms.effect_type = m_dust_shader->uniform_handle("u_effect_type");
     m_uniforms.camera_pos = m_dust_shader->uniform_handle("u_camera_pos");
+    m_uniforms.span = m_dust_shader->optional_uniform_handle("u_span");
   }
 
   if (m_blood_shader != nullptr) {
@@ -203,7 +212,8 @@ auto CombatDustPipeline::is_initialized() const -> bool {
   return m_dust_shader != nullptr && m_dust_mesh.vao != 0 &&
          m_dust_mesh.index_count > 0 && m_fireball_mesh.vao != 0 &&
          m_fireball_mesh.index_count > 0 && m_metal_spark_mesh.vao != 0 &&
-         m_metal_spark_mesh.index_count > 0;
+         m_metal_spark_mesh.index_count > 0 && m_weapon_arc_mesh.vao != 0 &&
+         m_weapon_arc_mesh.index_count > 0;
 }
 
 struct DustVertex {
@@ -418,6 +428,55 @@ auto CombatDustPipeline::create_metal_spark_geometry() -> bool {
   return upload_dust_mesh(*this, m_metal_spark_mesh, "metal spark", vertices, indices);
 }
 
+auto CombatDustPipeline::create_weapon_arc_geometry() -> bool {
+  initializeOpenGLFunctions();
+  release_mesh_buffers(*this, m_weapon_arc_mesh);
+  clear_gl_errors();
+
+  std::vector<DustVertex> vertices;
+  std::vector<unsigned int> indices;
+
+  constexpr int segment_count = 64;
+  constexpr int band_count = 3;
+  constexpr float pi = std::numbers::pi_v<float>;
+  constexpr float inner_radius = 0.50F;
+  vertices.reserve(static_cast<std::size_t>((segment_count + 1) * (band_count + 1)));
+  indices.reserve(static_cast<std::size_t>(segment_count * band_count * 6));
+
+  for (int segment = 0; segment <= segment_count; ++segment) {
+    float const along = static_cast<float>(segment) / static_cast<float>(segment_count);
+    float const angle = (along - 0.5F) * 2.0F * pi;
+    float const sin_a = std::sin(angle);
+    float const cos_a = std::cos(angle);
+    for (int band = 0; band <= band_count; ++band) {
+      float const across = static_cast<float>(band) / static_cast<float>(band_count);
+      float const ring = inner_radius + (1.0F - inner_radius) * across;
+      DustVertex vertex{};
+      vertex.position[0] = sin_a * ring;
+      vertex.position[1] = 0.0F;
+      vertex.position[2] = cos_a * ring;
+      vertex.normal[0] = 0.0F;
+      vertex.normal[1] = 1.0F;
+      vertex.normal[2] = 0.0F;
+      vertex.tex_coord[0] = along;
+      vertex.tex_coord[1] = across;
+      vertices.push_back(vertex);
+    }
+  }
+
+  auto const stride = static_cast<unsigned int>(band_count + 1);
+  for (int segment = 0; segment < segment_count; ++segment) {
+    for (int band = 0; band < band_count; ++band) {
+      unsigned int const a =
+          static_cast<unsigned int>(segment) * stride + static_cast<unsigned int>(band);
+      unsigned int const b = a + stride;
+      indices.insert(indices.end(), {a, b, a + 1U, a + 1U, b, b + 1U});
+    }
+  }
+
+  return upload_dust_mesh(*this, m_weapon_arc_mesh, "weapon arc", vertices, indices);
+}
+
 auto CombatDustPipeline::create_blood_geometry() -> bool {
   initializeOpenGLFunctions();
   release_mesh_buffers(*this, m_blood_mesh);
@@ -498,8 +557,10 @@ void CombatDustPipeline::render_dust_batch(const DustInstanceData* instances,
     }
 
     bool const use_fireball_geometry = inst.effect_type == EffectType::Fireball;
-    bool const use_additive_blending =
-        use_fireball_geometry || inst.effect_type == EffectType::MetalSpark;
+    bool const use_weapon_arc_geometry = inst.effect_type == EffectType::WeaponArc;
+    bool const use_additive_blending = use_fireball_geometry ||
+                                       inst.effect_type == EffectType::MetalSpark ||
+                                       use_weapon_arc_geometry;
     EffectStateMode const target_state =
         use_additive_blending ? EffectStateMode::Additive
                               : (inst.overlay ? EffectStateMode::AlphaOverlay
@@ -517,15 +578,14 @@ void CombatDustPipeline::render_dust_batch(const DustInstanceData* instances,
     }
 
     bool const use_metal_spark_geometry = inst.effect_type == EffectType::MetalSpark;
-    GLuint const target_vao =
+    StaticMeshBuffers const& target_mesh =
         use_fireball_geometry
-            ? m_fireball_mesh.vao
-            : (use_metal_spark_geometry ? m_metal_spark_mesh.vao : m_dust_mesh.vao);
-    GLsizei const target_index_count =
-        use_fireball_geometry
-            ? m_fireball_mesh.index_count
-            : (use_metal_spark_geometry ? m_metal_spark_mesh.index_count
-                                        : m_dust_mesh.index_count);
+            ? m_fireball_mesh
+            : (use_metal_spark_geometry
+                   ? m_metal_spark_mesh
+                   : (use_weapon_arc_geometry ? m_weapon_arc_mesh : m_dust_mesh));
+    GLuint const target_vao = target_mesh.vao;
+    GLsizei const target_index_count = target_mesh.index_count;
     if (target_vao == 0 || target_index_count <= 0) {
       continue;
     }
@@ -538,6 +598,9 @@ void CombatDustPipeline::render_dust_batch(const DustInstanceData* instances,
     QMatrix4x4 model;
     if (use_metal_spark_geometry) {
       model = spark_model_matrix(inst.position, inst.radius, inst.direction);
+    } else if (use_weapon_arc_geometry) {
+      model = weapon_arc_model_matrix(
+          inst.position, inst.radius, inst.direction, inst.tilt);
     } else {
       model.setToIdentity();
       model.translate(inst.position);
@@ -556,6 +619,9 @@ void CombatDustPipeline::render_dust_batch(const DustInstanceData* instances,
     m_dust_shader->set_uniform(m_uniforms.effect_type,
                                static_cast<int>(inst.effect_type));
     m_dust_shader->set_uniform(m_uniforms.camera_pos, m_view_position);
+    if (m_uniforms.span != GL::Shader::InvalidUniform) {
+      m_dust_shader->set_uniform(m_uniforms.span, inst.span);
+    }
 
     glDrawElements(GL_TRIANGLES, current_index_count, GL_UNSIGNED_INT, nullptr);
   }

--- a/render/gl/backend/combat_dust_pipeline.h
+++ b/render/gl/backend/combat_dust_pipeline.h
@@ -21,7 +21,8 @@ enum class EffectType {
   StoneImpact = 2,
   Fireball = 3,
   BurningFlame = 4,
-  MetalSpark = 5
+  MetalSpark = 5,
+  WeaponArc = 6
 };
 
 class CombatDustPipeline final : public IPipeline {
@@ -45,6 +46,8 @@ public:
     bool overlay{false};
 
     QVector3D direction{0.0F, 0.0F, 0.0F};
+    float span{0.0F};
+    float tilt{0.0F};
   };
 
   void render_dust_batch(const DustInstanceData* instances,
@@ -72,6 +75,7 @@ private:
   auto create_dust_geometry() -> bool;
   auto create_fireball_geometry() -> bool;
   auto create_metal_spark_geometry() -> bool;
+  auto create_weapon_arc_geometry() -> bool;
   auto create_blood_geometry() -> bool;
   void release_geometry();
 
@@ -82,6 +86,7 @@ private:
   StaticMeshBuffers m_dust_mesh;
   StaticMeshBuffers m_fireball_mesh;
   StaticMeshBuffers m_metal_spark_mesh;
+  StaticMeshBuffers m_weapon_arc_mesh;
   StaticMeshBuffers m_blood_mesh;
 
   struct DustUniforms {
@@ -94,6 +99,7 @@ private:
     GL::Shader::UniformHandle dust_color{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle effect_type{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle camera_pos{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle span{GL::Shader::InvalidUniform};
   };
 
   struct BloodUniforms {

--- a/render/gl/backend/effects_command_executor.cpp
+++ b/render/gl/backend/effects_command_executor.cpp
@@ -22,6 +22,8 @@ auto billboard_effect_type(EffectBatchCmd::Kind kind) -> BackendPipelines::Effec
     return BackendPipelines::EffectType::StoneImpact;
   case EffectBatchCmd::Kind::MetalSpark:
     return BackendPipelines::EffectType::MetalSpark;
+  case EffectBatchCmd::Kind::WeaponArc:
+    return BackendPipelines::EffectType::WeaponArc;
   default:
     return BackendPipelines::EffectType::Dust;
   }
@@ -36,7 +38,9 @@ auto make_dust_instance(const EffectBatchCmd& eff)
           .time = eff.time,
           .effect_type = billboard_effect_type(eff.kind),
           .overlay = false,
-          .direction = eff.direction};
+          .direction = eff.direction,
+          .span = eff.span,
+          .tilt = eff.tilt};
 }
 } // namespace
 
@@ -304,7 +308,8 @@ void Backend::execute_effects_commands(const PreparedBatch& prepared,
     case EffectBatchCmd::Kind::BurningFlame:
     case EffectBatchCmd::Kind::Fireball:
     case EffectBatchCmd::Kind::StoneImpact:
-    case EffectBatchCmd::Kind::MetalSpark: {
+    case EffectBatchCmd::Kind::MetalSpark:
+    case EffectBatchCmd::Kind::WeaponArc: {
       if (m_combat_dust_pipeline == nullptr ||
           !m_combat_dust_pipeline->is_initialized()) {
         break;

--- a/render/gl/backend/spark_orientation.h
+++ b/render/gl/backend/spark_orientation.h
@@ -53,4 +53,44 @@ inline constexpr float k_min_spark_direction_length_squared = 1.0e-6F;
   return model;
 }
 
+[[nodiscard]] inline auto weapon_arc_model_matrix(const QVector3D& position,
+                                                  float radius,
+                                                  const QVector3D& direction,
+                                                  float tilt_radians) -> QMatrix4x4 {
+  QMatrix4x4 model;
+  model.setToIdentity();
+  model.translate(position);
+
+  QVector3D forward(direction.x(), 0.0F, direction.z());
+  if (forward.lengthSquared() <= k_min_spark_direction_length_squared) {
+    forward = QVector3D(0.0F, 0.0F, 1.0F);
+  }
+  forward.normalize();
+  QVector3D const up(0.0F, 1.0F, 0.0F);
+  QVector3D const side = QVector3D::crossProduct(up, forward).normalized();
+  float const cos_t = std::cos(tilt_radians);
+  float const sin_t = std::sin(tilt_radians);
+  QVector3D const across = side * cos_t + up * sin_t;
+  QVector3D const normal = up * cos_t - side * sin_t;
+
+  model *= QMatrix4x4(across.x(),
+                      normal.x(),
+                      forward.x(),
+                      0.0F,
+                      across.y(),
+                      normal.y(),
+                      forward.y(),
+                      0.0F,
+                      across.z(),
+                      normal.z(),
+                      forward.z(),
+                      0.0F,
+                      0.0F,
+                      0.0F,
+                      0.0F,
+                      1.0F);
+  model.scale(radius);
+  return model;
+}
+
 } // namespace Render::GL::BackendPipelines

--- a/render/gl/humanoid/animation/animation_inputs.cpp
+++ b/render/gl/humanoid/animation/animation_inputs.cpp
@@ -185,9 +185,10 @@ void reset_humanoid_animation_state(
   case Game::Systems::CombatActions::CombatActionId::RtsElephantStomp:
   case Game::Systems::CombatActions::CombatActionId::None:
   case Game::Systems::CombatActions::CombatActionId::RtsCommanderThrust:
-  case Game::Systems::CombatActions::CombatActionId::RtsCommanderCut:
   case Game::Systems::CombatActions::CombatActionId::RtsCommanderShot:
     break;
+  case Game::Systems::CombatActions::CombatActionId::RtsCommanderCut:
+    return Animation::SwordAttackAnimation::RpgOverhead;
   case Game::Systems::CombatActions::CombatActionId::RtsHeavyOverhead:
     return Animation::SwordAttackAnimation::RpgOverhead;
   case Game::Systems::CombatActions::CombatActionId::RtsSwordStrike:
@@ -583,8 +584,21 @@ auto sample_anim_state(const DrawContext& ctx) -> AnimationInputs {
 
     anim.simulation_owns_root_motion = presentation->fpv_controlled;
 
-    bool const has_authored_action =
-        presentation->fpv_controlled && presentation->authored_action_id != 0U;
+    auto const* authored_definition =
+        presentation->authored_action_id != 0U
+            ? Game::Systems::CombatActions::find_combat_action_definition(
+                  static_cast<Game::Systems::CombatActions::CombatActionId>(
+                      presentation->authored_action_id))
+            : nullptr;
+    bool const commander_link =
+        authored_definition != nullptr &&
+        (authored_definition->commander_only ||
+         authored_definition->id ==
+             Game::Systems::CombatActions::CombatActionId::RtsCommanderCut ||
+         authored_definition->id ==
+             Game::Systems::CombatActions::CombatActionId::RtsCommanderThrust);
+    bool const has_authored_action = presentation->authored_action_id != 0U &&
+                                     (presentation->fpv_controlled || commander_link);
 
     bool const authored_timeline_is_authoritative =
         has_authored_action &&

--- a/render/scene_renderer.h
+++ b/render/scene_renderer.h
@@ -375,6 +375,14 @@ public:
                    float intensity,
                    float time,
                    const QVector3D& direction = {});
+  void weapon_arc(const QVector3D& position,
+                  const QVector3D& color,
+                  float radius,
+                  float intensity,
+                  float time,
+                  const QVector3D& direction,
+                  float span,
+                  float tilt = 0.0F);
   void mode_indicator(const QMatrix4x4& model,
                       int mode_type,
                       const QVector3D& color,

--- a/tests/systems/commander_duel_test.cpp
+++ b/tests/systems/commander_duel_test.cpp
@@ -7,6 +7,7 @@
 #include "core/entity.h"
 #include "core/world.h"
 #include "game/map/terrain_service.h"
+#include "game/systems/arrow_projectile.h"
 #include "game/systems/combat_actions/combat_action_definition.h"
 #include "game/systems/default_content.h"
 #include "game/systems/formation_combat_geometry.h"
@@ -14,6 +15,7 @@
 #include "game/systems/nav_grid.h"
 #include "game/systems/owner_registry.h"
 #include "game/systems/projectile_system.h"
+#include "game/systems/rpg_combat_system/rpg_targeting.h"
 #include "game/systems/runtime_system_registry.h"
 #include "units/commander_catalog.h"
 #include "units/factory.h"
@@ -493,4 +495,243 @@ TEST_F(CommanderDuelTest, SweepSignatureCatchesASecondFighter) {
 
   EXPECT_LT(bystander_unit->health, bystander_health_before)
       << "a sweeping signature has to catch the fighters crowding the commander";
+}
+
+namespace {
+
+using Engine::Core::CommanderSignaturePresentationComponent;
+using Engine::Core::CommanderStrikeCue;
+
+auto action_definition_of(const RpgCommanderActionComponent& action)
+    -> const Game::Systems::CombatActions::CombatActionDefinition* {
+  return Game::Systems::CombatActions::find_combat_action_definition(
+      static_cast<CombatActionId>(action.combat_action_id));
+}
+
+} // namespace
+
+TEST_F(CommanderDuelTest, EveryCommanderLinkLeavesASwingCueNotOnlyTheSignature) {
+  Engine::Core::World world;
+  Game::Systems::register_runtime_systems(world);
+
+  auto* commander = spawn(world,
+                          Game::Units::SpawnType::CarthageSwordCommander,
+                          1,
+                          QVector3D(-4.0F, 0.0F, 0.0F),
+                          Game::Systems::NationID::Carthage);
+  auto* rival = spawn(world,
+                      Game::Units::SpawnType::Knight,
+                      2,
+                      QVector3D(0.0F, 0.0F, 0.0F),
+                      Game::Systems::NationID::RomanRepublic);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(rival, nullptr);
+  order_attack(*commander, *rival);
+
+  std::set<Engine::Core::CommanderSignatureForm> swing_forms;
+  int swing_cues = 0;
+  int impact_cues = 0;
+  for (int tick = 0; tick < 800; ++tick) {
+    world.update(0.05F);
+    auto const* presentation =
+        commander->get_component<CommanderSignaturePresentationComponent>();
+    if (presentation == nullptr) {
+      continue;
+    }
+    for (auto const& entry : presentation->entries) {
+      if (entry.age > 0.0F) {
+        continue;
+      }
+      if (entry.cue == CommanderStrikeCue::Swing) {
+        ++swing_cues;
+        swing_forms.insert(entry.form);
+        EXPECT_GT(entry.reach, 1.0F);
+        EXPECT_NEAR(std::hypot(entry.dir_x, entry.dir_z), 1.0F, 0.01F);
+      } else {
+        ++impact_cues;
+      }
+    }
+  }
+
+  EXPECT_GE(swing_cues, 4) << "a commander chain left almost no swing arcs to draw";
+  EXPECT_GE(swing_forms.size(), 2U)
+      << "the chain's links all read as the same arc; the finisher and sweep "
+         "should have their own form";
+  EXPECT_GE(impact_cues, 2) << "ordinary links landed but left no impact burst";
+}
+
+TEST_F(CommanderDuelTest, CommanderPressesIntoAFormationInsteadOfBeingShovedOut) {
+  Engine::Core::World world;
+  Game::Systems::register_runtime_systems(world);
+
+  auto* commander = spawn(world,
+                          Game::Units::SpawnType::RomanVeteranConsul,
+                          1,
+                          QVector3D(-5.0F, 0.0F, 0.0F),
+                          Game::Systems::NationID::RomanRepublic);
+  auto* block = spawn(world,
+                      Game::Units::SpawnType::Spearman,
+                      2,
+                      QVector3D(0.0F, 0.0F, 0.0F),
+                      Game::Systems::NationID::Carthage);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(block, nullptr);
+  auto* block_unit = block->get_component<UnitComponent>();
+  ASSERT_NE(block_unit, nullptr);
+  block_unit->render_individuals_per_unit_override = 0;
+  int const block_health_at_start = block_unit->health;
+
+  order_attack(*commander, *block);
+  order_attack(*block, *commander);
+
+  auto distance_to_block = [&] {
+    auto const* a = commander->get_component<TransformComponent>();
+    float nearest = 1.0e9F;
+    for (auto const& soldier : Game::Systems::RpgCombat::live_soldier_targets(*block)) {
+      nearest = std::min(nearest,
+                         std::hypot(soldier.position.x() - a->position.x,
+                                    soldier.position.z() - a->position.z));
+    }
+    return nearest;
+  };
+
+  float closest_after_contact = 1.0e9F;
+  float farthest_after_contact = 0.0F;
+  bool contact = false;
+  for (int tick = 0; tick < 480; ++tick) {
+    world.update(0.05F);
+    auto const* attack = commander->get_component<Engine::Core::AttackComponent>();
+    if (attack != nullptr && attack->in_melee_lock) {
+      contact = true;
+    }
+    if (contact && tick >= 160) {
+      float const d = distance_to_block();
+      closest_after_contact = std::min(closest_after_contact, d);
+      farthest_after_contact = std::max(farthest_after_contact, d);
+    }
+  }
+
+  ASSERT_TRUE(contact) << "the commander never engaged the spear block";
+  EXPECT_LT(farthest_after_contact, 3.2F)
+      << "the commander was shoved out of the press by the block's flinches";
+  EXPECT_LT(closest_after_contact, 1.6F)
+      << "the commander's strikes never carried him into the block";
+  EXPECT_LT(block_unit->health, block_health_at_start)
+      << "a commander pressed into a block has to be landing blows";
+}
+
+TEST_F(CommanderDuelTest, CommanderChainLinksAreNotCutOffMidSwing) {
+  Engine::Core::World world;
+  Game::Systems::register_runtime_systems(world);
+
+  auto* commander = spawn(world,
+                          Game::Units::SpawnType::CarthageSwordCommander,
+                          1,
+                          QVector3D(-4.0F, 0.0F, 0.0F),
+                          Game::Systems::NationID::Carthage);
+  auto* rival = spawn(world,
+                      Game::Units::SpawnType::Knight,
+                      2,
+                      QVector3D(0.0F, 0.0F, 0.0F),
+                      Game::Systems::NationID::RomanRepublic);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(rival, nullptr);
+  order_attack(*commander, *rival);
+
+  std::uint8_t previous_id = 0U;
+  float previous_time = 0.0F;
+  bool previous_running = false;
+  bool previous_staggered = false;
+  int links = 0;
+  int cut_short = 0;
+  for (int tick = 0; tick < 800; ++tick) {
+    world.update(0.05F);
+    auto const* action = commander->get_component<RpgCommanderActionComponent>();
+    bool const staggered = commander->has_component<Engine::Core::StaggerComponent>();
+    if (action == nullptr) {
+      continue;
+    }
+    bool const restarted =
+        action->action_running && (action->combat_action_id != previous_id ||
+                                   action->normalized_action_time < previous_time);
+    if (restarted && previous_running) {
+      auto const* previous_definition =
+          Game::Systems::CombatActions::find_combat_action_definition(
+              static_cast<CombatActionId>(previous_id));
+      if (previous_definition != nullptr && previous_definition->commander_only &&
+          !staggered && !previous_staggered) {
+        ++links;
+        if (previous_time < 0.85F) {
+          ++cut_short;
+        }
+      }
+    }
+    previous_id = action->combat_action_id;
+    previous_time = action->normalized_action_time;
+    previous_running = action->action_running;
+    previous_staggered = staggered;
+  }
+
+  EXPECT_GE(links, 4) << "the commander never chained links";
+  EXPECT_EQ(cut_short, 0) << "a link was replaced before its clip reached ExitSafe";
+}
+
+TEST_F(CommanderDuelTest, CommanderArrowsCarryTheCommanderStyle) {
+  Engine::Core::World world;
+  Game::Systems::register_runtime_systems(world);
+
+  auto* commander = spawn(world,
+                          Game::Units::SpawnType::RomanFieldCommander,
+                          1,
+                          QVector3D(-7.0F, 0.0F, 0.0F),
+                          Game::Systems::NationID::RomanRepublic);
+  auto* rival = spawn(world,
+                      Game::Units::SpawnType::Knight,
+                      2,
+                      QVector3D(0.0F, 0.0F, 0.0F),
+                      Game::Systems::NationID::RomanRepublic);
+  ASSERT_NE(commander, nullptr);
+  ASSERT_NE(rival, nullptr);
+  if (auto* rival_unit = rival->get_component<UnitComponent>()) {
+    rival_unit->speed = 0.0F;
+  }
+  order_attack(*commander, *rival);
+
+  auto* projectiles = world.get_system<Game::Systems::ProjectileSystem>();
+  ASSERT_NE(projectiles, nullptr);
+
+  int routine = 0;
+  int signature = 0;
+  int other = 0;
+  std::set<const Game::Systems::Projectile*> seen;
+  for (int tick = 0; tick < 400; ++tick) {
+    world.update(0.05F);
+    for (auto const& projectile : projectiles->projectiles()) {
+      if (!seen.insert(projectile.get()).second) {
+        continue;
+      }
+      auto const* arrow =
+          dynamic_cast<const Game::Systems::ArrowProjectile*>(projectile.get());
+      if (arrow == nullptr || arrow->get_attacker_id() != commander->get_id()) {
+        continue;
+      }
+      switch (arrow->visual_style()) {
+      case Game::Systems::ArrowVisualStyle::Commander:
+        ++routine;
+        break;
+      case Game::Systems::ArrowVisualStyle::CommanderSignature:
+        ++signature;
+        EXPECT_GT(arrow->get_scale(), 1.5F);
+        break;
+      default:
+        ++other;
+        break;
+      }
+    }
+  }
+
+  EXPECT_GT(routine, 0) << "the bow commander's routine shots look like any archer's";
+  EXPECT_GE(signature, 3) << "the point-blank volley signature should loose a fan of "
+                             "three commander arrows";
+  EXPECT_EQ(other, 0) << "a commander arrow fell back to the generic style";
 }

--- a/tools/arena/arena_scenario_catalog.cpp
+++ b/tools/arena/arena_scenario_catalog.cpp
@@ -3239,6 +3239,113 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
   }
 
   {
+    struct PressScene {
+      const char* id;
+      const char* label;
+      const char* description;
+      Troop commander;
+      bool ranged;
+    };
+    constexpr std::array<PressScene, 3> press_scenes{{
+        {k_commander_press_sword_id,
+         "Commander in the Press: Scipio",
+         "A sword commander wades into a Carthaginian spear block with a "
+         "cohort at his back. The battle camera that has to show his combo "
+         "links, arcs and knockdowns among eighty bodies.",
+         Troop::RomanVeteranConsul,
+         false},
+        {k_commander_press_spear_id,
+         "Commander in the Press: Fabius",
+         "A spear commander holds the front of a spear block: thrusts, sweeps "
+         "and the phalanx sweep signature read from a zoomed-out camera.",
+         Troop::RomanLegionOrganizer,
+         false},
+        {k_commander_press_bow_id,
+         "Commander in the Press: Marcellus",
+         "A bow commander shoots over his own line into the press: commander "
+         "arrows and the point-blank volley signature.",
+         Troop::RomanFieldCommander,
+         true},
+    }};
+
+    for (auto const& scene : press_scenes) {
+      auto s = definition(QString::fromLatin1(scene.id),
+                          QString::fromLatin1(scene.label),
+                          QString::fromLatin1(scene.description),
+                          26.0F,
+                          {15.0F, 48.0F, 20.0F});
+      s.suppress_terrain_scatter = true;
+      s.select_spawned_units = false;
+      s.suppress_spawn_anchor = true;
+      s.suppress_ui_overlays = true;
+      s.camera_focus = QVector3D(-4.0F, 0.9F, 1.0F);
+
+      auto commander = group(QStringLiteral("commander"),
+                             scene.commander,
+                             1,
+                             1,
+                             {0.0F, 0.0F, scene.ranged ? -11.0F : -5.0F},
+                             1);
+      commander.health_override = commander.max_health_override = 9000;
+      auto roman_swords = group(QStringLiteral("roman_swords"),
+                                Troop::Swordsman,
+                                1,
+                                2,
+                                {-5.0F, 0.0F, -8.0F},
+                                16,
+                                {10.0F, 0.0F, 0.0F});
+      auto punic_spears = group(QStringLiteral("punic_spears"),
+                                Troop::Spearman,
+                                2,
+                                3,
+                                {-8.0F, 0.0F, 6.0F},
+                                16,
+                                {8.0F, 0.0F, 0.0F});
+      auto punic_swords = group(QStringLiteral("punic_swords"),
+                                Troop::Swordsman,
+                                2,
+                                2,
+                                {-5.0F, 0.0F, 11.0F},
+                                16,
+                                {10.0F, 0.0F, 0.0F});
+      s.groups = {commander, roman_swords, punic_spears, punic_swords};
+      s.steps = {
+          at(0.4F,
+             scene.ranged ? Command::Attack : Command::AttackMove,
+             QStringLiteral("commander"),
+             QStringLiteral("punic_spears")),
+          at(0.4F,
+             Command::AttackMove,
+             QStringLiteral("roman_swords"),
+             QStringLiteral("punic_spears")),
+          at(0.4F,
+             Command::AttackMove,
+             QStringLiteral("punic_spears"),
+             QStringLiteral("commander")),
+          at(0.4F,
+             Command::AttackMove,
+             QStringLiteral("punic_swords"),
+             QStringLiteral("roman_swords")),
+      };
+      for (auto const& name :
+           {QStringLiteral("commander"), QStringLiteral("punic_spears")}) {
+        s.expectations.push_back(expectation(Expect::NoPoseOscillation, name));
+        s.expectations.push_back(expectation(Expect::MovementIsContinuous, name));
+        s.expectations.push_back(expectation(Expect::GroupIsRendered, name));
+      }
+      s.expectations.push_back(
+          expectation(Expect::NoRootTeleport, QStringLiteral("commander")));
+      s.expectations.push_back(expectation(Expect::FrameBudget, {}, {}, 33.34F, 0.25F));
+      s.expectations.push_back(
+          expectation(Expect::GroupExists, QStringLiteral("commander")));
+      s.expectations.push_back(expectation(Expect::AttackHasVisibleContact,
+                                           QStringLiteral("commander"),
+                                           QStringLiteral("punic_spears")));
+      result.push_back(std::move(s));
+    }
+  }
+
+  {
     auto s = definition(QString::fromLatin1(k_sword_duel_id),
                         QStringLiteral("Sword Duel"),
                         QStringLiteral("Baseline reciprocal sword attack flow."),

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -103,6 +103,9 @@ inline constexpr char k_commander_signature_sword_vs_bow_id[] =
     "commander_signature_sword_vs_bow";
 inline constexpr char k_commander_signature_bow_vs_spear_id[] =
     "commander_signature_bow_vs_spear";
+inline constexpr char k_commander_press_sword_id[] = "commander_press_sword";
+inline constexpr char k_commander_press_spear_id[] = "commander_press_spear";
+inline constexpr char k_commander_press_bow_id[] = "commander_press_bow";
 inline constexpr char k_path_bridge_crossing_id[] = "path_bridge_crossing";
 inline constexpr char k_path_uphill_advance_id[] = "path_uphill_advance";
 inline constexpr char k_path_wall_detour_id[] = "path_wall_detour";

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -372,8 +372,8 @@ ArenaViewport::ArenaViewport(Game::Session::SessionContext& session, QWidget* pa
   m_boundary_fog = std::move(rendering.boundary_fog);
   m_ambient_fog = std::move(rendering.ambient_fog);
   m_rain = std::move(rendering.rain);
-  m_camera_service =
-      std::make_unique<Game::Systems::CameraService>(m_session.visibility());
+  m_camera_service = std::make_unique<Game::Systems::CameraService>(
+      m_session.visibility(), m_session.terrain());
   m_picking_service = std::make_unique<Game::Systems::PickingService>();
   m_rpg_commander_controller = std::make_unique<CommanderControlController>();
   m_rpg_telegraphs = std::make_unique<Render::GL::RpgTelegraphRenderer>();


### PR DESCRIPTION
Extend commander combat actions with authored link timing, root motion, and formation-aware contact so chained attacks can carry through the press without being interrupted or shoved away before their safe exit points. Classify each commander strike by form and intensity, and record both swing telegraphs and impact cues with reach, span, and directional data.

Add commander-specific projectile profiles, combat-dust shader branches, render submission data, spark orientation, and OpenGL pipeline support so melee arcs, slams, sweeps, rings, and signature arrows read clearly at battlefield scale. Keep routine and signature ranged attacks visually distinct while preserving the existing projectile flow.

Cover the new behavior with commander duel regressions for swing and impact cues, formation pressure, uninterrupted action links, and commander arrow styling. Add sword, spear, and bow commander press scenarios to the arena catalog and provide terrain-aware camera construction for those views.