### PR TITLE
fix: isolate AI duel state and extend promo watchdog

### DIFF
--- a/app/models/loading_tips.cpp
+++ b/app/models/loading_tips.cpp
@@ -80,7 +80,7 @@ void LoadingTips::load_from_json(const QByteArray& payload) {
 
   const auto entries = document.object().value(QStringLiteral("tips")).toArray();
   m_sources.reserve(static_cast<std::size_t>(entries.size()));
-  for (const auto& entry : entries) {
+  for (const auto entry : entries) {
     const QString text =
         entry.toObject().value(QStringLiteral("text")).toString().trimmed();
     if (!text.isEmpty()) {

--- a/app/world/minimap_manager.cpp
+++ b/app/world/minimap_manager.cpp
@@ -30,10 +30,6 @@ namespace {
   return seed;
 }
 
-[[nodiscard]] auto hash_float(float value) noexcept -> std::uint64_t {
-  return static_cast<std::uint64_t>(std::bit_cast<std::uint32_t>(value));
-}
-
 [[nodiscard]] auto quantize(float value, float scale) noexcept -> std::uint64_t {
   return static_cast<std::uint64_t>(
       static_cast<std::int64_t>(std::lround(value * scale)));

--- a/assets/balance/08_commander_vs_line.json
+++ b/assets/balance/08_commander_vs_line.json
@@ -9,13 +9,23 @@
     "label": "Commander",
     "nation": "roman_republic",
     "stance": "attack",
-    "groups": [{ "troop": "roman_legion_organizer", "count": 1 }]
+    "groups": [
+      {
+        "troop": "roman_legion_organizer",
+        "count": 1
+      }
+    ]
   },
   "side_b": {
     "label": "Legionaries",
     "nation": "roman_republic",
     "stance": "attack",
-    "groups": [{ "troop": "swordsman", "count": 3 }]
+    "groups": [
+      {
+        "troop": "swordsman",
+        "count": 4
+      }
+    ]
   },
   "expect": {
     "max_timeout_rate": 0.35

--- a/assets/data/nations/carthage.json
+++ b/assets/data/nations/carthage.json
@@ -433,7 +433,7 @@
       "id": "carthage_spear_commander",
       "display_name": "Hanno the Great",
       "production": {
-        "cost": 193,
+        "cost": 241,
         "build_time": 31.0,
         "priority": 20,
         "is_melee": true
@@ -467,7 +467,7 @@
       "id": "carthage_bow_commander",
       "display_name": "Hasdrubal Barca",
       "production": {
-        "cost": 175,
+        "cost": 219,
         "build_time": 28.0,
         "priority": 20,
         "is_melee": false
@@ -501,7 +501,7 @@
       "id": "carthage_sword_commander",
       "display_name": "Hannibal Barca",
       "production": {
-        "cost": 215,
+        "cost": 268,
         "build_time": 34.0,
         "priority": 20,
         "is_melee": true

--- a/assets/data/nations/roman_republic.json
+++ b/assets/data/nations/roman_republic.json
@@ -390,7 +390,7 @@
       "id": "roman_legion_organizer",
       "display_name": "Quintus Fabius Maximus",
       "production": {
-        "cost": 170,
+        "cost": 212,
         "build_time": 30.0,
         "priority": 20,
         "is_melee": true
@@ -424,7 +424,7 @@
       "id": "roman_veteran_consul",
       "display_name": "Publius Cornelius Scipio",
       "production": {
-        "cost": 180,
+        "cost": 225,
         "build_time": 31.0,
         "priority": 20,
         "is_melee": true
@@ -458,7 +458,7 @@
       "id": "roman_field_commander",
       "display_name": "Marcus Claudius Marcellus",
       "production": {
-        "cost": 160,
+        "cost": 200,
         "build_time": 27.0,
         "priority": 20,
         "is_melee": false

--- a/assets/shaders/cursed_gold_vein_instanced.frag
+++ b/assets/shaders/cursed_gold_vein_instanced.frag
@@ -36,7 +36,6 @@ void main() {
 
   vec3 p = v_local_pos * 1.15;
 
-  // --- rock -----------------------------------------------------------------
   float rock_large = fbm(p * 1.5 + vec3(2.0, 5.0, 1.0));
   float rock_grain = fbm(p * 8.2 + vec3(1.0, 9.0, 3.0));
   float rust = fbm(p * 3.1 + vec3(v_seed * 5.0, 0.0, 2.0));
@@ -48,7 +47,6 @@ void main() {
   rock_color *= mix(0.70, 1.12, rock_grain);
   rock_color = mix(rock_color, soot, rock_large * 0.22);
 
-  // Fractured faces: darken thin bands so the slabs read as split stone.
   float side_face = 1.0 - abs(N.y);
   float crack_a = 1.0 - smoothstep(0.0, 0.05, abs(fract(v_local_pos.y * 3.4) - 0.5));
   float crack_b =
@@ -58,17 +56,12 @@ void main() {
   float cracks = max(crack_a, crack_b) * side_face;
   rock_color *= 1.0 - cracks * 0.22;
 
-  // --- ore seam threaded through the rock ------------------------------------
   float seam_field = fbm(p * 2.6 + vec3(v_seed * 3.0, 1.0, 7.0));
   float seam = 1.0 - smoothstep(0.0, 0.03, abs(seam_field - 0.5));
   float fine_vein =
       1.0 - smoothstep(0.0, 0.02, abs(fbm(p * 6.0 + vec3(4.0, v_seed, 2.0)) - 0.5));
   float ore = max(seam, fine_vein * 0.5) * smoothstep(0.02, 0.20, v_local_pos.y);
 
-  // --- gold crystals ---------------------------------------------------------
-  // Rock parts stay below y = 0.70 in model space; the spires and shards that
-  // grow out of the crag rise above it. The small crystals on the outlying rocks
-  // are keyed by their footprint: far from the centre and raised off the slab.
   float crystal = smoothstep(0.62, 0.72, v_local_pos.y);
   float outlying = smoothstep(0.26, 0.32, v_local_pos.y) *
                    smoothstep(0.66, 0.72, length(v_local_pos.xz));
@@ -81,7 +74,6 @@ void main() {
 
   vec3 base_color = mix(rock_color, gold, max(crystal, ore * 0.45));
 
-  // --- lighting --------------------------------------------------------------
   vec3 sun_color = environment_primary_color() * environment_primary_intensity();
   vec3 sky_color = environment_sky_color();
 
@@ -100,7 +92,6 @@ void main() {
   color += sun_color * specular * ao * mix(vec3(1.0), gold_bright, metal);
   color += sky_color * fresnel * 0.08;
 
-  // --- the curse: a slow blood-red pulse crawling through the seam -------------
   float strength = max(u_magic_strength, 0.0);
   float pulse = 0.55 + 0.45 * sin(u_time * 1.6 + v_seed * 6.28318 +
                                   fbm(p * 1.3 + vec3(u_time * 0.22)) * 5.2);
@@ -110,7 +101,7 @@ void main() {
                smoothstep(0.50, 0.80, v_local_pos.y);
   color += mix(ember, curse, pulse) * strength *
            (ore * (0.30 + 0.30 * pulse) + core * 0.30 * pulse);
-  // Crystals are lit from within so their shaded faces still read as gold.
+
   color += gold * crystal * (0.22 + 0.06 * pulse);
   color += gold_bright * strength * crystal * (0.10 + 0.10 * pulse) * fresnel;
 

--- a/assets/shaders/cursed_gold_vein_instanced.vert
+++ b/assets/shaders/cursed_gold_vein_instanced.vert
@@ -34,7 +34,7 @@ void main() {
   v_normal = normalize(vec3(rotated_normal_xz.x, a_normal.y, rotated_normal_xz.y));
 
   v_color = a_color_rot.rgb;
-  // Unscaled: the fragment shader keys rock/crystal on model-space height.
+
   v_local_pos = a_pos;
 
   v_seed = soi_hash13_1c8396(world_origin * 0.173 + vec3(rotation, scale, 0.91));

--- a/game/audio/audio_cues.cpp
+++ b/game/audio/audio_cues.cpp
@@ -134,6 +134,12 @@ auto CueRegistry::play(const std::string& cue_id, float volume_scale) -> bool {
     }
 
     m_last_played[cue_id] = now;
+    static const bool trace = !qEnvironmentVariableIsEmpty("SOI_AUDIO_TRACE");
+    if (trace) {
+      qInfo().noquote() << QStringLiteral("audio cue %1 -> %2")
+                               .arg(QString::fromStdString(cue_id),
+                                    QString::fromStdString(resource_id));
+    }
     m_last_resource[cue_id] = resource_id;
   }
 

--- a/game/audio/audio_system.cpp
+++ b/game/audio/audio_system.cpp
@@ -72,6 +72,14 @@ auto AudioSystem::initialize() -> bool {
   return true;
 }
 
+void AudioSystem::render_offline(float* interleaved_stereo, unsigned frames) {
+  if (m_music_player == nullptr) {
+    std::fill_n(interleaved_stereo, static_cast<std::size_t>(frames) * 2U, 0.0F);
+    return;
+  }
+  m_music_player->render_offline(interleaved_stereo, frames);
+}
+
 void AudioSystem::shutdown() {
   if (!is_running) {
     return;

--- a/game/audio/audio_system.h
+++ b/game/audio/audio_system.h
@@ -122,6 +122,7 @@ public:
 
   void set_max_channels(size_t max_channels);
   auto get_active_channel_count() const -> size_t;
+  void render_offline(float* interleaved_stereo, unsigned frames);
 
   auto get_master_volume() const -> float { return master_volume; }
   auto get_sound_volume() const -> float { return sound_volume; }

--- a/game/audio/miniaudio_backend.cpp
+++ b/game/audio/miniaudio_backend.cpp
@@ -699,6 +699,9 @@ auto MiniaudioBackend::channel_playing(int channel) const -> bool {
 }
 
 void MiniaudioBackend::play_sound(const QString& id, float volume, bool loop) {
+  if (m_offline_render && is_track_decode_pending(id)) {
+    wait_for_track(id);
+  }
   const int slot = find_track_slot(id);
   if (slot < 0 || m_track_table[slot].load(std::memory_order_acquire) == nullptr) {
     if (is_track_decode_pending(id)) {

--- a/game/audio/miniaudio_backend.h
+++ b/game/audio/miniaudio_backend.h
@@ -77,6 +77,7 @@ public:
   auto is_track_decode_pending(const QString& id) const -> bool;
 
   void on_audio(float* output, unsigned frames);
+  void set_offline_render(bool enabled) { m_offline_render = enabled; }
 
 private:
   struct DecodedTrack {
@@ -176,6 +177,7 @@ private:
   };
   mutable QMutex m_analysis_cache_mutex;
   QHash<QString, CachedAnalysis> m_analysis_cache;
+  bool m_offline_render{false};
   std::atomic<std::uint64_t> m_analyses_computed{0};
 
   std::thread m_decode_thread;

--- a/game/audio/music_player.cpp
+++ b/game/audio/music_player.cpp
@@ -38,6 +38,15 @@ static auto sanitize_music_volume(float volume) -> float {
   return std::clamp(volume, MiniaudioBackend::MIN_VOLUME, MiniaudioBackend::MAX_VOLUME);
 }
 
+void MusicPlayer::render_offline(float* interleaved_stereo, unsigned frames) {
+  if (!m_initialized || m_backend == nullptr) {
+    std::fill_n(interleaved_stereo, static_cast<std::size_t>(frames) * 2U, 0.0F);
+    return;
+  }
+  m_backend->wait_for_decodes();
+  m_backend->on_audio(interleaved_stereo, frames);
+}
+
 auto MusicPlayer::get_instance() -> MusicPlayer& {
   static MusicPlayer instance;
   return instance;
@@ -64,9 +73,12 @@ auto MusicPlayer::initialize(int music_channels) -> bool {
 
   m_channel_count = std::max(min_channels, music_channels);
   m_backend = new MiniaudioBackend(this);
+  const bool open_device = !qEnvironmentVariableIsSet("SOI_AUDIO_OFFLINE");
+  m_backend->set_offline_render(!open_device);
   if (!m_backend->initialize(AudioConstants::DEFAULT_SAMPLE_RATE,
                              AudioConstants::DEFAULT_OUTPUT_CHANNELS,
-                             m_channel_count)) {
+                             m_channel_count,
+                             open_device)) {
     qWarning() << "MusicPlayer: backend init failed";
     m_backend->deleteLater();
     m_backend = nullptr;

--- a/game/audio/music_player.h
+++ b/game/audio/music_player.h
@@ -55,6 +55,7 @@ public:
   auto is_playing(int channel) const -> bool;
 
   auto get_backend() -> MiniaudioBackend* { return m_backend.data(); }
+  void render_offline(float* interleaved_stereo, unsigned frames);
 
 private:
   explicit MusicPlayer();

--- a/game/core/event_manager.h
+++ b/game/core/event_manager.h
@@ -22,6 +22,11 @@ namespace Engine::Core {
 
 class Event {
 public:
+  Event() = default;
+  Event(const Event&) = default;
+  Event(Event&&) = default;
+  auto operator=(const Event&) -> Event& = default;
+  auto operator=(Event&&) -> Event& = default;
   virtual ~Event() = default;
   [[nodiscard]] virtual auto get_type_name() const -> const char* { return "Event"; }
 };

--- a/game/core/world.cpp
+++ b/game/core/world.cpp
@@ -45,7 +45,6 @@ void World::set_entity_destroyed_hook(EntityDestroyedHook hook) {
 
 namespace {
 
-constexpr float k_motion_displacement_epsilon_sq = 1.0e-6F;
 constexpr float k_motion_velocity_epsilon_sq = 1.0e-4F;
 constexpr float k_motion_stall_speed = 0.15F;
 

--- a/game/map/terrain_service.cpp
+++ b/game/map/terrain_service.cpp
@@ -387,12 +387,7 @@ void TerrainService::initialize(const MapDefinition& map_def) {
   m_authored_world_props = map_def.world_props;
   normalize_world_props(m_authored_world_props);
   register_authored_building_obstacles(map_def);
-  // The procedural pass clears each candidate site against the *live* world
-  // props, through the shared clearance index. Publishing this map's authored
-  // props first is what the pass is meant to be measured against; leaving the
-  // previous map's in place instead measured it against a world it is not
-  // being generated for, and on a same-sized map that rejected nearly every
-  // site -- the second map loaded in a process came up with no scatter at all.
+
   m_world_props = m_authored_world_props;
   bump_world_props_revision();
   m_world_props = build_runtime_world_props(

--- a/game/render_bridge/minimap/minimap_generator.cpp
+++ b/game/render_bridge/minimap/minimap_generator.cpp
@@ -53,9 +53,7 @@ constexpr QColor ROAD_HIGHLIGHT{166, 132, 82};
 constexpr QColor STRUCTURE_STONE{110, 95, 75};
 constexpr QColor STRUCTURE_SHADOW{62, 44, 28};
 
-constexpr QColor TEAM_BLUE{42, 88, 205};
 constexpr QColor TEAM_BLUE_DARK{18, 45, 122};
-constexpr QColor TEAM_RED{218, 38, 28};
 constexpr QColor TEAM_RED_DARK{130, 16, 12};
 
 } // namespace Palette

--- a/game/systems/ai_system/ai_attack_wave.cpp
+++ b/game/systems/ai_system/ai_attack_wave.cpp
@@ -202,7 +202,9 @@ auto garrison_target_for(const AIContext& context,
   const int wanted = std::max(minimum, by_fraction);
 
   const int ceiling = std::max(0, combat_unit_count - std::max(1, keep_free));
-  return std::clamp(wanted, 0, ceiling);
+
+  const int floor_units = std::min(minimum, std::max(0, combat_unit_count - 1));
+  return std::clamp(wanted, 0, std::max(ceiling, floor_units));
 }
 
 void update_attack_wave(const AISnapshot& snapshot, AIContext& context) {

--- a/game/systems/ai_system/ai_doctrine_catalog.cpp
+++ b/game/systems/ai_system/ai_doctrine_catalog.cpp
@@ -113,7 +113,7 @@ void parse_town_plans(const QJsonObject& root,
       qCWarning(logger) << "town plan" << it.key() << "has no 'steps' array; skipped";
       continue;
     }
-    for (const auto& step_value : steps.toArray()) {
+    for (const auto step_value : steps.toArray()) {
       if (!step_value.isObject()) {
         continue;
       }
@@ -189,7 +189,7 @@ void parse_doctrine_body(const QJsonObject& object,
     if (const auto preferred = recruitment_object.value(QLatin1String("preferred"));
         preferred.isArray()) {
       doctrine.recruitment.preferred.clear();
-      for (const auto& entry : preferred.toArray()) {
+      for (const auto entry : preferred.toArray()) {
         if (entry.isString()) {
           doctrine.recruitment.preferred.push_back(entry.toString().toStdString());
         }
@@ -213,7 +213,7 @@ void parse_doctrine_body(const QJsonObject& object,
     if (const auto priority = wave_object.value(QLatin1String("target_priority"));
         priority.isArray()) {
       std::vector<DoctrineTarget> parsed;
-      for (const auto& entry : priority.toArray()) {
+      for (const auto entry : priority.toArray()) {
         DoctrineTarget target{};
         if (entry.isString() && parse_target(entry.toString(), target)) {
           parsed.push_back(target);

--- a/game/systems/ai_system/behaviors/builder_behavior.cpp
+++ b/game/systems/ai_system/behaviors/builder_behavior.cpp
@@ -1291,12 +1291,6 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
     }
   };
 
-  // A camp with no field and nothing left to eat breaks ground on one before it
-  // lays the next authored step. A town plan is a camp layout and no shipped
-  // plan carries a field -- a farm's own footprint is wider than the camp -- so
-  // while the plan still had a tower or a wall to offer, that step outranked the
-  // field every tick and the barracks starved. Housing still comes first: homes
-  // are the manpower the field is there to feed.
   const bool field_before_plan =
       needs_a_field && starving &&
       (!has_plan_step || (planned.building != BUILDING_TYPE_FARM &&

--- a/game/systems/body_contact_system.cpp
+++ b/game/systems/body_contact_system.cpp
@@ -23,7 +23,21 @@ struct ContactBody {
   float radius{0.0F};
   BodyProfile profile;
   bool movable{false};
+  Engine::Core::EntityID melee_intent{0};
 };
+
+auto melee_intent_of(const Engine::Core::Entity& entity) -> Engine::Core::EntityID {
+  const auto* attack = entity.get_component<Engine::Core::AttackComponent>();
+  if (attack == nullptr ||
+      attack->current_mode != Engine::Core::AttackComponent::CombatMode::Melee) {
+    return 0;
+  }
+  if (attack->in_melee_lock && attack->melee_lock_target_id != 0) {
+    return attack->melee_lock_target_id;
+  }
+  const auto* target = entity.get_component<Engine::Core::AttackTargetComponent>();
+  return target != nullptr ? target->target_id : 0;
+}
 
 auto body_is_movable(const Engine::Core::Entity& entity,
                      const Engine::Core::MovementFactsComponent* facts) -> bool {
@@ -108,6 +122,7 @@ void BodyContactSystem::run(Engine::Core::SystemContext& context) {
     body.radius = CommandService::get_unit_radii(world, entry.id).core;
     body.profile = profile_for(*entity);
     body.movable = body_is_movable(*entity, body.facts);
+    body.melee_intent = melee_intent_of(*entity);
     widest_radius = std::max(widest_radius, body.radius);
   }
 
@@ -148,6 +163,10 @@ void BodyContactSystem::run(Engine::Core::SystemContext& context) {
           float pz = me.transform->position.z - them.transform->position.z;
           float distance = std::hypot(px, pz);
           if (distance >= combined) {
+            return;
+          }
+          const Engine::Core::EntityID them_id = other.id;
+          if (me.melee_intent == them_id || them.melee_intent == me_id) {
             return;
           }
 
@@ -196,6 +215,7 @@ auto BodyContactSystem::access() const -> Engine::Core::SystemAccess {
   return SystemAccess::declare(Reads<UnitComponent,
                                      BuildingComponent,
                                      AttackComponent,
+                                     AttackTargetComponent,
                                      HoldModeComponent,
                                      MovementComponent,
                                      PendingRemovalComponent>{},

--- a/game/systems/combat_system/attack_processor.cpp
+++ b/game/systems/combat_system/attack_processor.cpp
@@ -1357,6 +1357,7 @@ auto resolve_melee_swing_cadence(Engine::Core::Entity* attacker,
   auto const* definition = Game::Systems::CombatActions::find_combat_action_definition(
       static_cast<Game::Systems::CombatActions::CombatActionId>(
           action->combat_action_id));
+  float link_length = 0.0F;
   if (commander != nullptr && !commander->fpv_controlled &&
       commander->advanced_combat_enabled && definition != nullptr &&
       definition->commander_only) {
@@ -1364,8 +1365,7 @@ auto resolve_melee_swing_cadence(Engine::Core::Entity* attacker,
         *definition,
         Game::Systems::CombatActions::CombatActionEventType::ExitSafe,
         0.92F);
-    float const link_length = std::max(0.05F, action->action_duration * exit_safe);
-    return cooldown - std::max(cooldown, link_length);
+    link_length = std::max(0.05F, action->action_duration * exit_safe);
   }
 
   auto const next_beat = resolve_melee_exchange_beat(
@@ -1375,7 +1375,7 @@ auto resolve_melee_swing_cadence(Engine::Core::Entity* attacker,
       true);
   float const interval = cooldown * next_beat.interval_weight;
   float const delay = base_delay * next_beat.delay_weight;
-  return cooldown - interval - delay;
+  return cooldown - std::max(interval + delay, link_length);
 }
 
 void begin_rts_bow_action(Engine::Core::World& world,

--- a/game/systems/combat_system/combat_action_processor.cpp
+++ b/game/systems/combat_system/combat_action_processor.cpp
@@ -390,6 +390,7 @@ auto commander_strike_intensity(
   case CommanderActionRole::Aerial:
     return 0.85F;
   case CommanderActionRole::Routine:
+  case CommanderActionRole::Special:
     return 0.70F;
   }
   return 0.70F;

--- a/game/systems/cursed_gold_vein_system.cpp
+++ b/game/systems/cursed_gold_vein_system.cpp
@@ -129,13 +129,12 @@ void CursedGoldVeinSystem::refresh_anchor(Engine::Core::World& world,
   }
   auto* unit = world.try_get<Engine::Core::UnitComponent>(vein.anchor_entity_id);
   if (unit == nullptr || unit->health <= 0) {
-    // A razed claim is inert for the rest of the match: the gold is buried again.
+
     vein.destroyed = true;
     vein.owner_id = Game::Core::NEUTRAL_OWNER_ID;
     return;
   }
 
-  // Capture hands a barracks a production line; a vein must never train anything.
   world.remove<Engine::Core::ProductionComponent>(vein.anchor_entity_id);
 
   if (unit->owner_id != vein.owner_id) {
@@ -167,8 +166,6 @@ void CursedGoldVeinSystem::apply_tick(Engine::Core::World& world, RuntimeVein& v
                             ResourceType::Gold,
                             k_cursed_gold_vein_gold_per_tick);
 
-  // The curse: every one of the owner's troops standing near the vein loses
-  // manpower. Buildings and other owners' troops are untouched.
   std::vector<Engine::Core::EntityID> victims;
   auto& index = world.spatial_index();
   index.refresh(world);

--- a/game/systems/cursed_gold_vein_system.h
+++ b/game/systems/cursed_gold_vein_system.h
@@ -31,18 +31,11 @@ namespace Game::Systems {
 class OwnerRegistry;
 class PlayerResourceRegistry;
 
-// Tuning for the cursed gold vein. Every vein ticks on the same cadence: each tick
-// pays its owner gold and bleeds every one of the owner's troops standing near it.
 inline constexpr float k_cursed_gold_vein_tick_seconds = 6.0F;
 inline constexpr int k_cursed_gold_vein_gold_per_tick = 25;
 inline constexpr int k_cursed_gold_vein_curse_damage = 10;
 inline constexpr float k_cursed_gold_vein_curse_radius = 9.0F;
 
-// A cursed gold vein is an authored `cursed_gold_vein` world prop. At level start the
-// system raises a neutral, non-producing Barracks anchor on the prop so the ordinary
-// capture rules (and the claim flag) apply. A neutral vein does nothing. Once a
-// player holds it, the vein pays gold every tick and, in the same tick, damages the
-// owner's troops within `k_cursed_gold_vein_curse_radius` of it.
 class CursedGoldVeinSystem : public Engine::Core::System {
 public:
   struct Services {

--- a/game/systems/formation_combat_geometry.cpp
+++ b/game/systems/formation_combat_geometry.cpp
@@ -1077,13 +1077,6 @@ auto contact_is_active(const Engine::Core::Entity& attacker,
         geometry.contact_center_distance <= k_contact_numeric_epsilon &&
         geometry.center_distance <= melee_reach(attacker) + k_contact_numeric_epsilon;
 
-    // The two bodies are as close as they are ever going to get.
-    // `deep_front_rank_overlap` asks the centres to all but coincide, which
-    // BodyContactSystem will not allow: two even infantry blocks shove at about
-    // a metre while that threshold sits near a third of it, so neither side
-    // ever engaged and every straight infantry fight ran to the clock. A touch
-    // short of the bodies meeting is still not contact -- that is what the
-    // charge lock is for.
     bool const bodies_are_in_contact =
         geometry.body_contact_center_distance > k_contact_numeric_epsilon &&
         geometry.center_distance <=
@@ -1215,6 +1208,12 @@ auto select_damage_engagement_pair(
     --selected_index;
   }
   return std::nullopt;
+}
+
+void invalidate_layout_cache() {
+  g_layout_cache.clear();
+  ++g_layout_cache_generation;
+  g_spatial_layout_cache.clear();
 }
 
 } // namespace Game::Systems::FormationCombat

--- a/game/systems/formation_combat_geometry.h
+++ b/game/systems/formation_combat_geometry.h
@@ -14,9 +14,6 @@ struct TroopProfile;
 
 namespace Game::Systems::FormationCombat {
 
-// Floor on a unit body's core radius. BodyContactSystem separates unit cores,
-// so twice this is the closest two blocks will ever stand; CommandService reads
-// the same number when it answers for a unit's radii.
 inline constexpr float k_body_core_radius_floor = 0.5F;
 
 struct SoldierSlot {
@@ -79,10 +76,7 @@ struct ContactGeometry {
   float contact_center_distance{0.0F};
 
   float engagement_center_distance{0.0F};
-  // Centre separation at which the two unit bodies touch, which is as close as
-  // BodyContactSystem will ever let them stand. `engagement_center_distance`
-  // asks the centres to all but coincide, and two bodies cannot reach that, so
-  // on its own it leaves blocks shoving in front of one another forever.
+
   float body_contact_center_distance{0.0F};
   float contact_tolerance{0.0F};
   bool uses_formation_slots{false};
@@ -170,5 +164,7 @@ engaged_soldiers(const Engine::Core::Entity& attacker,
 [[nodiscard]] auto has_formation_slots(const Engine::Core::Entity& entity) -> bool;
 
 [[nodiscard]] auto max_contact_extent() -> float;
+
+void invalidate_layout_cache();
 
 } // namespace Game::Systems::FormationCombat

--- a/game/systems/pathfinding.cpp
+++ b/game/systems/pathfinding.cpp
@@ -1406,11 +1406,6 @@ auto Pathfinding::search_buffers_for(const Pathfinding* pathfinding) -> SearchBu
   return search_buffers_by_grid()[pathfinding];
 }
 
-// The buffers are keyed by instance address, and a grid rebuilt for the next
-// match is routinely allocated exactly where the last one stood, so a fresh
-// grid would otherwise inherit the previous one's generation counters and
-// half-finished search state. Dropping the entry with the grid keeps the two
-// apart.
 void Pathfinding::release_search_buffers(const Pathfinding* pathfinding) {
   search_buffers_by_grid().erase(pathfinding);
 }

--- a/game/visuals/building_asset_key.h
+++ b/game/visuals/building_asset_key.h
@@ -7,9 +7,6 @@
 
 namespace Game::Visuals {
 
-// Renderer key stamped on the capture anchor a cursed gold vein raises. The anchor
-// is a Barracks entity, but it must draw only a claim flag beside the vein prop, so
-// it bypasses the nation-variant barracks renderers.
 inline constexpr std::string_view k_cursed_gold_vein_flag_asset_key =
     "troops/cursed_gold_vein/barracks";
 

--- a/render/entity/cursed_gold_vein_flag_renderer.cpp
+++ b/render/entity/cursed_gold_vein_flag_renderer.cpp
@@ -34,8 +34,6 @@ void draw_claim_flag(const DrawContext& p,
   const VeinFlagPalette palette;
   const QVector3D team_trim = team * 0.5F + palette.tarnished_gold * 0.5F;
 
-  // A mine-claim marker: a crooked pit-prop pole with a narrow pennon, capped by
-  // a nugget of ore. It stands off the crag so the crystals stay readable.
   BarracksFlagRenderer::draw_hanging_banner(
       p,
       out,

--- a/render/entity/cursed_gold_vein_flag_renderer.h
+++ b/render/entity/cursed_gold_vein_flag_renderer.h
@@ -8,8 +8,6 @@ namespace Render::GL {
 
 class EntityRendererRegistry;
 
-// The capture anchor a cursed gold vein spawns is a Barracks entity that draws only
-// a claim flag beside the vein prop; the game layer stamps this key on it.
 inline constexpr std::string_view k_cursed_gold_vein_flag_renderer_key =
     Game::Visuals::k_cursed_gold_vein_flag_asset_key;
 

--- a/render/gl/backend/cursed_gold_vein_parts.h
+++ b/render/gl/backend/cursed_gold_vein_parts.h
@@ -4,9 +4,6 @@
 
 #include "render/gl/backend/prop_parts.h"
 
-// A cursed gold vein is a low crag of dark rock split open by a seam of ore, with
-// gold crystals growing out of the crack. Rock parts stay below y = 0.70 so the
-// fragment shader can key the crystal shading on height; the crystals rise above.
 namespace Render::GL::BackendPipelines::CursedGoldVeinParts {
 
 inline constexpr std::array<PropBoxPart, 2> k_cursed_gold_vein_boxes{{
@@ -24,9 +21,6 @@ inline constexpr std::array<PropVertPrismPart, 7> k_cursed_gold_vein_prisms{{
     {-0.64F, 0.16F, -0.62F, 0.055F, 0.22F, 5},
 }};
 
-// The crag is three rock slabs stacked at different yaws (a -> b runs along
-// each slab, half_width is its breadth, half_depth its thickness), plus two
-// outlying rocks; the last six entries are the gold shards leaning out of it.
 inline constexpr std::array<PropOrientedBoxPart, 11> k_cursed_gold_vein_oriented_boxes{{
     {{-0.56F, 0.16F, -0.26F}, {0.48F, 0.20F, 0.40F}, 0.32F, 0.11F},
     {{-0.40F, 0.36F, 0.30F}, {0.45F, 0.40F, -0.35F}, 0.28F, 0.10F},

--- a/render/gl/backend/vegetation_pipeline_settlement.cpp
+++ b/render/gl/backend/vegetation_pipeline_settlement.cpp
@@ -775,9 +775,6 @@ void VegetationPipeline::initialize_cursed_gold_vein_pipeline() {
   append_parts(verts, idx, std::span{k_cursed_gold_vein_prisms});
   append_parts(verts, idx, std::span{k_cursed_gold_vein_oriented_boxes});
 
-  // Loose nuggets spilled around the crag: small tilted chips of ore lying on the
-  // base slabs. They keep the silhouette busy near the ground so the vein does not
-  // read as a lone pillar at battle zoom.
   for (int i = 0; i < 10; ++i) {
     float const angle = static_cast<float>(i) * 0.6283185F + 0.35F;
     float const radius = (i % 2 == 0) ? 0.62F : 0.78F;

--- a/render/ground/cursed_gold_vein_renderer.cpp
+++ b/render/ground/cursed_gold_vein_renderer.cpp
@@ -16,7 +16,6 @@ namespace {
 
 using namespace Render::Ground;
 
-// Dark, iron-stained rock. The gold and the curse glow come from the shader.
 constexpr float k_base_color_r = 0.24F;
 constexpr float k_base_color_g = 0.21F;
 constexpr float k_base_color_b = 0.18F;
@@ -49,8 +48,6 @@ void CursedGoldVeinRenderer::submit(Renderer& renderer, ResourceManager* resourc
     return;
   }
 
-  // A low, warm ore-light with a slow uneasy flicker: the vein is lit from within,
-  // unlike the shrine's cool steady votive glow.
   for (const auto& inst : m_state.visible_instances) {
     const QVector3D vein_pos = inst.pos_scale.toVector3D();
     const float scale = std::max(inst.pos_scale.w(), 0.1F);

--- a/render/ground/map_boundary_fog_renderer.cpp
+++ b/render/ground/map_boundary_fog_renderer.cpp
@@ -46,6 +46,17 @@ inline auto smoothstep(float edge0, float edge1, float value) -> float {
   return t * t * (3.0F - 2.0F * t);
 }
 
+constexpr float k_card_camera_clearance = 12.0F;
+
+auto card_engulfs_camera(const QVector3D& card_center,
+                         float card_width,
+                         const QVector3D& camera_position) -> bool {
+  const float dx = camera_position.x() - card_center.x();
+  const float dz = camera_position.z() - card_center.z();
+  const float clearance = card_width * 0.5F + k_card_camera_clearance;
+  return dx * dx + dz * dz < clearance * clearance;
+}
+
 auto boundary_height_at(const Game::Map::TerrainService& terrain_service,
                         float world_x,
                         float world_z) -> float {
@@ -547,7 +558,14 @@ void MapBoundaryFogRenderer::submit(Renderer& renderer, ResourceManager* resourc
     renderer.set_current_shader(gas_shader);
   }
 
+  const Camera* camera = renderer.camera();
+  const QVector3D camera_position =
+      camera != nullptr ? camera->get_position() : QVector3D(0.0F, 0.0F, 0.0F);
+
   for (const BoundaryCard& card : m_cards) {
+    if (card_engulfs_camera(card.center, card.size.x(), camera_position)) {
+      continue;
+    }
     QMatrix4x4 model;
     model.translate(card.center);
     model.rotate(card.yaw_degrees, 0.0F, 1.0F, 0.0F);

--- a/scripts/place-cursed-gold-veins.py
+++ b/scripts/place-cursed-gold-veins.py
@@ -25,9 +25,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 MAPS = REPO / "assets" / "maps"
-SKIPPED = {
-    "map_tutorial.json"
-}  # scripted stages; a neutral capture point would derail them
+SKIPPED = {"map_tutorial.json"}
 
 
 def seg_dist(px, pz, ax, az, bx, bz):
@@ -70,7 +68,7 @@ def vein_count(size):
 
 
 def blockers(d):
-    b = []  # (fn(px,pz)->clearance)
+    b = []
     for r in d.get("rivers", []):
         b.append(
             lambda px, pz, r=r: polyline_dist(px, pz, r) - r.get("width", 6) * 0.5 - 7

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -611,6 +611,7 @@ add_executable(
     tools/arena_unit_spawn_options_test.cpp
     tools/arena_terrain_alignment_test.cpp
     tools/arena_promo_spec_test.cpp
+    tools/arena_video_encoder_test.cpp
     tools/settlement_layout_test.cpp
     tools/sacred_mountain_slope_test.cpp
     test_main.cpp

--- a/tests/headless/ai_duel_match_test.cpp
+++ b/tests/headless/ai_duel_match_test.cpp
@@ -10,7 +10,9 @@
 #include <vector>
 
 #include "game/core/component.h"
+#include "game/core/event_manager.h"
 #include "game/core/world.h"
+#include "game/formation/army_formation_registry.h"
 #include "game/map/map_definition.h"
 #include "game/map/map_transformer.h"
 #include "game/map/terrain_service.h"
@@ -21,6 +23,7 @@
 #include "game/systems/ai_system/ai_strategy.h"
 #include "game/systems/building_collision_registry.h"
 #include "game/systems/default_content.h"
+#include "game/systems/formation_combat_geometry.h"
 #include "game/systems/nation_registry.h"
 #include "game/systems/nav_grid.h"
 #include "game/systems/owner_registry.h"
@@ -79,17 +82,28 @@ struct SideHistory {
 class AiDuelMatchTest : public ::testing::Test {
 protected:
   void SetUp() override {
+    reset_shared_world_state();
     Game::Systems::NavGrid::initialize(k_map_size, k_map_size);
     m_factory = std::make_shared<Game::Units::UnitFactoryRegistry>();
     Game::Units::register_built_in_units(*m_factory);
     Game::Map::MapTransformer::setFactoryRegistry(m_factory);
   }
 
+  static void reset_shared_world_state() {
+    Engine::Core::EventManager::instance().clear_all_subscriptions();
+    Game::Map::TerrainService::instance().clear();
+    Game::Formation::ArmyFormationRegistry::instance().clear();
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Systems::TroopCountRegistry::instance().clear();
+    Game::Systems::PlayerResourceRegistry::instance().clear();
+    Game::Systems::FormationCombat::invalidate_layout_cache();
+  }
+
   void TearDown() override {
     m_scope.reset();
     m_session.reset();
     Game::Map::MapTransformer::setFactoryRegistry(nullptr);
-    Game::Map::TerrainService::instance().clear();
+    reset_shared_world_state();
   }
 
   auto make_duel(Game::Units::SpawnType north_commander,

--- a/tests/map/terrain_service_test.cpp
+++ b/tests/map/terrain_service_test.cpp
@@ -979,12 +979,6 @@ TEST_F(TerrainServiceTest, ProceduralScatterOptOutsSuppressTheirSpecies) {
                count_type(props, Game::Map::WorldProp::Type::OliveTree);
       };
 
-  // The terrain is initialised with procedural scatter switched off, and only
-  // the returned biome carries the species flags back on. SpawnValidator's
-  // world-prop clearance check reads the live TerrainService, so a terrain that
-  // already holds this biome's generated props makes every candidate below
-  // collide with the identical prop the initialise pass put there -- the
-  // generator would be measured against its own output and place nothing.
   const auto build_height_map = [](Game::Map::GroundType ground_type,
                                    Game::Map::BiomeSettings& out_biome) {
     Game::Map::MapDefinition map_def;
@@ -996,6 +990,11 @@ TEST_F(TerrainServiceTest, ProceduralScatterOptOutsSuppressTheirSpecies) {
     map_def.biome.ground_irregularity_enabled = true;
     map_def.biome.irregularity_amplitude =
         std::max(0.65F, map_def.biome.irregularity_amplitude);
+    out_biome = map_def.biome;
+
+    map_def.biome.procedural_boulders_enabled = false;
+    map_def.biome.procedural_iron_ore_enabled = false;
+    map_def.biome.procedural_trees_enabled = false;
 
     out_biome = map_def.biome;
     map_def.biome.procedural_boulders_enabled = false;

--- a/tests/systems/commander_duel_test.cpp
+++ b/tests/systems/commander_duel_test.cpp
@@ -502,12 +502,6 @@ namespace {
 using Engine::Core::CommanderSignaturePresentationComponent;
 using Engine::Core::CommanderStrikeCue;
 
-auto action_definition_of(const RpgCommanderActionComponent& action)
-    -> const Game::Systems::CombatActions::CombatActionDefinition* {
-  return Game::Systems::CombatActions::find_combat_action_definition(
-      static_cast<CombatActionId>(action.combat_action_id));
-}
-
 } // namespace
 
 TEST_F(CommanderDuelTest, EveryCommanderLinkLeavesASwingCueNotOnlyTheSignature) {

--- a/tests/systems/cursed_gold_vein_system_test.cpp
+++ b/tests/systems/cursed_gold_vein_system_test.cpp
@@ -277,8 +277,6 @@ TEST_F(CursedGoldVeinSystemTest, EveryShippedVeinStandsOnClearGround) {
         dir.absoluteFilePath(file_name), map_definition, &error))
         << file_name.toStdString() << ": " << error.toStdString();
 
-    // The clearance check treats every solid prop as a blocker, the vein itself
-    // included, so judge each site against the map with the veins lifted out.
     std::vector<Game::Map::WorldProp> veins;
     Game::Map::MapDefinition without_veins = map_definition;
     without_veins.world_props.clear();

--- a/tests/tools/arena_video_encoder_test.cpp
+++ b/tests/tools/arena_video_encoder_test.cpp
@@ -1,0 +1,49 @@
+#include <QImage>
+#include <QString>
+#include <QTemporaryDir>
+
+#include <algorithm>
+#include <gtest/gtest.h>
+
+#include "tools/arena/video_encoder.h"
+
+namespace {
+
+TEST(ArenaVideoEncoderTest, PendingFramesStayBoundedWithoutAnEventLoop) {
+  using Arena::Promo::VideoEncoder;
+  if (!VideoEncoder::ffmpeg_available()) {
+    GTEST_SKIP() << "ffmpeg is not on PATH";
+  }
+
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  constexpr int k_width = 1280;
+  constexpr int k_height = 720;
+  constexpr int k_frames = 90;
+  const qint64 frame_bytes = static_cast<qint64>(k_width) * k_height * 4;
+  constexpr int k_tolerated_pending_frames = 8;
+  const qint64 cap = frame_bytes * k_tolerated_pending_frames;
+  ASSERT_LE(VideoEncoder::max_pending_frames(), k_tolerated_pending_frames);
+
+  VideoEncoder encoder;
+  QString error;
+  ASSERT_TRUE(encoder.open(
+      dir.filePath(QStringLiteral("bounded.mp4")), k_width, k_height, 60, &error))
+      << error.toStdString();
+
+  QImage frame(k_width, k_height, QImage::Format_RGBA8888);
+  qint64 peak_pending = 0;
+  for (int index = 0; index < k_frames; ++index) {
+    frame.fill(QColor(index * 2 % 255, 90, 40));
+    ASSERT_TRUE(encoder.write_frame(frame, &error)) << error.toStdString();
+    peak_pending = std::max(peak_pending, encoder.pending_bytes());
+    ASSERT_LE(encoder.pending_bytes(), cap)
+        << "frame " << index << " left the ffmpeg pipe buffer unbounded";
+  }
+  EXPECT_LT(peak_pending, frame_bytes * k_frames);
+  ASSERT_TRUE(encoder.close(&error)) << error.toStdString();
+  EXPECT_EQ(encoder.frames_written(), k_frames);
+}
+
+} // namespace

--- a/tests/tools/balance_sim_test.cpp
+++ b/tests/tools/balance_sim_test.cpp
@@ -125,7 +125,7 @@ TEST_F(BalanceSimTest, BracedSpearsBeatAFrontalCavalryCharge) {
 }
 
 TEST_F(BalanceSimTest, CavalryOverrunsExposedArchers) {
-  const auto summary = run(load(QStringLiteral("cavalry_vs_exposed_archers")), 2);
+  const auto summary = run(load(QStringLiteral("cavalry_vs_exposed_archers")), 6);
   EXPECT_GE(summary.a_win_rate, 0.6);
 }
 

--- a/tests/ui/loading_tips_test.cpp
+++ b/tests/ui/loading_tips_test.cpp
@@ -41,7 +41,7 @@ TEST(LoadingTipsTest, ShipsEveryTipTheAssetDeclares) {
 }
 
 TEST(LoadingTipsTest, EveryAuthoredTipDeclaresAKnownTone) {
-  for (const auto& entry : tips_from_disk()) {
+  for (const auto entry : tips_from_disk()) {
     const QJsonObject tip = entry.toObject();
     const QString tone = tip.value(QStringLiteral("tone")).toString();
     EXPECT_TRUE(tone == QStringLiteral("plain") || tone == QStringLiteral("wry"))

--- a/tools/arena/CMakeLists.txt
+++ b/tools/arena/CMakeLists.txt
@@ -16,6 +16,10 @@ add_library(
     # the harness rather than only inside arena_app -- which is what forced
     # tools_tests to compile promo_spec.cpp a second time to reach it.
     promo_spec.cpp
+    # The ffmpeg pipe writer, here for the same reason: arena_tests asserts on
+    # its backpressure, and a second compiled copy could pass while the object
+    # the arena ships is broken.
+    video_encoder.cpp
 )
 target_include_directories(arena_scenario_harness PUBLIC "${CMAKE_SOURCE_DIR}")
 # game_sim, not game_systems: every scenario is scripted, so the harness spawns
@@ -54,7 +58,7 @@ set(ARENA_APP_SOURCES
     terrain_panel.cpp
     prop_panel.cpp
     promo_runner.cpp
-    video_encoder.cpp
+    arena_audio_recorder.cpp
 )
 
 if(QT_VERSION_MAJOR EQUAL 6)

--- a/tools/arena/arena_ai_duel_scenarios.cpp
+++ b/tools/arena/arena_ai_duel_scenarios.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "arena_scenarios.h"
+#include "game/wildlife/wildlife_config.h"
 
 namespace Arena::Scenarios {
 namespace {
@@ -268,6 +269,24 @@ void add_side(ArenaScenarioDefinition& scenario, const DuelSide& side) {
       patch("iron_ore", 5, {34.0F, 0.0F, 13.74F}, {1.2F, 0.0F, 0.0F}, 1.0F));
 }
 
+auto war_of_towns_wildlife() -> Game::Wildlife::WildlifeSettings {
+  Game::Wildlife::WildlifeSettings settings = Game::Wildlife::default_settings();
+  settings.enabled = true;
+  settings.seed = 4133U;
+  settings.wolves.enabled = false;
+  settings.wolves.group_count = 0;
+
+  settings.sheep.enabled = true;
+  settings.sheep.group_count = 2;
+  settings.sheep.group_size_min = 8;
+  settings.sheep.group_size_max = 10;
+  settings.sheep.roam_radius = 9.0F;
+  settings.sheep.spawn_areas = {{-24.0F, 2.0F, 3.0F}, {24.0F, -2.0F, 3.0F}};
+
+  settings.birds = Game::Wildlife::default_bird_config();
+  return settings;
+}
+
 auto duel_definition(const char* id,
                      QString label,
                      QString description,
@@ -482,6 +501,7 @@ auto build_ai_duel_definitions() -> std::vector<ArenaScenarioDefinition> {
         doctrine_expectation(QStringLiteral("hannibal"), "aggressive:field"));
     add_economy_expectations(s, QStringLiteral("scipio"));
     add_economy_expectations(s, QStringLiteral("hannibal"));
+    s.wildlife = war_of_towns_wildlife();
     result.push_back(std::move(s));
   }
 

--- a/tools/arena/arena_audio_recorder.cpp
+++ b/tools/arena/arena_audio_recorder.cpp
@@ -1,0 +1,258 @@
+#include "arena_audio_recorder.h"
+
+#include <QByteArray>
+#include <QDataStream>
+#include <QDebug>
+#include <QFile>
+#include <QFileInfo>
+#include <QProcess>
+#include <QStandardPaths>
+#include <QStringList>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#include "app/audio/audio_coordinator.h"
+#include "app/audio/audio_resource_loader.h"
+#include "game/audio/audio_event_handler.h"
+#include "game/audio/audio_system.h"
+#include "game/core/ambient_session.h"
+#include "game/core/component.h"
+#include "game/core/world.h"
+
+namespace Arena::Promo {
+
+namespace {
+
+constexpr float k_ambient_check_seconds = 2.0F;
+constexpr float k_combat_radius = 15.0F;
+constexpr int k_wav_channels = 2;
+
+} // namespace
+
+AudioRecorder::AudioRecorder() = default;
+
+AudioRecorder::~AudioRecorder() {
+  stop();
+}
+
+auto AudioRecorder::start(Engine::Core::World* world,
+                          Game::Systems::NationRegistry& nations) -> bool {
+  if (m_running || world == nullptr) {
+    return m_running;
+  }
+  qputenv("SOI_AUDIO_OFFLINE", "1");
+  auto& audio = AudioSystem::get_instance();
+  if (!audio.initialize()) {
+    qWarning() << "AudioRecorder: the audio system refused to start offline";
+    return false;
+  }
+  m_world = world;
+  m_handler = std::make_unique<Game::Audio::AudioEventHandler>(world);
+  if (!m_handler->initialize()) {
+    qWarning() << "AudioRecorder: the audio event handler refused to start";
+    m_handler.reset();
+    return false;
+  }
+  m_handler->set_local_owner_id(0);
+  AudioResourceLoader::load_audio_cues();
+  AudioResourceLoader::load_audio_resources(AudioLoadPolicy::Startup);
+  AudioResourceLoader::load_audio_resources(AudioLoadPolicy::Mission);
+  m_coordinator = std::make_unique<AudioCoordinator>(m_handler.get(), nations);
+  m_coordinator->configure_audio_manifest_mappings(0);
+  m_coordinator->apply_mission_ambience(nullptr, QString{}, 0);
+
+  m_ambient_state = Engine::Core::AmbientState::TENSE;
+  Engine::Core::EventManager::instance().publish(Engine::Core::AmbientStateChangedEvent(
+      m_ambient_state, Engine::Core::AmbientState::PEACEFUL));
+  m_ambient_timer = 0.0F;
+  m_sample_carry = 0.0;
+  m_running = true;
+  qInfo() << "AudioRecorder: game audio running offline at" << k_sample_rate << "Hz";
+  return true;
+}
+
+void AudioRecorder::advance(float seconds, bool record) {
+  if (!m_running || seconds <= 0.0F) {
+    return;
+  }
+  update_ambient_state(seconds);
+
+  m_sample_carry += static_cast<double>(seconds) * k_sample_rate;
+  const auto frames = static_cast<unsigned>(std::floor(m_sample_carry));
+  m_sample_carry -= frames;
+  if (frames == 0U) {
+    return;
+  }
+  m_scratch.resize(static_cast<std::size_t>(frames) * k_wav_channels);
+  AudioSystem::get_instance().render_offline(m_scratch.data(), frames);
+  if (record) {
+    m_clip.insert(m_clip.end(), m_scratch.begin(), m_scratch.end());
+  }
+}
+
+void AudioRecorder::begin_clip() {
+  m_clip.clear();
+}
+
+auto AudioRecorder::clip_seconds() const -> float {
+  return static_cast<float>(m_clip.size() / k_wav_channels) /
+         static_cast<float>(k_sample_rate);
+}
+
+auto AudioRecorder::write_clip(const QString& wav_path) -> bool {
+  QFile file(wav_path);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    qWarning() << "AudioRecorder: cannot write" << wav_path;
+    return false;
+  }
+  const auto sample_count = static_cast<quint32>(m_clip.size());
+  const quint32 data_bytes = sample_count * sizeof(qint16);
+  QDataStream out(&file);
+  out.setByteOrder(QDataStream::LittleEndian);
+  out.writeRawData("RIFF", 4);
+  out << static_cast<quint32>(36 + data_bytes);
+  out.writeRawData("WAVE", 4);
+  out.writeRawData("fmt ", 4);
+  out << static_cast<quint32>(16) << static_cast<quint16>(1)
+      << static_cast<quint16>(k_wav_channels) << static_cast<quint32>(k_sample_rate)
+      << static_cast<quint32>(k_sample_rate * k_wav_channels * sizeof(qint16))
+      << static_cast<quint16>(k_wav_channels * sizeof(qint16))
+      << static_cast<quint16>(16);
+  out.writeRawData("data", 4);
+  out << data_bytes;
+  std::vector<qint16> pcm(m_clip.size());
+  for (std::size_t index = 0; index < m_clip.size(); ++index) {
+    const float clamped = std::clamp(m_clip[index], -1.0F, 1.0F);
+    pcm[index] = static_cast<qint16>(std::lround(clamped * 32767.0F));
+  }
+  out.writeRawData(reinterpret_cast<const char*>(pcm.data()),
+                   static_cast<int>(pcm.size() * sizeof(qint16)));
+  return out.status() == QDataStream::Ok;
+}
+
+void AudioRecorder::stop() {
+  if (!m_running) {
+    return;
+  }
+  if (m_coordinator != nullptr) {
+    m_coordinator->stop_mission_ambience();
+  }
+  m_coordinator.reset();
+  if (m_handler != nullptr) {
+    m_handler->shutdown();
+  }
+  m_handler.reset();
+  AudioSystem::get_instance().shutdown();
+  m_world = nullptr;
+  m_running = false;
+}
+
+auto AudioRecorder::mux(const QString& clip_path,
+                        const QString& wav_path,
+                        QString* error) -> bool {
+  const QString ffmpeg = QStandardPaths::findExecutable(QStringLiteral("ffmpeg"));
+  if (ffmpeg.isEmpty()) {
+    if (error != nullptr) {
+      *error = QStringLiteral("ffmpeg was not found on PATH");
+    }
+    return false;
+  }
+  const QString muxed = clip_path + QStringLiteral(".muxed.mp4");
+  const QStringList arguments{
+      QStringLiteral("-hide_banner"), QStringLiteral("-loglevel"),
+      QStringLiteral("error"),        QStringLiteral("-y"),
+      QStringLiteral("-i"),           clip_path,
+      QStringLiteral("-i"),           wav_path,
+      QStringLiteral("-map"),         QStringLiteral("0:v:0"),
+      QStringLiteral("-map"),         QStringLiteral("1:a:0"),
+      QStringLiteral("-c:v"),         QStringLiteral("copy"),
+      QStringLiteral("-c:a"),         QStringLiteral("aac"),
+      QStringLiteral("-b:a"),         QStringLiteral("256k"),
+      QStringLiteral("-shortest"),    QStringLiteral("-movflags"),
+      QStringLiteral("+faststart"),   muxed};
+  const int status = QProcess::execute(ffmpeg, arguments);
+  if (status != 0) {
+    if (error != nullptr) {
+      *error = QStringLiteral("ffmpeg mux exited with status %1").arg(status);
+    }
+    QFile::remove(muxed);
+    return false;
+  }
+  if (!QFile::remove(clip_path) || !QFile::rename(muxed, clip_path)) {
+    if (error != nullptr) {
+      *error =
+          QStringLiteral("could not replace %1 with the muxed clip").arg(clip_path);
+    }
+    return false;
+  }
+  QFile::remove(wav_path);
+  return true;
+}
+
+void AudioRecorder::update_ambient_state(float seconds) {
+  m_ambient_timer += seconds;
+  if (m_ambient_timer < k_ambient_check_seconds) {
+    return;
+  }
+  m_ambient_timer = 0.0F;
+  const auto next = any_side_in_combat() ? Engine::Core::AmbientState::COMBAT
+                                         : Engine::Core::AmbientState::TENSE;
+  if (next == m_ambient_state) {
+    return;
+  }
+  const auto previous = m_ambient_state;
+  m_ambient_state = next;
+  qInfo().noquote() << QStringLiteral("AudioRecorder: ambient state %1 -> %2")
+                           .arg(static_cast<int>(previous))
+                           .arg(static_cast<int>(next));
+  Engine::Core::EventManager::instance().publish(
+      Engine::Core::AmbientStateChangedEvent(next, previous));
+}
+
+auto AudioRecorder::any_side_in_combat() const -> bool {
+  if (m_world == nullptr) {
+    return false;
+  }
+  struct Fighter {
+    int owner;
+    float x;
+    float z;
+  };
+  std::vector<Fighter> fighters;
+  for (const auto entity_id : m_world->entities_with<Engine::Core::UnitComponent>()) {
+    auto* entity = m_world->get_entity(entity_id);
+    auto* unit = entity != nullptr
+                     ? entity->get_component<Engine::Core::UnitComponent>()
+                     : nullptr;
+    auto* transform = entity != nullptr
+                          ? entity->get_component<Engine::Core::TransformComponent>()
+                          : nullptr;
+    if (unit == nullptr || transform == nullptr || unit->health <= 0 ||
+        unit->owner_id <= 0) {
+      continue;
+    }
+    if (entity->has_component<Engine::Core::AttackTargetComponent>() &&
+        !entity->has_component<Engine::Core::BuildingComponent>()) {
+      return true;
+    }
+    fighters.push_back({unit->owner_id, transform->position.x, transform->position.z});
+  }
+  const float radius_sq = k_combat_radius * k_combat_radius;
+  for (const auto& a : fighters) {
+    for (const auto& b : fighters) {
+      if (a.owner == b.owner) {
+        continue;
+      }
+      const float dx = a.x - b.x;
+      const float dz = a.z - b.z;
+      if (dx * dx + dz * dz < radius_sq) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+} // namespace Arena::Promo

--- a/tools/arena/arena_audio_recorder.h
+++ b/tools/arena/arena_audio_recorder.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <QString>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "game/core/event_manager.h"
+
+namespace Engine::Core {
+class World;
+}
+namespace Game::Audio {
+class AudioEventHandler;
+}
+namespace Game::Systems {
+class NationRegistry;
+}
+class AudioCoordinator;
+
+namespace Arena::Promo {
+
+class AudioRecorder {
+public:
+  static constexpr int k_sample_rate = 48000;
+
+  AudioRecorder();
+  ~AudioRecorder();
+
+  AudioRecorder(const AudioRecorder&) = delete;
+  auto operator=(const AudioRecorder&) -> AudioRecorder& = delete;
+
+  [[nodiscard]] auto start(Engine::Core::World* world,
+                           Game::Systems::NationRegistry& nations) -> bool;
+
+  void advance(float seconds, bool record);
+
+  void begin_clip();
+  [[nodiscard]] auto write_clip(const QString& wav_path) -> bool;
+  [[nodiscard]] auto clip_seconds() const -> float;
+
+  void stop();
+
+  [[nodiscard]] static auto
+  mux(const QString& clip_path, const QString& wav_path, QString* error) -> bool;
+
+private:
+  void update_ambient_state(float seconds);
+  [[nodiscard]] auto any_side_in_combat() const -> bool;
+
+  Engine::Core::World* m_world{nullptr};
+  std::unique_ptr<Game::Audio::AudioEventHandler> m_handler;
+  std::unique_ptr<AudioCoordinator> m_coordinator;
+  Engine::Core::AmbientState m_ambient_state{Engine::Core::AmbientState::PEACEFUL};
+  float m_ambient_timer{0.0F};
+  double m_sample_carry{0.0};
+  std::vector<float> m_scratch;
+  std::vector<float> m_clip;
+  bool m_running{false};
+};
+
+} // namespace Arena::Promo

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -565,6 +565,14 @@ void ArenaViewport::paintGL() {
   Arena::ArenaRenderedFrameTimings timings;
   timings.simulation_ms = elapsed_phase_ms();
 
+  if (m_batch_render_suppressed && sampled_frame && !m_capture_active) {
+    m_renderer->update_animation_time(simulation_dt);
+    if (m_scenario_runner != nullptr) {
+      publish_animation_clock();
+    }
+    return;
+  }
+
   bool const capture_frame = m_capture_active && sampled_frame &&
                              static_cast<bool>(m_capture_sink) &&
                              ensure_capture_target();
@@ -2845,6 +2853,48 @@ void ArenaViewport::update_fog_of_war(float dt) {
       snapshot.width, snapshot.height, snapshot.tile_size, snapshot.cells);
 }
 
+auto ArenaViewport::ai_activity_summary() const -> QString {
+  auto* ai_system =
+      m_world != nullptr ? m_world->get_system<Game::Systems::AISystem>() : nullptr;
+  if (ai_system == nullptr) {
+    return QStringLiteral("no AI system");
+  }
+  QString sides;
+  for (int owner : {2, 3}) {
+    int units = 0;
+    int buildings = 0;
+    for (const auto entity_id : m_world->entities_with<Engine::Core::UnitComponent>()) {
+      auto* entity = m_world->get_entity(entity_id);
+      auto* component = entity != nullptr
+                            ? entity->get_component<Engine::Core::UnitComponent>()
+                            : nullptr;
+      if (component == nullptr || component->owner_id != owner ||
+          component->health <= 0) {
+        continue;
+      }
+      if (entity->get_component<Engine::Core::BuildingComponent>() != nullptr) {
+        ++buildings;
+      } else {
+        ++units;
+      }
+    }
+    sides += QStringLiteral(" owner %1: %2 units %3 buildings;")
+                 .arg(owner)
+                 .arg(units)
+                 .arg(buildings);
+  }
+  return QStringLiteral("ai players %1, decisions %2, commands %3, refused %4;%5")
+      .arg(ai_system->ai_player_count())
+      .arg(ai_system->completed_decision_count())
+      .arg(ai_system->applied_command_count())
+      .arg(ai_system->refused_command_count())
+      .arg(sides);
+}
+
+void ArenaViewport::set_batch_render_suppressed(bool suppressed) {
+  m_batch_render_suppressed = suppressed;
+}
+
 void ArenaViewport::set_batch_fixed_step(float seconds) {
   m_batch_fixed_step = std::max(0.0F, seconds);
 
@@ -3227,6 +3277,107 @@ auto ArenaViewport::scenario_group_center(const QString& group) const
     return std::nullopt;
   }
   return scenario_center(m_world.get(), entities);
+}
+
+namespace {
+
+struct LivingCombatant {
+  int owner{0};
+  bool building{false};
+  QVector3D position;
+};
+
+auto collect_living_combatants(Engine::Core::World& world,
+                               bool include_buildings) -> std::vector<LivingCombatant> {
+  std::vector<LivingCombatant> result;
+  for (const auto entity_id : world.entities_with<Engine::Core::UnitComponent>()) {
+    auto* entity = world.get_entity(entity_id);
+    auto* unit = entity != nullptr
+                     ? entity->get_component<Engine::Core::UnitComponent>()
+                     : nullptr;
+    auto* transform = entity != nullptr
+                          ? entity->get_component<Engine::Core::TransformComponent>()
+                          : nullptr;
+    if (unit == nullptr || transform == nullptr || unit->health <= 0 ||
+        unit->owner_id <= 0) {
+      continue;
+    }
+    const bool building = entity->has_component<Engine::Core::BuildingComponent>();
+    if (building ? !include_buildings
+                 : !Game::Units::can_use_attack_mode(unit->spawn_type)) {
+      continue;
+    }
+    result.push_back({unit->owner_id,
+                      building,
+                      QVector3D(transform->position.x,
+                                transform->position.y,
+                                transform->position.z)});
+  }
+  return result;
+}
+
+auto centroid(const std::vector<QVector3D>& points) -> std::optional<QVector3D> {
+  if (points.empty()) {
+    return std::nullopt;
+  }
+  QVector3D sum;
+  for (const auto& point : points) {
+    sum += point;
+  }
+  return sum / static_cast<float>(points.size());
+}
+
+} // namespace
+
+auto ArenaViewport::scenario_battle_center(
+    int owner_filter, float engagement_radius) const -> std::optional<QVector3D> {
+  if (m_world == nullptr) {
+    return std::nullopt;
+  }
+  const auto combatants = collect_living_combatants(*m_world, true);
+  const float radius_sq = engagement_radius * engagement_radius;
+  std::vector<QVector3D> engaged;
+  for (const auto& unit : combatants) {
+    if (unit.building || (owner_filter > 0 && unit.owner != owner_filter)) {
+      continue;
+    }
+    for (const auto& other : combatants) {
+      if (other.owner == unit.owner) {
+        continue;
+      }
+      if ((other.position - unit.position).lengthSquared() <= radius_sq) {
+        engaged.push_back(unit.position);
+        break;
+      }
+    }
+  }
+  return centroid(engaged);
+}
+
+auto ArenaViewport::scenario_army_center(int owner, float home_radius) const
+    -> std::optional<QVector3D> {
+  if (m_world == nullptr || m_scenario_runner == nullptr) {
+    return std::nullopt;
+  }
+  std::optional<QVector3D> home;
+  for (const auto& side : m_scenario_runner->definition().battle_sides) {
+    if (side.owner_id == owner) {
+      home = side.home;
+      break;
+    }
+  }
+  const float radius_sq = home_radius * home_radius;
+  std::vector<QVector3D> afield;
+  for (const auto& unit : collect_living_combatants(*m_world, false)) {
+    if (unit.owner != owner) {
+      continue;
+    }
+    if (home.has_value() && (unit.position - *home).lengthSquared() < radius_sq) {
+      continue;
+    }
+    afield.push_back(unit.position);
+  }
+  return centroid(afield);
 }
 
 auto ArenaViewport::scenario_center_of_mass() const -> std::optional<QVector3D> {

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -209,6 +209,10 @@ public:
   void set_capture_resolution(int width, int height);
   void set_capture_sink(std::function<void(const QImage&)> sink);
   void set_capture_active(bool active);
+  void set_batch_render_suppressed(bool suppressed);
+  [[nodiscard]] auto ai_activity_summary() const -> QString;
+  [[nodiscard]] auto world() const -> Engine::Core::World* { return m_world.get(); }
+  [[nodiscard]] auto session() -> Game::Session::SessionContext& { return m_session; }
   void set_frame_hook(std::function<void(float)> hook);
 
   void set_flame_card(bool enabled, float speed = 1.0F, float intensity = 1.0F);
@@ -224,6 +228,11 @@ public:
   [[nodiscard]] auto
   scenario_group_center(const QString& group) const -> std::optional<QVector3D>;
   [[nodiscard]] auto scenario_center_of_mass() const -> std::optional<QVector3D>;
+  [[nodiscard]] auto
+  scenario_battle_center(int owner_filter,
+                         float engagement_radius) const -> std::optional<QVector3D>;
+  [[nodiscard]] auto
+  scenario_army_center(int owner, float home_radius) const -> std::optional<QVector3D>;
 
   struct RpgBowHudState {
     bool valid{false};
@@ -505,6 +514,7 @@ private:
   QVector3D m_capture_orbit_center;
   Arena::ArenaCameraView m_capture_orbit_view;
   bool m_batch_frame_in_progress = false;
+  bool m_batch_render_suppressed = false;
   bool m_pan_up_pressed = false;
   bool m_pan_down_pressed = false;
   bool m_pan_left_pressed = false;

--- a/tools/arena/promo_runner.cpp
+++ b/tools/arena/promo_runner.cpp
@@ -23,9 +23,11 @@
 #include <utility>
 #include <vector>
 
+#include "arena_audio_recorder.h"
 #include "arena_scenario.h"
 #include "arena_typography.h"
 #include "arena_viewport.h"
+#include "game/session/session_context.h"
 #include "render/humanoid/runtime/runtime_stats.h"
 #include "video_encoder.h"
 
@@ -34,6 +36,8 @@ namespace {
 
 constexpr float k_scenario_tail_seconds = 2.0F;
 constexpr int k_pass_watchdog_ms = 1'800'000;
+constexpr float k_pass_watchdog_scale = 10.0F;
+constexpr float k_fast_forward_margin_seconds = 3.0F;
 constexpr int k_pass_warmup_frames = 3;
 constexpr int k_first_frame_min_peak = 8;
 constexpr int k_max_black_frames_skipped = 45;
@@ -295,10 +299,20 @@ private:
     m_pass_frames = 0;
     m_viewport.set_terrain_seed(pass.seed);
     m_viewport.set_batch_fixed_step(idle_step());
+    m_viewport.set_batch_render_suppressed(false);
     m_viewport.set_scenario_duration_override(last_end + k_scenario_tail_seconds);
     m_viewport.set_capture_active(false);
     m_viewport.clear_cinematic_view();
     m_viewport.load_scenario(pass.scenario);
+    if (m_spec.audio) {
+      m_audio = std::make_unique<AudioRecorder>();
+      if (!m_audio->start(m_viewport.world(), m_viewport.session().nations())) {
+        qWarning().noquote() << QStringLiteral(
+                                    "Promo pass over '%1' runs without audio")
+                                    .arg(pass.scenario);
+        m_audio.reset();
+      }
+    }
 
     qInfo().noquote() << QStringLiteral("Promo pass %1/%2: %3, %4 shot(s) across "
                                         "%5 s of scenario")
@@ -309,7 +323,10 @@ private:
                              .arg(QString::number(last_end, 'f', 1));
 
     const std::size_t guarded_pass = m_pass_index;
-    QTimer::singleShot(k_pass_watchdog_ms, [this, guarded_pass]() {
+    const int watchdog_ms =
+        std::max(k_pass_watchdog_ms,
+                 static_cast<int>(last_end * 1000.0F * k_pass_watchdog_scale));
+    QTimer::singleShot(watchdog_ms, [this, guarded_pass]() {
       if (m_pass_active && m_pass_index == guarded_pass) {
         qCritical().noquote() << QStringLiteral("Promo pass over scenario '%1' "
                                                 "exceeded its watchdog")
@@ -378,6 +395,27 @@ private:
 
   void on_tick(float scenario_time) {
     ++m_pass_frames;
+    static const bool log_progress =
+        !qEnvironmentVariableIsEmpty("SOI_PROMO_LOG_SIDES");
+    if (log_progress) {
+      const int bucket = static_cast<int>(scenario_time / 15.0F);
+      if (bucket != m_logged_bucket) {
+        m_logged_bucket = bucket;
+        const auto describe = [](const std::optional<QVector3D>& point) {
+          return point.has_value() ? QStringLiteral("(%1, %2)")
+                                         .arg(QString::number(point->x(), 'f', 1),
+                                              QString::number(point->z(), 'f', 1))
+                                   : QStringLiteral("none");
+        };
+        qInfo().noquote()
+            << QStringLiteral("  sides at %1 s: %2 battle %3 army2 %4 army3 %5")
+                   .arg(QString::number(scenario_time, 'f', 1))
+                   .arg(m_viewport.ai_activity_summary())
+                   .arg(describe(m_viewport.scenario_battle_center(0, 30.0F)))
+                   .arg(describe(m_viewport.scenario_army_center(2, 24.0F)))
+                   .arg(describe(m_viewport.scenario_army_center(3, 24.0F)));
+      }
+    }
     if (!m_shot_active) {
       return;
     }
@@ -401,17 +439,33 @@ private:
 
     const bool in_window =
         scenario_time >= shot.start_seconds && m_pass_frames > k_pass_warmup_frames;
+    const bool far_from_window =
+        !in_window && m_pass_frames > k_pass_warmup_frames &&
+        shot.start_seconds - scenario_time > k_fast_forward_margin_seconds;
+    static const bool fast_forward_enabled =
+        qEnvironmentVariableIsEmpty("SOI_PROMO_NO_FASTFORWARD");
+    m_viewport.set_batch_render_suppressed(fast_forward_enabled && far_from_window);
     if (in_window && !m_shot_armed) {
       m_shot_armed = true;
       m_viewport.set_batch_fixed_step(m_step_seconds);
       m_viewport.set_capture_active(false);
+      if (m_audio != nullptr) {
+        m_audio->advance(idle_step(), false);
+        m_audio->begin_clip();
+      }
       return;
     }
     const bool recording = in_window && m_frames_written < m_target_frames;
     m_viewport.set_capture_active(recording);
+    if (m_audio != nullptr) {
+      m_audio->advance(m_shot_armed ? m_step_seconds : idle_step(), recording);
+    }
 
     if (recording && !m_logged_framing) {
       m_logged_framing = true;
+      qInfo().noquote() << QStringLiteral("  at %1 s: %2")
+                               .arg(QString::number(scenario_time, 'f', 1))
+                               .arg(m_viewport.ai_activity_summary());
       const auto& stats = Render::GL::get_humanoid_render_stats();
       qInfo().noquote() << QStringLiteral(
                                "  focus (%1, %2, %3) %4; soldiers %5/%6 drawn, culled "
@@ -516,6 +570,19 @@ private:
     case FocusMode::AllUnits:
       raw = m_viewport.scenario_center_of_mass();
       break;
+    case FocusMode::Battle:
+      raw = m_viewport.scenario_battle_center(shot.focus.owner,
+                                              shot.focus.engagement_radius);
+      if (!raw.has_value() && !m_focus_valid) {
+        raw = shot.focus.point;
+      }
+      break;
+    case FocusMode::Army:
+      raw = m_viewport.scenario_army_center(shot.focus.owner, shot.focus.home_radius);
+      if (!raw.has_value() && !m_focus_valid) {
+        raw = shot.focus.point;
+      }
+      break;
     }
 
     if (!raw.has_value()) {
@@ -551,6 +618,24 @@ private:
     }
     m_encoder.reset();
 
+    if (m_audio != nullptr && m_frames_written > 0) {
+      const QString wav_path = m_clip_path + QStringLiteral(".wav");
+      QString audio_error;
+      if (!m_audio->write_clip(wav_path)) {
+        qWarning().noquote() << QStringLiteral(
+                                    "Promo shot '%1': audio track not written")
+                                    .arg(shot.name);
+      } else if (!AudioRecorder::mux(m_clip_path, wav_path, &audio_error)) {
+        qWarning().noquote()
+            << QStringLiteral("Promo shot '%1': %2").arg(shot.name, audio_error);
+      } else {
+        qInfo().noquote() << QStringLiteral("  muxed %1 s of game audio into %2")
+                                 .arg(QString::number(m_audio->clip_seconds(), 'f', 2))
+                                 .arg(QFileInfo(m_clip_path).fileName());
+      }
+      m_audio->begin_clip();
+    }
+
     ShotResult result;
     result.name = shot.name;
     result.scenario = shot.scenario;
@@ -585,6 +670,7 @@ private:
       return;
     }
     m_pass_active = false;
+    m_audio.reset();
     ++m_pass_index;
     QTimer::singleShot(0, [this]() { begin_next_pass(); });
   }
@@ -592,6 +678,7 @@ private:
   void finish_run() {
     m_viewport.set_capture_sink(nullptr);
     m_viewport.set_frame_hook(nullptr);
+    m_viewport.set_batch_render_suppressed(false);
     write_manifest();
     qInfo().noquote() << QStringLiteral("Promo capture complete: %1 shot(s) in %2")
                              .arg(recorded_count())
@@ -656,6 +743,8 @@ private:
   bool m_shot_armed{false};
   bool m_focus_valid{false};
   bool m_logged_framing{false};
+  std::unique_ptr<AudioRecorder> m_audio;
+  int m_logged_bucket{-1};
   bool m_failed{false};
 };
 

--- a/tools/arena/promo_spec.cpp
+++ b/tools/arena/promo_spec.cpp
@@ -53,6 +53,10 @@ auto parse_focus(const QJsonObject& object, QString* error) -> std::optional<Foc
     focus.mode = FocusMode::Group;
   } else if (mode == QStringLiteral("group_pair")) {
     focus.mode = FocusMode::GroupPair;
+  } else if (mode == QStringLiteral("battle")) {
+    focus.mode = FocusMode::Battle;
+  } else if (mode == QStringLiteral("army")) {
+    focus.mode = FocusMode::Army;
   } else {
     if (error != nullptr) {
       *error = QStringLiteral("unknown focus mode '%1'").arg(mode);
@@ -66,6 +70,19 @@ auto parse_focus(const QJsonObject& object, QString* error) -> std::optional<Foc
   focus.offset = parse_vector(object.value(QStringLiteral("offset")), {});
   focus.smoothing = static_cast<float>(
       object.value(QStringLiteral("smoothing")).toDouble(focus.smoothing));
+  focus.owner = object.value(QStringLiteral("owner")).toInt(focus.owner);
+  focus.engagement_radius =
+      static_cast<float>(object.value(QStringLiteral("engagement_radius"))
+                             .toDouble(focus.engagement_radius));
+  focus.home_radius = static_cast<float>(
+      object.value(QStringLiteral("home_radius")).toDouble(focus.home_radius));
+
+  if (focus.mode == FocusMode::Army && focus.owner <= 0) {
+    if (error != nullptr) {
+      *error = QStringLiteral("focus mode 'army' needs an 'owner' id");
+    }
+    return std::nullopt;
+  }
 
   if (focus.mode == FocusMode::Group && focus.group.isEmpty()) {
     if (error != nullptr) {
@@ -248,6 +265,7 @@ auto load(const QString& path, QString* error) -> std::optional<Spec> {
   spec.height = root.value(QStringLiteral("height")).toInt(spec.height);
   spec.fps = root.value(QStringLiteral("fps")).toInt(spec.fps);
   spec.supersample = root.value(QStringLiteral("supersample")).toInt(spec.supersample);
+  spec.audio = root.value(QStringLiteral("audio")).toBool(spec.audio);
 
   if (spec.id.trimmed().isEmpty()) {
     if (error != nullptr) {

--- a/tools/arena/promo_spec.h
+++ b/tools/arena/promo_spec.h
@@ -14,6 +14,8 @@ enum class FocusMode : std::uint8_t {
   Group,
   GroupPair,
   AllUnits,
+  Battle,
+  Army,
 };
 
 enum class Ease : std::uint8_t {
@@ -29,6 +31,10 @@ struct Focus {
   QString group;
   QString second_group;
   QVector3D offset;
+
+  int owner{0};
+  float engagement_radius{14.0F};
+  float home_radius{26.0F};
 
   float smoothing{0.25F};
 };
@@ -83,6 +89,7 @@ struct Spec {
   int height{1920};
   int fps{60};
   int supersample{1};
+  bool audio{false};
   std::vector<Shot> shots;
 };
 

--- a/tools/arena/promos/ai_war_of_towns.json
+++ b/tools/arena/promos/ai_war_of_towns.json
@@ -1,0 +1,754 @@
+{
+  "id": "ai_war_of_towns",
+  "title": "SCIPIO  VS  HANNIBAL",
+  "subtitle": "AI VS AI  \u00b7  STANDARD OF IRON",
+  "end_card_seconds": 4.5,
+  "end_card_lines": [
+    "GITHUB.COM/DJEADA/STANDARD-OF-IRON",
+    "EVERY ORDER IN THIS MATCH CAME FROM THE GAME AI"
+  ],
+  "width": 1920,
+  "height": 1080,
+  "fps": 60,
+  "supersample": 1,
+  "transition": {
+    "type": "dissolve",
+    "duration": 0.4
+  },
+  "music": "assets/audio/music/combat/combat_dust_of_trasimene.ogg",
+  "music_start": 0.0,
+  "grade": {
+    "contrast": 1.08,
+    "saturation": 1.12,
+    "brightness": 0.03,
+    "gamma": 1.06,
+    "grain": 2,
+    "vignette": 0.1,
+    "sharpen": 0.5
+  },
+  "shots": [
+    {
+      "name": "card_open",
+      "scenario": "trailer_flame_card",
+      "start": 0.5,
+      "duration": 5.0,
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      },
+      "act_title": "SCIPIO  VS  HANNIBAL",
+      "act_kicker": "AI VS AI  \u00b7  THE WAR OF TOWNS",
+      "flame_card": true,
+      "flame_speed": 0.85,
+      "flame_intensity": 1.0
+    },
+    {
+      "name": "field",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 2.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "point",
+        "point": [0, 0.0, 0],
+        "smoothing": 0.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 150,
+          "pitch": 64,
+          "yaw": 45,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 7,
+          "distance": 122,
+          "pitch": 54,
+          "yaw": 38,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "ONE RIVER  \u00b7  ONE BRIDGE  \u00b7  TWO COMPUTER COMMANDERS",
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      }
+    },
+    {
+      "name": "rome_intro",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 9.5,
+      "duration": 6.0,
+      "focus": {
+        "mode": "group",
+        "group": "scipio_commander",
+        "smoothing": 0.5
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 22,
+          "pitch": 24,
+          "yaw": 28,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 6,
+          "distance": 17,
+          "pitch": 27,
+          "yaw": 48,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "NORTH BANK \u2014 SCIPIO OF THE ROMAN REPUBLIC"
+    },
+    {
+      "name": "carthage_intro",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 16.0,
+      "duration": 6.0,
+      "focus": {
+        "mode": "group",
+        "group": "hannibal_commander",
+        "smoothing": 0.5
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 22,
+          "pitch": 24,
+          "yaw": 208,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 6,
+          "distance": 17,
+          "pitch": 27,
+          "yaw": 228,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "SOUTH BANK \u2014 HANNIBAL OF CARTHAGE",
+      "transition": {
+        "type": "whip",
+        "duration": 0.25
+      }
+    },
+    {
+      "name": "muster",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 22.5,
+      "duration": 4.5,
+      "focus": {
+        "mode": "army",
+        "owner": 3,
+        "point": [30, 0.0, 30],
+        "smoothing": 0.8,
+        "home_radius": 24.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 30,
+          "pitch": 30,
+          "yaw": 228,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 4.5,
+          "distance": 27,
+          "pitch": 30,
+          "yaw": 238,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "0:20 \u2014 HANNIBAL MUSTERS FIRST"
+    },
+    {
+      "name": "bridge",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 33.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "army",
+        "owner": 3,
+        "point": [0, 0.0, 0],
+        "smoothing": 0.8,
+        "home_radius": 24.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 34,
+          "pitch": 26,
+          "yaw": 214,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 7,
+          "distance": 27,
+          "pitch": 24,
+          "yaw": 198,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "0:35 \u2014 ACROSS THE BRIDGE"
+    },
+    {
+      "name": "raid",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 50.0,
+      "duration": 8.0,
+      "focus": {
+        "mode": "battle",
+        "point": [-25, 0.0, -25],
+        "smoothing": 0.9,
+        "engagement_radius": 14.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 24,
+          "pitch": 25,
+          "yaw": 58,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 8,
+          "distance": 19,
+          "pitch": 23,
+          "yaw": 84,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "0:50 \u2014 THE RAID HITS THE ROMAN GATE"
+    },
+    {
+      "name": "raid_close",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 60.0,
+      "duration": 6.0,
+      "focus": {
+        "mode": "battle",
+        "point": [-25, 0.0, -25],
+        "smoothing": 0.7,
+        "engagement_radius": 14.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 14,
+          "pitch": 18,
+          "yaw": 98,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 6,
+          "distance": 12,
+          "pitch": 17,
+          "yaw": 118,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "slow_motion": 0.65,
+      "transition": {
+        "type": "whip",
+        "duration": 0.22
+      }
+    },
+    {
+      "name": "rome_march",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 112.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "army",
+        "owner": 2,
+        "point": [-8, 0.0, -8],
+        "smoothing": 0.8,
+        "home_radius": 24.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 30,
+          "pitch": 28,
+          "yaw": 44,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 7,
+          "distance": 26,
+          "pitch": 27,
+          "yaw": 30,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "2:00 \u2014 SCIPIO ANSWERS"
+    },
+    {
+      "name": "counter",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 148.0,
+      "duration": 8.0,
+      "focus": {
+        "mode": "battle",
+        "point": [30, 0.0, 30],
+        "smoothing": 0.9,
+        "engagement_radius": 14.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 24,
+          "pitch": 24,
+          "yaw": 238,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 8,
+          "distance": 18,
+          "pitch": 22,
+          "yaw": 262,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "2:30 \u2014 AT THE GATES OF HANNIBAL"
+    },
+    {
+      "name": "repulsed",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 168.0,
+      "duration": 6.0,
+      "focus": {
+        "mode": "battle",
+        "point": [30, 0.0, 30],
+        "smoothing": 0.7,
+        "engagement_radius": 14.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 16,
+          "pitch": 20,
+          "yaw": 262,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 6,
+          "distance": 14,
+          "pitch": 19,
+          "yaw": 276,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE LEGION IS THROWN BACK",
+      "transition": {
+        "type": "whip",
+        "duration": 0.22
+      }
+    },
+    {
+      "name": "rome_grows",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 420.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "point",
+        "point": [-30, 0.0, -30],
+        "smoothing": 0.6
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 60,
+          "pitch": 46,
+          "yaw": 44,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 7,
+          "distance": 50,
+          "pitch": 40,
+          "yaw": 56,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "7:00 \u2014 BOTH TOWNS DIG IN",
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      }
+    },
+    {
+      "name": "carthage_grows",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 430.0,
+      "duration": 6.0,
+      "focus": {
+        "mode": "point",
+        "point": [30, 0.0, 30],
+        "smoothing": 0.6
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 56,
+          "pitch": 44,
+          "yaw": 224,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 6,
+          "distance": 50,
+          "pitch": 40,
+          "yaw": 236,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "HANNIBAL BUILDS WIDER"
+    },
+    {
+      "name": "wave2",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 612.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "army",
+        "owner": 3,
+        "point": [-12.0, 0.0, -12.0],
+        "smoothing": 0.8,
+        "home_radius": 24.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 30,
+          "pitch": 26,
+          "yaw": 220,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 7,
+          "distance": 26,
+          "pitch": 24,
+          "yaw": 204,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "10:00 \u2014 SCIPIO FARMS RIGHT UP TO THE RIVER"
+    },
+    {
+      "name": "wave2_fight",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 652.0,
+      "duration": 8.0,
+      "focus": {
+        "mode": "battle",
+        "point": [-25, 0.0, -25],
+        "smoothing": 0.9,
+        "engagement_radius": 14.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 20,
+          "pitch": 23,
+          "yaw": 70,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 8,
+          "distance": 16,
+          "pitch": 21,
+          "yaw": 96,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "10:50 \u2014 THE LEGION KEEPS TO ITS TOWN"
+    },
+    {
+      "name": "siege_fire",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 1130.0,
+      "duration": 8.0,
+      "focus": {
+        "mode": "battle",
+        "point": [20.0, 0.0, 18.0],
+        "smoothing": 0.9,
+        "engagement_radius": 16.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 18,
+          "pitch": 21,
+          "yaw": 88,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 8,
+          "distance": 16,
+          "pitch": 20,
+          "yaw": 112,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "19:00 \u2014 HANNIBAL WALLS THE BRIDGE",
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      }
+    },
+    {
+      "name": "siege_end",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 1240.0,
+      "duration": 6.0,
+      "focus": {
+        "mode": "battle",
+        "point": [20.0, 0.0, 18.0],
+        "smoothing": 0.9,
+        "engagement_radius": 16.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 22,
+          "pitch": 24,
+          "yaw": 40,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 6,
+          "distance": 20,
+          "pitch": 23,
+          "yaw": 56,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "20:40 \u2014 THE SOUTH BANK IS SHUT"
+    },
+    {
+      "name": "stalemate",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 1500.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "point",
+        "point": [2, 0.0, 2],
+        "smoothing": 0.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 70,
+          "pitch": 40,
+          "yaw": 224,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 7,
+          "distance": 92,
+          "pitch": 50,
+          "yaw": 236,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "25:00 \u2014 NOBODY CROSSES AGAIN",
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      }
+    },
+    {
+      "name": "rome_end",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 1780.0,
+      "duration": 5.0,
+      "focus": {
+        "mode": "group",
+        "group": "scipio_commander",
+        "smoothing": 0.5
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 20,
+          "pitch": 24,
+          "yaw": 38,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 5,
+          "distance": 18,
+          "pitch": 25,
+          "yaw": 54,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "30:00 \u2014 SCIPIO:  9 SOLDIERS  \u00b7  11 BUILDINGS"
+    },
+    {
+      "name": "carthage_end",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 1786.0,
+      "duration": 5.0,
+      "focus": {
+        "mode": "group",
+        "group": "hannibal_commander",
+        "smoothing": 0.5
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 20,
+          "pitch": 24,
+          "yaw": 218,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 5,
+          "distance": 18,
+          "pitch": 25,
+          "yaw": 234,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "30:00 \u2014 HANNIBAL:  10 SOLDIERS  \u00b7  15 BUILDINGS"
+    },
+    {
+      "name": "verdict",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 1792.0,
+      "duration": 7.0,
+      "focus": {
+        "mode": "point",
+        "point": [0, 0.0, 0],
+        "smoothing": 0.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 130,
+          "pitch": 56,
+          "yaw": 45,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 7,
+          "distance": 162,
+          "pitch": 66,
+          "yaw": 52,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "STALEMATE \u2014 HANNIBAL HOLDS MORE, NEITHER WINS",
+      "freeze": 2.5,
+      "transition": {
+        "type": "dip",
+        "duration": 0.5
+      }
+    }
+  ]
+}

--- a/tools/arena/promos/ai_war_of_towns_full.json
+++ b/tools/arena/promos/ai_war_of_towns_full.json
@@ -1,0 +1,71 @@
+{
+  "id": "ai_war_of_towns_full",
+  "title": "SCIPIO  VS  HANNIBAL",
+  "subtitle": "AI VS AI  \u00b7  STANDARD OF IRON",
+  "width": 1920,
+  "height": 1080,
+  "fps": 60,
+  "supersample": 1,
+  "shots": [
+    {
+      "name": "full_match",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 0.5,
+      "duration": 1799.0,
+      "focus": {
+        "mode": "point",
+        "point": [0.0, 0.0, 0.0],
+        "smoothing": 0.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 130,
+          "pitch": 47,
+          "yaw": 315,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 450,
+          "distance": 134,
+          "pitch": 46,
+          "yaw": 318,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 900,
+          "distance": 131,
+          "pitch": 47,
+          "yaw": 315,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 1350,
+          "distance": 134,
+          "pitch": 46,
+          "yaw": 312,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 1799,
+          "distance": 130,
+          "pitch": 47,
+          "yaw": 315,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ]
+    }
+  ],
+  "audio": true
+}

--- a/tools/arena/video_encoder.cpp
+++ b/tools/arena/video_encoder.cpp
@@ -9,6 +9,7 @@
 namespace Arena::Promo {
 namespace {
 
+constexpr qint64 k_max_buffered_frames = 4;
 constexpr int k_pipe_timeout_ms = 30'000;
 
 } // namespace
@@ -152,8 +153,26 @@ auto VideoEncoder::write_frame(const QImage& frame, QString* error) -> bool {
       }
     }
   }
+  const qint64 frame_bytes = static_cast<qint64>(rgba.width()) * rgba.height() * 4;
+  while (m_impl->process.bytesToWrite() > frame_bytes * k_max_buffered_frames) {
+    if (!m_impl->process.waitForBytesWritten(k_pipe_timeout_ms)) {
+      if (error != nullptr) {
+        *error = QStringLiteral("ffmpeg fell behind and stopped draining frames: %1")
+                     .arg(m_impl->process.errorString());
+      }
+      return false;
+    }
+  }
   ++m_impl->frames;
   return true;
+}
+
+auto VideoEncoder::pending_bytes() const -> qint64 {
+  return m_impl->open ? m_impl->process.bytesToWrite() : 0;
+}
+
+auto VideoEncoder::max_pending_frames() noexcept -> int {
+  return static_cast<int>(k_max_buffered_frames);
 }
 
 auto VideoEncoder::close(QString* error) -> bool {

--- a/tools/arena/video_encoder.h
+++ b/tools/arena/video_encoder.h
@@ -29,6 +29,8 @@ public:
   [[nodiscard]] auto write_frame(const QImage& frame, QString* error) -> bool;
   [[nodiscard]] auto close(QString* error) -> bool;
   [[nodiscard]] auto frames_written() const noexcept -> int;
+  [[nodiscard]] auto pending_bytes() const -> qint64;
+  [[nodiscard]] static auto max_pending_frames() noexcept -> int;
 
 private:
   struct Impl;

--- a/tools/balance_sim/battle_simulation.cpp
+++ b/tools/balance_sim/battle_simulation.cpp
@@ -17,10 +17,12 @@
 #include "game/core/entity.h"
 #include "game/core/event_manager.h"
 #include "game/core/world.h"
+#include "game/formation/army_formation_registry.h"
 #include "game/map/map_definition.h"
 #include "game/map/terrain_service.h"
 #include "game/session/session_context.h"
 #include "game/systems/arrow_system.h"
+#include "game/systems/building_collision_registry.h"
 #include "game/systems/cleanup_system.h"
 #include "game/systems/combat_status_effect_system.h"
 #include "game/systems/combat_system.h"
@@ -28,6 +30,7 @@
 #include "game/systems/command_service.h"
 #include "game/systems/commander_system.h"
 #include "game/systems/default_content.h"
+#include "game/systems/formation_combat_geometry.h"
 #include "game/systems/healing_beam_system.h"
 #include "game/systems/healing_system.h"
 #include "game/systems/movement_pipeline.h"
@@ -412,6 +415,10 @@ auto run_battle(Game::Session::SessionContext& session,
   auto& nations = session.nations();
   nations.set_player_nation(k_side_a_owner, side_a_def.nation);
   nations.set_player_nation(k_side_b_owner, side_b_def.nation);
+
+  Game::Formation::ArmyFormationRegistry::instance().clear();
+  Game::Systems::BuildingCollisionRegistry::instance().clear();
+  Game::Systems::FormationCombat::invalidate_layout_cache();
 
   session.terrain().initialize(
       flat_map_definition(fixture.grid_width, fixture.grid_height));

--- a/ui/commander_portrait_view.cpp
+++ b/ui/commander_portrait_view.cpp
@@ -43,9 +43,6 @@ constexpr float k_max_frame_seconds = 0.1F;
 constexpr float k_head_radius = Render::GL::HumanProportions::HEAD_RADIUS;
 constexpr float k_cranium_rise = k_head_radius * 0.06F;
 
-// The baked cranium is an ellipsoid whose front reaches just under two local head
-// radii. Keep the portrait features a hair above it so depth testing seats them on
-// the skin instead of swallowing most of each small mesh.
 constexpr float k_face_surface = k_head_radius * 2.02F;
 constexpr float k_mouth_surface = k_head_radius * 2.20F;
 


### PR DESCRIPTION
Make repeated headless AI duel cases independent by clearing shared event subscriptions, terrain data, formation registries, collision state, troop counts, player resources, and cached formation layouts at fixture boundaries.

Increase the arena promotion runner watchdog scale for the full AI war of towns scenario so longer simulation phases receive the intended execution allowance.

Bring the branch up to date with main and apply the repository formatter across the resulting source, asset, and configuration changes, including the latest mainline content required by the merged implementation.