### PR TITLE
feat: add hill navigation coverage and arena promo scenarios

### DIFF
--- a/game/systems/pathfinding.cpp
+++ b/game/systems/pathfinding.cpp
@@ -23,6 +23,15 @@ namespace Game::Systems {
 
 namespace {
 
+auto hill_entrance_opens_cell(const Game::Map::TerrainHeightMap& height_map,
+                              Game::Map::TerrainType terrain_type,
+                              int x,
+                              int z) -> bool {
+  return height_map.isHillEntrance(x, z) &&
+         terrain_type != Game::Map::TerrainType::Mountain &&
+         !Game::Map::is_water_terrain(terrain_type);
+}
+
 auto terrain_cell_value(const Game::Map::TerrainService& terrain_service,
                         const Game::Map::TerrainHeightMap* height_map,
                         int x,
@@ -37,7 +46,8 @@ auto terrain_cell_value(const Game::Map::TerrainService& terrain_service,
     return Pathfinding::CellValue::Blocked;
   }
 
-  if (height_map->isBridgeCell(x, z) || height_map->isHillEntrance(x, z)) {
+  if (height_map->isBridgeCell(x, z) ||
+      hill_entrance_opens_cell(*height_map, terrain_type, x, z)) {
     return Pathfinding::CellValue::Walkable;
   }
 
@@ -371,12 +381,7 @@ void Pathfinding::mark_navigation_grid_dirty() {
 
 void Pathfinding::mark_region_dirty(int min_x, int max_x, int min_z, int max_z) {
 
-  min_x = std::max(0, min_x);
-  max_x = std::min(m_width - 1, max_x);
-  min_z = std::max(0, min_z);
-  max_z = std::min(m_height - 1, max_z);
-
-  if (min_x > max_x || min_z > max_z) {
+  if (!clamp_to_grid(min_x, max_x, min_z, max_z)) {
     return;
   }
 
@@ -502,15 +507,12 @@ void Pathfinding::update_region(int min_x, int max_x, int min_z, int max_z) {
   force_map_passage_cells_walkable(min_x, max_x, min_z, max_z);
   apply_gate_blocker_cells(min_x, max_x, min_z, max_z);
 
+  rebuild_elevation(min_x - 1, max_x + 1, min_z - 1, max_z + 1);
   rebuild_clearance(min_x - 1, max_x + 1, min_z - 1, max_z + 1);
 }
 
 void Pathfinding::apply_gate_blocker_cells(int min_x, int max_x, int min_z, int max_z) {
-  min_x = std::max(0, min_x);
-  max_x = std::min(m_width - 1, max_x);
-  min_z = std::max(0, min_z);
-  max_z = std::min(m_height - 1, max_z);
-  if (min_x > max_x || min_z > max_z) {
+  if (!clamp_to_grid(min_x, max_x, min_z, max_z)) {
     return;
   }
   for (auto const& blocker : GateService::blockers()) {
@@ -535,11 +537,7 @@ void Pathfinding::force_navigation_passages_walkable(int min_x,
                                                      int max_x,
                                                      int min_z,
                                                      int max_z) {
-  min_x = std::max(0, min_x);
-  max_x = std::min(m_width - 1, max_x);
-  min_z = std::max(0, min_z);
-  max_z = std::min(m_height - 1, max_z);
-  if (min_x > max_x || min_z > max_z) {
+  if (!clamp_to_grid(min_x, max_x, min_z, max_z)) {
     return;
   }
 
@@ -621,11 +619,7 @@ void Pathfinding::force_map_passage_cells_walkable(int min_x,
     return;
   }
 
-  min_x = std::max(0, min_x);
-  max_x = std::min(m_width - 1, max_x);
-  min_z = std::max(0, min_z);
-  max_z = std::min(m_height - 1, max_z);
-  if (min_x > max_x || min_z > max_z) {
+  if (!clamp_to_grid(min_x, max_x, min_z, max_z)) {
     return;
   }
 
@@ -638,7 +632,8 @@ void Pathfinding::force_map_passage_cells_walkable(int min_x,
         continue;
       }
       if (!height_map->isBridgeCell(x, z) && !height_map->isBridgeCenterline(x, z) &&
-          !height_map->isHillEntrance(x, z)) {
+          !hill_entrance_opens_cell(
+              *height_map, terrain_service.get_terrain_type(x, z), x, z)) {
         continue;
       }
 
@@ -1170,7 +1165,7 @@ auto Pathfinding::find_path_internal(const Point& start,
           current.g_cost +
           ((step_x != 0 && step_z != 0) ? k_diagonal_step_cost : k_straight_step_cost) +
           (clearance_penalty(neighbor.x, neighbor.y) * clearance_weight) +
-          (turns ? k_turn_penalty : 0);
+          climb_penalty(current.index, neighbor_idx) + (turns ? k_turn_penalty : 0);
       if (tentative_gcost >= get_g_cost(buffers, neighbor_idx, generation)) {
         continue;
       }
@@ -1280,12 +1275,64 @@ auto Pathfinding::calculate_heuristic(const Point& a, const Point& b) -> int {
   return octile * k_heuristic_weight_numerator / k_heuristic_weight_denominator;
 }
 
+auto Pathfinding::clamp_to_grid(int& min_x,
+                                int& max_x,
+                                int& min_z,
+                                int& max_z) const -> bool {
+  min_x = std::max(0, min_x);
+  max_x = std::min(m_width - 1, max_x);
+  min_z = std::max(0, min_z);
+  max_z = std::min(m_height - 1, max_z);
+  return min_x <= max_x && min_z <= max_z;
+}
+
 auto Pathfinding::clearance_penalty(int x, int y) const -> int {
   auto const index = static_cast<std::size_t>(to_index(x, y));
   if (index >= m_clearance_penalty.size()) {
     return 0;
   }
   return m_clearance_penalty[index];
+}
+
+void Pathfinding::rebuild_elevation(int min_x, int max_x, int min_z, int max_z) {
+  auto const total =
+      static_cast<std::size_t>(m_width) * static_cast<std::size_t>(m_height);
+  if (m_cell_height.size() != total) {
+    m_cell_height.assign(total, 0.0F);
+  }
+
+  auto& terrain_service = *m_terrain;
+  const auto* height_map =
+      terrain_service.is_initialized() ? terrain_service.get_height_map() : nullptr;
+  if (height_map == nullptr) {
+    return;
+  }
+
+  if (!clamp_to_grid(min_x, max_x, min_z, max_z)) {
+    return;
+  }
+
+  for (int z = min_z; z <= max_z; ++z) {
+    for (int x = min_x; x <= max_x; ++x) {
+      m_cell_height[static_cast<std::size_t>(to_index(x, z))] =
+          height_map->get_height_at_grid(x, z);
+    }
+  }
+}
+
+auto Pathfinding::climb_penalty(int from_index, int to_index) const -> int {
+  auto const from = static_cast<std::size_t>(from_index);
+  auto const to = static_cast<std::size_t>(to_index);
+  if (from >= m_cell_height.size() || to >= m_cell_height.size()) {
+    return 0;
+  }
+  float const rise = std::abs(m_cell_height[to] - m_cell_height[from]);
+  if (rise < k_climb_noise_floor_metres * m_grid_cell_size) {
+    return 0;
+  }
+  return std::min(
+      k_max_climb_penalty,
+      static_cast<int>(std::lround(rise * static_cast<float>(k_climb_cost_per_metre))));
 }
 
 void Pathfinding::rebuild_clearance(int min_x, int max_x, int min_z, int max_z) {
@@ -1295,11 +1342,7 @@ void Pathfinding::rebuild_clearance(int min_x, int max_x, int min_z, int max_z) 
     m_clearance_penalty.assign(total, 0);
   }
 
-  min_x = std::max(0, min_x);
-  max_x = std::min(m_width - 1, max_x);
-  min_z = std::max(0, min_z);
-  max_z = std::min(m_height - 1, max_z);
-  if (min_x > max_x || min_z > max_z) {
+  if (!clamp_to_grid(min_x, max_x, min_z, max_z)) {
     return;
   }
 

--- a/game/systems/pathfinding.h
+++ b/game/systems/pathfinding.h
@@ -169,8 +169,14 @@ private:
 
   static auto calculate_heuristic(const Point& a, const Point& b) -> int;
 
+  [[nodiscard]] auto
+  clamp_to_grid(int& min_x, int& max_x, int& min_z, int& max_z) const -> bool;
+
   [[nodiscard]] auto clearance_penalty(int x, int y) const -> int;
   void rebuild_clearance(int min_x, int max_x, int min_z, int max_z);
+
+  void rebuild_elevation(int min_x, int max_x, int min_z, int max_z);
+  [[nodiscard]] auto climb_penalty(int from_index, int to_index) const -> int;
 
   static constexpr int k_straight_step_cost = 10;
   static constexpr int k_diagonal_step_cost = 14;
@@ -182,6 +188,10 @@ private:
   static constexpr int k_clearance_ring_penalty = 4;
   static constexpr int k_clearance_avoid_weight = 6;
   static constexpr int k_turn_penalty = 1;
+
+  static constexpr float k_climb_noise_floor_metres = 0.05F;
+  static constexpr int k_climb_cost_per_metre = 40;
+  static constexpr int k_max_climb_penalty = 400;
 
   static constexpr int k_heuristic_weight_numerator = 12;
   static constexpr int k_heuristic_weight_denominator = 10;
@@ -317,6 +327,7 @@ private:
   std::unordered_map<int, CellValue> m_world_prop_cells;
   std::vector<bool> m_forest_cells;
   std::vector<std::uint8_t> m_clearance_penalty;
+  std::vector<float> m_cell_height;
   std::atomic<std::uint64_t> m_navigation_revision{1};
   std::uint64_t m_path_cache_revision{0};
   std::unordered_map<PathCacheKey, std::vector<Point>, PathCacheKeyHash> m_path_cache;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(
     map/terrain_topology_audit_test.cpp
     map/map_transformer_test.cpp
     map/hill_crown_geometry_test.cpp
+    map/hill_navigation_test.cpp
     map/hill_shape_test.cpp
     map/terrain_footprint_test.cpp
     map/undead_shrine_placement_test.cpp
@@ -220,6 +221,7 @@ add_executable(
     headless/gate_traversal_test.cpp
     headless/wall_siege_test.cpp
     headless/tight_gap_navigation_test.cpp
+    headless/hill_traversal_test.cpp
     headless/playable_ground_test.cpp
     headless/battle_speed_load_test.cpp
     headless/selected_unit_readout_test.cpp

--- a/tests/headless/hill_traversal_test.cpp
+++ b/tests/headless/hill_traversal_test.cpp
@@ -1,0 +1,405 @@
+
+
+#include <QDir>
+#include <QString>
+#include <QVector3D>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "game/core/component.h"
+#include "game/core/world.h"
+#include "game/map/map_definition.h"
+#include "game/map/map_loader.h"
+#include "game/map/terrain_service.h"
+#include "game/session/session_context.h"
+#include "game/session/simulation_clock.h"
+#include "game/systems/building_collision_registry.h"
+#include "game/systems/command_service.h"
+#include "game/systems/default_content.h"
+#include "game/systems/nation_registry.h"
+#include "game/systems/nav_grid.h"
+#include "game/systems/owner_registry.h"
+#include "game/systems/pathfinding.h"
+#include "game/systems/runtime_system_registry.h"
+#include "game/units/factory.h"
+#include "game/units/spawn_type.h"
+#include "tests/support/hill_plateaus.h"
+
+namespace {
+
+using Engine::Core::EntityID;
+using Engine::Core::TransformComponent;
+using Game::Session::SessionContext;
+using Game::Systems::CommandService;
+using Game::Systems::NavGrid;
+using Game::Systems::Point;
+
+constexpr int k_owner = 1;
+constexpr int k_synthetic_grid = 160;
+constexpr float k_hill_radius = 26.0F;
+constexpr float k_hill_height = 7.0F;
+constexpr float k_shape_extent = 60.0F;
+
+struct ShapeCase {
+  const char* name;
+  Game::Map::HillShape shape;
+  float thickness;
+};
+
+const ShapeCase k_shapes[] = {
+    {"round", Game::Map::HillShape::Blob, 0.0F},
+    {"ridge", Game::Map::HillShape::Corridor, 20.0F},
+    {"crescent", Game::Map::HillShape::Arc, 20.0F},
+    {"elbow", Game::Map::HillShape::Elbow, 20.0F},
+    {"ring", Game::Map::HillShape::Ring, 16.0F},
+};
+
+class HillTraversalTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    Game::Systems::NationRegistry::instance().clear();
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Systems::initialize_default_content(
+        Game::Systems::NationRegistry::instance());
+    m_factory = std::make_shared<Game::Units::UnitFactoryRegistry>();
+    Game::Units::register_built_in_units(*m_factory);
+  }
+
+  void TearDown() override {
+    m_scope.reset();
+    m_session.reset();
+    Game::Map::TerrainService::instance().clear();
+    Game::Systems::BuildingCollisionRegistry::instance().clear();
+    Game::Systems::NationRegistry::instance().clear();
+  }
+
+  auto match(const Game::Map::MapDefinition& map) -> SessionContext& {
+    m_scope.reset();
+    m_session.reset();
+    m_session = std::make_unique<SessionContext>();
+    m_session->world().set_presentation_enabled(false);
+    m_scope = std::make_unique<Game::Session::ScopedSession>(*m_session);
+    m_session->owners().register_owner_with_id(
+        k_owner, Game::Systems::OwnerType::Player, "carthage");
+    m_session->owners().set_owner_team(k_owner, 1);
+    Game::Systems::initialize_default_content(m_session->nations());
+    Game::Systems::register_runtime_systems(m_session->world());
+    m_session->terrain().initialize(map);
+    NavGrid::initialize(map.grid.width, map.grid.height);
+    NavGrid::get_pathfinder()->update_navigation_grid();
+    m_grid = map.grid.width;
+    return *m_session;
+  }
+
+  auto one_hill(Game::Map::HillShape shape,
+                float thickness,
+                int entrances) -> SessionContext& {
+    Game::Map::MapDefinition map;
+    map.grid.width = k_synthetic_grid;
+    map.grid.height = k_synthetic_grid;
+    map.grid.tile_size = 1.0F;
+    map.coordSystem = Game::Map::CoordSystem::World;
+    map.biome.procedural_boulders_enabled = false;
+    map.biome.procedural_iron_ore_enabled = false;
+    map.biome.procedural_trees_enabled = false;
+
+    Game::Map::TerrainFeature hill;
+    hill.type = Game::Map::TerrainType::Hill;
+    hill.center_x = 0.0F;
+    hill.center_z = 0.0F;
+    hill.radius = k_hill_radius;
+    hill.height = k_hill_height;
+    hill.shape = shape;
+    if (shape != Game::Map::HillShape::Blob) {
+      hill.width = k_shape_extent;
+      hill.depth = k_shape_extent;
+      hill.thickness = thickness;
+    }
+    if (entrances >= 1) {
+      hill.entrances.emplace_back(-(k_hill_radius + 2.0F), 0.0F, 0.0F);
+    }
+    if (entrances >= 2) {
+      hill.entrances.emplace_back(k_hill_radius + 2.0F, 0.0F, 0.0F);
+    }
+    map.terrain.push_back(hill);
+    return match(map);
+  }
+
+  auto spawn(const QVector3D& position) -> EntityID {
+    Game::Units::SpawnParams params;
+    params.position = position;
+    params.player_id = k_owner;
+    params.spawn_type = Game::Units::SpawnType::Spearman;
+    params.nation_id = Game::Systems::NationID::Carthage;
+    auto unit =
+        m_factory->create(Game::Units::SpawnType::Spearman, m_session->world(), params);
+    return unit ? unit->id() : 0;
+  }
+
+  auto position_of(EntityID id) -> QVector3D {
+    auto* entity = m_session->world().get_entity(id);
+    if (entity == nullptr) {
+      return {};
+    }
+    const auto* transform = entity->get_component<TransformComponent>();
+    return transform == nullptr ? QVector3D()
+                                : QVector3D(transform->position.x,
+                                            transform->position.y,
+                                            transform->position.z);
+  }
+
+  struct Trace {
+    float lowest{0.0F};
+    float highest{0.0F};
+    int off_walkable_samples{0};
+    QVector3D first_off_walkable;
+  };
+
+  auto trace(const std::vector<EntityID>& troops, double seconds) -> Trace {
+    Trace result;
+    result.lowest = std::numeric_limits<float>::infinity();
+    result.highest = -std::numeric_limits<float>::infinity();
+    auto const* heights = m_session->terrain().get_height_map();
+    double const step = m_session->clock().tick_seconds();
+    for (double elapsed = 0.0; elapsed < seconds; elapsed += step) {
+      m_session->clock().advance(step);
+      while (m_session->clock().consume_tick()) {
+        m_session->world().update(static_cast<float>(step));
+      }
+      for (auto const troop : troops) {
+        auto const position = position_of(troop);
+        float const ground = heights->get_height_at(position.x(), position.z());
+        result.lowest = std::min(result.lowest, ground);
+        result.highest = std::max(result.highest, ground);
+        auto const cell = NavGrid::world_to_grid(position.x(), position.z());
+        if (!m_session->terrain().is_walkable(cell.x, cell.y)) {
+          if (result.off_walkable_samples == 0) {
+            result.first_off_walkable = position;
+          }
+          ++result.off_walkable_samples;
+        }
+      }
+    }
+    return result;
+  }
+
+  [[nodiscard]] auto crown() const -> std::vector<QVector3D> {
+    auto const plateaus = TestSupport::hill_plateaus(m_grid);
+    std::vector<QVector3D> cells;
+    if (plateaus.empty()) {
+      return cells;
+    }
+    auto const* heights = m_session->terrain().get_height_map();
+    for (auto const& cell : TestSupport::crown_of(plateaus.front(), *heights)) {
+      cells.push_back(NavGrid::grid_to_world(cell));
+    }
+    return cells;
+  }
+
+  std::unique_ptr<SessionContext> m_session;
+  std::unique_ptr<Game::Session::ScopedSession> m_scope;
+  std::shared_ptr<Game::Units::UnitFactoryRegistry> m_factory;
+  int m_grid{0};
+};
+
+auto ends_of(const std::vector<QVector3D>& cells) -> std::pair<QVector3D, QVector3D> {
+  QVector3D first = cells.front();
+  QVector3D second = cells.front();
+  float best = 0.0F;
+  for (std::size_t i = 0; i < cells.size(); i += 3U) {
+    for (std::size_t j = i + 1U; j < cells.size(); j += 5U) {
+      float const span = (cells[i] - cells[j]).length();
+      if (span > best) {
+        best = span;
+        first = cells[i];
+        second = cells[j];
+      }
+    }
+  }
+  return {first, second};
+}
+
+auto crossings(const std::vector<QVector3D>& cells,
+               std::size_t wanted) -> std::vector<std::pair<QVector3D, QVector3D>> {
+  std::vector<std::pair<QVector3D, QVector3D>> candidates;
+  for (std::size_t i = 0; i < cells.size(); i += 37U) {
+    for (std::size_t j = i + 1U; j < cells.size(); j += 53U) {
+      float const span = (cells[i] - cells[j]).length();
+      if (span < 12.0F || span > 40.0F) {
+        continue;
+      }
+      candidates.emplace_back(cells[i], cells[j]);
+    }
+  }
+  if (candidates.size() <= wanted) {
+    return candidates;
+  }
+
+  std::vector<std::pair<QVector3D, QVector3D>> found;
+  found.reserve(wanted);
+  for (std::size_t pick = 0; pick < wanted; ++pick) {
+    found.push_back(candidates[pick * candidates.size() / wanted]);
+  }
+  return found;
+}
+
+TEST_F(HillTraversalTest, ATroopCrossingAHilltopStaysOnIt) {
+  for (auto const& shape : k_shapes) {
+    one_hill(shape.shape, shape.thickness, 1);
+    auto const cells = crown();
+    ASSERT_GE(cells.size(), 2U) << shape.name << " grew no plateau";
+
+    auto const [near_end, far_end] = ends_of(cells);
+    auto const* heights = m_session->terrain().get_height_map();
+    float const crown_height = heights->get_height_at(near_end.x(), near_end.z());
+
+    auto const troop = spawn(near_end);
+    ASSERT_NE(troop, 0U);
+    trace({troop}, 2.0);
+
+    CommandService::move_units(m_session->world(), {troop}, {far_end});
+    auto const crossing = trace({troop}, 60.0);
+
+    EXPECT_GT(crossing.lowest, crown_height - 4.0F)
+        << shape.name << ": crossing the hilltop from (" << near_end.x() << ", "
+        << near_end.z() << ") to (" << far_end.x() << ", " << far_end.z()
+        << ") dropped to " << crossing.lowest << " m off a " << crown_height
+        << " m crown";
+    EXPECT_EQ(crossing.off_walkable_samples, 0)
+        << shape.name << ": stood on ground it may not stand on near ("
+        << crossing.first_off_walkable.x() << ", " << crossing.first_off_walkable.z()
+        << ")";
+  }
+}
+
+TEST_F(HillTraversalTest, ATroopOrderedOntoAHillClimbsItAndStaysOnWalkableGround) {
+  for (auto const& shape : k_shapes) {
+    one_hill(shape.shape, shape.thickness, 1);
+    auto const cells = crown();
+    ASSERT_FALSE(cells.empty()) << shape.name << " grew no plateau";
+
+    auto const troop = spawn(QVector3D(-(k_hill_radius + 30.0F), 0.0F, 0.0F));
+    ASSERT_NE(troop, 0U);
+    trace({troop}, 1.0);
+
+    CommandService::move_units(m_session->world(), {troop}, {cells.front()});
+    auto const climb = trace({troop}, 90.0);
+
+    EXPECT_GT(climb.highest, k_hill_height * 2.0F)
+        << shape.name << ": never got up the hill (reached " << climb.highest << " m)";
+    EXPECT_EQ(climb.off_walkable_samples, 0)
+        << shape.name << ": climbed over ground it may not stand on near ("
+        << climb.first_off_walkable.x() << ", " << climb.first_off_walkable.z() << ")";
+  }
+}
+
+TEST_F(HillTraversalTest, EveryCrossingOfAnAuthoredHilltopStaysOnIt) {
+  Game::Map::MapDefinition map;
+  QString error;
+  ASSERT_TRUE(Game::Map::MapLoader::load_from_json_file(
+      QDir(QStringLiteral("assets/maps"))
+          .filePath(QStringLiteral("map_copper_canyons.json")),
+      map,
+      &error))
+      << error.toStdString();
+  match(map);
+
+  auto const cells = crown();
+  ASSERT_GE(cells.size(), 40U);
+  auto const* heights = m_session->terrain().get_height_map();
+  auto const pairs = crossings(cells, 12U);
+  ASSERT_FALSE(pairs.empty());
+
+  for (auto const& [from, to] : pairs) {
+    float const crown_height = heights->get_height_at(from.x(), from.z());
+    auto const troop = spawn(from);
+    ASSERT_NE(troop, 0U);
+    trace({troop}, 1.0);
+
+    CommandService::move_units(m_session->world(), {troop}, {to});
+    auto const crossing = trace({troop}, 40.0);
+
+    EXPECT_GT(crossing.lowest, crown_height - 4.0F)
+        << "crossing the hilltop from (" << from.x() << ", " << from.z() << ") to ("
+        << to.x() << ", " << to.z() << ") dropped to " << crossing.lowest << " m off a "
+        << crown_height << " m crown";
+    EXPECT_EQ(crossing.off_walkable_samples, 0);
+    m_session->world().destroy_entity(troop);
+  }
+}
+
+TEST_F(HillTraversalTest, AGroupCrossingAnAuthoredHilltopStaysOnIt) {
+  Game::Map::MapDefinition map;
+  QString error;
+  ASSERT_TRUE(Game::Map::MapLoader::load_from_json_file(
+      QDir(QStringLiteral("assets/maps"))
+          .filePath(QStringLiteral("map_copper_canyons.json")),
+      map,
+      &error))
+      << error.toStdString();
+  match(map);
+
+  auto const cells = crown();
+  ASSERT_GE(cells.size(), 40U);
+  auto const* heights = m_session->terrain().get_height_map();
+  auto const pairs = crossings(cells, 4U);
+  ASSERT_FALSE(pairs.empty());
+
+  for (auto const& [from, to] : pairs) {
+    float const crown_height = heights->get_height_at(from.x(), from.z());
+
+    std::vector<QVector3D> staging;
+    for (auto const& cell : cells) {
+      if ((cell - from).length() > 10.0F) {
+        continue;
+      }
+      bool clear = true;
+      for (auto const& taken : staging) {
+        if ((taken - cell).length() < 2.5F) {
+          clear = false;
+          break;
+        }
+      }
+      if (clear) {
+        staging.push_back(cell);
+      }
+      if (staging.size() == 6U) {
+        break;
+      }
+    }
+    if (staging.size() < 6U) {
+      continue;
+    }
+
+    std::vector<EntityID> troops;
+    troops.reserve(staging.size());
+    for (auto const& spot : staging) {
+      troops.push_back(spawn(spot));
+    }
+    trace(troops, 2.0);
+
+    std::vector<QVector3D> const destinations(troops.size(), to);
+    CommandService::move_units(m_session->world(), troops, destinations);
+    auto const crossing = trace(troops, 45.0);
+
+    EXPECT_GT(crossing.lowest, crown_height - 4.0F)
+        << "six troops crossing one hilltop from (" << from.x() << ", " << from.z()
+        << ") to (" << to.x() << ", " << to.z() << ") dropped to " << crossing.lowest
+        << " m off a " << crown_height << " m crown";
+    EXPECT_EQ(crossing.off_walkable_samples, 0);
+
+    for (auto const troop : troops) {
+      m_session->world().destroy_entity(troop);
+    }
+  }
+}
+
+} // namespace

--- a/tests/map/hill_navigation_test.cpp
+++ b/tests/map/hill_navigation_test.cpp
@@ -1,0 +1,244 @@
+
+
+#include <QDir>
+#include <QString>
+#include <QVector3D>
+#include <queue>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "game/map/map_definition.h"
+#include "game/map/map_loader.h"
+#include "game/map/terrain.h"
+#include "game/map/terrain_service.h"
+#include "game/systems/nav_grid.h"
+#include "game/systems/pathfinding.h"
+#include "tests/support/hill_plateaus.h"
+
+namespace {
+
+using Game::Systems::NavGrid;
+using Game::Systems::Point;
+
+const char* const k_authored_maps[] = {"map_rivers.json",
+                                       "map_forest.json",
+                                       "map_mountain.json",
+                                       "map_spanish_grove.json",
+                                       "map_copper_canyons.json",
+                                       "map_amber_delta.json",
+                                       "map_sallow_ford.json",
+                                       "map_pinewater_cut.json"};
+
+class HillNavigationTest : public ::testing::Test {
+protected:
+  void SetUp() override { Game::Map::TerrainService::instance().clear(); }
+  void TearDown() override { Game::Map::TerrainService::instance().clear(); }
+
+  auto activate(const Game::Map::MapDefinition& map) -> void {
+    Game::Map::TerrainService::instance().clear();
+    Game::Map::TerrainService::instance().initialize(map);
+    NavGrid::initialize(map.grid.width, map.grid.height);
+    ASSERT_NE(NavGrid::get_pathfinder(), nullptr);
+    NavGrid::get_pathfinder()->update_navigation_grid();
+    m_grid = map.grid.width;
+  }
+
+  auto load(const char* file_name) -> Game::Map::MapDefinition {
+    Game::Map::MapDefinition map;
+    QString error;
+    EXPECT_TRUE(Game::Map::MapLoader::load_from_json_file(
+        QDir(QStringLiteral("assets/maps")).filePath(QString::fromLatin1(file_name)),
+        map,
+        &error))
+        << file_name << ": " << error.toStdString();
+    return map;
+  }
+
+  static auto terrain() -> Game::Map::TerrainService& {
+    return Game::Map::TerrainService::instance();
+  }
+
+  static auto heights() -> const Game::Map::TerrainHeightMap& {
+    return *Game::Map::TerrainService::instance().get_height_map();
+  }
+
+  static auto pathfinder() -> Game::Systems::Pathfinding& {
+    return *NavGrid::get_pathfinder();
+  }
+
+  [[nodiscard]] auto index_of(Point cell) const -> std::size_t {
+    return static_cast<std::size_t>(cell.y) * m_grid + cell.x;
+  }
+
+  [[nodiscard]] auto in_grid(Point cell) const -> bool {
+    return cell.x >= 0 && cell.x < m_grid && cell.y >= 0 && cell.y < m_grid;
+  }
+
+  [[nodiscard]] auto highest_route_available(Point from, Point to) const -> float {
+    std::vector<float> best(static_cast<std::size_t>(m_grid) * m_grid,
+                            -std::numeric_limits<float>::infinity());
+    std::priority_queue<std::pair<float, int>> open;
+    best[index_of(from)] = heights().get_height_at_grid(from.x, from.y);
+    open.emplace(best[index_of(from)], (from.y * m_grid) + from.x);
+    while (!open.empty()) {
+      auto const [value, packed] = open.top();
+      open.pop();
+      Point const cell{packed % m_grid, packed / m_grid};
+      if (value < best[index_of(cell)]) {
+        continue;
+      }
+      if (cell.x == to.x && cell.y == to.y) {
+        return value;
+      }
+      constexpr int k_dirs[8][2] = {
+          {1, 0}, {-1, 0}, {0, 1}, {0, -1}, {1, 1}, {1, -1}, {-1, 1}, {-1, -1}};
+      for (auto const& dir : k_dirs) {
+        Point const next{cell.x + dir[0], cell.y + dir[1]};
+        if (!in_grid(next) || !pathfinder().is_walkable(next.x, next.y)) {
+          continue;
+        }
+        float const candidate =
+            std::min(value, heights().get_height_at_grid(next.x, next.y));
+        if (candidate <= best[index_of(next)]) {
+          continue;
+        }
+        best[index_of(next)] = candidate;
+        open.emplace(candidate, (next.y * m_grid) + next.x);
+      }
+    }
+    return -std::numeric_limits<float>::infinity();
+  }
+
+  [[nodiscard]] auto
+  lowest_point_on_route(const std::vector<Point>& route) const -> float {
+    float lowest = std::numeric_limits<float>::infinity();
+    for (auto const& step : route) {
+      lowest = std::min(lowest, heights().get_height_at_grid(step.x, step.y));
+    }
+    return lowest;
+  }
+
+  int m_grid{0};
+};
+
+TEST_F(HillNavigationTest, RoutesAcrossOneHilltopKeepToTheHighGround) {
+
+  constexpr float k_height_given_up_allowance = 2.0F;
+
+  constexpr float k_nearby_metres = 40.0F;
+
+  for (const char* file_name : k_authored_maps) {
+    auto const map = load(file_name);
+    activate(map);
+
+    int compared = 0;
+    for (auto const& cells : TestSupport::hill_plateaus(m_grid)) {
+      if (cells.size() < 40U) {
+        continue;
+      }
+      auto const crown = TestSupport::crown_of(cells, heights());
+      if (crown.empty() ||
+          heights().get_height_at_grid(crown.front().x, crown.front().y) < 3.0F) {
+        continue;
+      }
+
+      for (std::size_t i = 0; i < crown.size(); i += 29U) {
+        for (std::size_t j = i + 1U; j < crown.size(); j += 37U) {
+          Point const from = crown[i];
+          Point const to = crown[j];
+          if (std::hypot(static_cast<float>(from.x - to.x),
+                         static_cast<float>(from.y - to.y)) > k_nearby_metres) {
+            continue;
+          }
+          auto const route = pathfinder().find_path(from, to);
+          if (route.empty() || route.back().x != to.x || route.back().y != to.y) {
+            continue;
+          }
+          ++compared;
+          float const available = highest_route_available(from, to);
+          float const taken = lowest_point_on_route(route);
+          EXPECT_GE(taken, available - k_height_given_up_allowance)
+              << file_name << ": the route from (" << from.x << ", " << from.y
+              << ") to (" << to.x << ", " << to.y << ") on one hilltop dropped to "
+              << taken << " m when it could have stayed at " << available << " m";
+        }
+      }
+    }
+    EXPECT_GT(compared, 0) << file_name << " offered no hilltop to cross";
+  }
+}
+
+TEST_F(HillNavigationTest, HillEntrancesNeverOpenWaterOrMountain) {
+  for (const char* file_name : k_authored_maps) {
+    auto const map = load(file_name);
+    activate(map);
+
+    int opened = 0;
+    Point worst{};
+    for (int z = 0; z < m_grid; ++z) {
+      for (int x = 0; x < m_grid; ++x) {
+        if (!heights().isHillEntrance(x, z) || terrain().is_walkable(x, z) ||
+            !pathfinder().is_walkable(x, z)) {
+          continue;
+        }
+        if (heights().isBridgeCell(x, z) || heights().isBridgeCenterline(x, z)) {
+          continue;
+        }
+        ++opened;
+        worst = {x, z};
+      }
+    }
+    EXPECT_EQ(opened, 0) << file_name << ": a hill entrance opened " << opened
+                         << " cells the terrain blocks, e.g. (" << worst.x << ", "
+                         << worst.y << ")";
+  }
+}
+
+TEST_F(HillNavigationTest, AMarchAcrossOpenGroundGoesRoundAHillNotOverIt) {
+  Game::Map::MapDefinition map;
+  map.grid.width = 120;
+  map.grid.height = 120;
+  map.grid.tile_size = 1.0F;
+  map.coordSystem = Game::Map::CoordSystem::World;
+  map.biome.procedural_trees_enabled = false;
+  map.biome.procedural_boulders_enabled = false;
+  map.biome.procedural_iron_ore_enabled = false;
+
+  Game::Map::TerrainFeature hill;
+  hill.type = Game::Map::TerrainType::Hill;
+  hill.center_x = 0.0F;
+  hill.center_z = 0.0F;
+  hill.radius = 18.0F;
+  hill.height = 9.0F;
+  hill.entrances.emplace_back(-20.0F, 0.0F, 0.0F);
+  hill.entrances.emplace_back(20.0F, 0.0F, 0.0F);
+  map.terrain.push_back(hill);
+
+  activate(map);
+
+  Point const west = NavGrid::world_to_grid(-40.0F, 0.0F);
+  Point const east = NavGrid::world_to_grid(40.0F, 0.0F);
+  ASSERT_TRUE(pathfinder().is_walkable(west.x, west.y));
+  ASSERT_TRUE(pathfinder().is_walkable(east.x, east.y));
+
+  auto const route = pathfinder().find_path(west, east);
+  ASSERT_FALSE(route.empty());
+  ASSERT_EQ(route.back().x, east.x);
+  ASSERT_EQ(route.back().y, east.y);
+
+  float highest = 0.0F;
+  for (auto const& step : route) {
+    highest = std::max(highest, heights().get_height_at_grid(step.x, step.y));
+  }
+  EXPECT_LT(highest, 3.0F) << "a march across open ground climbed " << highest
+                           << " m over the hill rather than walking round its foot";
+}
+
+} // namespace

--- a/tests/support/hill_plateaus.h
+++ b/tests/support/hill_plateaus.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "game/map/terrain.h"
+#include "game/map/terrain_service.h"
+#include "game/systems/nav_grid.h"
+#include "game/systems/pathfinding.h"
+
+namespace TestSupport {
+
+[[nodiscard]] inline auto on_walkable_hill(Game::Systems::Point cell,
+                                           int grid) -> bool {
+  if (cell.x < 0 || cell.x >= grid || cell.y < 0 || cell.y >= grid) {
+    return false;
+  }
+  auto const& terrain = Game::Map::TerrainService::instance();
+  auto const* pathfinder = Game::Systems::NavGrid::get_pathfinder();
+  return terrain.get_terrain_type(cell.x, cell.y) == Game::Map::TerrainType::Hill &&
+         terrain.is_walkable(cell.x, cell.y) && pathfinder != nullptr &&
+         pathfinder->is_walkable(cell.x, cell.y);
+}
+
+[[nodiscard]] inline auto
+hill_plateaus(int grid) -> std::vector<std::vector<Game::Systems::Point>> {
+  using Game::Systems::Point;
+
+  std::vector<std::uint8_t> seen(static_cast<std::size_t>(grid) * grid, 0U);
+  std::vector<std::vector<Point>> found;
+  for (int z = 0; z < grid; ++z) {
+    for (int x = 0; x < grid; ++x) {
+      Point const seed{x, z};
+      auto const seed_index = static_cast<std::size_t>(z) * grid + x;
+      if (seen[seed_index] != 0U || !on_walkable_hill(seed, grid)) {
+        continue;
+      }
+      std::vector<Point> cells{seed};
+      std::vector<Point> queue{seed};
+      seen[seed_index] = 1U;
+      while (!queue.empty()) {
+        Point const cell = queue.back();
+        queue.pop_back();
+        constexpr int k_dirs[4][2] = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+        for (auto const& dir : k_dirs) {
+          Point const next{cell.x + dir[0], cell.y + dir[1]};
+          if (!on_walkable_hill(next, grid)) {
+            continue;
+          }
+          auto& mark = seen[static_cast<std::size_t>(next.y) * grid + next.x];
+          if (mark != 0U) {
+            continue;
+          }
+          mark = 1U;
+          cells.push_back(next);
+          queue.push_back(next);
+        }
+      }
+      found.push_back(std::move(cells));
+    }
+  }
+  std::sort(found.begin(), found.end(), [](auto const& a, auto const& b) {
+    return a.size() > b.size();
+  });
+  return found;
+}
+
+[[nodiscard]] inline auto
+crown_of(const std::vector<Game::Systems::Point>& plateau,
+         const Game::Map::TerrainHeightMap& heights,
+         float fraction_of_top = 0.85F) -> std::vector<Game::Systems::Point> {
+  float top = 0.0F;
+  for (auto const& cell : plateau) {
+    top = std::max(top, heights.get_height_at_grid(cell.x, cell.y));
+  }
+  std::vector<Game::Systems::Point> crown;
+  for (auto const& cell : plateau) {
+    if (heights.get_height_at_grid(cell.x, cell.y) >= top * fraction_of_top) {
+      crown.push_back(cell);
+    }
+  }
+  return crown;
+}
+
+} // namespace TestSupport

--- a/tools/arena/README.md
+++ b/tools/arena/README.md
@@ -488,6 +488,16 @@ Shot fields:
   chase camera. A gameplay shot needs no `focus` or `camera` block, and any it
   declares is ignored.
 
+- `report_card` closes the shot with the scenario's battle report held on screen
+  for that many seconds: the victor (or STALEMATE, or MUTUAL DESTRUCTION), the
+  decision time, and each side's doctrine, units raised, peak army, building
+  census, survivors and time spent attacking. It waits for the scenario to
+  finish so the outcome is final — with a `BattleReachesDecision` scenario the
+  shot ends at the decision and the card follows immediately, so the clip is
+  exactly as long as the match needed. Painted from
+  `ArenaViewport::active_scenario_report`, encoded with the audio kept in step,
+  and the shot's poster becomes the card. `ai_duel_hannibal_mirror.json` records
+  a whole `ai_duel_hannibal_vs_hannibal` match this way.
 - `rpg_hud` paints the commander's bow HUD onto the captured frame: the spread
   reticle projected through the live vertical FOV, the draw ring, the hit
   confirm, HP and stamina, the renock meter, and a takedown counter. It is drawn
@@ -1290,6 +1300,33 @@ unit regardless of how large that unit is drawn.
 The path scenes suppress incidental scatter and use a fixed feature-centered
 camera so the route, obstacle, and formation motion remain readable in batch
 captures.
+
+## Hill contracts
+
+A hill is a wall with gates cut into it. Two things follow, and each has its own
+family of scenarios.
+
+`nav_hill_{blob,corridor,arc,elbow,ring}_{0,1,2}_entrances` cover getting on and
+off one: a troop climbs a 10-cell, 7 m hill from `(-22, 0, 0)` and is then sent
+back to where it started. They assert the troop and its rendered soldiers only
+ever stand on ground they are allowed to stand on, that at least 4.5 m of
+elevation is gained, and that neither leg reverses. See the notes on
+`k_leg_reversal_tolerance` in the source: a curved crown legitimately dips about
+a metre as a troop follows it, so the tolerance is not arbitrary.
+
+`nav_hill_crown_{blob,corridor,arc,elbow,ring}` cover being on one. A troop that
+already stands on the crown is sent to another spot on the same crown and then
+back. Nothing is being climbed, so the whole run has to hold above
+`ElevationHeldAbove`. This is the family that catches a route which leaves by
+one ramp and climbs back up another -- which is what a two-dimensional search
+does whenever that is the shorter way in plan view, and was the behaviour
+`Pathfinding::climb_penalty` was added to stop. The two crown spots per shape are
+measured from the generated hill, not guessed; if the hill generator changes
+shape, re-measure them rather than loosening the floor.
+
+A full sweep of both families is about 25 minutes. Run them one at a time while
+iterating, and never relink `arena_app` mid-sweep -- the remaining scenarios die
+without a PASS/FAIL line.
 
 ## Road and bridge surface contracts
 

--- a/tools/arena/arena_ai_duel_scenarios.cpp
+++ b/tools/arena/arena_ai_duel_scenarios.cpp
@@ -464,6 +464,40 @@ auto build_ai_duel_definitions() -> std::vector<ArenaScenarioDefinition> {
   }
 
   {
+    DuelSide north;
+    north.label = QStringLiteral("hannibal_north");
+    north.owner_id = 2;
+    north.nation = Nation::Carthage;
+    north.commander = Troop::CarthageSwordCommander;
+
+    DuelSide south;
+    south.label = QStringLiteral("hannibal_south");
+    south.owner_id = 3;
+    south.nation = Nation::Carthage;
+    south.commander = Troop::CarthageSwordCommander;
+
+    auto s = duel_definition(
+        k_ai_duel_hannibal_vs_hannibal_id,
+        QStringLiteral("AI Duel: Hannibal vs Hannibal"),
+        QStringLiteral("The mirror match: the same decisive Barcid doctrine on "
+                       "both corners, a war chest of 3000 gold apiece, and "
+                       "nothing standing but each side's barracks. Whatever "
+                       "separates the towns they raise and the armies they "
+                       "field is the doctrine meeting itself."),
+        1800.0F,
+        north,
+        south);
+    s.ai_starting_resources.gold = 3000;
+    s.expectations.push_back(
+        doctrine_expectation(QStringLiteral("hannibal_north"), "aggressive:field"));
+    s.expectations.push_back(
+        doctrine_expectation(QStringLiteral("hannibal_south"), "aggressive:field"));
+    add_economy_expectations(s, QStringLiteral("hannibal_north"));
+    add_economy_expectations(s, QStringLiteral("hannibal_south"));
+    result.push_back(std::move(s));
+  }
+
+  {
     DuelSide scipio;
     scipio.label = QStringLiteral("scipio");
     scipio.owner_id = 2;

--- a/tools/arena/arena_navigation_scenarios.cpp
+++ b/tools/arena/arena_navigation_scenarios.cpp
@@ -164,6 +164,9 @@ struct HillTraversalShape {
   Game::Map::HillShape shape;
   float thickness;
   QVector3D crown;
+
+  QVector3D crown_start;
+  QVector3D crown_far;
 };
 
 auto hill_traversal_scenario(const HillTraversalShape& profile,
@@ -280,6 +283,89 @@ auto hill_traversal_scenario(const HillTraversalShape& profile,
   return scenario;
 }
 
+auto hill_crown_traverse_scenario(const HillTraversalShape& profile)
+    -> ArenaScenarioDefinition {
+  constexpr float k_hill_radius = 14.0F;
+  constexpr float k_hill_height = 9.0F;
+  constexpr float k_shape_extent = 32.0F;
+  constexpr float k_cross_order = 1.0F;
+  constexpr float k_return_order = 26.0F;
+  constexpr float k_duration = 52.0F;
+  constexpr float k_settle_seconds = 1.5F;
+
+  constexpr float k_crown_floor = 5.0F;
+  constexpr float k_soldier_ground_transient_samples = 24.0F;
+
+  auto scenario = definition(
+      QStringLiteral("nav_hill_crown_%1").arg(QString::fromLatin1(profile.slug)),
+      QStringLiteral("Navigation: Crossing The Top Of A %1 Hill")
+          .arg(QString::fromLatin1(profile.prose)),
+      QStringLiteral("A troop standing on a %1 hill is sent to another spot on the "
+                     "same crown and then back again. It has to walk across the top: "
+                     "going down the ramp and climbing back up is not a route, it is "
+                     "the bug this scenario exists for.")
+          .arg(QString::fromLatin1(profile.prose)),
+      k_duration,
+      {40.0F, 46.0F, 25.0F});
+  scenario.terrain_grid_extent = 120;
+  scenario.arena_floor_half_extent = 34.0F;
+  scenario.camera_focus = QVector3D(0.0F, 0.0F, 0.0F);
+  scenario.terrain_height_scale_override = 0.5F;
+  scenario.suppress_terrain_scatter = true;
+
+  Game::Map::TerrainFeature hill;
+  hill.type = Game::Map::TerrainType::Hill;
+  hill.center_x = 0.0F;
+  hill.center_z = 0.0F;
+  hill.radius = k_hill_radius;
+  hill.height = k_hill_height;
+  hill.shape = profile.shape;
+  if (profile.shape != Game::Map::HillShape::Blob) {
+    hill.width = k_shape_extent;
+    hill.depth = k_shape_extent;
+    hill.thickness = profile.thickness;
+  }
+  hill.entrances.push_back(QVector3D(-16.0F, 0.0F, 0.0F));
+  scenario.terrain_features.push_back(hill);
+
+  const QString crossers = QStringLiteral("crossers");
+  scenario.groups = {group(crossers,
+                           Troop::Spearman,
+                           1,
+                           1,
+                           profile.crown_start,
+                           4,
+                           QVector3D(0.0F, 0.0F, 2.0F))};
+  scenario.steps = {move_to(k_cross_order, crossers, profile.crown_far),
+                    move_to(k_return_order, crossers, profile.crown_start)};
+
+  scenario.expectations.push_back(
+      expectation(Expect::AllGroupsRespondWithin, crossers, 2.5F));
+  scenario.expectations.push_back(
+      expectation(Expect::MovementAnimationObserved, crossers));
+  scenario.expectations.push_back(expectation(Expect::NoRootTeleport, crossers));
+  scenario.expectations.push_back(expectation(Expect::GroupIsRendered, crossers));
+  scenario.expectations.push_back(
+      expectation(Expect::UnitsStayOnWalkableGround, crossers));
+  scenario.expectations.push_back(expectation(Expect::SoldiersStayOnWalkableGround,
+                                              crossers,
+                                              k_soldier_ground_transient_samples,
+                                              0.0F,
+                                              k_settle_seconds));
+
+  auto stayed_up = expectation(
+      Expect::ElevationHeldAbove, crossers, k_crown_floor, 0.0F, k_settle_seconds);
+  scenario.expectations.push_back(std::move(stayed_up));
+
+  auto returned = expectation(Expect::GroupReachedDestination, crossers);
+  returned.distance = 5.0F;
+  returned.position = profile.crown_start;
+  scenario.expectations.push_back(std::move(returned));
+
+  scenario.expectations.push_back(expectation(Expect::FrameBudget, {}, 33.34F));
+  return scenario;
+}
+
 auto hill_gap_scenario(const char* id,
                        const char* label,
                        const char* description,
@@ -375,32 +461,43 @@ auto build_navigation_definitions() -> std::vector<ArenaScenarioDefinition> {
          "round",
          Game::Map::HillShape::Blob,
          0.0F,
-         QVector3D(2.0F, 0.0F, 0.0F)},
+         QVector3D(2.0F, 0.0F, 0.0F),
+         QVector3D(-8.5F, 0.0F, -0.5F),
+         QVector3D(7.5F, 0.0F, -0.5F)},
         {"corridor",
          "ridge",
          Game::Map::HillShape::Corridor,
          9.0F,
-         QVector3D(0.0F, 0.0F, 0.0F)},
+         QVector3D(0.0F, 0.0F, 0.0F),
+         QVector3D(-10.5F, 0.0F, 0.5F),
+         QVector3D(10.5F, 0.0F, -0.5F)},
         {"arc",
          "crescent",
          Game::Map::HillShape::Arc,
          9.0F,
-         QVector3D(7.0F, 0.0F, 0.0F)},
+         QVector3D(7.0F, 0.0F, 0.0F),
+         QVector3D(6.5F, 0.0F, 9.5F),
+         QVector3D(7.5F, 0.0F, -8.5F)},
         {"elbow",
          "elbow",
          Game::Map::HillShape::Elbow,
          9.0F,
-         QVector3D(-2.0F, 0.0F, -6.0F)},
+         QVector3D(-2.0F, 0.0F, -6.0F),
+         QVector3D(-10.5F, 0.0F, 9.5F),
+         QVector3D(11.5F, 0.0F, -11.5F)},
         {"ring",
          "ring",
          Game::Map::HillShape::Ring,
          7.0F,
-         QVector3D(5.0F, 0.0F, -5.0F)},
+         QVector3D(5.0F, 0.0F, -5.0F),
+         QVector3D(-0.5F, 0.0F, 12.5F),
+         QVector3D(12.5F, 0.0F, -0.5F)},
     };
     for (const auto& shape : shapes) {
       for (int entrances = 0; entrances <= 2; ++entrances) {
         result.push_back(hill_traversal_scenario(shape, entrances));
       }
+      result.push_back(hill_crown_traverse_scenario(shape));
     }
   }
 

--- a/tools/arena/arena_scenario.cpp
+++ b/tools/arena/arena_scenario.cpp
@@ -899,6 +899,13 @@ struct ArenaScenarioRunner::Impl {
   };
   QHash<QString, ElevationLegState> elevation_climb_legs;
   QHash<QString, ElevationLegState> elevation_descent_legs;
+  struct ElevationFloorState {
+    bool seeded{false};
+    float lowest{0.0F};
+    float lowest_at{0.0F};
+    QVector3D lowest_where;
+  };
+  QHash<QString, ElevationFloorState> elevation_floors;
   struct OffGroundState {
     int samples{0};
     QVector3D worst;
@@ -2687,6 +2694,16 @@ struct ArenaScenarioRunner::Impl {
         track_elevation_leg(
             elevation_descent_legs[group], position.y(), false, expectation.distance);
         break;
+      case ArenaExpectationKind::ElevationHeldAbove: {
+        auto& floor = elevation_floors[group];
+        if (!floor.seeded || position.y() < floor.lowest) {
+          floor.seeded = true;
+          floor.lowest = position.y();
+          floor.lowest_at = elapsed;
+          floor.lowest_where = position;
+        }
+        break;
+      }
       case ArenaExpectationKind::UnitsStayOnWalkableGround: {
         if (Game::Systems::NavGrid::is_world_position_walkable(position)) {
           break;
@@ -5265,6 +5282,28 @@ struct ArenaScenarioRunner::Impl {
                   .arg(climbing ? QStringLiteral("climb") : QStringLiteral("descent"))
                   .arg(leg.worst_at, 0, 'f', 2)
                   .arg(tolerance, 0, 'f', 2));
+        }
+        break;
+      }
+      case ArenaExpectationKind::ElevationHeldAbove: {
+        auto const floor = elevation_floors.value(expectation.group);
+        if (!floor.seeded) {
+          add_issue(QStringLiteral("elevation_floor_not_sampled"),
+                    QStringLiteral("%1 produced no elevation sample while it was "
+                                   "meant to be holding the high ground")
+                        .arg(expectation.group));
+          break;
+        }
+        if (floor.lowest < expectation.threshold) {
+          add_issue(QStringLiteral("elevation_floor_broken"),
+                    QStringLiteral("%1 dropped to %2 m at %3 s near (%4, %5); it "
+                                   "was meant to stay above %6 m")
+                        .arg(expectation.group)
+                        .arg(floor.lowest, 0, 'f', 2)
+                        .arg(floor.lowest_at, 0, 'f', 2)
+                        .arg(floor.lowest_where.x(), 0, 'f', 2)
+                        .arg(floor.lowest_where.z(), 0, 'f', 2)
+                        .arg(expectation.threshold, 0, 'f', 2));
         }
         break;
       }

--- a/tools/arena/arena_scenario.h
+++ b/tools/arena/arena_scenario.h
@@ -290,6 +290,7 @@ enum class ArenaExpectationKind : std::uint8_t {
   ElevationGainObserved,
   ElevationClimbIsMonotonic,
   ElevationDescentIsMonotonic,
+  ElevationHeldAbove,
   UnitsStayOnWalkableGround,
   SoldiersStayOnWalkableGround,
   OwnerCompletesConstruction,

--- a/tools/arena/arena_scenarios.h
+++ b/tools/arena/arena_scenarios.h
@@ -168,6 +168,8 @@ inline constexpr char k_ai_duel_marcellus_vs_hanno_id[] = "ai_duel_marcellus_vs_
 inline constexpr char k_ai_war_of_towns_id[] = "ai_war_of_towns";
 inline constexpr char k_ai_duel_hannibal_vs_hasdrubal_id[] =
     "ai_duel_hannibal_vs_hasdrubal";
+inline constexpr char k_ai_duel_hannibal_vs_hannibal_id[] =
+    "ai_duel_hannibal_vs_hannibal";
 inline constexpr char k_seven_ai_scale_id[] = "seven_ai_scale";
 inline constexpr char k_village_harvest_cycle_id[] = "village_harvest_cycle";
 inline constexpr char k_village_day_life_id[] = "village_day_life";

--- a/tools/arena/promo_runner.cpp
+++ b/tools/arena/promo_runner.cpp
@@ -203,6 +203,197 @@ void paint_rpg_bow_hud(QImage& frame, const ArenaViewport::RpgBowHudState& state
   painter.drawText(counter, Qt::AlignRight | Qt::AlignVCenter, takedowns);
 }
 
+auto format_clock(float seconds) -> QString {
+  const int total = std::max(0, static_cast<int>(std::lround(seconds)));
+  return QStringLiteral("%1:%2")
+      .arg(total / 60)
+      .arg(total % 60, 2, 10, QLatin1Char('0'));
+}
+
+auto side_display_name(QString label) -> QString {
+  return label.replace(QLatin1Char('_'), QLatin1Char(' ')).toUpper();
+}
+
+auto census_display(const QString& census) -> QString {
+  QStringList parts;
+  for (const QString& entry : census.split(QLatin1Char(','), Qt::SkipEmptyParts)) {
+    const qsizetype split = entry.lastIndexOf(QLatin1Char('x'));
+    if (split <= 0) {
+      parts.push_back(entry.toUpper());
+      continue;
+    }
+    parts.push_back(QStringLiteral("%1 × %2").arg(
+        entry.mid(split + 1),
+        entry.left(split).replace(QLatin1Char('_'), QLatin1Char(' ')).toUpper()));
+  }
+  return parts.join(QStringLiteral("   "));
+}
+
+auto card_font(double ui, double pixels) -> QFont {
+  QFont font = Arena::Typography::small_label(1.0);
+  font.setPixelSize(static_cast<int>(std::lround(pixels * ui)));
+  return font;
+}
+
+auto paint_report_card(const Spec& spec,
+                       const Arena::ArenaScenarioReport* report) -> QImage {
+  QImage card(spec.width, spec.height, QImage::Format_RGB32);
+  card.fill(QColor(11, 10, 8));
+
+  const double width = card.width();
+  const double height = card.height();
+  const double ui = std::clamp(height / 1080.0, 0.4, 2.4);
+
+  const QColor parchment(238, 232, 218);
+  const QColor faded(168, 158, 138);
+  const QColor gold(214, 186, 116);
+  const QColor blood(206, 74, 56);
+  const QColor laurel(122, 178, 112);
+
+  QPainter painter(&card);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setRenderHint(QPainter::TextAntialiasing, true);
+
+  const auto line = [&](double y, const QColor& color) {
+    painter.setPen(QPen(color, std::max(1.0, 2.0 * ui)));
+    painter.drawLine(QPointF(width * 0.14, y), QPointF(width * 0.86, y));
+  };
+  const auto text = [&](double y,
+                        double pixels,
+                        const QColor& color,
+                        const QString& value,
+                        double left = 0.0,
+                        double right = 1.0) {
+    painter.setFont(card_font(ui, pixels));
+    painter.setPen(color);
+    painter.drawText(QRectF(width * left, y, width * (right - left), pixels * ui * 1.6),
+                     Qt::AlignHCenter | Qt::AlignVCenter,
+                     value);
+    return y + (pixels * ui * 1.6);
+  };
+
+  double y = height * 0.16;
+  y = text(y, 20.0, faded, spec.title);
+  y += 6.0 * ui;
+  y = text(y, 46.0, parchment, QStringLiteral("BATTLE REPORT"));
+  y += 14.0 * ui;
+  line(y, QColor(gold.red(), gold.green(), gold.blue(), 140));
+  y += 26.0 * ui;
+
+  const bool tracked =
+      report != nullptr && report->battle.tracked && !report->battle.sides.empty();
+
+  QString verdict = QStringLiteral("SCENARIO COMPLETE");
+  QString clock_line;
+  QColor verdict_color = parchment;
+  if (tracked) {
+    const auto& battle = report->battle;
+    if (battle.decided && !battle.victor_label.isEmpty()) {
+      verdict = QStringLiteral("%1 WINS").arg(side_display_name(battle.victor_label));
+      verdict_color = gold;
+      clock_line =
+          QStringLiteral("DECIDED AT %1").arg(format_clock(battle.decided_at_seconds));
+    } else if (battle.decided) {
+      verdict = QStringLiteral("MUTUAL DESTRUCTION");
+      verdict_color = blood;
+      clock_line =
+          QStringLiteral("DECIDED AT %1").arg(format_clock(battle.decided_at_seconds));
+    } else {
+      verdict = QStringLiteral("STALEMATE");
+      clock_line = QStringLiteral("NO DECISION AFTER %1")
+                       .arg(format_clock(report->elapsed_seconds));
+    }
+  }
+  y = text(y, 52.0, verdict_color, verdict);
+  if (!clock_line.isEmpty()) {
+    y += 4.0 * ui;
+    y = text(y, 20.0, faded, clock_line);
+  }
+  y += 24.0 * ui;
+
+  if (!tracked) {
+    return card;
+  }
+
+  const std::size_t columns = std::min<std::size_t>(report->battle.sides.size(), 2U);
+  const double column_top = y;
+  double column_bottom = y;
+  for (std::size_t index = 0; index < columns; ++index) {
+    const auto& side = report->battle.sides[index];
+    const double left = index == 0 ? 0.10 : 0.52;
+    const double right = index == 0 ? 0.48 : 0.90;
+
+    double row = column_top;
+    row = text(row, 30.0, parchment, side_display_name(side.label), left, right);
+    row += 4.0 * ui;
+    const QString doctrine =
+        QStringLiteral("%1 · %2").arg(side.strategy.toUpper(), side.posture.toUpper());
+    row = text(row, 17.0, gold, doctrine.trimmed(), left, right);
+    row += 14.0 * ui;
+    row = text(row,
+               19.0,
+               parchment,
+               QStringLiteral("UNITS RAISED %1  ·  PEAK ARMY %2")
+                   .arg(side.units_produced)
+                   .arg(side.peak_units),
+               left,
+               right);
+    row = text(row,
+               19.0,
+               parchment,
+               QStringLiteral("BUILDINGS RAISED %1").arg(side.buildings_constructed),
+               left,
+               right);
+    if (!side.building_census.isEmpty()) {
+      painter.setFont(card_font(ui, 14.0));
+      painter.setPen(faded);
+      const QRectF census_rect(
+          width * left, row, width * (right - left), 14.0 * ui * 4.0);
+      const int census_flags = Qt::AlignHCenter | Qt::AlignTop | Qt::TextWordWrap;
+      const QString census = census_display(side.building_census);
+      painter.drawText(census_rect, census_flags, census);
+      row +=
+          painter.boundingRect(census_rect, census_flags, census).height() + (6.0 * ui);
+    }
+    row += 10.0 * ui;
+    row = text(row,
+               19.0,
+               parchment,
+               QStringLiteral("STANDING %1 UNITS  ·  %2 BUILDINGS")
+                   .arg(side.living_units)
+                   .arg(side.living_buildings),
+               left,
+               right);
+    row = text(row,
+               19.0,
+               parchment,
+               QStringLiteral("TIME ON THE ATTACK %1")
+                   .arg(format_clock(side.seconds_attacking)),
+               left,
+               right);
+    row += 12.0 * ui;
+    if (side.eliminated_at >= 0.0F) {
+      row = text(row,
+                 21.0,
+                 blood,
+                 QStringLiteral("FELL AT %1").arg(format_clock(side.eliminated_at)),
+                 left,
+                 right);
+    } else {
+      row = text(row, 21.0, laurel, QStringLiteral("STANDS AT THE END"), left, right);
+    }
+    column_bottom = std::max(column_bottom, row);
+  }
+
+  painter.setPen(QPen(QColor(faded.red(), faded.green(), faded.blue(), 90),
+                      std::max(1.0, 2.0 * ui)));
+  painter.drawLine(QPointF(width * 0.5, column_top + (6.0 * ui)),
+                   QPointF(width * 0.5, column_bottom));
+
+  line(column_bottom + (26.0 * ui), QColor(gold.red(), gold.green(), gold.blue(), 140));
+  return card;
+}
+
 auto brightest_sample(const QImage& frame) -> int {
   if (frame.isNull()) {
     return 0;
@@ -379,6 +570,10 @@ private:
     m_logged_framing = false;
     m_shot_active = true;
     m_shot_armed = false;
+    m_card_active = false;
+    m_card_frames_written = 0;
+    m_card_frames_target = 0;
+    m_card_image.reset();
     m_last_frame.reset();
     m_viewport.set_batch_fixed_step(idle_step());
     m_viewport.set_flame_card(shot.flame_card, shot.flame_speed, shot.flame_intensity);
@@ -417,6 +612,10 @@ private:
       }
     }
     if (!m_shot_active) {
+      return;
+    }
+    if (m_card_active) {
+      tick_report_card();
       return;
     }
     const Shot& shot = current_shot();
@@ -483,6 +682,9 @@ private:
     }
 
     if (!recording && m_frames_written >= m_target_frames) {
+      if (begin_report_card()) {
+        return;
+      }
       end_shot();
       advance_within_pass();
       return;
@@ -494,6 +696,59 @@ private:
                                   .arg(shot.name)
                                   .arg(m_frames_written)
                                   .arg(m_target_frames);
+      if (begin_report_card()) {
+        return;
+      }
+      end_shot();
+      end_pass();
+    }
+  }
+
+  [[nodiscard]] auto begin_report_card() -> bool {
+    if (m_card_active || m_encoder == nullptr || m_frames_written == 0 ||
+        current_shot().report_card_seconds <= 0.0F) {
+      return false;
+    }
+    m_card_active = true;
+    m_card_frames_written = 0;
+    m_card_frames_target =
+        std::max(1,
+                 static_cast<int>(std::lround(current_shot().report_card_seconds *
+                                              static_cast<float>(m_spec.fps))));
+    m_viewport.set_capture_active(false);
+    m_viewport.set_batch_render_suppressed(true);
+    qInfo().noquote() << QStringLiteral("  closing on the battle report (%1 s)")
+                             .arg(QString::number(
+                                 current_shot().report_card_seconds, 'f', 1));
+    return true;
+  }
+
+  void tick_report_card() {
+    m_viewport.set_capture_active(false);
+    if (!m_viewport.active_scenario_finished()) {
+
+      return;
+    }
+    if (!m_card_image.has_value()) {
+      m_card_image = paint_report_card(m_spec, m_viewport.active_scenario_report());
+      m_last_frame = m_card_image;
+    }
+    QString error;
+    if (!m_encoder->write_frame(*m_card_image, &error)) {
+      qCritical().noquote() << QStringLiteral("Promo encode failed: %1").arg(error);
+      m_failed = true;
+      m_card_active = false;
+      end_shot();
+      end_pass();
+      return;
+    }
+    ++m_frames_written;
+    ++m_card_frames_written;
+    if (m_audio != nullptr) {
+      m_audio->advance(idle_step(), true);
+    }
+    if (m_card_frames_written >= m_card_frames_target) {
+      m_card_active = false;
       end_shot();
       end_pass();
     }
@@ -729,6 +984,10 @@ private:
   std::unique_ptr<VideoEncoder> m_encoder;
   std::vector<ShotResult> m_results;
   std::optional<QImage> m_last_frame;
+  std::optional<QImage> m_card_image;
+  int m_card_frames_written{0};
+  int m_card_frames_target{0};
+  bool m_card_active{false};
   QString m_clip_path;
   QVector3D m_smoothed_focus;
   std::size_t m_pass_index{0};

--- a/tools/arena/promo_spec.cpp
+++ b/tools/arena/promo_spec.cpp
@@ -328,6 +328,11 @@ auto load(const QString& path, QString* error) -> std::optional<Spec> {
         static_cast<float>(shot_object.value(QStringLiteral("flame_intensity"))
                                .toDouble(shot.flame_intensity));
     shot.rpg_hud = shot_object.value(QStringLiteral("rpg_hud")).toBool(shot.rpg_hud);
+    shot.report_card_seconds =
+        std::clamp(static_cast<float>(shot_object.value(QStringLiteral("report_card"))
+                                          .toDouble(shot.report_card_seconds)),
+                   0.0F,
+                   30.0F);
 
     if (shot.scenario.isEmpty()) {
       if (error != nullptr) {

--- a/tools/arena/promo_spec.h
+++ b/tools/arena/promo_spec.h
@@ -67,6 +67,8 @@ struct Shot {
   float flame_intensity{1.0F};
 
   bool rpg_hud{false};
+
+  float report_card_seconds{0.0F};
   Focus focus;
   std::vector<CameraKey> keys;
 };

--- a/tools/arena/promos/ai_duel_hannibal_mirror.json
+++ b/tools/arena/promos/ai_duel_hannibal_mirror.json
@@ -1,0 +1,72 @@
+{
+  "id": "ai_duel_hannibal_mirror",
+  "title": "HANNIBAL  VS  HANNIBAL",
+  "subtitle": "AI VS AI  ·  STANDARD OF IRON",
+  "width": 1920,
+  "height": 1080,
+  "fps": 30,
+  "supersample": 1,
+  "shots": [
+    {
+      "name": "full_match",
+      "scenario": "ai_duel_hannibal_vs_hannibal",
+      "seed": 1337,
+      "start": 0.5,
+      "duration": 1799.0,
+      "report_card": 30.0,
+      "focus": {
+        "mode": "point",
+        "point": [0.0, 0.0, 0.0],
+        "smoothing": 0.0
+      },
+      "camera": [
+        {
+          "time": 0,
+          "distance": 130,
+          "pitch": 47,
+          "yaw": 315,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 450,
+          "distance": 134,
+          "pitch": 46,
+          "yaw": 318,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 900,
+          "distance": 131,
+          "pitch": 47,
+          "yaw": 315,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 1350,
+          "distance": 134,
+          "pitch": 46,
+          "yaw": 312,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 1799,
+          "distance": 130,
+          "pitch": 47,
+          "yaw": 315,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ]
+    }
+  ],
+  "audio": true
+}


### PR DESCRIPTION
Extend pathfinding with hill-aware traversal and plateau handling so navigation can reason about authored elevation changes consistently. Add focused headless and map-level coverage for hill traversal, update the arena navigation and AI-duel scenario catalogs, and document the new scenario workflow. Introduce promo specification execution support and add the Hannibal mirror duel promo definition for repeatable authored demonstrations.