### PR TITLE
feat: polish building and vegetation rendering

### DIFF
--- a/assets/shaders/pine_instanced.frag
+++ b/assets/shaders/pine_instanced.frag
@@ -93,8 +93,8 @@ void main() {
   float bough_edge = smoothstep(0.30, 0.95, v_bough) * (1.0 - underside);
   float canopy_height = clamp(v_tex_coord.y, 0.0, 1.12);
 
-  float shelf = mix(1.0, 0.46, clamp(shelf_ao, 0.0, 1.0));
-  float core = mix(1.0, 0.74, canopy_core * 0.85);
+  float shelf = mix(1.0, 0.60, clamp(shelf_ao, 0.0, 1.0));
+  float core = mix(1.0, 0.80, canopy_core * 0.85);
   float tier = mix(0.84, 1.12, smoothstep(0.34, 1.06, canopy_height));
   float bough_lift = mix(1.0, 1.12, bough_edge);
   float hemi = clamp(geometric_normal.y * 0.5 + 0.5, 0.0, 1.0);

--- a/render/entity/barracks_renderer_common.cpp
+++ b/render/entity/barracks_renderer_common.cpp
@@ -1,5 +1,7 @@
 #include "barracks_renderer_common.h"
 
+#include <array>
+
 #include "../entity_appearance.h"
 #include "game/core/component.h"
 #include "render/gl/backend.h"
@@ -38,8 +40,12 @@ void register_barracks_renderer_variant(EntityRendererRegistry& registry,
           cloth.banner_shader = ctx.backend->banner_shader();
         }
 
+        const std::array<QVector3D, 1> palette{team};
         submit_building_instance(
-            out, ctx, config.archetype(resolve_building_state(ctx), unit, white));
+            out,
+            ctx,
+            config.archetype(resolve_building_state(ctx), unit, white),
+            palette);
         config.draw_ornaments(ctx, out, unit, white, team, &cloth);
         draw_building_selection_overlay(out, ctx, config.selection);
       });

--- a/render/entity/nations/carthage/barracks_renderer.cpp
+++ b/render/entity/nations/carthage/barracks_renderer.cpp
@@ -330,6 +330,38 @@ void draw_fortress_walls(const DrawContext& p,
   if (state != BuildingState::Destroyed) {
     float const lower_band_y = wall_height * 0.25F * height_multiplier + 0.26F;
     float const upper_band_y = wall_height * 0.70F * height_multiplier + 0.26F;
+
+    for (float const course_t : {0.40F, 0.55F, 0.85F}) {
+      float const course_y = wall_height * course_t * height_multiplier + 0.26F;
+      draw_box(out,
+               unit,
+               white,
+               p.model,
+               QVector3D(0.0F, course_y, -1.33F),
+               QVector3D(1.55F, 0.008F, 0.15F),
+               c.stone_base * 0.90F);
+      draw_box(out,
+               unit,
+               white,
+               p.model,
+               QVector3D(0.0F, course_y, 1.33F),
+               QVector3D(1.55F, 0.008F, 0.15F),
+               c.stone_base * 0.90F);
+      draw_box(out,
+               unit,
+               white,
+               p.model,
+               QVector3D(-1.63F, course_y, 0.0F),
+               QVector3D(0.15F, 0.008F, 1.23F),
+               c.stone_base * 0.90F);
+      draw_box(out,
+               unit,
+               white,
+               p.model,
+               QVector3D(1.63F, course_y, 0.0F),
+               QVector3D(0.15F, 0.008F, 1.23F),
+               c.stone_base * 0.90F);
+    }
     for (float const band_y : {lower_band_y, upper_band_y}) {
       draw_box(out,
                unit,
@@ -394,51 +426,51 @@ void draw_fortress_walls(const DrawContext& p,
   if (state != BuildingState::Destroyed) {
     float const merlon_top = wall_height * height_multiplier + 0.32F;
     const int front_merlons = (state == BuildingState::Damaged) ? 5 : 7;
-    add_merlon_strip_x(
+
+    auto merlon_box =
         [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
           draw_box(out, unit, white, p.model, center, size, color);
-        },
-        merlon_top,
-        -1.28F,
-        (state == BuildingState::Damaged) ? -0.80F : -1.22F,
-        0.42F,
-        front_merlons,
-        QVector3D(0.16F, 0.06F, 0.06F),
-        c.brick);
+          draw_box(out,
+                   unit,
+                   white,
+                   p.model,
+                   center + QVector3D(0.0F, size.y() + 0.02F, 0.0F),
+                   QVector3D(size.x() + 0.012F, 0.02F, size.z() + 0.012F),
+                   c.brick_dark);
+        };
+    add_merlon_strip_x(merlon_box,
+                       merlon_top,
+                       -1.28F,
+                       (state == BuildingState::Damaged) ? -0.80F : -1.22F,
+                       0.42F,
+                       front_merlons,
+                       QVector3D(0.16F, 0.06F, 0.06F),
+                       c.stone_light);
     if (detailed && state == BuildingState::Normal) {
-      add_merlon_strip_x(
-          [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-            draw_box(out, unit, white, p.model, center, size, color);
-          },
-          merlon_top,
-          1.28F,
-          -1.22F,
-          0.42F,
-          7,
-          QVector3D(0.16F, 0.06F, 0.06F),
-          c.brick);
-      add_merlon_strip_z(
-          [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-            draw_box(out, unit, white, p.model, center, size, color);
-          },
-          -1.58F,
-          merlon_top,
-          -1.0F,
-          0.40F,
-          6,
-          QVector3D(0.06F, 0.06F, 0.16F),
-          c.brick_dark);
-      add_merlon_strip_z(
-          [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-            draw_box(out, unit, white, p.model, center, size, color);
-          },
-          1.58F,
-          merlon_top,
-          -1.0F,
-          0.40F,
-          6,
-          QVector3D(0.06F, 0.06F, 0.16F),
-          c.brick_dark);
+      add_merlon_strip_x(merlon_box,
+                         merlon_top,
+                         1.28F,
+                         -1.22F,
+                         0.42F,
+                         7,
+                         QVector3D(0.16F, 0.06F, 0.06F),
+                         c.stone_light);
+      add_merlon_strip_z(merlon_box,
+                         -1.58F,
+                         merlon_top,
+                         -1.0F,
+                         0.40F,
+                         6,
+                         QVector3D(0.06F, 0.06F, 0.16F),
+                         c.stone_base);
+      add_merlon_strip_z(merlon_box,
+                         1.58F,
+                         merlon_top,
+                         -1.0F,
+                         0.40F,
+                         6,
+                         QVector3D(0.06F, 0.06F, 0.16F),
+                         c.stone_base);
     }
   }
 
@@ -633,7 +665,7 @@ void draw_courtyard(const DrawContext& p,
              p.model,
              QVector3D(-1.52F, 0.80F, 0.0F),
              QVector3D(0.02F, 0.22F, 0.32F),
-             c.ember);
+             c.tile_red);
 
     if (detailed) {
 

--- a/render/entity/nations/carthage/defense_tower_renderer.cpp
+++ b/render/entity/nations/carthage/defense_tower_renderer.cpp
@@ -55,11 +55,11 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
 
   const bool damaged = state == BuildingState::Damaged;
   const bool destroyed = state == BuildingState::Destroyed;
-  const float core_half_y = destroyed ? 0.46F : (damaged ? 0.62F : 0.76F);
+  const float core_half_y = destroyed ? 0.46F : (damaged ? 0.80F : 0.98F);
   const float core_top = 0.5F + core_half_y * 2.0F;
-  const float upper_drum_y = destroyed ? 0.0F : (damaged ? 1.52F : 1.72F);
-  const float deck_y = destroyed ? 0.0F : (damaged ? 1.80F : 2.08F);
-  const float roof_y = destroyed ? 0.0F : (damaged ? 2.10F : 2.50F);
+  const float upper_drum_y = destroyed ? 0.0F : (damaged ? 1.86F : 2.16F);
+  const float deck_y = destroyed ? 0.0F : (damaged ? 2.20F : 2.52F);
+  const float roof_y = destroyed ? 0.0F : (damaged ? 2.50F : 2.94F);
 
   desc.add_box(
       QVector3D(0.0F, 0.04F, 0.0F), QVector3D(1.24F, 0.04F, 1.24F), c.stone_dark);
@@ -96,22 +96,32 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
       QVector3D(destroyed ? 0.68F : 0.78F, core_half_y, destroyed ? 0.68F : 0.78F),
       c.stone_light);
 
+  {
+    const float core_half = destroyed ? 0.68F : 0.78F;
+    const float core_top_y = 0.52F + core_half_y * 2.0F;
+    for (float y = 0.86F; y < core_top_y - 0.10F; y += 0.32F) {
+      desc.add_box(QVector3D(0.0F, y, 0.0F),
+                   QVector3D(core_half + 0.006F, 0.011F, core_half + 0.006F),
+                   c.stone_base * 0.86F);
+    }
+  }
+
   if (!destroyed) {
     add_embrasures(
         [&desc](const QVector3D& centre, const QVector3D& half, const QVector3D& col) {
           desc.add_box(centre, half, col, BuildingStateMask::All);
         },
-        damaged ? 0.90F : 1.02F,
+        damaged ? 1.05F : 1.20F,
         (destroyed ? 0.68F : 0.78F) * 0.98F,
         QVector3D(0.05F, 0.18F, 0.05F),
         c.brick_dark * 0.5F);
 
-    desc.add_box(QVector3D(0.0F, damaged ? 1.04F : 1.22F, 0.0F),
+    desc.add_box(QVector3D(0.0F, damaged ? 1.22F : 1.40F, 0.0F),
                  QVector3D(damaged ? 0.76F : 0.82F, 0.04F, damaged ? 0.76F : 0.82F),
                  c.stone_dark,
                  BuildingStateMask::All);
 
-    desc.add_box(QVector3D(0.0F, damaged ? 1.38F : 1.56F, 0.0F),
+    desc.add_box(QVector3D(0.0F, damaged ? 1.62F : 1.86F, 0.0F),
                  QVector3D(damaged ? 0.72F : 0.80F, 0.03F, damaged ? 0.72F : 0.80F),
                  c.brick_dark,
                  BuildingStateMask::All);
@@ -127,17 +137,17 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
     const float ox = std::sin(angle) * 0.68F;
     const float oz = std::cos(angle) * 0.68F;
     desc.add_cylinder(QVector3D(ox, 0.4F, oz),
-                      QVector3D(ox, damaged ? 1.88F : 2.14F, oz),
+                      QVector3D(ox, damaged ? 2.26F : 2.58F, oz),
                       damaged ? 0.14F : 0.16F,
                       c.stone_dark);
 
-    desc.add_box(QVector3D(ox, damaged ? 1.94F : 2.20F, oz),
+    desc.add_box(QVector3D(ox, damaged ? 2.32F : 2.64F, oz),
                  QVector3D(damaged ? 0.18F : 0.22F, 0.08F, damaged ? 0.18F : 0.22F),
                  c.stone_light,
                  BuildingStateMask::All);
 
     if (!destroyed && !damaged) {
-      desc.add_box(QVector3D(ox, 2.32F, oz),
+      desc.add_box(QVector3D(ox, 2.76F, oz),
                    QVector3D(0.10F, 0.08F, 0.10F),
                    c.brick,
                    BuildingStateMask::All);
@@ -179,7 +189,7 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
                    BuildingStateMask::All);
     }
 
-    desc.add_box(QVector3D(0.0F, damaged ? 1.90F : 2.02F, 0.0F),
+    desc.add_box(QVector3D(0.0F, damaged ? 2.30F : 2.46F, 0.0F),
                  QVector3D(damaged ? 0.94F : 1.04F, 0.04F, damaged ? 0.94F : 1.04F),
                  c.stone_dark,
                  BuildingStateMask::All);
@@ -188,7 +198,7 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
                  c.wood);
 
     const float parapet_half = damaged ? 0.78F : 0.88F;
-    const float merlon_y = damaged ? 2.08F : 2.28F;
+    const float merlon_y = damaged ? 2.44F : 2.72F;
     auto add_part =
         [&desc](const QVector3D& centre, const QVector3D& half, const QVector3D& col) {
           desc.add_box(centre, half, col, BuildingStateMask::All);
@@ -199,7 +209,14 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
                        parapet_half,
                        damaged ? 3 : 4,
                        QVector3D(0.12F, damaged ? 0.16F : 0.20F, 0.12F),
-                       c.brick,
+                       c.stone_light,
+                       23);
+    add_square_parapet(add_part,
+                       merlon_y + (damaged ? 0.17F : 0.21F),
+                       parapet_half,
+                       damaged ? 3 : 4,
+                       QVector3D(0.135F, 0.03F, 0.135F),
+                       c.brick_dark,
                        23);
 
     if (!damaged) {
@@ -207,7 +224,7 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
       for (const float ox : {-parapet_half, parapet_half}) {
         for (const float oz : {-parapet_half, parapet_half}) {
           add_part(
-              QVector3D(ox, 2.50F, oz), QVector3D(0.08F, 0.06F, 0.08F), c.brick_dark);
+              QVector3D(ox, 2.94F, oz), QVector3D(0.08F, 0.06F, 0.08F), c.brick_dark);
         }
       }
     }
@@ -233,9 +250,9 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
 
   if (damaged) {
     desc.add_box(
-        QVector3D(0.44F, 1.52F, 0.32F), QVector3D(0.20F, 0.12F, 0.18F), c.brick_dark);
+        QVector3D(0.44F, 1.92F, 0.32F), QVector3D(0.20F, 0.12F, 0.18F), c.brick_dark);
     desc.add_box(
-        QVector3D(-0.34F, 1.28F, -0.36F), QVector3D(0.18F, 0.14F, 0.16F), c.stone_dark);
+        QVector3D(-0.34F, 1.66F, -0.36F), QVector3D(0.18F, 0.14F, 0.16F), c.stone_dark);
   }
 
   if (destroyed) {
@@ -252,7 +269,7 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
   if (!destroyed) {
     add_punic_tanit_relief(
         desc,
-        QVector3D(0.0F, damaged ? 1.18F : 1.34F, damaged ? 0.70F : 0.80F),
+        QVector3D(0.0F, damaged ? 1.36F : 1.52F, damaged ? 0.70F : 0.80F),
         BuildingFacadePlane::XY,
         damaged ? 0.58F : 0.72F,
         c.brick,
@@ -296,7 +313,7 @@ auto tower_archetype(BuildingState state) -> const RenderArchetype& {
 auto tower_banner_style(BuildingState state)
     -> BarracksFlagRenderer::HangingBannerStyle {
   if (state == BuildingState::Damaged) {
-    return {.pole_base = QVector3D(0.0F, 2.10F, 0.0F),
+    return {.pole_base = QVector3D(0.0F, 2.50F, 0.0F),
             .pole_height = 0.88F,
             .pole_radius = 0.042F,
             .banner_width = 0.56F,
@@ -320,7 +337,7 @@ auto tower_banner_style(BuildingState state)
             .ring_color = QVector3D()};
   }
 
-  return {.pole_base = QVector3D(0.0F, 2.48F, 0.0F),
+  return {.pole_base = QVector3D(0.0F, 2.94F, 0.0F),
           .pole_height = 1.16F,
           .pole_radius = 0.045F,
           .banner_width = 0.72F,
@@ -391,7 +408,7 @@ void register_defense_tower_renderer(Render::GL::EntityRendererRegistry& registr
                                  .archetype = &tower_archetype,
                                  .draw_banner = &draw_tower_banner_for_team,
                                  .selection = BuildingSelectionStyle{1.6F, 1.6F},
-                                 .night_brazier_deck_y = 2.24F,
+                                 .night_brazier_deck_y = 2.68F,
                                  .night_brazier_offset = 0.60F});
 }
 

--- a/render/entity/nations/roman/barracks_renderer.cpp
+++ b/render/entity/nations/roman/barracks_renderer.cpp
@@ -4,6 +4,8 @@
 #include <QVector3D>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 
 #include "game/core/component.h"
 #include "game/visuals/team_colors.h"
@@ -13,30 +15,28 @@
 #include "render/entity/barracks_stockpile.h"
 #include "render/entity/building_archetype_desc.h"
 #include "render/entity/building_decay.h"
-#include "render/entity/building_ornament_emit.h"
 #include "render/entity/building_ornaments.h"
 #include "render/entity/building_render_common.h"
 #include "render/entity/building_state.h"
 #include "render/entity/registry.h"
-#include "render/geom/flag.h"
-#include "render/geom/transforms.h"
 #include "render/gl/backend.h"
-#include "render/gl/backend/banner_pipeline.h"
 #include "render/gl/primitives.h"
 #include "render/gl/resources.h"
 #include "render/render_archetype.h"
-#include "render/rig_dsl/defs/barracks_rig.h"
-#include "render/rig_dsl/rig_interpreter.h"
-#include "render/rig_dsl/static_resolver.h"
 #include "render/submitter.h"
-#include "render/template_cache.h"
 
 namespace Render::GL::Roman {
 namespace {
 
 using Render::Geom::clamp_vec_01;
 
+constexpr std::uint8_t k_team_slot = 0;
+
+constexpr auto k_mask_intact = k_building_state_mask_intact;
+
 struct RomanPalette {
+  QVector3D plaster{0.90F, 0.86F, 0.76F};
+  QVector3D plaster_shade{0.82F, 0.77F, 0.66F};
   QVector3D limestone{0.96F, 0.94F, 0.88F};
   QVector3D limestone_shade{0.88F, 0.85F, 0.78F};
   QVector3D limestone_dark{0.80F, 0.76F, 0.70F};
@@ -45,8 +45,8 @@ struct RomanPalette {
   QVector3D cedar_dark{0.38F, 0.26F, 0.16F};
   QVector3D terracotta{0.76F, 0.32F, 0.18F};
   QVector3D terracotta_dark{0.46F, 0.12F, 0.07F};
-  QVector3D blue_accent{0.28F, 0.48F, 0.68F};
-  QVector3D blue_light{0.40F, 0.60F, 0.80F};
+  QVector3D dado{0.52F, 0.18F, 0.12F};
+  QVector3D iron{0.30F, 0.30F, 0.32F};
   QVector3D gold{0.85F, 0.72F, 0.35F};
   QVector3D team{0.8F, 0.9F, 1.0F};
   QVector3D team_trim{0.48F, 0.54F, 0.60F};
@@ -60,641 +60,328 @@ inline auto make_palette(const QVector3D& team) -> RomanPalette {
   return p;
 }
 
-inline void draw_box(ISubmitter& out,
-                     Mesh* unit,
-                     Texture* white,
-                     const QMatrix4x4& model,
-                     const QVector3D& pos,
-                     const QVector3D& size,
-                     const QVector3D& color) {
-  submit_building_box(out, unit, white, model, pos, size, color);
+constexpr float k_platform_top = 0.16F;
+constexpr float k_block_half_x = 1.60F;
+constexpr float k_block_front_z = 0.50F;
+constexpr float k_block_back_z = -1.62F;
+constexpr float k_wall_top = 1.80F;
+constexpr float k_veranda_post_z = 1.30F;
+constexpr float k_roof_rise = 0.70F;
+constexpr float k_roof_front_z = 1.52F;
+constexpr float k_roof_back_z = -1.74F;
+
+void add_platform(BuildingArchetypeDesc& desc, const RomanPalette& c) {
+  desc.add_box(
+      QVector3D(0.0F, 0.04F, 0.0F), QVector3D(1.72F, 0.04F, 1.52F), c.limestone_dark);
+  desc.add_box(
+      QVector3D(0.0F, 0.10F, 0.0F), QVector3D(1.62F, 0.02F, 1.42F), c.limestone_shade);
+  desc.add_box(
+      QVector3D(0.0F, 0.14F, 0.0F), QVector3D(1.55F, 0.02F, 1.42F), c.limestone);
+
+  desc.add_box(
+      QVector3D(0.0F, 0.04F, 1.68F), QVector3D(1.02F, 0.04F, 0.20F), c.limestone_dark);
+  desc.add_box(QVector3D(0.0F, 0.10F, 1.54F),
+               QVector3D(0.88F, 0.04F, 0.14F),
+               c.limestone_shade,
+               k_mask_intact);
+
+  desc.add_box(
+      QVector3D(0.0F, k_platform_top + 0.004F, (k_block_front_z + 1.42F) * 0.5F),
+      QVector3D(k_block_half_x, 0.004F, (1.42F - k_block_front_z) * 0.5F),
+      c.limestone_shade,
+      k_mask_intact);
 }
 
-inline void draw_cyl(ISubmitter& out,
-                     const QMatrix4x4& model,
-                     const QVector3D& a,
-                     const QVector3D& b,
-                     float r,
-                     const QVector3D& color,
-                     Texture* white) {
-  submit_building_cylinder(out, model, a, b, r, color, white);
+void add_block(BuildingArchetypeDesc& desc,
+               const RomanPalette& c,
+               BuildingState state) {
+  const bool destroyed = state == BuildingState::Destroyed;
+  const float block_cz = (k_block_front_z + k_block_back_z) * 0.5F;
+  const float block_hz = (k_block_front_z - k_block_back_z) * 0.5F;
+  const float wall_top = destroyed ? 0.72F : k_wall_top;
+  const float wall_cy = (k_platform_top + wall_top) * 0.5F;
+  const float wall_hy = (wall_top - k_platform_top) * 0.5F;
+
+  desc.add_box(QVector3D(0.0F, wall_cy, block_cz),
+               QVector3D(k_block_half_x, wall_hy, block_hz),
+               c.plaster);
+
+  desc.add_box(QVector3D(0.0F, k_platform_top + 0.15F, block_cz),
+               QVector3D(k_block_half_x + 0.008F, 0.15F, block_hz + 0.008F),
+               c.dado);
+
+  for (const float qx : {-k_block_half_x, k_block_half_x}) {
+    for (const float qz : {k_block_back_z, k_block_front_z}) {
+      desc.add_box(QVector3D(qx, wall_cy, qz),
+                   QVector3D(0.07F, wall_hy, 0.07F),
+                   c.limestone_shade);
+    }
+  }
+
+  if (destroyed) {
+    return;
+  }
+
+  desc.add_box(QVector3D(0.0F, k_wall_top - 0.04F, block_cz),
+               QVector3D(k_block_half_x + 0.05F, 0.04F, block_hz + 0.05F),
+               c.limestone_shade,
+               k_mask_intact);
+
+  for (const float wx : {-1.20F, -0.40F, 0.40F, 1.20F}) {
+    desc.add_box(QVector3D(wx, 1.36F, k_block_back_z - 0.012F),
+                 QVector3D(0.11F, 0.13F, 0.015F),
+                 c.cedar_dark * 0.55F,
+                 k_mask_intact);
+    desc.add_box(QVector3D(wx, 1.51F, k_block_back_z - 0.02F),
+                 QVector3D(0.14F, 0.02F, 0.02F),
+                 c.limestone_shade,
+                 k_mask_intact);
+  }
+  for (const float sx : {-k_block_half_x - 0.012F, k_block_half_x + 0.012F}) {
+    for (const float wz : {-1.10F, -0.30F}) {
+      desc.add_box(QVector3D(sx, 1.36F, wz),
+                   QVector3D(0.015F, 0.13F, 0.11F),
+                   c.cedar_dark * 0.55F,
+                   k_mask_intact);
+    }
+  }
+
+  for (const float dx : {-1.00F, 0.0F, 1.00F}) {
+    desc.add_box(QVector3D(dx, k_platform_top + 0.56F, k_block_front_z + 0.012F),
+                 QVector3D(0.20F, 0.56F, 0.015F),
+                 c.cedar_dark * 0.45F,
+                 k_mask_intact);
+    for (const float fx : {-0.22F, 0.22F}) {
+      desc.add_box(QVector3D(dx + fx, k_platform_top + 0.58F, k_block_front_z + 0.02F),
+                   QVector3D(0.03F, 0.58F, 0.025F),
+                   c.cedar,
+                   k_mask_intact);
+    }
+    desc.add_box(QVector3D(dx, k_platform_top + 1.18F, k_block_front_z + 0.02F),
+                 QVector3D(0.27F, 0.035F, 0.03F),
+                 c.cedar,
+                 k_mask_intact);
+  }
+
+  for (const float sx : {-0.50F, 0.50F}) {
+    desc.add_box(QVector3D(sx, 1.02F, k_block_front_z + 0.04F),
+                 QVector3D(0.15F, 0.23F, 0.02F),
+                 c.cedar_dark,
+                 BuildingStateMask::Normal);
+    desc.add_palette_box(QVector3D(sx, 1.02F, k_block_front_z + 0.055F),
+                         QVector3D(0.13F, 0.21F, 0.012F),
+                         k_team_slot,
+                         BuildingStateMask::Normal);
+    desc.add_box(QVector3D(sx, 1.02F, k_block_front_z + 0.075F),
+                 QVector3D(0.035F, 0.035F, 0.012F),
+                 c.gold,
+                 BuildingStateMask::Normal);
+  }
 }
 
-void draw_static_structure(const DrawContext& p, ISubmitter& out);
-void draw_platform(const DrawContext& p,
-                   ISubmitter& out,
-                   Mesh* unit,
-                   Texture* white,
-                   const RomanPalette& c,
-                   bool detailed);
-void draw_podium(const DrawContext& p,
-                 ISubmitter& out,
-                 Mesh* unit,
-                 Texture* white,
+void add_veranda(BuildingArchetypeDesc& desc,
                  const RomanPalette& c,
-                 BuildingState state);
-void draw_colonnade(const DrawContext& p,
-                    ISubmitter& out,
-                    Mesh* unit,
-                    Texture* white,
-                    const RomanPalette& c,
-                    BuildingState state,
-                    bool detailed);
-void draw_terrace(const DrawContext& p,
-                  ISubmitter& out,
-                  Mesh* unit,
-                  Texture* white,
-                  const RomanPalette& c,
-                  BuildingState state,
-                  bool detailed);
-void draw_roofline(const DrawContext& p,
-                   ISubmitter& out,
-                   Mesh* unit,
-                   Texture* white,
-                   const RomanPalette& c,
-                   BuildingState state,
-                   bool detailed);
+                 BuildingState state) {
+  if (state == BuildingState::Destroyed) {
+    return;
+  }
+  constexpr std::array<float, 5> k_post_x{-1.50F, -0.75F, 0.0F, 0.75F, 1.50F};
+  const float beam_y = k_wall_top - 0.16F;
+  for (std::size_t i = 0; i < k_post_x.size(); ++i) {
+    const float px = k_post_x[i];
 
-auto barracks_ruin_desc(const RomanPalette& c) -> const BuildingArchetypeDesc& {
-  static const BuildingArchetypeDesc k_desc = [&] {
-    BuildingArchetypeDesc desc("roman_barracks_ruin");
-    add_ruin_dressing(desc,
-                      RuinDressing{.extent = QVector3D(1.46F, 0.0F, 1.28F),
-                                   .stone = c.limestone_shade,
-                                   .stone_dark = c.limestone_dark,
-                                   .timber = c.cedar_dark * 0.6F,
-                                   .ground_y = 0.16F,
-                                   .scale = 1.25F,
-                                   .seed = 443});
-    return desc;
-  }();
-  return k_desc;
+    const BuildingStateMask states =
+        (i == 1 || i == 3) ? BuildingStateMask::Normal : k_mask_intact;
+    desc.add_box(QVector3D(px, k_platform_top + 0.03F, k_veranda_post_z),
+                 QVector3D(0.09F, 0.03F, 0.09F),
+                 c.limestone_shade,
+                 states);
+    desc.add_cylinder(QVector3D(px, k_platform_top, k_veranda_post_z),
+                      QVector3D(px, beam_y, k_veranda_post_z),
+                      0.062F,
+                      c.cedar,
+                      states);
+    desc.add_box(QVector3D(px, beam_y - 0.02F, k_veranda_post_z),
+                 QVector3D(0.09F, 0.03F, 0.09F),
+                 c.cedar_dark,
+                 states);
+  }
+  desc.add_box(QVector3D(0.0F, beam_y + 0.04F, k_veranda_post_z),
+               QVector3D(k_block_half_x + 0.06F, 0.045F, 0.06F),
+               c.cedar_dark,
+               k_mask_intact);
+
+  for (const float rx : {-1.30F, -0.90F, -0.45F, 0.0F, 0.45F, 0.90F, 1.30F}) {
+    desc.add_box(
+        QVector3D(rx, beam_y + 0.10F, (k_block_front_z + k_veranda_post_z) * 0.5F),
+        QVector3D(0.03F, 0.03F, (k_veranda_post_z - k_block_front_z) * 0.5F),
+        c.cedar_dark,
+        k_mask_intact);
+  }
 }
 
-auto build_barracks_archetype(BuildingState state,
-                              Mesh* unit,
-                              Texture* white) -> RenderArchetype {
-  RomanPalette const palette = make_palette(QVector3D(1.0F, 1.0F, 1.0F));
-  auto record_variant = [&](TemplateRecorder& recorder, bool detailed) {
-    DrawContext local_ctx;
-    local_ctx.model = QMatrix4x4{};
-    draw_static_structure(local_ctx, recorder);
-    draw_podium(local_ctx, recorder, unit, white, palette, state);
-    draw_platform(local_ctx, recorder, unit, white, palette, detailed);
-    draw_colonnade(local_ctx, recorder, unit, white, palette, state, detailed);
-    draw_terrace(local_ctx, recorder, unit, white, palette, state, detailed);
-    draw_roofline(local_ctx, recorder, unit, white, palette, state, detailed);
-    emit_building_ornament(barracks_ruin_desc(palette),
-                           local_ctx.model,
-                           recorder,
-                           unit,
-                           white,
-                           detailed,
-                           nullptr,
-                           0,
-                           state);
-  };
+void add_roof(BuildingArchetypeDesc& desc, const RomanPalette& c, BuildingState state) {
+  if (state == BuildingState::Destroyed) {
+    return;
+  }
+  const float centre_z = (k_roof_front_z + k_roof_back_z) * 0.5F;
+  const float half_depth = (k_roof_front_z - k_roof_back_z) * 0.5F;
+  const float eave_y = k_wall_top;
+  const float theta = std::atan2(k_roof_rise, half_depth);
+  const float theta_deg = theta * 180.0F / 3.14159265F;
+  const float slope_len =
+      std::sqrt(half_depth * half_depth + k_roof_rise * k_roof_rise);
+  const float overhang = 0.10F;
+  const QVector3D slab_scale(
+      k_block_half_x + overhang, 0.045F, slope_len * 0.5F + overhang);
+  const float cy = eave_y + k_roof_rise * 0.5F;
 
-  TemplateRecorder full_recorder;
-  TemplateRecorder minimal_recorder;
-  full_recorder.reset(144);
-  record_variant(full_recorder, true);
-  return build_building_archetype_from_recorded(
-      "roman_barracks", full_recorder.take_commands(), state);
+  desc.add_rotated_box(QVector3D(0.0F, cy, centre_z + half_depth * 0.5F),
+                       slab_scale,
+                       QVector3D(theta_deg, 0.0F, 0.0F),
+                       c.terracotta,
+                       BuildingStateMask::Normal);
+  desc.add_rotated_box(QVector3D(0.0F, cy, centre_z - half_depth * 0.5F),
+                       slab_scale,
+                       QVector3D(-theta_deg, 0.0F, 0.0F),
+                       c.terracotta * 0.96F,
+                       k_mask_intact);
+
+  for (const float rx : {-1.40F, -0.70F, 0.0F, 0.70F, 1.40F}) {
+    desc.add_rotated_box(QVector3D(rx, cy + 0.02F, centre_z + half_depth * 0.5F),
+                         QVector3D(0.035F, 0.035F, slope_len * 0.5F),
+                         QVector3D(theta_deg, 0.0F, 0.0F),
+                         c.cedar_dark,
+                         BuildingStateMask::Damaged);
+  }
+
+  const QVector3D normal(0.0F, std::cos(theta), std::sin(theta));
+  for (const float f : {0.22F, 0.46F, 0.70F, 0.92F}) {
+    const float y = eave_y + k_roof_rise * f;
+    const float dz = half_depth * (1.0F - f);
+    const QVector3D lift = normal * 0.05F;
+    desc.add_rotated_box(QVector3D(0.0F, y, centre_z + dz) +
+                             QVector3D(0.0F, lift.y(), lift.z()),
+                         QVector3D(k_block_half_x + overhang - 0.02F, 0.012F, 0.035F),
+                         QVector3D(theta_deg, 0.0F, 0.0F),
+                         c.terracotta_dark,
+                         BuildingStateMask::Normal);
+    desc.add_rotated_box(QVector3D(0.0F, y, centre_z - dz) +
+                             QVector3D(0.0F, lift.y(), -lift.z()),
+                         QVector3D(k_block_half_x + overhang - 0.02F, 0.012F, 0.035F),
+                         QVector3D(-theta_deg, 0.0F, 0.0F),
+                         c.terracotta_dark,
+                         k_mask_intact);
+  }
+
+  desc.add_box(QVector3D(0.0F, eave_y + k_roof_rise + 0.02F, centre_z),
+               QVector3D(k_block_half_x + overhang + 0.02F, 0.035F, 0.07F),
+               c.terracotta_dark,
+               k_mask_intact);
+
+  for (const float gx : {-k_block_half_x, k_block_half_x}) {
+    struct Step {
+      float y;
+      float half_z;
+      float half_y;
+    };
+    const std::array<Step, 4> steps{Step{1.94F, 1.30F, 0.14F},
+                                    Step{2.20F, 0.90F, 0.12F},
+                                    Step{2.40F, 0.44F, 0.10F},
+                                    Step{2.50F, 0.14F, 0.04F}};
+    for (const Step& s : steps) {
+      desc.add_box(QVector3D(gx, s.y, centre_z),
+                   QVector3D(0.05F, s.half_y, s.half_z),
+                   c.plaster_shade,
+                   k_mask_intact);
+    }
+  }
+
+  add_roman_roof_standard(desc,
+                          QVector3D(0.0F, eave_y + k_roof_rise + 0.05F, centre_z),
+                          0.86F,
+                          c.gold,
+                          c.terracotta_dark,
+                          BuildingStateMask::Normal);
+}
+
+void add_yard_props(BuildingArchetypeDesc& desc, const RomanPalette& c) {
+
+  const float rx = -1.45F;
+  const float rz = 0.95F;
+  for (const float dz : {-0.22F, 0.22F}) {
+    desc.add_box(QVector3D(rx, k_platform_top + 0.36F, rz + dz),
+                 QVector3D(0.03F, 0.36F, 0.03F),
+                 c.cedar_dark,
+                 k_mask_intact);
+  }
+  desc.add_box(QVector3D(rx, k_platform_top + 0.70F, rz),
+               QVector3D(0.03F, 0.02F, 0.26F),
+               c.cedar_dark,
+               k_mask_intact);
+  for (const float dz : {-0.15F, -0.05F, 0.05F, 0.15F}) {
+    desc.add_cylinder(QVector3D(rx + 0.10F, k_platform_top, rz + dz),
+                      QVector3D(rx - 0.02F, k_platform_top + 1.55F, rz + dz),
+                      0.012F,
+                      c.cedar,
+                      BuildingStateMask::Normal);
+    desc.add_cone(QVector3D(rx - 0.02F, k_platform_top + 1.55F, rz + dz),
+                  QVector3D(rx - 0.04F, k_platform_top + 1.78F, rz + dz),
+                  0.018F,
+                  c.iron,
+                  BuildingStateMask::Normal);
+  }
+
+  desc.add_box(QVector3D(1.40F, k_platform_top + 0.12F, 0.95F),
+               QVector3D(0.14F, 0.12F, 0.30F),
+               c.limestone_dark,
+               k_mask_intact);
+  desc.add_box(QVector3D(1.40F, k_platform_top + 0.22F, 0.95F),
+               QVector3D(0.11F, 0.01F, 0.27F),
+               QVector3D(0.30F, 0.42F, 0.50F),
+               k_mask_intact);
+}
+
+auto build_barracks_archetype(BuildingState state) -> RenderArchetype {
+  RomanPalette const c = make_palette(QVector3D(1.0F, 1.0F, 1.0F));
+  BuildingArchetypeDesc desc("roman_barracks");
+
+  add_platform(desc, c);
+  add_block(desc, c, state);
+  add_veranda(desc, c, state);
+  add_roof(desc, c, state);
+  add_yard_props(desc, c);
+
+  if (state == BuildingState::Damaged) {
+    add_rubble_field(desc,
+                     RubbleField{.center = QVector3D(0.6F, k_platform_top, 1.0F),
+                                 .extent = QVector3D(0.9F, 0.0F, 0.35F),
+                                 .stone = c.terracotta_dark,
+                                 .stone_dark = c.limestone_dark,
+                                 .chunk_scale = 0.8F,
+                                 .count = 6,
+                                 .seed = 449,
+                                 .states = BuildingStateMask::Damaged});
+  }
+
+  add_ruin_dressing(desc,
+                    RuinDressing{.extent = QVector3D(1.46F, 0.0F, 1.28F),
+                                 .stone = c.limestone_shade,
+                                 .stone_dark = c.limestone_dark,
+                                 .timber = c.cedar_dark * 0.6F,
+                                 .ground_y = 0.16F,
+                                 .scale = 1.25F,
+                                 .seed = 443});
+
+  return build_building_archetype(desc, state);
 }
 
 auto barracks_archetype(BuildingState state,
-                        Mesh* unit,
-                        Texture* white) -> const RenderArchetype& {
+                        Mesh*,
+                        Texture*) -> const RenderArchetype& {
   static const BuildingArchetypeSet k_set =
-      build_stateful_building_archetype_set([unit, white](BuildingState current_state) {
-        return build_barracks_archetype(current_state, unit, white);
-      });
+      build_stateful_building_archetype_set(build_barracks_archetype);
   return k_set.for_state(state);
-}
-
-void draw_platform(const DrawContext& p,
-                   ISubmitter& out,
-                   Mesh* unit,
-                   Texture* white,
-                   const RomanPalette& c,
-                   bool detailed) {
-
-  if (!detailed) {
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 0.04F, 0.0F),
-             QVector3D(1.72F, 0.04F, 1.52F),
-             c.limestone_dark);
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 0.10F, 0.0F),
-             QVector3D(1.62F, 0.02F, 1.42F),
-             c.limestone_shade);
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 0.14F, 0.0F),
-             QVector3D(1.55F, 0.02F, 1.35F),
-             c.limestone);
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 0.21F, 0.0F),
-             QVector3D(1.48F, 0.015F, 1.28F),
-             c.terracotta);
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 0.235F, 0.0F),
-             QVector3D(1.38F, 0.012F, 1.18F),
-             c.terracotta_dark);
-    return;
-  }
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 0.04F, 0.0F),
-           QVector3D(1.72F, 0.04F, 1.52F),
-           c.limestone_dark);
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 0.10F, 0.0F),
-           QVector3D(1.62F, 0.02F, 1.42F),
-           c.limestone_shade);
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 0.14F, 0.0F),
-           QVector3D(1.55F, 0.02F, 1.42F),
-           c.limestone);
-
-  for (float x = -1.4F; x <= 1.4F; x += 0.32F) {
-    for (float z = -1.2F; z <= 1.2F; z += 0.32F) {
-      if (fabsf(x) > 0.6F || fabsf(z) > 0.5F) {
-        draw_box(out,
-                 unit,
-                 white,
-                 p.model,
-                 QVector3D(x, 0.21F, z),
-                 QVector3D(0.14F, 0.01F, 0.14F),
-                 c.terracotta);
-      }
-    }
-  }
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 0.20F, 0.0F),
-           QVector3D(0.52F, 0.015F, 0.42F),
-           c.blue_light);
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 0.22F, -0.44F),
-           QVector3D(0.56F, 0.02F, 0.04F),
-           c.marble);
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 0.22F, 0.44F),
-           QVector3D(0.56F, 0.02F, 0.04F),
-           c.marble);
-}
-
-void draw_podium(const DrawContext& p,
-                 ISubmitter& out,
-                 Mesh* unit,
-                 Texture* white,
-                 const RomanPalette& c,
-                 BuildingState state) {
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 0.04F, 1.68F),
-           QVector3D(1.02F, 0.04F, 0.20F),
-           c.limestone_dark);
-  if (state != BuildingState::Destroyed) {
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 0.10F, 1.52F),
-             QVector3D(0.88F, 0.04F, 0.16F),
-             c.limestone_shade);
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 0.16F, 1.38F),
-             QVector3D(0.72F, 0.04F, 0.14F),
-             c.limestone);
-
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 0.22F, 1.24F),
-             QVector3D(0.60F, 0.02F, 0.12F),
-             c.marble);
-  }
-}
-
-void draw_static_structure(const DrawContext& p, ISubmitter& out) {
-  using namespace Render::RigDSL::Barracks;
-
-  constexpr std::size_t k_anchor_count = static_cast<std::size_t>(Goods_Amp3Top) + 1U;
-  Render::RigDSL::StaticAnchorResolver<k_anchor_count> anchors;
-
-  auto set = [&](Render::RigDSL::AnchorId id, float x, float y, float z) {
-    anchors.set(id, QVector3D(x, y, z));
-  };
-
-  set(Platform_BaseLow, -2.0F, 0.00F, -1.8F);
-  set(Platform_BaseHigh, 2.0F, 0.16F, 1.8F);
-  set(Platform_TopLow, -1.8F, 0.16F, -1.6F);
-  set(Platform_TopHigh, 1.8F, 0.20F, 1.6F);
-
-  set(Court_StoneLow, -1.3F, 0.21F, -1.1F);
-  set(Court_StoneHigh, 1.3F, 0.23F, 1.1F);
-  set(Court_PoolLow, -0.7F, 0.22F, -0.5F);
-  set(Court_PoolHigh, 0.7F, 0.26F, 0.5F);
-  set(Court_PoolTrimSLow, -0.72F, 0.23F, -0.54F);
-  set(Court_PoolTrimSHigh, 0.72F, 0.27F, -0.50F);
-  set(Court_PoolTrimNLow, -0.72F, 0.23F, 0.50F);
-  set(Court_PoolTrimNHigh, 0.72F, 0.27F, 0.54F);
-  set(Court_PillarBot, 0.0F, 0.25F, 0.0F);
-  set(Court_PillarTop, 0.0F, 0.55F, 0.0F);
-  set(Court_PillarCapLow, -0.08F, 0.55F, -0.08F);
-  set(Court_PillarCapHigh, 0.08F, 0.61F, 0.08F);
-
-  set(Wall_BackLow, -1.4F, 0.20F, -1.3F);
-  set(Wall_BackHigh, 1.4F, 1.60F, -1.1F);
-  set(Wall_LeftLow, -1.6F, 0.20F, -1.1F);
-  set(Wall_LeftHigh, -1.4F, 1.60F, 0.1F);
-  set(Wall_RightLow, 1.4F, 0.20F, -1.1F);
-  set(Wall_RightHigh, 1.6F, 1.60F, 0.1F);
-
-  set(Door_LDoorLow, -0.85F, 0.30F, -1.18F);
-  set(Door_LDoorHigh, -0.35F, 1.00F, -1.12F);
-  set(Door_LLintelLow, -0.85F, 0.93F, -1.18F);
-  set(Door_LLintelHigh, -0.35F, 1.03F, -1.12F);
-  set(Door_RDoorLow, 0.35F, 0.30F, -1.18F);
-  set(Door_RDoorHigh, 0.85F, 1.00F, -1.12F);
-  set(Door_RLintelLow, 0.35F, 0.93F, -1.18F);
-  set(Door_RLintelHigh, 0.85F, 1.03F, -1.12F);
-
-  set(Goods_Amp1Bot, -1.2F, 0.20F, 1.10F);
-  set(Goods_Amp1Top, -1.2F, 0.50F, 1.10F);
-  set(Goods_Amp2Bot, -0.9F, 0.20F, 1.15F);
-  set(Goods_Amp2Top, -0.9F, 0.45F, 1.15F);
-  set(Goods_Amp3Bot, 1.1F, 0.20F, -0.90F);
-  set(Goods_Amp3Top, 1.1F, 0.42F, -0.90F);
-
-  Render::RigDSL::InterpretContext ictx;
-  ictx.model = p.model;
-  ictx.anchors = &anchors;
-  ictx.palette = nullptr;
-  ictx.scalars = nullptr;
-  ictx.material = nullptr;
-  ictx.lod = 0;
-  ictx.global_alpha = 1.0F;
-  Render::RigDSL::render_rig(k_rig, ictx, out);
-}
-
-void draw_colonnade(const DrawContext& p,
-                    ISubmitter& out,
-                    Mesh* unit,
-                    Texture* white,
-                    const RomanPalette& c,
-                    BuildingState state,
-                    bool detailed) {
-  float const col_height = 1.7F;
-  float const col_radius = 0.10F;
-  static constexpr float FRONT_COLUMN_SPACING_RANGE = 2.6F;
-  static constexpr float SIDE_COLUMN_SPACING_RANGE = 2.1F;
-
-  float height_multiplier = 1.0F;
-  int num_columns = 7;
-  if (state == BuildingState::Damaged) {
-    height_multiplier = 0.7F;
-    num_columns = 5;
-  } else if (state == BuildingState::Destroyed) {
-    height_multiplier = 0.4F;
-    num_columns = 3;
-  }
-  if (!detailed) {
-    num_columns = std::min(num_columns, 5);
-  }
-
-  for (int i = 0; i < num_columns; ++i) {
-    float const x = -1.30F + float(i) * (num_columns > 1 ? FRONT_COLUMN_SPACING_RANGE /
-                                                               (num_columns - 1)
-                                                         : 0.0F);
-    float const z = 1.42F;
-
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(x, 0.22F, z),
-             QVector3D(col_radius * 1.4F, 0.04F, col_radius * 1.4F),
-             c.marble);
-
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(x, 0.17F, z),
-             QVector3D(col_radius * 1.6F, 0.03F, col_radius * 1.6F),
-             c.limestone_shade);
-
-    draw_cyl(out,
-             p.model,
-             QVector3D(x, 0.2F, z),
-             QVector3D(x, 0.2F + col_height * height_multiplier, z),
-             col_radius,
-             c.limestone,
-             white);
-
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(x, 0.2F + col_height * height_multiplier + 0.05F, z),
-             QVector3D(col_radius * 1.6F, 0.08F, col_radius * 1.6F),
-             c.marble);
-
-    if (state != BuildingState::Destroyed && detailed) {
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(x, 0.2F + col_height * height_multiplier + 0.12F, z),
-               QVector3D(col_radius * 1.3F, 0.03F, col_radius * 1.3F),
-               c.gold);
-    }
-  }
-
-  int const side_columns = (state == BuildingState::Destroyed) ? 2 : (detailed ? 4 : 3);
-  for (int i = 0; i < side_columns; ++i) {
-    float const z = -1.0F + float(i) * (side_columns > 1 ? SIDE_COLUMN_SPACING_RANGE /
-                                                               (side_columns - 1)
-                                                         : 0.0F);
-
-    for (float const x_side : {-1.62F, 1.62F}) {
-
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(x_side, 0.22F, z),
-               QVector3D(col_radius * 1.4F, 0.04F, col_radius * 1.4F),
-               c.marble);
-
-      draw_cyl(out,
-               p.model,
-               QVector3D(x_side, 0.2F, z),
-               QVector3D(x_side, 0.2F + col_height * height_multiplier, z),
-               col_radius,
-               c.limestone,
-               white);
-
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(x_side, 0.2F + col_height * height_multiplier + 0.05F, z),
-               QVector3D(col_radius * 1.6F, 0.08F, col_radius * 1.6F),
-               c.marble);
-    }
-  }
-
-  if (state != BuildingState::Destroyed) {
-    float const entab_y = 0.2F + col_height * height_multiplier + 0.16F;
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, entab_y, 1.42F),
-             QVector3D(1.38F, 0.05F, 0.08F),
-             c.limestone);
-
-    if (detailed) {
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(0.0F, entab_y + 0.06F, 1.42F),
-               QVector3D(1.32F, 0.03F, 0.06F),
-               c.blue_accent);
-    }
-
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, entab_y - 0.04F, 1.42F),
-             QVector3D(1.34F, 0.02F, 0.07F),
-             c.marble);
-  }
-}
-
-void draw_terrace(const DrawContext& p,
-                  ISubmitter& out,
-                  Mesh* unit,
-                  Texture* white,
-                  const RomanPalette& c,
-                  BuildingState state,
-                  bool detailed) {
-
-  if (state == BuildingState::Destroyed) {
-    return;
-  }
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 2.12F, 0.0F),
-           QVector3D(1.74F, 0.08F, 1.54F),
-           c.marble);
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 2.19F, 1.48F),
-           QVector3D(1.68F, 0.04F, 0.05F),
-           c.gold);
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(-1.68F, 2.19F, 0.0F),
-           QVector3D(0.04F, 0.04F, 1.48F),
-           c.blue_accent);
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(1.68F, 2.19F, 0.0F),
-           QVector3D(0.04F, 0.04F, 1.48F),
-           c.blue_accent);
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 2.24F, -0.2F),
-           QVector3D(detailed ? 1.54F : 1.42F, 0.04F, detailed ? 1.04F : 0.96F),
-           c.terracotta);
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 2.34F, -0.68F),
-           QVector3D(1.48F, 0.06F, 0.05F),
-           c.limestone);
-
-  for (float const x : {-1.44F, 1.44F}) {
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(x, 2.42F, -0.68F),
-             QVector3D(0.09F, 0.09F, 0.09F),
-             c.gold);
-  }
-
-  if (detailed) {
-
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 2.46F, -0.68F),
-             QVector3D(0.14F, 0.12F, 0.04F),
-             c.gold);
-  }
-}
-
-void draw_roofline(const DrawContext& p,
-                   ISubmitter& out,
-                   Mesh* unit,
-                   Texture* white,
-                   const RomanPalette& c,
-                   BuildingState state,
-                   bool detailed) {
-  if (state == BuildingState::Destroyed) {
-    return;
-  }
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, detailed ? 2.32F : 2.28F, 1.28F),
-           QVector3D(detailed ? 1.24F : 1.02F, 0.04F, 0.14F),
-           c.limestone_shade);
-
-  if (detailed) {
-    add_tile_rows_z(
-        [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-          draw_box(out,
-                   unit,
-                   white,
-                   p.model,
-                   center + QVector3D(0.0F, 0.0F, 0.18F),
-                   size,
-                   color);
-        },
-        2.40F,
-        -0.62F,
-        0.58F,
-        0.26F,
-        QVector3D(1.38F, 0.025F, 0.05F),
-        c.terracotta_dark);
-  }
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, 2.48F, 1.14F),
-           QVector3D(detailed ? 0.90F : 0.72F, 0.05F, 0.06F),
-           c.terracotta);
-
-  draw_box(out,
-           unit,
-           white,
-           p.model,
-           QVector3D(0.0F, state == BuildingState::Damaged ? 2.54F : 2.58F, 1.02F),
-           QVector3D(state == BuildingState::Damaged ? 0.50F : 0.62F, 0.05F, 0.05F),
-           c.terracotta_dark);
-
-  if (state == BuildingState::Normal) {
-
-    draw_box(out,
-             unit,
-             white,
-             p.model,
-             QVector3D(0.0F, 2.66F, 0.92F),
-             QVector3D(detailed ? 0.34F : 0.26F, 0.05F, 0.04F),
-             c.blue_accent);
-
-    if (detailed) {
-
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(-0.88F, 2.50F, 1.16F),
-               QVector3D(0.06F, 0.08F, 0.06F),
-               c.gold);
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(0.88F, 2.50F, 1.16F),
-               QVector3D(0.06F, 0.08F, 0.06F),
-               c.gold);
-
-      draw_box(out,
-               unit,
-               white,
-               p.model,
-               QVector3D(0.0F, 2.74F, 0.92F),
-               QVector3D(0.08F, 0.10F, 0.04F),
-               c.gold);
-    }
-
-    BuildingArchetypeDesc aquila("roman_barracks_aquila");
-    add_roman_roof_standard(
-        aquila, QVector3D(0.0F, 2.64F, 0.92F), 0.86F, c.gold, c.terracotta_dark);
-    emit_building_ornament(aquila, p.model, out, unit, white, detailed);
-  }
 }
 
 void draw_phoenician_banner(const DrawContext& p,

--- a/render/entity/nations/roman/defense_tower_renderer.cpp
+++ b/render/entity/nations/roman/defense_tower_renderer.cpp
@@ -59,7 +59,8 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
 
   const bool damaged = state == BuildingState::Damaged;
   const bool destroyed = state == BuildingState::Destroyed;
-  const float shaft_top = destroyed ? 1.56F : (damaged ? 2.04F : 2.30F);
+
+  const float shaft_top = destroyed ? 1.56F : (damaged ? 2.50F : 2.90F);
   const float shaft_radius = destroyed ? 0.76F : (damaged ? 0.84F : 0.90F);
   const float belt_radius = (damaged ? 0.86F : 0.93F);
   const float platform_radius = damaged ? 0.96F : 1.06F;
@@ -67,6 +68,7 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
   const float battlement_half_extent = damaged ? 0.13F : 0.15F;
   const float deck_y = destroyed ? 0.0F : shaft_top + 0.12F;
   const float battlement_y = destroyed ? 0.0F : shaft_top + (damaged ? 0.28F : 0.34F);
+  const QVector3D merlon_cap = c.limestone_dark * 0.62F;
 
   desc.add_box(
       QVector3D(0.0F, 0.04F, 0.0F), QVector3D(1.30F, 0.04F, 1.30F), c.limestone_dark);
@@ -81,7 +83,7 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
       if (std::fabs(x) > 0.32F || std::fabs(z) > 0.32F) {
         desc.add_box(QVector3D(x, 0.31F, z),
                      QVector3D(0.18F, 0.01F, 0.18F),
-                     c.terracotta,
+                     c.sandstone_base,
                      BuildingStateMask::All);
       }
     }
@@ -90,24 +92,26 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
   desc.add_box(
       QVector3D(0.0F, 0.44F, 0.0F), QVector3D(0.94F, 0.12F, 0.94F), c.sandstone_light);
 
-  const float shaft_mid = 0.52F + (shaft_top - 0.52F) * 0.55F;
-  desc.add_cylinder(QVector3D(0.0F, 0.52F, 0.0F),
-                    QVector3D(0.0F, shaft_mid, 0.0F),
-                    shaft_radius,
-                    c.limestone);
-  desc.add_cylinder(QVector3D(0.0F, shaft_mid - 0.02F, 0.0F),
-                    QVector3D(0.0F, shaft_top, 0.0F),
-                    shaft_radius * 0.92F,
-                    c.limestone);
+  constexpr int k_courses = 6;
+  const float course_height = (shaft_top - 0.52F) / static_cast<float>(k_courses);
+  for (int i = 0; i < k_courses; ++i) {
+    const float y0 = 0.52F + course_height * static_cast<float>(i);
+    const bool even = (i % 2) == 0;
+    desc.add_cylinder(QVector3D(0.0F, y0, 0.0F),
+                      QVector3D(0.0F, y0 + course_height + 0.005F, 0.0F),
+                      even ? shaft_radius : shaft_radius * 0.985F,
+                      even ? c.limestone : c.limestone_shade);
+  }
 
   if (!destroyed) {
-    desc.add_cylinder(QVector3D(0.0F, damaged ? 1.18F : 1.38F, 0.0F),
-                      QVector3D(0.0F, damaged ? 1.24F : 1.44F, 0.0F),
+    const float belt_low = 0.52F + (shaft_top - 0.52F) * 0.40F;
+    const float belt_high = 0.52F + (shaft_top - 0.52F) * 0.72F;
+    desc.add_cylinder(QVector3D(0.0F, belt_low, 0.0F),
+                      QVector3D(0.0F, belt_low + 0.06F, 0.0F),
                       belt_radius,
                       c.marble);
-
-    desc.add_cylinder(QVector3D(0.0F, damaged ? 1.58F : 1.82F, 0.0F),
-                      QVector3D(0.0F, damaged ? 1.62F : 1.86F, 0.0F),
+    desc.add_cylinder(QVector3D(0.0F, belt_high, 0.0F),
+                      QVector3D(0.0F, belt_high + 0.04F, 0.0F),
                       belt_radius * 0.98F,
                       c.limestone_shade);
 
@@ -115,18 +119,18 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
         [&desc](const QVector3D& centre, const QVector3D& half, const QVector3D& col) {
           desc.add_box(centre, half, col, BuildingStateMask::All);
         },
-        damaged ? 1.02F : 1.14F,
+        belt_low - 0.28F,
         shaft_radius * 0.94F,
         QVector3D(0.045F, 0.17F, 0.05F),
-        c.limestone_dark * 0.55F);
+        c.limestone_dark * 0.45F);
     add_embrasures(
         [&desc](const QVector3D& centre, const QVector3D& half, const QVector3D& col) {
           desc.add_box(centre, half, col, BuildingStateMask::All);
         },
-        damaged ? 1.64F : 1.94F,
+        belt_high + 0.26F,
         shaft_radius * 0.90F,
         QVector3D(0.04F, 0.13F, 0.05F),
-        c.limestone_dark * 0.55F);
+        c.limestone_dark * 0.45F);
   }
 
   const std::array<int, 4> corner_indices =
@@ -152,28 +156,9 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
                  QVector3D(0.15F, 0.10F, 0.15F),
                  c.marble,
                  BuildingStateMask::All);
-
-    if (!damaged) {
-      desc.add_box(QVector3D(ox, column_top + 0.14F, oz),
-                   QVector3D(0.08F, 0.05F, 0.08F),
-                   c.gold,
-                   BuildingStateMask::All);
-    }
   }
 
   if (!destroyed) {
-    const int spoke_count = damaged ? 2 : 4;
-    for (int i = 0; i < spoke_count; ++i) {
-      const float angle =
-          static_cast<float>(i) * (damaged ? std::numbers::pi_v<float> : 1.57F);
-      const float ox = std::sin(angle) * (shaft_radius + 0.06F);
-      const float oz = std::cos(angle) * (shaft_radius + 0.06F);
-      desc.add_box(QVector3D(ox, damaged ? 1.00F : 1.24F, oz),
-                   QVector3D(0.04F, damaged ? 0.18F : 0.24F, 0.04F),
-                   c.sandstone_dark,
-                   BuildingStateMask::All);
-    }
-
     desc.add_cylinder(QVector3D(0.0F, shaft_top + 0.02F, 0.0F),
                       QVector3D(0.0F, shaft_top + 0.08F, 0.0F),
                       damaged ? 0.90F : 0.96F,
@@ -204,35 +189,60 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
         damaged ? 3 : 4,
         QVector3D(
             battlement_half_extent, damaged ? 0.20F : 0.24F, battlement_half_extent),
-        c.terracotta,
+        c.limestone,
+        11);
+    add_square_parapet(
+        [&desc,
+         merlon_cap](const QVector3D& centre, const QVector3D& half, const QVector3D&) {
+          desc.add_box(centre, half, merlon_cap, BuildingStateMask::All);
+        },
+        battlement_y + (damaged ? 0.21F : 0.25F),
+        battlement_radius,
+        damaged ? 3 : 4,
+        QVector3D(
+            battlement_half_extent + 0.015F, 0.03F, battlement_half_extent + 0.015F),
+        merlon_cap,
         11);
 
-    desc.add_box(QVector3D(0.0F, battlement_y + 0.14F, 0.0F),
-                 QVector3D(damaged ? 0.98F : 1.10F, 0.04F, damaged ? 0.98F : 1.10F),
-                 c.limestone);
-
     if (!damaged) {
-      for (float const x : {-1.02F, 1.02F}) {
-        for (float const z : {-1.02F, 1.02F}) {
-          desc.add_box(QVector3D(x, battlement_y + 0.22F, z),
-                       QVector3D(0.07F, 0.08F, 0.07F),
-                       c.blue_accent,
-                       BuildingStateMask::All);
+
+      const float roof_y = battlement_y + 0.62F;
+      const float post_offset = battlement_radius - 0.30F;
+      for (const float px : {-post_offset, post_offset}) {
+        for (const float pz : {-post_offset, post_offset}) {
+          desc.add_box(QVector3D(px, (deck_y + roof_y) * 0.5F, pz),
+                       QVector3D(0.05F, (roof_y - deck_y) * 0.5F, 0.05F),
+                       c.cedar_dark,
+                       BuildingStateMask::Normal);
         }
       }
+      desc.add_box(QVector3D(0.0F, roof_y - 0.03F, 0.0F),
+                   QVector3D(1.10F, 0.025F, 1.10F),
+                   c.cedar_dark,
+                   BuildingStateMask::Normal);
 
-      desc.add_box(QVector3D(0.0F, battlement_y + 0.24F, 0.0F),
-                   QVector3D(0.10F, 0.10F, 0.10F),
-                   c.gold,
+      constexpr int k_roof_steps = 6;
+      const QVector3D tile = c.terracotta * 0.94F;
+      for (int i = 0; i < k_roof_steps; ++i) {
+        const float t = static_cast<float>(i) / static_cast<float>(k_roof_steps);
+        const float half = 1.14F - (1.14F - 0.26F) * t;
+        desc.add_box(QVector3D(0.0F, roof_y + 0.056F * static_cast<float>(i), 0.0F),
+                     QVector3D(half, 0.032F, half),
+                     (i % 2 == 0) ? tile : tile * 0.93F,
+                     BuildingStateMask::Normal);
+      }
+      desc.add_box(QVector3D(0.0F, roof_y + 0.34F, 0.0F),
+                   QVector3D(0.14F, 0.04F, 0.14F),
+                   c.terracotta_dark,
                    BuildingStateMask::Normal);
     }
   }
 
   if (damaged) {
-    desc.add_box(QVector3D(0.48F, 1.82F, 0.24F),
+    desc.add_box(QVector3D(0.48F, 2.22F, 0.24F),
                  QVector3D(0.18F, 0.12F, 0.14F),
                  c.sandstone_dark);
-    desc.add_box(QVector3D(-0.40F, 1.68F, -0.44F),
+    desc.add_box(QVector3D(-0.40F, 2.08F, -0.44F),
                  QVector3D(0.16F, 0.14F, 0.18F),
                  c.limestone_dark);
   }
@@ -255,16 +265,11 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
   if (!destroyed) {
     add_roman_aquila_relief(
         desc,
-        QVector3D(0.0F, damaged ? 1.43F : 1.62F, shaft_radius + 0.02F),
+        QVector3D(0.0F, damaged ? 1.62F : 1.86F, shaft_radius + 0.02F),
         BuildingFacadePlane::XY,
         damaged ? 0.54F : 0.68F,
         c.gold,
         c.terracotta_dark);
-    add_roman_roof_standard(desc,
-                            QVector3D(0.0F, battlement_y + 0.20F, 0.0F),
-                            damaged ? 0.48F : 0.66F,
-                            c.gold,
-                            c.terracotta_dark);
   }
 
   add_broken_rim(desc,
@@ -298,7 +303,7 @@ auto tower_archetype(BuildingState state) -> const RenderArchetype& {
 auto tower_banner_style(BuildingState state)
     -> BarracksFlagRenderer::HangingBannerStyle {
   if (state == BuildingState::Damaged) {
-    return {.pole_base = QVector3D(0.0F, 2.42F, 0.0F),
+    return {.pole_base = QVector3D(0.0F, 2.90F, 0.0F),
             .pole_height = 0.92F,
             .pole_radius = 0.042F,
             .banner_width = 0.52F,
@@ -322,7 +327,7 @@ auto tower_banner_style(BuildingState state)
             .ring_color = QVector3D()};
   }
 
-  return {.pole_base = QVector3D(0.0F, 2.74F, 0.0F),
+  return {.pole_base = QVector3D(0.0F, 4.24F, 0.0F),
           .pole_height = 1.18F,
           .pole_radius = 0.044F,
           .banner_width = 0.68F,
@@ -392,7 +397,9 @@ void register_defense_tower_renderer(Render::GL::EntityRendererRegistry& registr
       DefenseTowerRendererConfig{.nation_slug = "roman",
                                  .archetype = &tower_archetype,
                                  .draw_banner = &draw_tower_banner_for_team,
-                                 .selection = BuildingSelectionStyle{1.6F, 1.6F}});
+                                 .selection = BuildingSelectionStyle{1.6F, 1.6F},
+                                 .night_brazier_deck_y = 3.20F,
+                                 .night_brazier_offset = 0.62F});
 }
 
 } // namespace Render::GL::Roman

--- a/render/entity/wall_gate_renderer_common.cpp
+++ b/render/entity/wall_gate_renderer_common.cpp
@@ -21,6 +21,11 @@ constexpr float k_jamb_offset = Engine::Core::GateComponent::k_passage_half_widt
 constexpr float k_structure_half_span =
     Engine::Core::GateComponent::k_structure_half_span;
 constexpr float k_jamb_depth = 0.30F;
+
+constexpr float k_tower_center_x = k_jamb_offset + 0.50F;
+constexpr float k_tower_half_x = 0.46F;
+constexpr float k_tower_half_z = 0.44F;
+constexpr float k_tower_rise = 0.90F;
 constexpr float k_leaf_thickness = 0.075F;
 constexpr float k_leaf_swing_degrees = 100.0F;
 constexpr float k_leaf_height_ratio = 0.82F;
@@ -34,6 +39,131 @@ auto leaf_height(const WallGeometry& geometry) -> float {
 
 auto lintel_height(const WallGeometry& geometry) -> float {
   return leaf_height(geometry) + 0.24F;
+}
+
+auto tower_top(const WallGeometry& geometry) -> float {
+  return geometry.stake_height + geometry.post_extra_height + k_tower_rise;
+}
+
+void add_gate_tower(BuildingArchetypeDesc& desc,
+                    const WallPalette& palette,
+                    const WallGeometry& geometry,
+                    float side) {
+  const float cx = side * k_tower_center_x;
+  const float bottom = geometry.earthwork_base ? geometry.berm_height * 0.5F : 0.02F;
+  const float top = tower_top(geometry);
+  const float half_height = (top - bottom) * 0.5F;
+  const QVector3D plank = palette.wood_mid * 0.96F;
+  const QVector3D seam = palette.wood_dark * 0.62F;
+
+  desc.add_box(QVector3D(cx, bottom + half_height, 0.0F),
+               QVector3D(k_tower_half_x, half_height, k_tower_half_z),
+               plank,
+               k_mask_intact);
+  desc.add_box(QVector3D(cx, bottom + half_height * 0.32F, 0.0F),
+               QVector3D(k_tower_half_x, half_height * 0.32F, k_tower_half_z),
+               palette.wood_dark * 0.7F,
+               BuildingStateMask::Destroyed);
+
+  for (const float t : {0.30F, 0.55F, 0.80F}) {
+    desc.add_box(QVector3D(cx, bottom + (top - bottom) * t, 0.0F),
+                 QVector3D(k_tower_half_x + 0.012F, 0.012F, k_tower_half_z + 0.012F),
+                 seam,
+                 k_mask_intact);
+  }
+
+  for (const float pz : {-1.0F, 1.0F}) {
+    desc.add_box(
+        QVector3D(cx, bottom + (top - bottom) * 0.62F, pz * (k_tower_half_z + 0.01F)),
+        QVector3D(0.03F, 0.14F, 0.02F),
+        palette.wood_dark * 0.35F,
+        BuildingStateMask::Normal);
+  }
+
+  const float post_radius = geometry.post_radius * 0.40F;
+  for (const float px : {-1.0F, 1.0F}) {
+    for (const float pz : {-1.0F, 1.0F}) {
+      const QVector3D foot(cx + px * k_tower_half_x, 0.02F, pz * k_tower_half_z);
+      desc.add_cylinder(foot,
+                        QVector3D(foot.x(), top + 0.34F, foot.z()),
+                        post_radius,
+                        palette.wood_dark,
+                        k_mask_intact);
+      desc.add_cone(
+          QVector3D(foot.x(), top + 0.33F, foot.z()),
+          QVector3D(foot.x(), top + 0.34F + geometry.tip_height * 0.7F, foot.z()),
+          post_radius * 1.02F,
+          palette.wood_dark,
+          BuildingStateMask::Normal);
+      desc.add_cylinder(foot,
+                        QVector3D(foot.x() + px * 0.05F, top * 0.30F, foot.z()),
+                        post_radius,
+                        palette.wood_dark,
+                        BuildingStateMask::Destroyed);
+    }
+  }
+
+  desc.add_box(QVector3D(cx, top + 0.03F, 0.0F),
+               QVector3D(k_tower_half_x + 0.08F, 0.035F, k_tower_half_z + 0.08F),
+               palette.wood_light,
+               k_mask_intact);
+  const float parapet_y = top + 0.21F;
+  desc.add_box(QVector3D(cx, parapet_y, 0.0F),
+               QVector3D(k_tower_half_x + 0.08F, 0.15F, 0.025F),
+               plank,
+               BuildingStateMask::Normal);
+  for (const float pz : {-1.0F, 1.0F}) {
+    desc.add_box(QVector3D(cx, parapet_y, pz * (k_tower_half_z + 0.06F)),
+                 QVector3D(k_tower_half_x + 0.08F, 0.15F, 0.025F),
+                 plank,
+                 BuildingStateMask::Normal);
+  }
+  for (const float px : {-1.0F, 1.0F}) {
+    desc.add_box(QVector3D(cx + px * (k_tower_half_x + 0.06F), parapet_y, 0.0F),
+                 QVector3D(0.025F, 0.15F, k_tower_half_z + 0.08F),
+                 plank,
+                 BuildingStateMask::Normal);
+  }
+}
+
+void add_gate_bridge(BuildingArchetypeDesc& desc,
+                     const WallPalette& palette,
+                     const WallGeometry& geometry) {
+  const float y = tower_top(geometry) - 0.30F;
+  const float half_length = k_tower_center_x - k_tower_half_x;
+  const float half_depth = 0.40F;
+
+  desc.add_box(QVector3D(0.0F, y, 0.0F),
+               QVector3D(half_length, 0.05F, half_depth),
+               palette.wood_light,
+               k_mask_intact);
+  for (const float pz : {-1.0F, 1.0F}) {
+    desc.add_box(QVector3D(0.0F, y - 0.09F, pz * (half_depth - 0.08F)),
+                 QVector3D(half_length, 0.05F, 0.05F),
+                 palette.wood_dark,
+                 k_mask_intact);
+    desc.add_box(QVector3D(0.0F, y + 0.21F, pz * half_depth),
+                 QVector3D(half_length, 0.16F, 0.025F),
+                 palette.wood_mid,
+                 BuildingStateMask::Normal);
+    desc.add_box(QVector3D(0.0F, y + 0.50F, pz * half_depth),
+                 QVector3D(half_length, 0.02F, 0.02F),
+                 palette.wood_dark,
+                 BuildingStateMask::Normal);
+    for (float px = -2.4F; px <= 2.41F; px += 0.8F) {
+      desc.add_box(QVector3D(px, y + 0.27F, pz * half_depth),
+                   QVector3D(0.035F, 0.26F, 0.035F),
+                   palette.wood_dark,
+                   BuildingStateMask::Normal);
+    }
+  }
+
+  for (float px = -2.4F; px <= 2.41F; px += 0.6F) {
+    desc.add_box(QVector3D(px, y + 0.052F, 0.0F),
+                 QVector3D(0.008F, 0.004F, half_depth),
+                 palette.wood_dark * 0.7F,
+                 k_mask_intact);
+  }
 }
 
 void add_jamb(BuildingArchetypeDesc& desc,
@@ -81,8 +211,8 @@ void add_jamb(BuildingArchetypeDesc& desc,
 void add_piers(BuildingArchetypeDesc& desc,
                const WallPalette& palette,
                const WallGeometry& geometry) {
-  constexpr int k_stakes_per_pier = 5;
-  const float pier_inner = k_jamb_offset + 0.16F;
+  constexpr int k_stakes_per_pier = 2;
+  const float pier_inner = k_tower_center_x + k_tower_half_x + 0.02F;
   const float pier_outer = k_structure_half_span;
   const float span = pier_outer - pier_inner;
   const float spacing = span / static_cast<float>(k_stakes_per_pier);
@@ -172,17 +302,10 @@ auto build_wall_gate_archetype(std::string_view name_prefix,
                  k_mask_intact);
   }
 
-  desc.add_box(QVector3D(0.0F, lintel_y + 0.26F, 0.0F),
-               QVector3D(k_jamb_offset + 0.26F, 0.085F, k_jamb_depth + 0.14F),
-               palette.wood_light,
-               BuildingStateMask::Normal);
-
-  for (int i = -2; i <= 2; ++i) {
-    desc.add_box(QVector3D(static_cast<float>(i) * 0.74F, lintel_y + 0.40F, 0.0F),
-                 QVector3D(0.22F, 0.06F, k_jamb_depth + 0.07F),
-                 (i % 2 == 0) ? palette.wood_mid : palette.wood_light,
-                 BuildingStateMask::Normal);
+  for (const float side : {-1.0F, 1.0F}) {
+    add_gate_tower(desc, palette, geometry, side);
   }
+  add_gate_bridge(desc, palette, geometry);
 
   desc.add_rotated_box(QVector3D(0.35F, 0.10F, k_jamb_depth * 1.6F),
                        QVector3D(k_jamb_offset * 0.9F, 0.075F, 0.16F),
@@ -283,6 +406,17 @@ void submit_wall_gate(ISubmitter& out,
 
       if (!detailed) {
         continue;
+      }
+
+      for (const float seam_ratio : {0.2F, 0.4F, 0.6F, 0.8F}) {
+        submit_building_box(
+            out,
+            mesh,
+            white,
+            hinge,
+            QVector3D(-side * length * seam_ratio, (height * 0.5F) + 0.03F, 0.0F),
+            QVector3D(0.010F, (height * 0.5F) - 0.02F, k_leaf_thickness + 0.004F),
+            decayed_color(palette.wood_dark * 0.55F, state, 11));
       }
 
       for (const float band_ratio : {0.28F, 0.72F}) {

--- a/render/entity/wall_renderer_common.cpp
+++ b/render/entity/wall_renderer_common.cpp
@@ -1,5 +1,6 @@
 #include "wall_renderer_common.h"
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -395,29 +396,61 @@ void add_rails(BuildingArchetypeDesc& desc,
   }
 }
 
+void add_span_backing(BuildingArchetypeDesc& desc,
+                      const WallPalette& palette,
+                      const WallGeometry& geometry,
+                      std::size_t dir,
+                      float reach) {
+  const float bottom = geometry.earthwork_base ? geometry.berm_height * 0.5F : 0.02F;
+  const float top = geometry.upper_rail_y + 0.16F;
+  const float half_height = (top - bottom) * 0.5F;
+  const float along_half = reach * 0.5F;
+  const float lateral_half = geometry.stake_radius * 0.62F;
+  const QVector3D plank = palette.wood_dark * 0.92F;
+  desc.add_box(point_at(dir, along_half, 0.0F, bottom + half_height),
+               extents_at(dir, along_half, half_height, lateral_half),
+               plank,
+               k_mask_intact);
+
+  for (const float seam_y :
+       {bottom + (top - bottom) * 0.36F, bottom + (top - bottom) * 0.68F}) {
+    desc.add_box(point_at(dir, along_half, 0.0F, seam_y),
+                 extents_at(dir, along_half, 0.012F, lateral_half + 0.006F),
+                 palette.wood_dark * 0.62F,
+                 k_mask_intact);
+  }
+}
+
 void add_span_braces(BuildingArchetypeDesc& desc,
                      const WallPalette& palette,
                      const WallGeometry& geometry,
                      std::size_t dir,
                      float length) {
-  const float lateral = rail_offset(geometry) * 1.24F;
-  const float radius = geometry.rail_radius * 0.82F;
-  const float near_end = length * 0.16F;
-  const float far_end = length * 0.86F;
+  const float radius = geometry.rail_radius * 0.90F;
+  const float foot_lateral = std::min(geometry.berm_half_width * 1.30F - 0.06F, 0.33F);
+  const float head_lateral = rail_offset(geometry) + (geometry.rail_radius * 0.6F);
+  const float foot_y = geometry.earthwork_base ? geometry.berm_height * 0.55F : 0.02F;
+  const float head_y = geometry.upper_rail_y - 0.04F;
 
-  for (int side = -1; side <= 1; side += 2) {
-    const float offset = static_cast<float>(side) * lateral;
-    desc.add_cylinder(point_at(dir, near_end, offset, 0.32F),
-                      point_at(dir, far_end, offset, geometry.upper_rail_y),
-                      radius,
-                      palette.wood_dark,
-                      k_mask_intact);
-    if (geometry.cross_braced) {
-      desc.add_cylinder(point_at(dir, far_end, offset, 0.32F),
-                        point_at(dir, near_end, offset, geometry.upper_rail_y),
+  const std::array<float, 2> k_strut_t = geometry.cross_braced
+                                             ? std::array<float, 2>{0.30F, 0.72F}
+                                             : std::array<float, 2>{0.52F, -1.0F};
+  for (const float t : k_strut_t) {
+    if (t < 0.0F) {
+      continue;
+    }
+    const float along = length * t;
+    for (int side = -1; side <= 1; side += 2) {
+      const float s = static_cast<float>(side);
+      desc.add_cylinder(point_at(dir, along, s * foot_lateral, foot_y),
+                        point_at(dir, along, s * head_lateral, head_y),
                         radius,
-                        palette.wood_mid,
-                        BuildingStateMask::Normal);
+                        palette.wood_dark,
+                        k_mask_intact);
+      desc.add_box(point_at(dir, along, s * foot_lateral, foot_y + 0.03F),
+                   extents_at(dir, radius * 1.3F, 0.035F, 0.05F),
+                   palette.wood_dark * 0.7F,
+                   k_mask_intact);
     }
   }
 }
@@ -457,13 +490,25 @@ void add_earth_berm(BuildingArchetypeDesc& desc,
                     const WallGeometry& geometry,
                     const WallLayout& layout) {
   constexpr float k_sink = 0.03F;
+
+  constexpr float k_bank_spread = 1.30F;
+  constexpr float k_bank_height_ratio = 0.55F;
   const float half_height = (geometry.berm_height + k_sink) * 0.5F;
   const float center_y = (geometry.berm_height - k_sink) * 0.5F;
   const float half_width = geometry.berm_half_width;
+  const float bank_half_width = half_width * k_bank_spread;
+  const float bank_half_height =
+      ((geometry.berm_height * k_bank_height_ratio) + k_sink) * 0.5F;
+  const float bank_center_y =
+      ((geometry.berm_height * k_bank_height_ratio) - k_sink) * 0.5F;
+  const QVector3D bank_color = palette.earth_light * 0.92F + palette.earth_dark * 0.08F;
 
   desc.add_box(QVector3D(0.0F, center_y, 0.0F),
                QVector3D(half_width, half_height, half_width),
                palette.earth_light);
+  desc.add_box(QVector3D(0.0F, bank_center_y, 0.0F),
+               QVector3D(bank_half_width, bank_half_height, bank_half_width),
+               bank_color);
 
   constexpr std::array<float, 2> k_rubble_t{0.34F, 0.72F};
   for (std::size_t dir = 0; dir < k_dir_count; ++dir) {
@@ -481,10 +526,18 @@ void add_earth_berm(BuildingArchetypeDesc& desc,
     desc.add_box(point_at(dir, along_center, 0.0F, center_y),
                  extents_at(dir, along_half, half_height, half_width),
                  palette.earth_light);
+    const float bank_along_half = (length - bank_half_width) * 0.5F;
+    if (bank_along_half > 0.02F) {
+      desc.add_box(
+          point_at(dir, bank_half_width + bank_along_half, 0.0F, bank_center_y),
+          extents_at(dir, bank_along_half, bank_half_height, bank_half_width),
+          bank_color);
+    }
 
     for (std::size_t i = 0; i < k_rubble_t.size(); ++i) {
       const float along = half_width + ((length - half_width) * k_rubble_t[i]);
-      const float lateral = (i % 2 == 0) ? half_width : -half_width;
+      const float lateral =
+          (i % 2 == 0) ? bank_half_width - 0.08F : -(bank_half_width - 0.08F);
       const float size = 0.055F + (0.015F * static_cast<float>((dir + i) % 3U));
       desc.add_box(point_at(dir, along, lateral, size * 0.7F),
                    QVector3D(size, size * 0.7F, size),
@@ -589,6 +642,7 @@ void add_palisade(BuildingArchetypeDesc& desc,
     const float length = span_length(layout, dir, geometry);
     add_span_stakes(
         desc, palette, geometry, dir, length, layout[dir] == SpanKind::Open);
+    add_span_backing(desc, palette, geometry, dir, rail_reach(layout, dir, geometry));
     add_span_braces(desc, palette, geometry, dir, rail_reach(layout, dir, geometry));
     add_span_debris(desc, palette, dir, length, rail_offset(geometry) * 1.6F);
   }

--- a/render/gl/backend/vegetation_pipeline_natural.cpp
+++ b/render/gl/backend/vegetation_pipeline_natural.cpp
@@ -257,9 +257,9 @@ void VegetationPipeline::initialize_pine_pipeline() {
     QVector3D normal;
   };
 
-  constexpr int k_segments = 20;
+  constexpr int k_segments = 24;
   RingLoftBuilder loft(k_segments);
-  loft.reserve(32);
+  loft.reserve(44);
 
   const int trunk_bottom = loft.add_ring({0.088F, -0.01F, -0.08F, 0.00F, 0.0F});
   const int trunk_kink =
@@ -267,19 +267,21 @@ void VegetationPipeline::initialize_pine_pipeline() {
   const int trunk_mid =
       loft.add_ring({0.054F, 0.32F, 0.03F, 0.16F, 0.0F, QVector2D(0.022F, 0.012F)});
   const int trunk_top =
-      loft.add_ring({0.046F, 0.48F, 0.08F, 0.26F, 0.0F, QVector2D(0.020F, 0.014F)});
+      loft.add_ring({0.046F, 0.46F, 0.08F, 0.26F, 0.0F, QVector2D(0.020F, 0.014F)});
 
   struct TierPlan {
     float base_y;
     float outer_r;
     QVector2D offset;
   };
-  constexpr std::array<TierPlan, 5> k_tiers{{
-      {0.52F, 0.330F, QVector2D(-0.030F, 0.044F)},
-      {0.70F, 0.280F, QVector2D(0.036F, -0.024F)},
-      {0.86F, 0.230F, QVector2D(-0.020F, -0.030F)},
-      {1.00F, 0.180F, QVector2D(0.024F, 0.018F)},
-      {1.12F, 0.132F, QVector2D(-0.014F, 0.022F)},
+  constexpr std::array<TierPlan, 7> k_tiers{{
+      {0.50F, 0.345F, QVector2D(-0.030F, 0.044F)},
+      {0.61F, 0.308F, QVector2D(0.036F, -0.024F)},
+      {0.72F, 0.270F, QVector2D(-0.020F, -0.030F)},
+      {0.83F, 0.232F, QVector2D(0.026F, 0.018F)},
+      {0.94F, 0.194F, QVector2D(-0.016F, 0.024F)},
+      {1.05F, 0.156F, QVector2D(0.018F, -0.014F)},
+      {1.15F, 0.116F, QVector2D(-0.010F, 0.012F)},
   }};
 
   std::vector<int> chain{trunk_bottom, trunk_kink, trunk_mid, trunk_top};
@@ -287,20 +289,21 @@ void VegetationPipeline::initialize_pine_pipeline() {
     const TierPlan& tier = k_tiers[t];
     float const r = tier.outer_r;
     float const y = tier.base_y;
-    float const v0 = 0.34F + (0.145F * static_cast<float>(t));
+    float const v0 = 0.34F + (0.104F * static_cast<float>(t));
     const QVector2D& o = tier.offset;
 
-    chain.push_back(loft.add_ring({r * 0.36F, y, 0.14F, v0, 0.00F, o * 0.12F}));
     chain.push_back(
-        loft.add_ring({r * 0.76F, y + 0.028F, 0.28F, v0 + 0.035F, 0.60F, o * 0.42F}));
-    chain.push_back(loft.add_ring({r, y + 0.050F, 0.42F, v0 + 0.062F, 1.00F, o}));
+        loft.add_ring({r * 0.34F, y + 0.020F, 0.10F, v0, 0.00F, o * 0.12F}));
     chain.push_back(
-        loft.add_ring({r * 0.78F, y + 0.096F, 0.62F, v0 + 0.092F, 0.74F, o * 0.55F}));
+        loft.add_ring({r * 0.72F, y + 0.036F, 0.22F, v0 + 0.028F, 0.60F, o * 0.42F}));
+    chain.push_back(loft.add_ring({r, y + 0.012F, 0.36F, v0 + 0.050F, 1.00F, o}));
     chain.push_back(
-        loft.add_ring({r * 0.44F, y + 0.138F, 0.80F, v0 + 0.118F, 0.30F, o * 0.22F}));
+        loft.add_ring({r * 0.78F, y + 0.064F, 0.62F, v0 + 0.072F, 0.74F, o * 0.55F}));
+    chain.push_back(
+        loft.add_ring({r * 0.44F, y + 0.106F, 0.80F, v0 + 0.092F, 0.30F, o * 0.22F}));
   }
 
-  const int tip_ring = loft.add_ring({0.024F, 1.32F, 0.95F, 1.10F, 0.20F});
+  const int tip_ring = loft.add_ring({0.022F, 1.31F, 0.95F, 1.10F, 0.20F});
   chain.push_back(tip_ring);
 
   for (std::size_t i = 1; i < chain.size(); ++i) {
@@ -359,11 +362,11 @@ void VegetationPipeline::initialize_olive_pipeline() {
     loft.cap(ring, cap_y, offset, v);
   };
 
-  int const t0 = add_ring(0.19F, -0.015F, -0.30F, 0.00F, QVector2D(-0.018F, 0.004F));
-  int const t1 = add_ring(0.14F, 0.09F, -0.05F, 0.07F, QVector2D(0.012F, -0.014F));
-  int const t2 = add_ring(0.105F, 0.18F, 0.08F, 0.14F, QVector2D(0.030F, 0.006F));
-  int const t3 = add_ring(0.080F, 0.28F, 0.20F, 0.22F, QVector2D(0.012F, 0.030F));
-  int const t4 = add_ring(0.065F, 0.36F, 0.34F, 0.29F, QVector2D(0.006F, 0.038F));
+  int const t0 = add_ring(0.215F, -0.015F, -0.30F, 0.00F, QVector2D(-0.022F, 0.006F));
+  int const t1 = add_ring(0.165F, 0.09F, -0.05F, 0.07F, QVector2D(0.018F, -0.020F));
+  int const t2 = add_ring(0.125F, 0.18F, 0.08F, 0.14F, QVector2D(0.038F, 0.008F));
+  int const t3 = add_ring(0.092F, 0.27F, 0.20F, 0.22F, QVector2D(0.016F, 0.036F));
+  int const t4 = add_ring(0.072F, 0.34F, 0.34F, 0.29F, QVector2D(0.008F, 0.044F));
   connect_rings(t0, t1);
   connect_rings(t1, t2);
   connect_rings(t2, t3);
@@ -382,6 +385,10 @@ void VegetationPipeline::initialize_olive_pipeline() {
     float const len = std::sqrt(dir_x * dir_x + dir_z * dir_z);
     dir_x /= len;
     dir_z /= len;
+
+    length *= 1.28F;
+    rise *= 0.88F;
+    leaf_r *= 1.12F;
 
     QVector2D const dir(dir_x, dir_z);
     QVector2D const ortho(-dir_z, dir_x);
@@ -607,9 +614,9 @@ void VegetationPipeline::initialize_cypress_pipeline() {
       {0.042F, 0.28F, 0.06F, 0.22F, 0.0F, QVector2D(0.016F, 0.009F)},
       {0.078F, 0.32F, -0.42F, 0.36F, 0.35F, QVector2D(0.014F, 0.008F)},
       {0.132F, 0.46F, -0.16F, 0.44F, 0.70F, QVector2D(0.010F, -0.006F)},
-      {0.158F, 0.64F, 0.02F, 0.53F, 1.00F, QVector2D(-0.008F, 0.010F)},
-      {0.162F, 0.84F, 0.04F, 0.62F, 1.00F, QVector2D(0.012F, 0.006F)},
-      {0.150F, 1.04F, 0.08F, 0.70F, 1.00F, QVector2D(-0.010F, -0.008F)},
+      {0.170F, 0.64F, 0.02F, 0.53F, 1.00F, QVector2D(-0.008F, 0.010F)},
+      {0.176F, 0.84F, 0.04F, 0.62F, 1.00F, QVector2D(0.012F, 0.006F)},
+      {0.162F, 1.04F, 0.08F, 0.70F, 1.00F, QVector2D(-0.010F, -0.008F)},
       {0.128F, 1.22F, 0.14F, 0.78F, 0.95F, QVector2D(0.008F, 0.012F)},
       {0.098F, 1.38F, 0.24F, 0.85F, 0.85F, QVector2D(-0.006F, 0.006F)},
       {0.062F, 1.52F, 0.42F, 0.92F, 0.70F, QVector2D(0.004F, -0.004F)},
@@ -663,11 +670,15 @@ void VegetationPipeline::initialize_palm_pipeline() {
   constexpr int k_trunk_segments = olive_tree_segments;
   constexpr float k_pi = 3.14159265F;
   constexpr float k_two_pi = 6.28318530718F;
-  constexpr int k_frond_count = 11;
-  constexpr int k_frond_stations = 7;
+  constexpr int k_frond_count = 14;
+  constexpr int k_frond_stations = 9;
+  constexpr int k_dead_frond_count = 7;
+
+  constexpr float k_leaf_v = 0.60F;
+  constexpr float k_dead_v = 0.30F;
 
   RingLoftBuilder loft(k_trunk_segments);
-  loft.reserve(10);
+  loft.reserve(16);
 
   struct TrunkRing {
     float radius;
@@ -676,15 +687,16 @@ void VegetationPipeline::initialize_palm_pipeline() {
     float v;
     QVector2D offset;
   };
-  constexpr std::array<TrunkRing, 8> k_trunk{{
-      {0.088F, -0.015F, -0.34F, 0.04F, QVector2D(0.0F, 0.0F)},
-      {0.086F, 0.20F, -0.04F, 0.11F, QVector2D(0.010F, 0.004F)},
-      {0.072F, 0.42F, 0.02F, 0.19F, QVector2D(0.024F, 0.010F)},
-      {0.062F, 0.62F, 0.06F, 0.27F, QVector2D(0.040F, 0.016F)},
-      {0.055F, 0.76F, 0.10F, 0.36F, QVector2D(0.050F, 0.019F)},
-      {0.050F, 0.84F, 0.14F, 0.45F, QVector2D(0.055F, 0.021F)},
-      {0.046F, 0.90F, 0.18F, 0.52F, QVector2D(0.058F, 0.022F)},
-      {0.042F, 0.95F, 0.26F, 0.58F, QVector2D(0.060F, 0.022F)},
+  constexpr std::array<TrunkRing, 9> k_trunk{{
+      {0.092F, -0.015F, -0.34F, 0.04F, QVector2D(0.0F, 0.0F)},
+      {0.088F, 0.22F, -0.04F, 0.10F, QVector2D(0.010F, 0.004F)},
+      {0.076F, 0.46F, 0.02F, 0.16F, QVector2D(0.026F, 0.011F)},
+      {0.066F, 0.68F, 0.06F, 0.22F, QVector2D(0.044F, 0.018F)},
+      {0.058F, 0.86F, 0.10F, 0.28F, QVector2D(0.058F, 0.023F)},
+      {0.052F, 0.98F, 0.14F, 0.34F, QVector2D(0.066F, 0.026F)},
+      {0.048F, 1.06F, 0.18F, 0.40F, QVector2D(0.070F, 0.027F)},
+      {0.044F, 1.12F, 0.26F, 0.46F, QVector2D(0.072F, 0.028F)},
+      {0.040F, 1.16F, 0.34F, 0.50F, QVector2D(0.073F, 0.028F)},
   }};
   std::vector<int> trunk_chain;
   trunk_chain.reserve(k_trunk.size());
@@ -697,41 +709,72 @@ void VegetationPipeline::initialize_palm_pipeline() {
   }
   loft.cap(trunk_chain.front(), -0.04F, QVector2D(0.0F, 0.0F), 0.0F, 0.0F, false);
 
+  const QVector3D crown(
+      k_trunk.back().offset.x(), k_trunk.back().y, k_trunk.back().offset.y());
+
+  {
+    const QVector2D cc(crown.x(), crown.z());
+    const int h0 =
+        loft.add_ring({0.070F, crown.y() - 0.02F, -0.20F, k_leaf_v, 0.0F, cc});
+    const int h1 =
+        loft.add_ring({0.105F, crown.y() + 0.06F, 0.10F, k_leaf_v + 0.06F, 0.0F, cc});
+    const int h2 =
+        loft.add_ring({0.080F, crown.y() + 0.15F, 0.55F, k_leaf_v + 0.12F, 0.0F, cc});
+    loft.connect(trunk_chain.back(), h0);
+    loft.connect(h0, h1);
+    loft.connect(h1, h2);
+    loft.cap(h2, crown.y() + 0.24F, cc, k_leaf_v + 0.18F, 0.0F, true);
+  }
+
+  for (const float yaw : {0.9F, 3.6F}) {
+    const QVector2D cc(crown.x() + std::cos(yaw) * 0.12F,
+                       crown.z() + std::sin(yaw) * 0.12F);
+    const int d0 =
+        loft.add_ring({0.030F, crown.y() - 0.30F, -0.60F, k_dead_v, 0.0F, cc});
+    const int d1 =
+        loft.add_ring({0.060F, crown.y() - 0.20F, -0.10F, k_dead_v, 0.0F, cc});
+    const int d2 =
+        loft.add_ring({0.045F, crown.y() - 0.08F, 0.40F, k_dead_v, 0.0F, cc});
+    loft.connect(d0, d1);
+    loft.connect(d1, d2);
+    loft.cap(d0, crown.y() - 0.35F, cc, k_dead_v, 0.0F, false);
+    loft.cap(d2, crown.y() - 0.02F, cc, k_dead_v, 0.0F, true);
+  }
+
   std::vector<PalmVertex> vertices;
   vertices.reserve(loft.vertices().size() +
-                   static_cast<std::size_t>(k_frond_count * k_frond_stations * 4));
+                   static_cast<std::size_t>((k_frond_count + k_dead_frond_count) *
+                                            k_frond_stations * 4));
   for (const auto& vertex : loft.vertices()) {
     vertices.push_back({vertex.position, QVector2D(vertex.u, vertex.v), vertex.normal});
   }
   std::vector<std::uint16_t> indices = loft.indices();
 
-  const QVector3D crown(
-      k_trunk.back().offset.x(), k_trunk.back().y, k_trunk.back().offset.y());
   const auto first_frond_vertex = static_cast<std::uint16_t>(vertices.size());
 
-  for (int f = 0; f < k_frond_count; ++f) {
-    const float frond_u = static_cast<float>(f) / static_cast<float>(k_frond_count);
-    const float wobble = std::sin(static_cast<float>(f) * 2.399963F);
-    const float yaw = frond_u * k_two_pi + wobble * 0.12F;
-    const float length = 0.66F + wobble * 0.08F;
-    const float rise = 0.26F + wobble * 0.05F;
-    const float droop = 0.62F + wobble * 0.10F;
+  auto add_frond = [&](float yaw,
+                       float length,
+                       float rise,
+                       float droop,
+                       float width,
+                       float base_lift,
+                       float v_base,
+                       float v_span,
+                       float frond_u) {
     const QVector3D dir(std::cos(yaw), 0.0F, std::sin(yaw));
     const QVector3D side(-std::sin(yaw), 0.0F, std::cos(yaw));
-
     const auto base = static_cast<std::uint16_t>(vertices.size());
     for (int station = 0; station < k_frond_stations; ++station) {
       const float t =
           static_cast<float>(station) / static_cast<float>(k_frond_stations - 1);
-      const float lift = rise * std::sin(t * 1.7278F) - droop * t * t * t;
-
-      const float pinnate = (station % 2 == 0) ? 1.0F : 0.64F;
+      const float lift = base_lift + rise * std::sin(t * 1.9F) - droop * t * t * t;
+      const float pinnate = (station % 2 == 0) ? 1.0F : 0.60F;
       const float half_width =
-          0.104F * pinnate * std::sin(std::clamp(t * 0.86F + 0.10F, 0.0F, 1.0F) * k_pi);
-      const float fold = -half_width * 1.15F;
+          width * pinnate * std::sin(std::clamp(t * 0.90F + 0.08F, 0.0F, 1.0F) * k_pi);
+      const float fold = -half_width * (0.9F + 0.5F * t);
 
       const QVector3D spine = crown + dir * (length * t) + QVector3D(0.0F, lift, 0.0F);
-      const QVector2D uv(frond_u, 0.60F + t * 0.34F);
+      const QVector2D uv(frond_u, v_base + t * v_span);
       const QVector3D up(0.0F, 1.0F, 0.0F);
       const QVector3D droop_edge(0.0F, fold, 0.0F);
 
@@ -740,7 +783,6 @@ void VegetationPipeline::initialize_palm_pipeline() {
       vertices.push_back({spine, uv, up});
       vertices.push_back({spine - side * half_width + droop_edge, uv, up});
     }
-
     for (int station = 0; station + 1 < k_frond_stations; ++station) {
       const auto lower = static_cast<std::uint16_t>(base + station * 4);
       const auto upper = static_cast<std::uint16_t>(lower + 4);
@@ -752,6 +794,36 @@ void VegetationPipeline::initialize_palm_pipeline() {
         indices.insert(indices.end(), {a0, b0, b1, a0, b1, a1});
       }
     }
+  };
+
+  for (int f = 0; f < k_frond_count; ++f) {
+    const float frond_u = static_cast<float>(f) / static_cast<float>(k_frond_count);
+    const float wobble = std::sin(static_cast<float>(f) * 2.399963F);
+    const float ring = (f % 2 == 0) ? 1.0F : 0.0F;
+    const float yaw = frond_u * k_two_pi + wobble * 0.14F;
+    add_frond(yaw,
+              0.70F + wobble * 0.07F - ring * 0.08F,
+              0.30F + wobble * 0.04F + ring * 0.08F,
+              0.52F + wobble * 0.08F,
+              0.118F,
+              0.08F + ring * 0.05F,
+              k_leaf_v,
+              0.34F,
+              frond_u);
+  }
+  for (int f = 0; f < k_dead_frond_count; ++f) {
+    const float frond_u =
+        (static_cast<float>(f) + 0.5F) / static_cast<float>(k_dead_frond_count);
+    const float wobble = std::sin(static_cast<float>(f) * 1.7F + 0.6F);
+    add_frond(frond_u * k_two_pi + wobble * 0.2F,
+              0.30F + wobble * 0.04F,
+              0.0F,
+              0.62F,
+              0.070F,
+              -0.03F,
+              k_dead_v,
+              0.0F,
+              frond_u);
   }
 
   for (std::size_t i = first_frond_vertex; i < vertices.size(); ++i) {

--- a/render/ground/map_boundary_fog_renderer.cpp
+++ b/render/ground/map_boundary_fog_renderer.cpp
@@ -7,10 +7,13 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <unordered_map>
 
+#include "game/map/terrain.h"
 #include "game/map/terrain_noise.h"
 #include "game/map/terrain_service.h"
 #include "render/scene_renderer.h"
+#include "terrain_renderer.h"
 
 namespace Render::GL {
 
@@ -22,21 +25,23 @@ constexpr int k_clear_outside_tiles = 2;
 constexpr int k_band_outside = 16;
 constexpr int k_cards_per_side = 3;
 constexpr int k_curtain_rings = 2;
-constexpr int k_mountain_depth_segments = 22;
 
-constexpr std::array<float, k_curtain_rings> k_ring_offset_scale = {0.52F, 1.06F};
-constexpr std::array<float, k_curtain_rings> k_ring_height_scale = {2.55F, 3.35F};
-constexpr std::array<float, k_curtain_rings> k_ring_alpha = {0.34F, 0.20F};
+constexpr std::array<float, k_curtain_rings> k_ring_offset_scale = {0.78F, 1.36F};
+constexpr std::array<float, k_curtain_rings> k_ring_height_scale = {1.70F, 2.30F};
+constexpr std::array<float, k_curtain_rings> k_ring_alpha = {0.30F, 0.20F};
 constexpr std::array<float, k_curtain_rings> k_ring_width_scale = {1.18F, 1.42F};
 
 constexpr float k_fog_r = 0.55F;
 constexpr float k_fog_g = 0.58F;
 constexpr float k_fog_b = 0.56F;
 
-constexpr float k_mountain_inner_tiles = 0.45F;
-constexpr float k_mountain_outer_tiles = 13.80F;
-constexpr float k_mountain_peak_tiles = 18.50F;
-constexpr float k_mountain_base_lift = 0.025F;
+constexpr float k_foothill_tiles = 4.5F;
+constexpr float k_mountain_outer_tiles = 28.0F;
+constexpr float k_mountain_peak_tiles = 21.0F;
+constexpr float k_mountain_edge_step_tiles = 0.75F;
+constexpr int k_mountain_depth_segments = 40;
+constexpr int k_mountain_min_side_segments = 12;
+constexpr int k_mountain_max_side_segments = 768;
 
 inline auto smoothstep(float edge0, float edge1, float value) -> float {
   if (edge0 == edge1) {
@@ -44,6 +49,12 @@ inline auto smoothstep(float edge0, float edge1, float value) -> float {
   }
   const float t = std::clamp((value - edge0) / (edge1 - edge0), 0.0F, 1.0F);
   return t * t * (3.0F - 2.0F * t);
+}
+
+inline auto ridge_bump(float t, float centre, float width) -> float {
+  const float tent =
+      std::clamp(1.0F - std::abs(t - centre) / std::max(width, 0.001F), 0.0F, 1.0F);
+  return std::pow(tent, 1.25F);
 }
 
 constexpr float k_card_camera_clearance = 12.0F;
@@ -57,14 +68,42 @@ auto card_engulfs_camera(const QVector3D& card_center,
   return dx * dx + dz * dz < clearance * clearance;
 }
 
-auto boundary_height_at(const Game::Map::TerrainService& terrain_service,
-                        float world_x,
-                        float world_z) -> float {
-  const auto* height_map = terrain_service.get_height_map();
-  if (!terrain_service.is_initialized() || height_map == nullptr) {
+auto edge_height_at(const Game::Map::TerrainHeightMap* height_map,
+                    float world_x,
+                    float world_z) -> float {
+  if (height_map == nullptr) {
     return 0.0F;
   }
-  return std::max(0.0F, height_map->get_height_at(world_x, world_z));
+  const int width = height_map->get_width();
+  const int height = height_map->get_height();
+  const auto& data = height_map->get_height_data();
+  if (width <= 0 || height <= 0 ||
+      data.size() <
+          static_cast<std::size_t>(width) * static_cast<std::size_t>(height)) {
+    return 0.0F;
+  }
+  const float tile = std::max(height_map->get_tile_size(), 0.0001F);
+  const float gx =
+      std::clamp(world_x / tile + (static_cast<float>(width) * 0.5F - 0.5F),
+                 0.0F,
+                 static_cast<float>(width - 1));
+  const float gz =
+      std::clamp(world_z / tile + (static_cast<float>(height) * 0.5F - 0.5F),
+                 0.0F,
+                 static_cast<float>(height - 1));
+  const int x0 = std::min(static_cast<int>(std::floor(gx)), width - 1);
+  const int z0 = std::min(static_cast<int>(std::floor(gz)), height - 1);
+  const int x1 = std::min(x0 + 1, width - 1);
+  const int z1 = std::min(z0 + 1, height - 1);
+  const float tx = gx - static_cast<float>(x0);
+  const float tz = gz - static_cast<float>(z0);
+  const auto at = [&](int x, int z) {
+    return data[static_cast<std::size_t>(z) * static_cast<std::size_t>(width) +
+                static_cast<std::size_t>(x)];
+  };
+  const float h0 = at(x0, z0) * (1.0F - tx) + at(x1, z0) * tx;
+  const float h1 = at(x0, z1) * (1.0F - tx) + at(x1, z1) * tx;
+  return h0 * (1.0F - tz) + h1 * tz;
 }
 
 struct MountainPatchConfig {
@@ -73,24 +112,26 @@ struct MountainPatchConfig {
   QVector3D axis_v{0.0F, 0.0F, 1.0F};
   int u_segments = 1;
   int v_segments = 1;
+
+  bool seam_row = false;
 };
 
 struct BoundaryMountainConfig {
-  float half_width = 0.0F;
-  float half_height = 0.0F;
-  float inner_offset = 0.0F;
-  float mountain_band = 0.0F;
+  float edge_half_width = 0.0F;
+  float edge_half_height = 0.0F;
+  float foothill = 0.0F;
+  float band = 0.0F;
   float tile_size = 1.0F;
-  float max_relief_height = 0.0F;
-  Game::Map::MountainNoiseSettings noise_settings{};
+  float peak = 0.0F;
 
-  const Game::Map::TerrainService* terrain = nullptr;
+  float detail_frequency_cap = 1.0F;
+  Game::Map::MountainNoiseSettings noise_settings{};
+  const Game::Map::TerrainHeightMap* height_map = nullptr;
 };
 
 struct BoundaryMountainSample {
   float height = 0.0F;
-  float presence = 0.0F;
-  float relief = 0.0F;
+  float foot = 0.0F;
 };
 
 auto resolve_mountain_noise_settings(const Game::Map::TerrainService& terrain_service,
@@ -112,142 +153,90 @@ auto sample_boundary_mountain(float world_x,
                               float world_z,
                               const BoundaryMountainConfig& config)
     -> BoundaryMountainSample {
-  const float outside_x = std::max(0.0F, std::abs(world_x) - config.half_width);
-  const float outside_z = std::max(0.0F, std::abs(world_z) - config.half_height);
-  const float outside_distance =
-      std::sqrt(outside_x * outside_x + outside_z * outside_z);
-  const float depth_hint = std::clamp((outside_distance - config.inner_offset) /
-                                          std::max(config.mountain_band, 0.001F),
-                                      0.0F,
-                                      1.0F);
+  const float tile = config.tile_size;
+  const float outside_x = std::max(0.0F, std::abs(world_x) - config.edge_half_width);
+  const float outside_z = std::max(0.0F, std::abs(world_z) - config.edge_half_height);
+  const float distance = std::sqrt(outside_x * outside_x + outside_z * outside_z);
+  const float band = std::max(config.band, 0.001F);
+  const float t = std::clamp(distance / band, 0.0F, 1.0F);
+  const float rise = smoothstep(config.foothill, band * 0.82F, distance);
 
-  const float warp_frequency =
-      std::clamp(config.noise_settings.frequency * 0.55F, 0.01F, 1.25F);
-  const int warp_octaves =
-      std::max(2, Game::Map::clamp_noise_octaves(config.noise_settings.octaves) - 1);
-  const float warp_strength = config.tile_size * (1.15F + depth_hint * 1.35F);
+  const auto& noise = config.noise_settings;
+  const int octaves = Game::Map::clamp_noise_octaves(noise.octaves);
+
+  const float warp_frequency = std::clamp(noise.frequency * 0.55F, 0.01F, 1.25F);
+  const float warp_strength = tile * (0.9F + 1.6F * t);
   const float warp_x = Game::Map::fbm_noise(world_x * warp_frequency,
                                             world_z * warp_frequency,
-                                            config.noise_settings.seed ^ 0x4B1D5A37U,
-                                            warp_octaves);
+                                            noise.seed ^ 0x4B1D5A37U,
+                                            std::max(2, octaves - 1));
   const float warp_z = Game::Map::fbm_noise(world_x * warp_frequency,
                                             world_z * warp_frequency,
-                                            config.noise_settings.seed ^ 0x91E10DA5U,
-                                            warp_octaves);
-  const float sample_x = world_x + (warp_x - 0.5F) * 2.0F * warp_strength;
-  const float sample_z = world_z + (warp_z - 0.5F) * 2.0F * warp_strength;
+                                            noise.seed ^ 0x91E10DA5U,
+                                            std::max(2, octaves - 1));
+  const float sx = world_x + (warp_x - 0.5F) * 2.0F * warp_strength;
+  const float sz = world_z + (warp_z - 0.5F) * 2.0F * warp_strength;
 
-  Game::Map::MountainNoiseSettings spread_settings = config.noise_settings;
-  spread_settings.frequency =
-      std::clamp(config.noise_settings.frequency * 0.36F, 0.01F, 0.45F);
-  spread_settings.octaves =
-      std::max(2, Game::Map::clamp_noise_octaves(config.noise_settings.octaves) - 1);
-  const float spread_noise =
-      Game::Map::sample_mountain_region(sample_x, sample_z, spread_settings);
-  const float band_noise = Game::Map::fbm_noise(
-      sample_x * std::clamp(spread_settings.frequency * 1.4F, 0.01F, 0.7F),
-      sample_z * std::clamp(spread_settings.frequency * 1.4F, 0.01F, 0.7F),
-      config.noise_settings.seed ^ 0x71A9C13DU,
-      3);
-  const float cluster_noise = Game::Map::fbm_noise(
-      sample_x * std::clamp(spread_settings.frequency * 0.9F, 0.01F, 0.4F),
-      sample_z * std::clamp(spread_settings.frequency * 0.9F, 0.01F, 0.4F),
-      config.noise_settings.seed ^ 0x18D42F7BU,
-      2);
-  Game::Map::MountainNoiseSettings chain_settings = config.noise_settings;
-  chain_settings.frequency =
-      std::clamp(config.noise_settings.frequency * 0.16F, 0.006F, 0.12F);
+  Game::Map::MountainNoiseSettings chain_settings = noise;
+  chain_settings.frequency = std::clamp(noise.frequency * 0.16F, 0.006F, 0.12F);
   chain_settings.octaves = 3;
-  const float chain_noise =
-      Game::Map::sample_mountain_region(sample_x, sample_z, chain_settings);
-  const float gap_noise = Game::Map::fbm_noise(
-      sample_x * std::clamp(chain_settings.frequency * 2.2F, 0.01F, 0.22F),
-      sample_z * std::clamp(chain_settings.frequency * 2.2F, 0.01F, 0.22F),
-      config.noise_settings.seed ^ 0x5D8E123FU,
-      2);
-  const float cluster =
-      smoothstep(0.34F, 0.68F, spread_noise * 0.58F + cluster_noise * 0.42F);
-  const float chain_presence = smoothstep(
-      0.46F, 0.70F, chain_noise * 0.72F + spread_noise * 0.20F + cluster_noise * 0.08F);
-  const float gap_presence =
-      1.0F - smoothstep(0.58F, 0.84F, gap_noise * 0.78F + band_noise * 0.22F);
-  const float sparsity =
-      std::clamp(std::pow(chain_presence, 1.20F) * gap_presence, 0.0F, 1.0F);
-  const float local_inner =
-      std::clamp(config.inner_offset + (0.5F - spread_noise) * config.tile_size * 4.6F +
-                     (0.5F - cluster_noise) * config.tile_size * 2.2F +
-                     (1.0F - sparsity) * config.mountain_band * 0.18F,
-                 0.0F,
-                 config.inner_offset + config.mountain_band * 0.55F);
-  const float local_band =
-      config.mountain_band *
-      std::clamp(0.72F + sparsity * 0.40F + band_noise * 0.38F, 0.58F, 1.55F);
-  const float depth_t = std::clamp(
-      (outside_distance - local_inner) / std::max(local_band, 0.001F), 0.0F, 1.0F);
-
-  const float region =
-      Game::Map::sample_mountain_region(sample_x, sample_z, config.noise_settings);
-  const float macro_frequency =
-      std::clamp(config.noise_settings.frequency * 0.42F, 0.01F, 0.5F);
-  const float macro = Game::Map::fbm_noise(sample_x * macro_frequency,
-                                           sample_z * macro_frequency,
-                                           config.noise_settings.seed ^ 0x2C9F51E3U,
-                                           3);
-  const float shape = std::clamp(region * 0.72F + macro * 0.28F, 0.0F, 1.0F);
+  const float chain = Game::Map::sample_mountain_region(sx, sz, chain_settings);
+  const float pass_frequency =
+      std::clamp(chain_settings.frequency * 2.2F, 0.01F, 0.22F);
+  const float pass_noise = Game::Map::fbm_noise(
+      sx * pass_frequency, sz * pass_frequency, noise.seed ^ 0x5D8E123FU, 2);
+  const float pass = smoothstep(0.60F, 0.86F, pass_noise);
+  const float cluster_frequency = std::clamp(noise.frequency * 0.32F, 0.01F, 0.4F);
+  const float cluster = Game::Map::fbm_noise(
+      sx * cluster_frequency, sz * cluster_frequency, noise.seed ^ 0x18D42F7BU, 2);
+  const float crag_frequency = std::min(std::clamp(noise.frequency * 2.6F, 0.05F, 0.9F),
+                                        config.detail_frequency_cap * 0.6F);
   const float crag = Game::Map::fbm_noise(
-      sample_x * std::clamp(config.noise_settings.frequency * 4.2F, 0.08F, 1.4F),
-      sample_z * std::clamp(config.noise_settings.frequency * 4.2F, 0.08F, 1.4F),
-      config.noise_settings.seed ^ 0xA4215F71U,
-      4);
+      sx * crag_frequency, sz * crag_frequency, noise.seed ^ 0xA4215F71U, 4);
+  const float tooth_frequency = std::min(
+      std::clamp(noise.frequency * 5.0F, 0.10F, 1.6F), config.detail_frequency_cap);
   const float tooth = Game::Map::fbm_noise(
-      sample_x * std::clamp(config.noise_settings.frequency * 9.0F, 0.14F, 2.4F),
-      sample_z * std::clamp(config.noise_settings.frequency * 9.0F, 0.14F, 2.4F),
-      config.noise_settings.seed ^ 0xD1B54A32U,
-      2);
-  const float jaggedness =
-      std::clamp(0.62F + crag * 0.42F + (tooth - 0.5F) * 0.36F, 0.42F, 1.35F);
+      sx * tooth_frequency, sz * tooth_frequency, noise.seed ^ 0xD1B54A32U, 2);
+  const float roll_frequency = std::clamp(noise.frequency * 1.6F, 0.02F, 0.6F);
+  const float roll = Game::Map::fbm_noise(
+      sx * roll_frequency, sz * roll_frequency, noise.seed ^ 0x2C9F51E3U, 3);
 
-  const float ridge_center =
-      std::clamp(0.20F + shape * 0.34F + (band_noise - 0.5F) * 0.14F, 0.12F, 0.70F);
-  const float ridge_width = 0.16F + (1.0F - shape) * 0.10F + (1.0F - sparsity) * 0.04F;
-  const float primary_ridge =
-      smoothstep(0.02F, ridge_center, depth_t) *
-      (1.0F - smoothstep(ridge_center + ridge_width, 0.96F, depth_t));
-  const float secondary_center =
-      std::clamp(ridge_center + 0.20F + (cluster_noise - 0.5F) * 0.10F, 0.28F, 0.88F);
-  const float secondary_width = 0.11F + (1.0F - shape) * 0.05F;
-  const float secondary_ridge =
-      smoothstep(0.10F, secondary_center, depth_t) *
-      (1.0F - smoothstep(secondary_center + secondary_width, 1.0F, depth_t));
-  const float inner_escarpment =
-      smoothstep(0.01F, 0.17F, depth_t) *
-      (1.0F - smoothstep(0.26F + shape * 0.10F, 0.58F, depth_t));
-  const float shoulder_profile =
-      smoothstep(0.0F, 0.14F, depth_t) * (1.0F - smoothstep(0.84F, 1.0F, depth_t));
-  const float relief_mask = std::clamp(
-      (primary_ridge * (0.58F + 0.48F * shape) +
-       secondary_ridge * (0.18F + 0.18F * cluster) +
-       inner_escarpment * (0.26F + 0.22F * crag) + shoulder_profile * 0.16F) *
-          std::clamp(0.62F + sparsity * 0.45F, 0.0F, 1.15F) *
-          std::clamp(0.42F + cluster * 0.85F, 0.0F, 1.15F) * jaggedness,
-      0.0F,
-      1.0F);
+  const float edge_height = edge_height_at(config.height_map, world_x, world_z);
+  const float carry = 1.0F - smoothstep(0.0F, config.foothill * 1.6F, distance);
+  float height = edge_height * carry;
 
-  const float boundary_blend = std::pow(std::max(0.0F, 1.0F - depth_t), 2.1F);
-  const float base_height =
-      (config.terrain != nullptr ? boundary_height_at(*config.terrain, world_x, world_z)
-                                 : 0.0F) *
-          boundary_blend +
-      config.tile_size * k_mountain_base_lift;
-  const float height_scale = std::clamp(
-      0.72F + sparsity * 0.34F + cluster * 0.16F + (crag - 0.5F) * 0.24F, 0.48F, 1.28F);
-  const float relief = config.max_relief_height * height_scale * relief_mask;
-  const float presence =
-      std::clamp((0.42F + sparsity * 0.58F) * (0.42F + 0.58F * cluster) *
-                     smoothstep(0.025F, 0.13F, relief_mask),
-                 0.0F,
-                 1.0F);
-  return {base_height + relief, presence, relief};
+  const float seam = smoothstep(0.0F, tile * 0.9F, distance);
+  const float foothill_t = smoothstep(0.0F, config.foothill, distance);
+  height += (roll - 0.5F) * 2.0F * tile * (0.30F + 1.10F * foothill_t) * seam *
+            (1.0F - 0.6F * rise);
+
+  const float massif = 0.55F + 0.45F * chain;
+  const float climb = smoothstep(tile * 0.5F, band * 0.5F, distance);
+  const float floor_height =
+      config.peak *
+      (0.12F * climb + 0.48F * std::pow(rise, 1.3F) * massif * (1.0F - 0.35F * pass));
+
+  const float front_centre = std::clamp(0.40F + (cluster - 0.5F) * 0.16F, 0.30F, 0.52F);
+  const float front_width = 0.17F + 0.06F * (1.0F - chain);
+  const float front = ridge_bump(t, front_centre, front_width) * config.peak * 0.55F *
+                      (0.50F + 0.50F * chain) * (1.0F - 0.55F * pass);
+  const float back_centre = std::clamp(0.76F + (cluster - 0.5F) * 0.10F, 0.66F, 0.86F);
+  const float back = ridge_bump(t, back_centre, 0.20F) * config.peak * 0.70F *
+                     (0.62F + 0.38F * chain) * (1.0F - 0.40F * pass);
+  const float wall = smoothstep(0.86F, 1.0F, t) * config.peak * 0.40F;
+  const float relief = floor_height + front + back + wall;
+
+  const float crag_amp =
+      config.peak * 0.12F *
+      smoothstep(0.05F, 0.45F, relief / std::max(config.peak, 0.001F));
+  const float detail =
+      ((crag - 0.5F) * 0.70F + (tooth - 0.5F) * 0.30F) * 2.0F * crag_amp;
+
+  height += relief + detail;
+
+  const float foot =
+      1.0F - smoothstep(config.foothill * 0.4F, config.foothill * 2.6F, distance);
+  return {height, std::clamp(foot, 0.0F, 1.0F)};
 }
 
 inline auto clamp01(const QVector3D& color) -> QVector3D {
@@ -257,101 +246,57 @@ inline auto clamp01(const QVector3D& color) -> QVector3D {
 }
 
 auto build_boundary_mountain_params(const Game::Map::TerrainService& terrain_service,
-                                    float tile_size,
-                                    int width,
-                                    int height) -> TerrainChunkParams {
-  TerrainChunkParams params;
+                                    float tile_size) -> TerrainChunkParams {
   Game::Map::BiomeSettings biome;
   if (terrain_service.is_initialized()) {
     biome = terrain_service.biome_settings();
   }
-
   const auto profiles = Game::Map::make_biome_profiles(biome);
-  const auto& surface_profile = profiles.surface;
-  const auto& climate_profile = profiles.climate;
-  params.ground_type = static_cast<int>(biome.ground_type);
-
-  params.grass_primary = clamp01(surface_profile.grass_primary * 0.97F);
-  params.grass_secondary = clamp01(surface_profile.grass_secondary * 0.93F);
-  params.grass_dry = clamp01(surface_profile.grass_dry * 0.90F);
-  params.soil_color = clamp01(surface_profile.soil_color * 0.82F);
-  params.rock_low = clamp01(surface_profile.rock_low);
-  params.rock_high = clamp01(surface_profile.rock_high);
-
-  params.tint = QVector3D(0.96F, 0.98F, 0.96F);
-  params.tile_size = std::max(0.25F, tile_size);
-  params.macro_noise_scale =
-      std::max(0.012F, surface_profile.terrain_macro_noise_scale * 0.95F);
-  params.detail_noise_scale =
-      std::max(0.045F, surface_profile.terrain_detail_noise_scale * 1.15F);
-  params.slope_rock_threshold =
-      std::clamp(surface_profile.terrain_rock_threshold + 0.30F, 0.40F, 0.90F);
-  params.slope_rock_sharpness =
-      std::clamp(surface_profile.terrain_rock_sharpness + 1.5F, 2.0F, 6.0F);
-  params.soil_blend_height = surface_profile.terrain_soil_height - 1.25F;
-  params.soil_blend_sharpness =
-      std::clamp(surface_profile.terrain_soil_sharpness * 0.75F, 1.5F, 5.0F);
-
-  constexpr float k_non_playable_margin_tiles = 48.0F;
-  const float margin = k_non_playable_margin_tiles * params.tile_size;
-  const float span_x =
-      width > 0 ? static_cast<float>(width) * params.tile_size + margin * 2.0F
-                : params.tile_size;
-  const float span_z =
-      height > 0 ? static_cast<float>(height) * params.tile_size + margin * 2.0F
-                 : params.tile_size;
-  const auto seed = static_cast<float>(biome.seed % 1024U);
-  params.noise_offset =
-      QVector2D(span_x * 0.37F + seed * 0.21F, span_z * 0.43F + seed * 0.17F);
-  params.noise_angle = std::fmod(seed * 0.6180339887F, 1.0F) * 6.28318530718F;
-
-  if (surface_profile.ground_irregularity_enabled) {
-    params.height_noise_strength =
-        std::clamp(surface_profile.irregularity_amplitude * 0.85F, 0.15F, 0.70F);
-    params.height_noise_frequency =
-        std::max(0.45F, surface_profile.irregularity_scale * 2.5F);
-  } else {
-    params.height_noise_strength =
-        std::clamp(surface_profile.height_noise_amplitude * 0.22F, 0.10F, 0.20F);
-    params.height_noise_frequency =
-        std::max(0.6F, surface_profile.height_noise_frequency * 1.05F);
-  }
-  params.ambient_boost = surface_profile.terrain_ambient_boost * 0.95F;
-  params.rock_detail_strength = surface_profile.terrain_rock_detail_strength * 0.42F;
-  params.light_direction = QVector3D(0.35F, 0.85F, 0.42F).normalized();
-  params.is_ground_plane = true;
-  params.snow_coverage = std::clamp(climate_profile.snow_coverage, 0.0F, 1.0F);
-  params.moisture_level = std::clamp(climate_profile.moisture_level, 0.0F, 1.0F);
-  params.crack_intensity = std::clamp(climate_profile.crack_intensity, 0.0F, 1.0F);
-  params.rock_exposure = std::clamp(climate_profile.rock_exposure * 0.72F +
-                                        climate_profile.crack_intensity * 0.18F +
-                                        (1.0F - climate_profile.moisture_level) * 0.08F,
-                                    0.04F,
-                                    0.82F);
-  params.grass_saturation = std::clamp(climate_profile.grass_saturation, 0.0F, 1.5F);
-  params.soil_roughness = std::clamp(climate_profile.soil_roughness, 0.0F, 1.0F);
-  params.micro_bump_amp = std::clamp(0.070F + climate_profile.soil_roughness * 0.085F +
-                                         params.rock_exposure * 0.055F,
-                                     0.07F,
-                                     0.22F);
-  params.micro_bump_freq = std::clamp(2.4F + climate_profile.soil_roughness * 2.3F +
-                                          climate_profile.crack_intensity * 1.1F,
-                                      2.2F,
-                                      6.2F);
-  params.micro_normal_weight = std::clamp(0.68F + params.rock_exposure * 0.20F +
-                                              climate_profile.moisture_level * 0.08F,
-                                          0.68F,
-                                          0.94F);
-  params.albedo_jitter = std::clamp(0.070F + climate_profile.soil_roughness * 0.060F +
-                                        climate_profile.crack_intensity * 0.035F,
-                                    0.06F,
-                                    0.18F);
-  params.snow_color = clamp01(climate_profile.snow_color);
+  TerrainChunkParams params =
+      make_terrain_chunk_params(biome,
+                                profiles.surface,
+                                profiles.climate,
+                                tile_size,
+                                biome.seed,
+                                Game::Map::TerrainType::Mountain,
+                                1.0F);
+  params.tint = clamp01(params.tint);
+  params.is_ground_plane = false;
   return params;
 }
 
+struct PositionKey {
+  std::int64_t x;
+  std::int64_t y;
+  std::int64_t z;
+  auto operator==(const PositionKey& other) const -> bool {
+    return x == other.x && y == other.y && z == other.z;
+  }
+};
+
+struct PositionKeyHash {
+  auto operator()(const PositionKey& key) const -> std::size_t {
+    std::uint64_t h = 1469598103934665603ULL;
+    for (const std::int64_t v : {key.x, key.y, key.z}) {
+      h ^= static_cast<std::uint64_t>(v);
+      h *= 1099511628211ULL;
+    }
+    return static_cast<std::size_t>(h);
+  }
+};
+
+auto position_key(const std::array<float, 3>& position) -> PositionKey {
+  const auto quantize = [](float value) -> std::int64_t {
+    return static_cast<std::int64_t>(std::llround(value * 1000.0));
+  };
+  return {quantize(position[0]), quantize(position[1]), quantize(position[2])};
+}
+
+using NormalAccumulator = std::unordered_map<PositionKey, QVector3D, PositionKeyHash>;
+
 void append_patch_mesh(std::vector<Vertex>& vertices,
                        std::vector<unsigned int>& indices,
+                       NormalAccumulator& extra_normals,
                        const MountainPatchConfig& config,
                        const BoundaryMountainConfig& mountain_config) {
   if (config.u_segments <= 0 || config.v_segments <= 0) {
@@ -362,11 +307,6 @@ void append_patch_mesh(std::vector<Vertex>& vertices,
   const int rows = config.v_segments + 1;
   const std::size_t base_index = vertices.size();
   vertices.resize(base_index + static_cast<std::size_t>(columns * rows));
-  std::vector<float> cell_presence(static_cast<std::size_t>(columns * rows), 0.0F);
-  std::vector<float> cell_relief(static_cast<std::size_t>(columns * rows), 0.0F);
-
-  const QVector3D flat_normal(0.0F, 1.0F, 0.0F);
-  const float tex_scale = 0.16F / std::max(mountain_config.tile_size, 0.25F);
 
   for (int v = 0; v <= config.v_segments; ++v) {
     const float fv = static_cast<float>(v) / static_cast<float>(config.v_segments);
@@ -379,14 +319,12 @@ void append_patch_mesh(std::vector<Vertex>& vertices,
 
       Vertex vertex{};
       vertex.position = {position.x(), position.y(), position.z()};
-      vertex.normal = {flat_normal.x(), flat_normal.y(), flat_normal.z()};
-      vertex.tex_coord = {position.x() * tex_scale, position.z() * tex_scale};
+      vertex.normal = {0.0F, 1.0F, 0.0F};
+
+      vertex.tex_coord = {sample.foot, 0.0F};
 
       const std::size_t local_index = static_cast<std::size_t>(v * columns + u);
-      const std::size_t vertex_index = base_index + local_index;
-      vertices[vertex_index] = vertex;
-      cell_presence[local_index] = sample.presence;
-      cell_relief[local_index] = sample.relief;
+      vertices[base_index + local_index] = vertex;
     }
   }
 
@@ -395,55 +333,62 @@ void append_patch_mesh(std::vector<Vertex>& vertices,
 
   for (int v = 0; v < config.v_segments; ++v) {
     for (int u = 0; u < config.u_segments; ++u) {
-      const std::size_t local_a = static_cast<std::size_t>(v * columns + u);
-      const std::size_t local_b = local_a + 1U;
-      const std::size_t local_c = local_a + static_cast<std::size_t>(columns);
-      const std::size_t local_d = local_c + 1U;
-      const float avg_presence = (cell_presence[local_a] + cell_presence[local_b] +
-                                  cell_presence[local_c] + cell_presence[local_d]) *
-                                 0.25F;
-      const float max_presence =
-          std::max(std::max(cell_presence[local_a], cell_presence[local_b]),
-                   std::max(cell_presence[local_c], cell_presence[local_d]));
-      const float max_relief =
-          std::max(std::max(cell_relief[local_a], cell_relief[local_b]),
-                   std::max(cell_relief[local_c], cell_relief[local_d]));
-      const float avg_relief = (cell_relief[local_a] + cell_relief[local_b] +
-                                cell_relief[local_c] + cell_relief[local_d]) *
-                               0.25F;
-      if ((max_presence < 0.035F) && (avg_presence < 0.02F) &&
-          (max_relief < mountain_config.tile_size * 0.35F) &&
-          (avg_relief < mountain_config.tile_size * 0.18F)) {
-        continue;
-      }
-
-      const unsigned int a = static_cast<unsigned int>(base_index + local_a);
+      const auto a = static_cast<unsigned int>(
+          base_index + static_cast<std::size_t>(v * columns + u));
       const unsigned int b = a + 1U;
       const unsigned int c = a + static_cast<unsigned int>(columns);
       const unsigned int d = c + 1U;
 
       if (flip_winding) {
-        indices.push_back(a);
-        indices.push_back(b);
-        indices.push_back(c);
-        indices.push_back(b);
-        indices.push_back(d);
-        indices.push_back(c);
+        indices.insert(indices.end(), {a, b, c, b, d, c});
       } else {
-        indices.push_back(a);
-        indices.push_back(c);
-        indices.push_back(b);
-        indices.push_back(b);
-        indices.push_back(c);
-        indices.push_back(d);
+        indices.insert(indices.end(), {a, c, b, b, c, d});
       }
+    }
+  }
+
+  if (!config.seam_row) {
+    return;
+  }
+
+  const QVector3D inward =
+      -config.axis_v / static_cast<float>(std::max(config.v_segments, 1));
+  std::vector<QVector3D> inner(static_cast<std::size_t>(columns));
+  for (int u = 0; u <= config.u_segments; ++u) {
+    const float fu = static_cast<float>(u) / static_cast<float>(config.u_segments);
+    QVector3D position = config.origin + config.axis_u * fu + inward;
+    position.setY(
+        edge_height_at(mountain_config.height_map, position.x(), position.z()));
+    inner[static_cast<std::size_t>(u)] = position;
+  }
+  const auto seam_position = [&](int u) {
+    const Vertex& vertex = vertices[base_index + static_cast<std::size_t>(u)];
+    return QVector3D(vertex.position[0], vertex.position[1], vertex.position[2]);
+  };
+  for (int u = 0; u < config.u_segments; ++u) {
+    const QVector3D s0 = seam_position(u);
+    const QVector3D s1 = seam_position(u + 1);
+    const QVector3D i0 = inner[static_cast<std::size_t>(u)];
+    const QVector3D i1 = inner[static_cast<std::size_t>(u + 1)];
+    QVector3D n0 = QVector3D::crossProduct(s1 - s0, i0 - s0);
+    QVector3D n1 = QVector3D::crossProduct(i0 - s1, i1 - s1);
+    if (n0.y() < 0.0F) {
+      n0 = -n0;
+    }
+    if (n1.y() < 0.0F) {
+      n1 = -n1;
+    }
+    for (const QVector3D& corner : {s0, s1}) {
+      extra_normals[position_key({corner.x(), corner.y(), corner.z()})] += n0 + n1;
     }
   }
 }
 
 void compute_vertex_normals(std::vector<Vertex>& vertices,
-                            const std::vector<unsigned int>& indices) {
-  std::vector<QVector3D> accumulated(vertices.size(), QVector3D(0.0F, 0.0F, 0.0F));
+                            const std::vector<unsigned int>& indices,
+                            const NormalAccumulator& extra_normals) {
+  NormalAccumulator accumulated = extra_normals;
+  accumulated.reserve(vertices.size());
 
   for (std::size_t i = 0; i + 2 < indices.size(); i += 3) {
     const unsigned int ia = indices[i];
@@ -459,23 +404,25 @@ void compute_vertex_normals(std::vector<Vertex>& vertices,
         vertices[ib].position[0], vertices[ib].position[1], vertices[ib].position[2]);
     const QVector3D c(
         vertices[ic].position[0], vertices[ic].position[1], vertices[ic].position[2]);
-    const QVector3D normal = QVector3D::crossProduct(b - a, c - a);
+    QVector3D normal = QVector3D::crossProduct(b - a, c - a);
     if (normal.lengthSquared() <= 0.0F) {
       continue;
     }
-    accumulated[ia] += normal;
-    accumulated[ib] += normal;
-    accumulated[ic] += normal;
+    if (normal.y() < 0.0F) {
+      normal = -normal;
+    }
+    for (const unsigned int index : {ia, ib, ic}) {
+      accumulated[position_key(vertices[index].position)] += normal;
+    }
   }
 
-  for (std::size_t i = 0; i < vertices.size(); ++i) {
-    QVector3D normal = accumulated[i];
-    if (normal.lengthSquared() <= 0.0F) {
-      normal = QVector3D(0.0F, 1.0F, 0.0F);
-    } else {
-      normal.normalize();
+  for (Vertex& vertex : vertices) {
+    QVector3D normal(0.0F, 1.0F, 0.0F);
+    const auto found = accumulated.find(position_key(vertex.position));
+    if (found != accumulated.end() && found->second.lengthSquared() > 0.0F) {
+      normal = found->second.normalized();
     }
-    vertices[i].normal = {normal.x(), normal.y(), normal.z()};
+    vertex.normal = {normal.x(), normal.y(), normal.z()};
   }
 }
 
@@ -484,20 +431,11 @@ auto compute_geometry_signature(const std::vector<Vertex>& vertices) -> std::uin
   constexpr std::uint64_t k_prime = 1099511628211ULL;
 
   for (const Vertex& vertex : vertices) {
-    const auto quantize = [](float value) -> std::int64_t {
-      return static_cast<std::int64_t>(std::llround(value * 1000.0));
-    };
-
-    const std::uint64_t px = static_cast<std::uint64_t>(quantize(vertex.position[0]));
-    const std::uint64_t py = static_cast<std::uint64_t>(quantize(vertex.position[1]));
-    const std::uint64_t pz = static_cast<std::uint64_t>(quantize(vertex.position[2]));
-
-    signature ^= px;
-    signature *= k_prime;
-    signature ^= py;
-    signature *= k_prime;
-    signature ^= pz;
-    signature *= k_prime;
+    const PositionKey key = position_key(vertex.position);
+    for (const std::int64_t v : {key.x, key.y, key.z}) {
+      signature ^= static_cast<std::uint64_t>(v);
+      signature *= k_prime;
+    }
   }
 
   return signature;
@@ -527,8 +465,8 @@ void MapBoundaryFogRenderer::submit(Renderer& renderer, ResourceManager* resourc
       TerrainSurfaceCmd cmd;
       cmd.mesh = m_mountain_mesh.get();
       cmd.model = k_identity_matrix;
-      cmd.params = build_boundary_mountain_params(
-          world().terrain_or_empty(), m_tile_size, m_width, m_height);
+      cmd.params =
+          build_boundary_mountain_params(world().terrain_or_empty(), m_tile_size);
       cmd.sort_key = 0x0080U;
       cmd.depth_write = true;
       cmd.horizon_dressing = true;
@@ -687,112 +625,97 @@ void MapBoundaryFogRenderer::build_mountains() {
     return;
   }
 
-  const float width_world = static_cast<float>(m_width) * m_tile_size;
-  const float height_world = static_cast<float>(m_height) * m_tile_size;
-  const float half_w = width_world * 0.5F;
-  const float half_h = height_world * 0.5F;
-  const float inner_offset = k_mountain_inner_tiles * m_tile_size;
-  const float outer_offset = k_mountain_outer_tiles * m_tile_size;
-  const float mountain_band = std::max(m_tile_size, outer_offset - inner_offset);
-  const float max_relief_height = k_mountain_peak_tiles * m_tile_size;
-  const float extended_width_world = width_world + inner_offset * 2.0F;
-  const float extended_height_world = height_world + inner_offset * 2.0F;
+  const float edge_half_w = (static_cast<float>(m_width) * 0.5F - 0.5F) * m_tile_size;
+  const float edge_half_h = (static_cast<float>(m_height) * 0.5F - 0.5F) * m_tile_size;
+  const float edge_width_world = edge_half_w * 2.0F;
+  const float edge_height_world = edge_half_h * 2.0F;
+  const float band = k_mountain_outer_tiles * m_tile_size;
+  const float foothill = k_foothill_tiles * m_tile_size;
+  const float peak = k_mountain_peak_tiles * m_tile_size;
 
+  const float edge_step = m_tile_size * k_mountain_edge_step_tiles;
   const int side_x_segments = std::clamp(
-      static_cast<int>(std::ceil(extended_width_world / (m_tile_size * 1.25F))),
-      12,
-      96);
+      static_cast<int>(std::ceil(std::max(edge_width_world, edge_step) / edge_step)),
+      k_mountain_min_side_segments,
+      k_mountain_max_side_segments);
   const int side_z_segments = std::clamp(
-      static_cast<int>(std::ceil(extended_height_world / (m_tile_size * 1.25F))),
-      12,
-      96);
-  const int corner_segments = std::clamp(k_mountain_depth_segments + 2, 8, 24);
+      static_cast<int>(std::ceil(std::max(edge_height_world, edge_step) / edge_step)),
+      k_mountain_min_side_segments,
+      k_mountain_max_side_segments);
+  const int depth_segments = k_mountain_depth_segments;
 
+  const auto& terrain = world().terrain_or_empty();
   const BoundaryMountainConfig mountain_config{
-      half_w,
-      half_h,
-      inner_offset,
-      mountain_band,
+      edge_half_w,
+      edge_half_h,
+      foothill,
+      band,
       m_tile_size,
-      max_relief_height,
-      resolve_mountain_noise_settings(world().terrain_or_empty(), m_width, m_height),
-      &world().terrain_or_empty()};
+      peak,
+      1.0F / (4.0F * std::max(edge_step, band / static_cast<float>(depth_segments))),
+      resolve_mountain_noise_settings(terrain, m_width, m_height),
+      terrain.is_initialized() ? terrain.get_height_map() : nullptr};
+
+  NormalAccumulator extra_normals;
 
   append_patch_mesh(m_mountain_vertices,
                     m_mountain_indices,
-                    MountainPatchConfig{
-                        QVector3D(-half_w - inner_offset, 0.0F, -half_h - inner_offset),
-                        QVector3D(extended_width_world, 0.0F, 0.0F),
-                        QVector3D(0.0F, 0.0F, -mountain_band),
-                        side_x_segments,
-                        k_mountain_depth_segments},
+                    extra_normals,
+                    MountainPatchConfig{QVector3D(-edge_half_w, 0.0F, -edge_half_h),
+                                        QVector3D(edge_width_world, 0.0F, 0.0F),
+                                        QVector3D(0.0F, 0.0F, -band),
+                                        side_x_segments,
+                                        depth_segments,
+                                        true},
                     mountain_config);
   append_patch_mesh(m_mountain_vertices,
                     m_mountain_indices,
-                    MountainPatchConfig{
-                        QVector3D(-half_w - inner_offset, 0.0F, half_h + inner_offset),
-                        QVector3D(extended_width_world, 0.0F, 0.0F),
-                        QVector3D(0.0F, 0.0F, mountain_band),
-                        side_x_segments,
-                        k_mountain_depth_segments},
+                    extra_normals,
+                    MountainPatchConfig{QVector3D(-edge_half_w, 0.0F, edge_half_h),
+                                        QVector3D(edge_width_world, 0.0F, 0.0F),
+                                        QVector3D(0.0F, 0.0F, band),
+                                        side_x_segments,
+                                        depth_segments,
+                                        true},
                     mountain_config);
   append_patch_mesh(m_mountain_vertices,
                     m_mountain_indices,
-                    MountainPatchConfig{
-                        QVector3D(-half_w - inner_offset, 0.0F, -half_h - inner_offset),
-                        QVector3D(0.0F, 0.0F, extended_height_world),
-                        QVector3D(-mountain_band, 0.0F, 0.0F),
-                        side_z_segments,
-                        k_mountain_depth_segments},
+                    extra_normals,
+                    MountainPatchConfig{QVector3D(-edge_half_w, 0.0F, -edge_half_h),
+                                        QVector3D(0.0F, 0.0F, edge_height_world),
+                                        QVector3D(-band, 0.0F, 0.0F),
+                                        side_z_segments,
+                                        depth_segments,
+                                        true},
                     mountain_config);
   append_patch_mesh(m_mountain_vertices,
                     m_mountain_indices,
-                    MountainPatchConfig{
-                        QVector3D(half_w + inner_offset, 0.0F, -half_h - inner_offset),
-                        QVector3D(0.0F, 0.0F, extended_height_world),
-                        QVector3D(mountain_band, 0.0F, 0.0F),
-                        side_z_segments,
-                        k_mountain_depth_segments},
+                    extra_normals,
+                    MountainPatchConfig{QVector3D(edge_half_w, 0.0F, -edge_half_h),
+                                        QVector3D(0.0F, 0.0F, edge_height_world),
+                                        QVector3D(band, 0.0F, 0.0F),
+                                        side_z_segments,
+                                        depth_segments,
+                                        true},
                     mountain_config);
 
-  append_patch_mesh(m_mountain_vertices,
-                    m_mountain_indices,
-                    MountainPatchConfig{
-                        QVector3D(-half_w - outer_offset, 0.0F, -half_h - outer_offset),
-                        QVector3D(mountain_band, 0.0F, 0.0F),
-                        QVector3D(0.0F, 0.0F, mountain_band),
-                        corner_segments,
-                        corner_segments},
-                    mountain_config);
-  append_patch_mesh(m_mountain_vertices,
-                    m_mountain_indices,
-                    MountainPatchConfig{
-                        QVector3D(half_w + outer_offset, 0.0F, -half_h - outer_offset),
-                        QVector3D(-mountain_band, 0.0F, 0.0F),
-                        QVector3D(0.0F, 0.0F, mountain_band),
-                        corner_segments,
-                        corner_segments},
-                    mountain_config);
-  append_patch_mesh(m_mountain_vertices,
-                    m_mountain_indices,
-                    MountainPatchConfig{
-                        QVector3D(-half_w - outer_offset, 0.0F, half_h + outer_offset),
-                        QVector3D(mountain_band, 0.0F, 0.0F),
-                        QVector3D(0.0F, 0.0F, -mountain_band),
-                        corner_segments,
-                        corner_segments},
-                    mountain_config);
-  append_patch_mesh(
-      m_mountain_vertices,
-      m_mountain_indices,
-      MountainPatchConfig{QVector3D(half_w + outer_offset, 0.0F, half_h + outer_offset),
-                          QVector3D(-mountain_band, 0.0F, 0.0F),
-                          QVector3D(0.0F, 0.0F, -mountain_band),
-                          corner_segments,
-                          corner_segments},
-      mountain_config);
+  for (const float sign_x : {-1.0F, 1.0F}) {
+    for (const float sign_z : {-1.0F, 1.0F}) {
+      append_patch_mesh(m_mountain_vertices,
+                        m_mountain_indices,
+                        extra_normals,
+                        MountainPatchConfig{
+                            QVector3D(sign_x * edge_half_w, 0.0F, sign_z * edge_half_h),
+                            QVector3D(sign_x * band, 0.0F, 0.0F),
+                            QVector3D(0.0F, 0.0F, sign_z * band),
+                            depth_segments,
+                            depth_segments,
+                            false},
+                        mountain_config);
+    }
+  }
 
-  compute_vertex_normals(m_mountain_vertices, m_mountain_indices);
+  compute_vertex_normals(m_mountain_vertices, m_mountain_indices, extra_normals);
   if (!m_mountain_vertices.empty()) {
     m_mountain_min_height = m_mountain_vertices.front().position[1];
     m_mountain_max_height = m_mountain_min_height;

--- a/render/ground/terrain_renderer.h
+++ b/render/ground/terrain_renderer.h
@@ -27,6 +27,15 @@ class Mesh;
 class Texture;
 class Shader;
 
+[[nodiscard]] auto
+make_terrain_chunk_params(const Game::Map::BiomeSettings& biome_settings,
+                          const Game::Map::TerrainSurfaceProfile& surface_profile,
+                          const Game::Map::ClimateProfile& climate_profile,
+                          float tile_size,
+                          std::uint32_t noise_seed,
+                          Game::Map::TerrainType chunk_type,
+                          float tint) -> TerrainChunkParams;
+
 class TerrainRenderer : public IRenderPass {
 public:
   TerrainRenderer();

--- a/render/ground/terrain_renderer_mesh.cpp
+++ b/render/ground/terrain_renderer_mesh.cpp
@@ -250,8 +250,24 @@ auto TerrainRenderer::make_chunk_params(
     const Game::Map::ClimateProfile& climate_profile,
     Game::Map::TerrainType chunk_type,
     float tint) const -> TerrainChunkParams {
+  return make_terrain_chunk_params(m_biome_settings,
+                                   surface_profile,
+                                   climate_profile,
+                                   m_tile_size,
+                                   m_noise_seed,
+                                   chunk_type,
+                                   tint);
+}
+
+auto make_terrain_chunk_params(const Game::Map::BiomeSettings& biome_settings,
+                               const Game::Map::TerrainSurfaceProfile& surface_profile,
+                               const Game::Map::ClimateProfile& climate_profile,
+                               float tile_size,
+                               std::uint32_t noise_seed,
+                               Game::Map::TerrainType chunk_type,
+                               float tint) -> TerrainChunkParams {
   TerrainChunkParams params;
-  params.ground_type = static_cast<int>(m_biome_settings.ground_type);
+  params.ground_type = static_cast<int>(biome_settings.ground_type);
   params.terrain_type = static_cast<int>(chunk_type);
   auto tint_color = [&](const QVector3D& base) {
     return clamp01(apply_tint(base, tint));
@@ -263,7 +279,7 @@ auto TerrainRenderer::make_chunk_params(
   params.rock_low = tint_color(surface_profile.rock_low);
   params.rock_high = tint_color(surface_profile.rock_high);
 
-  params.tile_size = std::max(0.001F, m_tile_size);
+  params.tile_size = std::max(0.001F, tile_size);
 
   params.macro_noise_scale = surface_profile.terrain_macro_noise_scale;
   params.detail_noise_scale = surface_profile.terrain_detail_noise_scale;
@@ -274,8 +290,8 @@ auto TerrainRenderer::make_chunk_params(
   params.soil_blend_sharpness = std::max(0.75F, surface_profile.terrain_soil_sharpness);
 
   constexpr float k_noise_offset_scale = 256.0F;
-  const uint32_t noise_key_a = hash_coords(0, 0, m_noise_seed ^ 0xB5297A4DU);
-  const uint32_t noise_key_b = hash_coords(0, 0, m_noise_seed ^ 0x68E31DA4U);
+  const uint32_t noise_key_a = hash_coords(0, 0, noise_seed ^ 0xB5297A4DU);
+  const uint32_t noise_key_b = hash_coords(0, 0, noise_seed ^ 0x68E31DA4U);
   params.noise_offset = QVector2D(hash_to_01(noise_key_a) * k_noise_offset_scale,
                                   hash_to_01(noise_key_b) * k_noise_offset_scale);
 

--- a/tools/building_preview/main.cpp
+++ b/tools/building_preview/main.cpp
@@ -315,15 +315,22 @@ auto main(int argc, char** argv) -> int {
 
   Render::GL::ResourceManager resources;
 
-  std::vector<std::string> types = {
-      "home", "farm", "barracks", "defense_tower", "marketplace", "temple", "wall"};
+  std::vector<std::string> types = {"home",
+                                    "farm",
+                                    "barracks",
+                                    "defense_tower",
+                                    "marketplace",
+                                    "temple",
+                                    "wall",
+                                    "gate"};
   std::vector<std::string> keys = {"home",
                                    "farm",
                                    "barracks",
                                    "defense_tower",
                                    "marketplace",
                                    "temple",
-                                   "wall_segment_straight"};
+                                   "wall_segment_straight",
+                                   "wall_gate"};
   if (!filter.empty()) {
     std::vector<std::string> f_types;
     std::vector<std::string> f_keys;


### PR DESCRIPTION
Refine the authored rendering geometry used by structures, walls, gates, and natural props so their silhouettes, material breakup, and state-specific presentation read more clearly in game and preview views.

Add masonry courses, caps, backing, relief, and improved parapet details to the Carthaginian fortress and tower variants, while extending Roman tower courses and adjusting damaged and destroyed proportions. Propagate team palette data through barracks instance submission and add the wall-gate preview entry points.

Improve wall and gate construction details with additional stone and timber geometry, update wall-state appearance, and expose terrain chunk parameter construction as a reusable helper for renderer consumers.

Increase vegetation mesh fidelity across pine, olive, cypress, and palm assets with denser tiers, fuller trunks and crowns, dead fronds, and adjusted leaf proportions. Brighten pine canopy shading to preserve detail through the rendered foliage.