### PR TITLE
Balance tree harvesting rewards for a more meaningful wood yield

### DIFF
--- a/game/systems/harvest_yields.h
+++ b/game/systems/harvest_yields.h
@@ -8,7 +8,7 @@
 
 namespace Game::Systems {
 
-inline constexpr int k_cut_tree_wood_reward = 40;
+inline constexpr int k_cut_tree_wood_reward = 80;
 inline constexpr int k_collect_stone_reward = 35;
 inline constexpr int k_collect_iron_ore_reward = 30;
 inline constexpr int k_harvest_grain_food_reward = 60;


### PR DESCRIPTION
Increase the wood reward granted when a tree is cut from 40 to 80 units so that the core early-game gathering action provides a more substantial return. The change is intentionally limited to the tree-cutting reward constant and does not alter stone, iron ore, or grain yields, preserving the existing balance relationships for the other basic resource actions. Keep this adjustment as a focused economy tuning change that improves the usefulness of wood gathering without broadening the surrounding harvesting systems.