### PR TITLE
feat: refine battlefield presentation and direct combat feel

### DIFF
--- a/app/commander/commander_control_controller.cpp
+++ b/app/commander/commander_control_controller.cpp
@@ -2273,7 +2273,9 @@ auto CommanderControlController::update_impl(Engine::Core::World& world,
     cmd_comp->fpv_motion_vx = (movement != nullptr) ? movement->get_vx() : 0.0F;
     cmd_comp->fpv_motion_vz = (movement != nullptr) ? movement->get_vz() : 0.0F;
     cmd_comp->fpv_motion_requested =
-        motor_requested_speed > 0.0F || m_planar_speed_smooth > 0.05F;
+        motor_requested_speed > 0.0F ||
+        m_planar_speed_smooth >
+            Engine::Core::CommanderComponent::k_direct_control_gait_floor_speed;
   }
 
   if (movement != nullptr && actual_speed_for_bob > 0.05F) {

--- a/assets/maps/map_amber_delta.json
+++ b/assets/maps/map_amber_delta.json
@@ -15,7 +15,7 @@
       0,
       150.0
     ],
-    "distance": 90.0,
+    "distance": 330.0,
     "tilt_deg": 48.0,
     "yaw": 225.0,
     "fov_y": 45.0,
@@ -27,33 +27,33 @@
     "start_time": 16.5,
     "time_mode": "continuous",
     "day_length_seconds": 2400.0,
-    "lighting_profile": "mediterranean_summer"
+    "lighting_profile": "delta_haze"
   },
   "biome": {
     "ground_type": "soil_fertile",
     "seed": 31877,
-    "patch_density": 4.2,
+    "patch_density": 5.0,
     "patch_jitter": 0.94,
-    "plant_density": 0.74,
+    "plant_density": 0.96,
     "grass_primary": [
-      0.26,
-      0.5,
-      0.23
+      0.18,
+      0.36,
+      0.18
     ],
     "grass_secondary": [
-      0.36,
-      0.6,
-      0.29
+      0.27,
+      0.46,
+      0.22
     ],
     "grass_dry": [
-      0.58,
-      0.52,
-      0.33
+      0.48,
+      0.42,
+      0.26
     ],
     "soil_color": [
-      0.21,
       0.16,
-      0.12
+      0.12,
+      0.09
     ],
     "height_noise": [
       0.19,
@@ -62,8 +62,8 @@
     "ground_irregularity_enabled": true,
     "irregularity_scale": 0.14,
     "irregularity_amplitude": 0.065,
-    "moisture_level": 0.86,
-    "grass_saturation": 1.14
+    "moisture_level": 0.92,
+    "grass_saturation": 0.94
   },
   "rain": {
     "enabled": false,

--- a/assets/maps/map_copper_canyons.json
+++ b/assets/maps/map_copper_canyons.json
@@ -15,7 +15,7 @@
       0,
       150.0
     ],
-    "distance": 90.0,
+    "distance": 330.0,
     "tilt_deg": 48.0,
     "yaw": 225.0,
     "fov_y": 45.0,
@@ -27,46 +27,48 @@
     "start_time": 15.5,
     "time_mode": "continuous",
     "day_length_seconds": 2400.0,
-    "lighting_profile": "mediterranean_summer"
+    "lighting_profile": "canyon_dry"
   },
   "biome": {
     "ground_type": "soil_rocky",
     "seed": 90144,
     "patch_density": 2.6,
     "patch_jitter": 0.84,
-    "plant_density": 0.3,
-    "rock_exposure": 0.8,
-    "soil_roughness": 0.86,
-    "moisture_level": 0.3,
+    "plant_density": 0.24,
+    "rock_exposure": 0.92,
+    "soil_roughness": 0.92,
+    "moisture_level": 0.12,
+    "crack_intensity": 0.56,
+    "grass_saturation": 0.76,
     "grass_primary": [
-      0.38,
-      0.44,
-      0.26
+      0.3,
+      0.31,
+      0.17
     ],
     "grass_secondary": [
-      0.46,
-      0.52,
-      0.3
+      0.39,
+      0.37,
+      0.2
     ],
     "grass_dry": [
-      0.6,
-      0.5,
-      0.34
+      0.55,
+      0.41,
+      0.24
     ],
     "soil_color": [
-      0.57,
-      0.42,
-      0.3
+      0.46,
+      0.27,
+      0.16
     ],
     "rock_low": [
-      0.58,
       0.44,
-      0.34
+      0.25,
+      0.16
     ],
     "rock_high": [
-      0.78,
-      0.66,
-      0.54
+      0.72,
+      0.46,
+      0.27
     ],
     "height_noise": [
       0.28,

--- a/assets/maps/map_forest.json
+++ b/assets/maps/map_forest.json
@@ -15,7 +15,7 @@
       0,
       88.0
     ],
-    "distance": 63.36,
+    "distance": 194.0,
     "tilt_deg": 48.0,
     "yaw": 225.0,
     "fov_y": 45.0,
@@ -27,33 +27,33 @@
     "start_time": 16.0,
     "time_mode": "continuous",
     "day_length_seconds": 2400.0,
-    "lighting_profile": "mediterranean_summer"
+    "lighting_profile": "pine_overcast"
   },
   "biome": {
     "ground_type": "forest_mud",
     "seed": 51844,
-    "patch_density": 3.5,
+    "patch_density": 5.4,
     "patch_jitter": 0.9,
-    "plant_density": 0.82,
+    "plant_density": 1.18,
     "grass_primary": [
-      0.21,
-      0.46,
-      0.25
+      0.12,
+      0.29,
+      0.17
     ],
     "grass_secondary": [
-      0.32,
-      0.56,
-      0.28
+      0.19,
+      0.38,
+      0.22
     ],
     "grass_dry": [
-      0.46,
-      0.42,
-      0.3
+      0.33,
+      0.3,
+      0.22
     ],
     "soil_color": [
-      0.2,
-      0.17,
-      0.13
+      0.11,
+      0.09,
+      0.07
     ],
     "height_noise": [
       0.24,
@@ -62,7 +62,9 @@
     "ground_irregularity_enabled": true,
     "irregularity_scale": 0.13,
     "irregularity_amplitude": 0.075,
-    "moisture_level": 0.85
+    "moisture_level": 0.92,
+    "grass_saturation": 0.86,
+    "soil_roughness": 0.72
   },
   "rain": {
     "enabled": true,

--- a/assets/maps/map_mountain.json
+++ b/assets/maps/map_mountain.json
@@ -15,7 +15,7 @@
       0,
       120.0
     ],
-    "distance": 76.8,
+    "distance": 264.0,
     "tilt_deg": 48.0,
     "yaw": 225.0,
     "fov_y": 45.0,
@@ -27,39 +27,39 @@
     "start_time": 9.0,
     "time_mode": "continuous",
     "day_length_seconds": 2400.0,
-    "lighting_profile": "mediterranean_summer"
+    "lighting_profile": "alpine_clear"
   },
   "biome": {
     "ground_type": "alpine_mix",
     "seed": 77310,
-    "patch_density": 2.4,
+    "patch_density": 2.8,
     "patch_jitter": 0.8,
     "plant_density": 0.24,
-    "snow_coverage": 0.62,
+    "snow_coverage": 0.82,
     "snow_color": [
       0.93,
       0.95,
       0.99
     ],
     "grass_primary": [
-      0.29,
-      0.4,
-      0.29
+      0.18,
+      0.25,
+      0.21
     ],
     "grass_secondary": [
-      0.35,
-      0.47,
-      0.34
+      0.24,
+      0.33,
+      0.27
     ],
     "rock_low": [
-      0.56,
-      0.59,
-      0.64
+      0.4,
+      0.44,
+      0.52
     ],
     "rock_high": [
-      0.88,
-      0.9,
-      0.95
+      0.7,
+      0.76,
+      0.86
     ],
     "height_noise": [
       0.26,
@@ -68,7 +68,9 @@
     "ground_irregularity_enabled": true,
     "irregularity_scale": 0.17,
     "irregularity_amplitude": 0.09,
-    "moisture_level": 0.35
+    "moisture_level": 0.42,
+    "grass_saturation": 0.78,
+    "rock_exposure": 0.74
   },
   "rain": {
     "enabled": true,

--- a/assets/maps/map_rivers.json
+++ b/assets/maps/map_rivers.json
@@ -15,7 +15,7 @@
       0,
       88.0
     ],
-    "distance": 63.36,
+    "distance": 194.0,
     "tilt_deg": 48.0,
     "yaw": 225.0,
     "fov_y": 45.0,
@@ -27,33 +27,33 @@
     "start_time": 8.5,
     "time_mode": "continuous",
     "day_length_seconds": 2400.0,
-    "lighting_profile": "mediterranean_summer"
+    "lighting_profile": "river_mist"
   },
   "biome": {
     "ground_type": "soil_fertile",
     "seed": 40217,
-    "patch_density": 3.9,
+    "patch_density": 4.8,
     "patch_jitter": 0.92,
-    "plant_density": 0.66,
+    "plant_density": 0.92,
     "grass_primary": [
-      0.23,
-      0.49,
+      0.16,
+      0.36,
       0.22
     ],
     "grass_secondary": [
-      0.33,
-      0.58,
-      0.27
+      0.22,
+      0.45,
+      0.28
     ],
     "grass_dry": [
-      0.53,
-      0.49,
-      0.32
+      0.42,
+      0.39,
+      0.27
     ],
     "soil_color": [
-      0.19,
-      0.15,
-      0.11
+      0.13,
+      0.11,
+      0.09
     ],
     "height_noise": [
       0.2,
@@ -62,8 +62,9 @@
     "ground_irregularity_enabled": true,
     "irregularity_scale": 0.15,
     "irregularity_amplitude": 0.07,
-    "moisture_level": 0.8,
-    "grass_saturation": 1.12
+    "moisture_level": 0.95,
+    "grass_saturation": 0.9,
+    "soil_roughness": 0.68
   },
   "rain": {
     "enabled": false,

--- a/assets/maps/map_spanish_grove.json
+++ b/assets/maps/map_spanish_grove.json
@@ -15,7 +15,7 @@
       0,
       120.0
     ],
-    "distance": 76.8,
+    "distance": 264.0,
     "tilt_deg": 48.0,
     "yaw": 225.0,
     "fov_y": 45.0,
@@ -27,46 +27,46 @@
     "start_time": 12.5,
     "time_mode": "continuous",
     "day_length_seconds": 2400.0,
-    "lighting_profile": "mediterranean_summer"
+    "lighting_profile": "iberian_high_sun"
   },
   "biome": {
     "ground_type": "grass_dry",
     "seed": 63052,
     "patch_density": 2.8,
     "patch_jitter": 0.86,
-    "plant_density": 0.34,
-    "crack_intensity": 0.6,
-    "moisture_level": 0.16,
-    "grass_saturation": 0.78,
+    "plant_density": 0.42,
+    "crack_intensity": 0.82,
+    "moisture_level": 0.08,
+    "grass_saturation": 0.66,
     "grass_primary": [
-      0.29,
-      0.44,
-      0.21
+      0.31,
+      0.34,
+      0.16
     ],
     "grass_secondary": [
       0.4,
-      0.53,
-      0.25
+      0.42,
+      0.2
     ],
     "grass_dry": [
-      0.55,
-      0.51,
-      0.28
+      0.62,
+      0.49,
+      0.23
     ],
     "soil_color": [
-      0.53,
-      0.45,
-      0.33
+      0.5,
+      0.32,
+      0.18
     ],
     "rock_low": [
-      0.63,
-      0.59,
-      0.53
+      0.56,
+      0.44,
+      0.32
     ],
     "rock_high": [
-      0.79,
       0.76,
-      0.71
+      0.64,
+      0.48
     ],
     "height_noise": [
       0.18,

--- a/assets/shaders/basic.frag
+++ b/assets/shaders/basic.frag
@@ -28,8 +28,8 @@ void main() {
   color = soi_material_variation(color, v_world_pos, normal, soi_material);
   color = soi_apply_damage_soot(color, v_world_pos, soi_damage_tier);
 
-  float avg_color = (u_color.r + u_color.g + u_color.b) / 3.0;
-  float wrap_amount = avg_color > 0.65 ? 0.52 : (avg_color > 0.40 ? 0.20 : 0.05);
+  float avg_color = (color.r + color.g + color.b) / 3.0;
+  float wrap_amount = avg_color > 0.65 ? 0.38 : (avg_color > 0.40 ? 0.16 : 0.04);
   vec3 albedo = color;
   color *= environment_lighting(normal, wrap_amount);
   color = apply_directional_shadow(color, v_world_pos, normal);

--- a/assets/shaders/basic_instanced.frag
+++ b/assets/shaders/basic_instanced.frag
@@ -28,9 +28,8 @@ void main() {
   color = soi_material_variation(color, v_world_pos, normal, soi_material);
   color = soi_apply_damage_soot(color, v_world_pos, soi_damage_tier);
 
-  float avg_color =
-      (v_instance_color.r + v_instance_color.g + v_instance_color.b) / 3.0;
-  float wrap_amount = avg_color > 0.65 ? 0.52 : (avg_color > 0.40 ? 0.20 : 0.05);
+  float avg_color = (color.r + color.g + color.b) / 3.0;
+  float wrap_amount = avg_color > 0.65 ? 0.38 : (avg_color > 0.40 ? 0.16 : 0.04);
   vec3 albedo = color;
   color *= environment_lighting(normal, wrap_amount);
   color = apply_directional_shadow(color, v_world_pos, normal);

--- a/assets/shaders/include/material_detail.glsl
+++ b/assets/shaders/include/material_detail.glsl
@@ -3,6 +3,7 @@
 uniform sampler2D u_material_detail;
 uniform bool u_has_material_detail;
 
+const int k_material_mineral = 0;
 const int k_material_metal = 1;
 const int k_material_wood = 2;
 const int k_material_cloth = 3;
@@ -27,6 +28,39 @@ float soi_detail_fine(vec2 lattice) {
 
 float soi_detail_micro(vec2 lattice) {
   return texture(u_material_detail, lattice / k_detail_cells_micro).a;
+}
+
+vec2 soi_surface_lattice(vec3 world_pos, vec3 normal) {
+  vec3 axis = abs(normal);
+  if (axis.x > axis.y && axis.x > axis.z) {
+    return world_pos.zy;
+  }
+  if (axis.y > axis.z) {
+    return world_pos.xz;
+  }
+  return world_pos.xy;
+}
+
+vec3 soi_mineral_variation(vec3 base_color, vec2 uv, vec3 normal) {
+  float broad = soi_detail_coarse(uv * 0.70) - 0.5;
+  float mottle = soi_detail_mid(uv * 2.3) - 0.5;
+  float grain = soi_detail_fine(uv * 8.5) - 0.5;
+  float upness = abs(normal.y);
+
+  vec3 cool_lime = base_color * vec3(0.94, 0.98, 1.025);
+  vec3 sun_worn = base_color * vec3(1.045, 0.995, 0.91);
+  vec3 variation = mix(cool_lime, sun_worn, smoothstep(-0.35, 0.35, broad));
+  variation *= 0.97 + broad * 0.10 + mottle * 0.075 + grain * 0.035;
+
+  float vertical_streak =
+      smoothstep(0.60, 0.90, soi_detail_mid(vec2(uv.x * 0.42, uv.y * 2.4)));
+  vertical_streak *= (1.0 - upness) * (0.35 + 0.65 * soi_detail_coarse(uv * 0.28));
+  variation =
+      mix(variation, variation * vec3(0.72, 0.75, 0.71), vertical_streak * 0.12);
+
+  float dust = upness * smoothstep(0.62, 0.92, soi_detail_coarse(uv * 0.46));
+  variation = mix(variation, variation * vec3(1.04, 0.995, 0.90), dust * 0.08);
+  return variation;
 }
 
 vec3 soi_wood_variation(vec3 base_color, vec2 uv, vec3 normal, float height) {
@@ -68,9 +102,11 @@ vec3 soi_material_variation(vec3 base_color,
   if (!u_has_material_detail) {
     return base_color;
   }
-  vec2 uv = world_pos.xz * 4.0;
+  vec2 uv = soi_surface_lattice(world_pos, normal) * 4.0;
   vec3 variation = base_color;
-  if (material_id == k_material_wood) {
+  if (material_id == k_material_mineral) {
+    variation = soi_mineral_variation(base_color, uv, normal);
+  } else if (material_id == k_material_wood) {
     variation = soi_wood_variation(base_color, uv, normal, world_pos.y);
   } else if (material_id == k_material_metal) {
     variation = soi_metal_variation(base_color, uv, normal);

--- a/assets/shaders/road.frag
+++ b/assets/shaders/road.frag
@@ -112,12 +112,13 @@ void main() {
   float boundary = clamp(v_tex_coord.y, 0.0, 1.0);
   float edge_noise = fbm_2d(uv * 0.42 + vec2(19.0, -7.0)) - 0.5;
   float edge_alpha =
-      smoothstep(0.0, 1.0, clamp(boundary + edge_noise * 0.28, 0.0, 1.0));
+      smoothstep(0.02, 0.92, clamp(boundary + edge_noise * 0.34, 0.0, 1.0));
   float edge_distance = boundary * 0.5;
 
   float broad = fbm_2d(uv * 0.055 + vec2(7.0, 13.0));
   float medium = fbm_2d(uv * 0.34 + vec2(-11.0, 3.0));
   float grain = noise_2d(uv * 3.7 + vec2(29.0, -17.0));
+  float road_age = fbm_2d(uv * 0.018 + vec2(-37.0, 23.0));
   float rut_wander = (noise_2d(uv * 0.075 + vec2(41.0, -9.0)) - 0.5) * 0.035;
   float rut_left = 1.0 - smoothstep(0.030, 0.090, abs(across - (0.31 + rut_wander)));
   float rut_right = 1.0 - smoothstep(0.030, 0.090, abs(across - (0.69 + rut_wander)));
@@ -132,20 +133,25 @@ void main() {
   float material_roughness;
 
   if (u_surface_kind == 2) {
-    vec2 stone_uv = uv * 1.05;
-    vec2 worley_result = worley_f(stone_uv * 1.35);
+    vec2 stone_warp = vec2(noise_2d(uv * 0.17 + vec2(17.0, -31.0)),
+                           noise_2d(uv * 0.17 + vec2(-43.0, 11.0))) -
+                      0.5;
+    vec2 stone_uv = uv * 2.05 + stone_warp * 0.42;
+    vec2 worley_result = worley_f(stone_uv);
     float edge_metric = worley_result.y - worley_result.x;
-    float stone_mask = smoothstep(0.045, 0.20, edge_metric);
+    float edge_aa = max(fwidth(edge_metric) * 1.35, 0.008);
+    float stone_mask = smoothstep(0.035 - edge_aa, 0.125 + edge_aa, edge_metric);
     float mortar_mask = 1.0 - stone_mask;
     float stone_variation =
-        (broad - 0.5) * 0.14 + (medium - 0.5) * 0.11 + (grain - 0.5) * 0.055;
-    vec3 stone_color = u_color * (1.0 + stone_variation);
-    vec3 mortar_color = u_color * 0.58;
+        (broad - 0.5) * 0.11 + (medium - 0.5) * 0.08 + (grain - 0.5) * 0.045;
+    float stone_face = 1.0 - smoothstep(0.08, 0.48, worley_result.x);
+    vec3 stone_color = u_color * (0.92 + stone_variation + stone_face * 0.035);
+    vec3 mortar_color = mix(u_color * 0.54, vec3(0.20, 0.17, 0.13), 0.18);
     base_color = mix(mortar_color, stone_color, stone_mask);
     float cavity = smoothstep(0.0, 0.18, edge_metric);
-    ao = mix(0.58, 1.0, cavity);
-    h = (medium - 0.5) * 0.035 * stone_mask - mortar_mask * 0.045;
-    material_roughness = 0.82;
+    ao = mix(0.64, 1.0, cavity);
+    h = (medium - 0.5) * 0.024 * stone_mask - mortar_mask * 0.032;
+    material_roughness = 0.90;
   } else if (u_surface_kind == 1) {
     vec3 dry_earth = u_color * 1.02;
     vec3 compressed_earth = u_color * 0.78;
@@ -155,7 +161,7 @@ void main() {
     vec2 gravel_cells = worley_f(uv * 3.1 + vec2(-11.0, 6.0));
     float gravel = smoothstep(0.035, 0.16, gravel_cells.y - gravel_cells.x);
     base_color = mix(base_color, base_color * 1.17, gravel * 0.55);
-    base_color *= 0.90 + broad * 0.13 + medium * 0.08;
+    base_color *= 0.88 + broad * 0.12 + medium * 0.07;
     h = (medium - 0.5) * 0.050 - ruts * 0.042 + gravel * 0.018;
     ao = 0.92 - ruts * 0.11 - (1.0 - medium) * 0.06;
     material_roughness = 0.97;
@@ -177,13 +183,20 @@ void main() {
     material_roughness = 0.94;
   }
 
+  float shoulder_grit =
+      1.0 - smoothstep(0.045, 0.19, edge_distance + edge_noise * 0.025);
+  vec3 shoulder_color = mix(base_color * 0.70, u_color * 0.58, 0.34);
+  base_color = mix(base_color, shoulder_color, shoulder_grit * 0.48);
+  base_color *= 0.94 + (road_age - 0.5) * 0.10;
+  base_color *= 1.0 - ruts * mix(0.025, 0.075, environment_wetness());
+
   float sx = dFdx(h);
   float sy = dFdy(h);
-  float bump_strength = 9.0;
+  float bump_strength = 6.5;
   vec3 n_bump = normalize(vec3(-sx * bump_strength, 1.0, -sy * bump_strength));
 
   vec3 n_geom = normalize(v_normal);
-  vec3 n_final = normalize(mix(n_geom, n_bump, 0.48));
+  vec3 n_final = normalize(mix(n_geom, n_bump, 0.38));
 
   vec3 light_dir = environment_primary_direction();
   vec3 view_dir = normalize(vec3(0.0, 0.9, 0.4));

--- a/docs/RPG_PLAYABILITY.md
+++ b/docs/RPG_PLAYABILITY.md
@@ -1131,6 +1131,79 @@ stashing the change and re-running.
   interpolation may not feed authoritative combat or navigation queries.
 - Run ASan/UBSan and the full normal suite before closing a milestone.
 
+## The swing ran slower than it was authored, 2 Sep 2026
+
+Reading `commander.combat` in `trace.jsonl` for `rpg_one_press_one_attack`: a light
+slash authored at `duration_seconds = 0.72` ran for 0.90 s, and the normalized time
+advanced 0.0185 per frame instead of 0.0231. The reason sits in
+`resolve_melee_intent`: `swing_speed = 0.80 + aim_rate * 0.55`, and
+`CombatActionService` divides the authored duration by it. A keyboard or controller
+player produces no aim rate during a press, so every light ran at 80% of its authored
+pace, and `k_heavy_maximum_swing_speed = 0.72` put heavies at 72% on top of timelines
+that are already the longest in the table (overhead 0.88 s became 1.22 s, the finisher
+1.15 s became 1.60 s). "A swing takes about 0.9 s" earlier in this document was a
+measurement of that scaling, not of the design.
+
+The definitions are the design. The solver now starts at 1.0 and clamps to
+[0.85, 1.35], so a plain press plays the authored timeline and a swipe can still
+quicken it; the heavy cap is 1.0 so heavy weight comes from the authored durations and
+stagger, not from a second multiplier. The tired-swing penalty is unchanged.
+
+Measured after the change, same scenario: slash 0.70-0.72 s, held-combo links still
+0.02 s apart, press-to-swing latency still 0-17 ms, and every accepted press still
+accounted for. Two scripts were authored against the slow cadence and are retuned in
+the same change: `rpg_one_press_one_attack` allows five links in the 1.6 s hold (the
+authored cadence fits five), and `rpg_attack_buffer_window` presses at 1.02 s and
+3.75 s so the late press still lands inside the 0.15 s buffer before recovery start and
+the early press still expires.
+
+Two things the same reading found that are not defects: the render's "Attack" visual
+outlives `action_running` by `exit_blend_duration` (0.10 s) -- that is the blend into
+idle, not a freeze -- and the 3000 deg/s view yaw in `rpg_commander_sword_grammar`
+during the dive is the harness (`track_rpg_aim` re-aims at the enemy centroid every
+frame while the dive carries the camera past it), not the camera.
+
+## The walk cycle outlived the stop
+
+`rpg_motor_start_stop` at the walk halt: the motor's smoothed speed decays with a
+0.06 s time constant, but the presented state stayed `Walk` until the speed was
+exactly zero, 0.23 s after the release, because `has_component_velocity` compared the
+motor's published velocity against a 0.01 m/s epsilon. The gait cycled at full stride
+under a body doing 0.3 m/s -- the foot slide every stop ended with.
+
+Direct control now has a gait floor, `CommanderComponent::k_direct_control_gait_floor_speed`
+(0.60 m/s). Three inputs to the presented state had to honour it, and the first two
+alone changed nothing, which is worth knowing before anyone repeats it: the published
+motor velocity (`has_component_velocity`), the per-tick displacement test
+(`displaced`), and the controller's `fpv_motion_requested`, which counted a smoothed
+speed above 0.05 m/s as a request and so kept "moving" true through the whole
+coast-down. With all three gated, the walk halt presents `Idle` at 1.90 s (0.08 s after
+the release, speed 0.54 m/s) instead of 2.05 s, and `locomotion_presence` fades from
+there while the motor finishes braking. Starts are unchanged because a held input
+counts as moving regardless of speed. Other units keep the epsilon.
+
+## Strafing slides the feet, and the fix is a clip, not code
+
+Projecting each foot's world velocity onto the travel direction in
+`rpg_motor_diagonal` (the commander always faces the view, so the axes are body-
+relative): walking forward the trailing foot moves at 0.64 m/s against a 2.69 m/s
+root and the leading foot at 4.54 -- a foot is planted. Backpedalling plants one at
+-0.03 m/s through the reverse gait. Both pure strafes read 2.28 / 2.34 m/s on both
+feet against a 2.31 m/s root: the walk cycle pumps forward and back while the body
+translates sideways, so the feet slide the whole way. Diagonals land in between
+(1.15 / 4.67).
+
+`NoPlantedFootSliding` cannot see it, because it only compares feet while the root
+is planted; slip during locomotion is unmeasured by the gate. Rotating the stride
+toward the travel direction in `resolve_locomotion_foot` was tried and is inert at
+runtime: humanoid bone palettes come from baked `.bpat` clips and the stride math
+only runs in `bpat_baker`. The fix is authored strafe (and ideally 8-way) locomotion
+clips selected by `travel_alignment` / `turn_amount`, which is Gate 3 content work
+and was not started here. Until then, lock-on circling is the move that looks worst.
+
+`rpg_motor_start_stop`, `rpg_locomotion`, `rpg_motor_figure_eight`,
+`rpg_motor_diagonal`, `rpg_locomotion_hitch` and `rpg_close_quarters` pass with it.
+
 ## Play-through findings, 2 Sep 2026
 
 A scripted play session (Xephyr + XTEST, `hold_the_sallow_ford`) entered direct

--- a/game/core/component.h
+++ b/game/core/component.h
@@ -1288,6 +1288,7 @@ public:
   float fpv_motion_vx{0.0F};
   float fpv_motion_vz{0.0F};
   bool fpv_motion_requested{false};
+  static constexpr float k_direct_control_gait_floor_speed = 0.60F;
   float posture{0.0F};
   float posture_max{100.0F};
   float punish_window_remaining{0.0F};

--- a/game/core/world.cpp
+++ b/game/core/world.cpp
@@ -319,8 +319,14 @@ void finalize_motion_presentation_frame(World& world, float delta_time) {
         float const motion_vx = motor_published ? facts->motor.accepted_vx : 0.0F;
         float const motion_vz = motor_published ? facts->motor.accepted_vz : 0.0F;
         float const movement_speed_sq = motion_vx * motion_vx + motion_vz * motion_vz;
+        bool const direct_control_commander =
+            commander != nullptr && commander->fpv_controlled;
         bool const has_component_velocity =
-            movement_speed_sq > k_motion_velocity_epsilon_sq;
+            direct_control_commander
+                ? movement_speed_sq >=
+                      CommanderComponent::k_direct_control_gait_floor_speed *
+                          CommanderComponent::k_direct_control_gait_floor_speed
+                : movement_speed_sq > k_motion_velocity_epsilon_sq;
 
         bool const has_active_navigation_segment =
             movement != nullptr &&
@@ -330,7 +336,11 @@ void finalize_motion_presentation_frame(World& world, float delta_time) {
                                     !has_active_navigation_segment &&
                                     !has_component_velocity;
 
-        float const gait_displacement_floor = k_motion_stall_speed * safe_dt;
+        float const gait_displacement_floor =
+            (direct_control_commander
+                 ? CommanderComponent::k_direct_control_gait_floor_speed
+                 : k_motion_stall_speed) *
+            safe_dt;
         bool const displaced =
             displacement_sq > (gait_displacement_floor * gait_displacement_floor) &&
             !melee_footwork;
@@ -344,9 +354,13 @@ void finalize_motion_presentation_frame(World& world, float delta_time) {
                 : 0.0F;
         bool const direct_control_velocity =
             direct_control_speed_sq > k_motion_velocity_epsilon_sq;
+        bool const direct_control_gait =
+            direct_control_speed_sq >=
+            CommanderComponent::k_direct_control_gait_floor_speed *
+                CommanderComponent::k_direct_control_gait_floor_speed;
         bool const direct_control_moving =
             commander != nullptr && commander->fpv_controlled &&
-            (direct_control_velocity || has_component_velocity ||
+            (direct_control_gait || has_component_velocity ||
              commander->fpv_motion_requested);
         bool const builder_bypass =
             builder_prod != nullptr && builder_prod->bypass_movement_active;
@@ -373,7 +387,8 @@ void finalize_motion_presentation_frame(World& world, float delta_time) {
         sample.displaced = displaced;
         sample.has_component_velocity = has_component_velocity;
 
-        sample.direct_control_velocity = direct_control_velocity;
+        sample.direct_control_velocity =
+            direct_control_moving && direct_control_velocity;
         sample.wants_locomotion = wants_locomotion;
         sample.is_running = stamina != nullptr && stamina->is_running;
         sample.forced_displacement = displaced && !motor_published;

--- a/game/map/environment_lighting.cpp
+++ b/game/map/environment_lighting.cpp
@@ -15,6 +15,26 @@ struct LightingKeyframe {
   EnvironmentLightingState lighting;
 };
 
+struct ProfileGrade {
+  QVector3D primary_scale{1.0F, 1.0F, 1.0F};
+  float primary_intensity_scale = 1.0F;
+  QVector3D sky_target{0.5F, 0.62F, 0.78F};
+  float sky_mix = 0.0F;
+  QVector3D bounce_target{0.24F, 0.20F, 0.15F};
+  float bounce_mix = 0.0F;
+  float ambient_scale = 1.0F;
+  QVector3D fog_target{0.58F, 0.65F, 0.72F};
+  float fog_mix = 0.0F;
+  float fog_density_add = 0.0F;
+  QVector3D shadow_target{0.30F, 0.34F, 0.44F};
+  float shadow_mix = 0.0F;
+  float shadow_strength_scale = 1.0F;
+  float shadow_softness_add = 0.0F;
+  float exposure_scale = 1.0F;
+  float cloud_floor = 0.0F;
+  float wetness_floor = 0.0F;
+};
+
 auto make_keyframe(float hour,
                    QVector3D direction,
                    QVector3D primary,
@@ -154,6 +174,181 @@ auto mediterranean_summer_profile() -> const std::array<LightingKeyframe, 8>& {
   return keyframes;
 }
 
+auto graded_profile(const ProfileGrade& grade) -> std::array<LightingKeyframe, 8> {
+  auto result = mediterranean_summer_profile();
+  for (auto& keyframe : result) {
+    auto& lighting = keyframe.lighting;
+    lighting.primary_color *= grade.primary_scale;
+    lighting.primary_intensity *= grade.primary_intensity_scale;
+    lighting.sky_color += (grade.sky_target - lighting.sky_color) * grade.sky_mix;
+    lighting.ground_bounce_color +=
+        (grade.bounce_target - lighting.ground_bounce_color) * grade.bounce_mix;
+    lighting.ambient_intensity *= grade.ambient_scale;
+    lighting.fog_color += (grade.fog_target - lighting.fog_color) * grade.fog_mix;
+    lighting.fog_density += grade.fog_density_add;
+    lighting.shadow_tint +=
+        (grade.shadow_target - lighting.shadow_tint) * grade.shadow_mix;
+    lighting.shadow_strength *= grade.shadow_strength_scale;
+    lighting.shadow_softness += grade.shadow_softness_add;
+    lighting.exposure *= grade.exposure_scale;
+    lighting.cloud_cover = std::max(lighting.cloud_cover, grade.cloud_floor);
+    lighting.wetness = std::max(lighting.wetness, grade.wetness_floor);
+    lighting = lighting.sanitized();
+  }
+  return result;
+}
+
+auto delta_haze_profile() -> const std::array<LightingKeyframe, 8>& {
+  static const std::array<LightingKeyframe, 8> keyframes = graded_profile({
+      .primary_scale = {1.02F, 0.96F, 0.86F},
+      .primary_intensity_scale = 0.96F,
+      .sky_target = {0.38F, 0.58F, 0.64F},
+      .sky_mix = 0.34F,
+      .bounce_target = {0.18F, 0.29F, 0.20F},
+      .bounce_mix = 0.42F,
+      .ambient_scale = 1.03F,
+      .fog_target = {0.49F, 0.62F, 0.57F},
+      .fog_mix = 0.48F,
+      .fog_density_add = 0.0035F,
+      .shadow_target = {0.18F, 0.29F, 0.29F},
+      .shadow_mix = 0.44F,
+      .shadow_strength_scale = 0.88F,
+      .shadow_softness_add = 0.12F,
+      .exposure_scale = 0.96F,
+      .cloud_floor = 0.12F,
+      .wetness_floor = 0.16F,
+  });
+  return keyframes;
+}
+
+auto canyon_dry_profile() -> const std::array<LightingKeyframe, 8>& {
+  static const std::array<LightingKeyframe, 8> keyframes = graded_profile({
+      .primary_scale = {1.08F, 0.90F, 0.73F},
+      .primary_intensity_scale = 1.04F,
+      .sky_target = {0.42F, 0.59F, 0.78F},
+      .sky_mix = 0.24F,
+      .bounce_target = {0.46F, 0.27F, 0.14F},
+      .bounce_mix = 0.42F,
+      .ambient_scale = 0.94F,
+      .fog_target = {0.67F, 0.48F, 0.31F},
+      .fog_mix = 0.40F,
+      .fog_density_add = 0.0012F,
+      .shadow_target = {0.29F, 0.23F, 0.34F},
+      .shadow_mix = 0.34F,
+      .shadow_strength_scale = 1.10F,
+      .shadow_softness_add = -0.05F,
+      .exposure_scale = 0.97F,
+  });
+  return keyframes;
+}
+
+auto pine_overcast_profile() -> const std::array<LightingKeyframe, 8>& {
+  static const std::array<LightingKeyframe, 8> keyframes = graded_profile({
+      .primary_scale = {0.82F, 0.90F, 0.92F},
+      .primary_intensity_scale = 0.78F,
+      .sky_target = {0.30F, 0.42F, 0.47F},
+      .sky_mix = 0.48F,
+      .bounce_target = {0.15F, 0.23F, 0.18F},
+      .bounce_mix = 0.48F,
+      .ambient_scale = 1.08F,
+      .fog_target = {0.29F, 0.39F, 0.39F},
+      .fog_mix = 0.58F,
+      .fog_density_add = 0.0055F,
+      .shadow_target = {0.14F, 0.23F, 0.24F},
+      .shadow_mix = 0.55F,
+      .shadow_strength_scale = 0.78F,
+      .shadow_softness_add = 0.22F,
+      .exposure_scale = 0.93F,
+      .cloud_floor = 0.48F,
+      .wetness_floor = 0.22F,
+  });
+  return keyframes;
+}
+
+auto alpine_clear_profile() -> const std::array<LightingKeyframe, 8>& {
+  static const std::array<LightingKeyframe, 8> keyframes = graded_profile({
+      .primary_scale = {0.92F, 0.98F, 1.08F},
+      .primary_intensity_scale = 1.06F,
+      .sky_target = {0.37F, 0.56F, 0.82F},
+      .sky_mix = 0.44F,
+      .bounce_target = {0.43F, 0.50F, 0.61F},
+      .bounce_mix = 0.48F,
+      .ambient_scale = 1.08F,
+      .fog_target = {0.66F, 0.76F, 0.86F},
+      .fog_mix = 0.46F,
+      .fog_density_add = 0.0018F,
+      .shadow_target = {0.30F, 0.43F, 0.63F},
+      .shadow_mix = 0.52F,
+      .shadow_strength_scale = 0.88F,
+      .shadow_softness_add = 0.06F,
+      .exposure_scale = 1.04F,
+  });
+  return keyframes;
+}
+
+auto river_mist_profile() -> const std::array<LightingKeyframe, 8>& {
+  static const std::array<LightingKeyframe, 8> keyframes = graded_profile({
+      .primary_scale = {0.91F, 0.96F, 0.98F},
+      .primary_intensity_scale = 0.91F,
+      .sky_target = {0.39F, 0.57F, 0.67F},
+      .sky_mix = 0.42F,
+      .bounce_target = {0.17F, 0.29F, 0.22F},
+      .bounce_mix = 0.46F,
+      .ambient_scale = 1.04F,
+      .fog_target = {0.48F, 0.62F, 0.64F},
+      .fog_mix = 0.58F,
+      .fog_density_add = 0.0048F,
+      .shadow_target = {0.19F, 0.31F, 0.36F},
+      .shadow_mix = 0.48F,
+      .shadow_strength_scale = 0.82F,
+      .shadow_softness_add = 0.17F,
+      .exposure_scale = 0.96F,
+      .cloud_floor = 0.20F,
+      .wetness_floor = 0.18F,
+  });
+  return keyframes;
+}
+
+auto iberian_high_sun_profile() -> const std::array<LightingKeyframe, 8>& {
+  static const std::array<LightingKeyframe, 8> keyframes = graded_profile({
+      .primary_scale = {1.06F, 0.93F, 0.77F},
+      .primary_intensity_scale = 1.08F,
+      .sky_target = {0.36F, 0.57F, 0.80F},
+      .sky_mix = 0.28F,
+      .bounce_target = {0.45F, 0.31F, 0.15F},
+      .bounce_mix = 0.40F,
+      .ambient_scale = 0.92F,
+      .fog_target = {0.75F, 0.61F, 0.41F},
+      .fog_mix = 0.30F,
+      .fog_density_add = 0.0008F,
+      .shadow_target = {0.34F, 0.28F, 0.35F},
+      .shadow_mix = 0.32F,
+      .shadow_strength_scale = 1.10F,
+      .shadow_softness_add = -0.05F,
+      .exposure_scale = 0.98F,
+  });
+  return keyframes;
+}
+
+auto arena_neutral_profile() -> const std::array<LightingKeyframe, 8>& {
+  static const std::array<LightingKeyframe, 8> keyframes = graded_profile({
+      .primary_scale = {0.96F, 0.98F, 1.02F},
+      .primary_intensity_scale = 0.96F,
+      .sky_target = {0.46F, 0.59F, 0.73F},
+      .sky_mix = 0.22F,
+      .bounce_target = {0.26F, 0.24F, 0.20F},
+      .bounce_mix = 0.24F,
+      .fog_target = {0.57F, 0.64F, 0.69F},
+      .fog_mix = 0.24F,
+      .fog_density_add = 0.0010F,
+      .shadow_target = {0.27F, 0.34F, 0.44F},
+      .shadow_mix = 0.24F,
+      .shadow_softness_add = 0.04F,
+      .exposure_scale = 0.98F,
+  });
+  return keyframes;
+}
+
 auto iron_sepulcher_profile() -> const std::array<LightingKeyframe, 8>& {
   static const std::array<LightingKeyframe, 8> keyframes = [] {
     auto result = mediterranean_summer_profile();
@@ -175,8 +370,29 @@ auto iron_sepulcher_profile() -> const std::array<LightingKeyframe, 8>& {
 }
 
 auto profile_for_name(const QString& name) -> const std::array<LightingKeyframe, 8>& {
-  if (name.trimmed().compare(QStringLiteral("iron_sepulcher"), Qt::CaseInsensitive) ==
-      0) {
+  const QString normalized = name.trimmed().toLower();
+  if (normalized == QStringLiteral("delta_haze")) {
+    return delta_haze_profile();
+  }
+  if (normalized == QStringLiteral("canyon_dry")) {
+    return canyon_dry_profile();
+  }
+  if (normalized == QStringLiteral("pine_overcast")) {
+    return pine_overcast_profile();
+  }
+  if (normalized == QStringLiteral("alpine_clear")) {
+    return alpine_clear_profile();
+  }
+  if (normalized == QStringLiteral("river_mist")) {
+    return river_mist_profile();
+  }
+  if (normalized == QStringLiteral("iberian_high_sun")) {
+    return iberian_high_sun_profile();
+  }
+  if (normalized == QStringLiteral("arena_neutral")) {
+    return arena_neutral_profile();
+  }
+  if (normalized == QStringLiteral("iron_sepulcher")) {
     return iron_sepulcher_profile();
   }
   return mediterranean_summer_profile();
@@ -204,8 +420,8 @@ auto apply_weather(EnvironmentLightingState state,
   const float storm = std::clamp(weather.storm, 0.0F, 1.0F);
   const float cloud = std::clamp((rain * 0.72F) + (storm * 0.95F), 0.0F, 1.0F);
 
-  state.cloud_cover = cloud;
-  state.wetness = rain;
+  state.cloud_cover = std::max(state.cloud_cover, cloud);
+  state.wetness = std::max(state.wetness, rain);
   state.primary_intensity *= 1.0F - (cloud * 0.48F);
   state.shadow_strength *= 1.0F - (cloud * 0.58F);
   state.shadow_softness =

--- a/game/systems/combat_actions/combat_action_service.cpp
+++ b/game/systems/combat_actions/combat_action_service.cpp
@@ -16,7 +16,7 @@ namespace Game::Systems::CombatActions {
 namespace {
 
 constexpr float k_heavy_minimum_charge = 0.60F;
-constexpr float k_heavy_maximum_swing_speed = 0.72F;
+constexpr float k_heavy_maximum_swing_speed = 1.0F;
 constexpr float k_heavy_follow_through = 0.78F;
 
 [[nodiscard]] auto should_request_ranged_action(

--- a/game/systems/combat_actions/melee_intent_solver.cpp
+++ b/game/systems/combat_actions/melee_intent_solver.cpp
@@ -94,8 +94,13 @@ auto resolve_melee_intent(const MeleeIntentInputs& inputs) noexcept
       std::clamp(inputs.held_duration / k_melee_full_charge_seconds, 0.0F, 1.0F);
 
   constexpr float k_rate_gain = 0.55F;
+  constexpr float k_authored_swing_speed = 1.0F;
+  constexpr float k_min_swing_speed = 0.85F;
+  constexpr float k_max_swing_speed = 1.35F;
   intent.swing_speed =
-      std::clamp(0.80F + (inputs.aim_rate * k_rate_gain), 0.45F, 2.10F);
+      std::clamp(k_authored_swing_speed + (inputs.aim_rate * k_rate_gain),
+                 k_min_swing_speed,
+                 k_max_swing_speed);
 
   intent.follow_through =
       std::clamp(0.32F + (0.46F * sweep) + (0.22F * intent.charge), 0.0F, 1.0F);

--- a/tests/map/time_of_day_test.cpp
+++ b/tests/map/time_of_day_test.cpp
@@ -1,5 +1,6 @@
 #include <QVector3D>
 
+#include <array>
 #include <gtest/gtest.h>
 
 #include "map/map_definition.h"
@@ -19,6 +20,8 @@ auto ambient_radiance(const EnvironmentLightingState& settings) -> float {
 auto ambient_radiance_at(TimeOfDay time_of_day) -> float {
   return ambient_radiance(lighting_for_time_of_day(time_of_day));
 }
+
+[[nodiscard]] auto lit_floor(const EnvironmentLightingState& lighting) -> float;
 
 TEST(TimeOfDayTest, LightingForDayReturnsHighSun) {
   const auto settings = lighting_for_time_of_day(TimeOfDay::Day);
@@ -131,6 +134,52 @@ TEST(TimeOfDayTest, RainSoftensShadowsAndDrivesWetnessAndFog) {
   EXPECT_GT(rain.fog_density, clear.fog_density);
   EXPECT_FLOAT_EQ(rain.cloud_cover, 0.72F);
   EXPECT_FLOAT_EQ(rain.wetness, 1.0F);
+}
+
+TEST(TimeOfDayTest, BattlefieldProfilesHaveDistinctAtmosphericSignatures) {
+  const auto mediterranean = lighting_for_hour(13.0F);
+  const auto delta = lighting_for_hour(13.0F, QStringLiteral("delta_haze"));
+  const auto canyon = lighting_for_hour(13.0F, QStringLiteral("canyon_dry"));
+  const auto forest = lighting_for_hour(13.0F, QStringLiteral("pine_overcast"));
+  const auto alpine = lighting_for_hour(13.0F, QStringLiteral("alpine_clear"));
+  const auto river = lighting_for_hour(13.0F, QStringLiteral("river_mist"));
+  const auto iberian = lighting_for_hour(13.0F, QStringLiteral("iberian_high_sun"));
+
+  EXPECT_GT(delta.fog_density, mediterranean.fog_density);
+  EXPECT_GT(delta.wetness, 0.0F);
+  EXPECT_GT(canyon.ground_bounce_color.x(), canyon.ground_bounce_color.z());
+  EXPECT_GT(forest.cloud_cover, mediterranean.cloud_cover);
+  EXPECT_LT(forest.primary_intensity, mediterranean.primary_intensity);
+  EXPECT_GT(alpine.shadow_tint.z(), alpine.shadow_tint.x());
+  EXPECT_GT(river.fog_density, mediterranean.fog_density);
+  EXPECT_GT(iberian.primary_color.x(), iberian.primary_color.z());
+
+  EXPECT_NE(delta.fog_color, canyon.fog_color);
+  EXPECT_NE(forest.sky_color, alpine.sky_color);
+  EXPECT_NE(river.shadow_tint, iberian.shadow_tint);
+}
+
+TEST(TimeOfDayTest, EveryBattlefieldProfileStaysReadableAcrossTheClock) {
+  constexpr std::array<const char*, 7> profiles{
+      "delta_haze",
+      "canyon_dry",
+      "pine_overcast",
+      "alpine_clear",
+      "river_mist",
+      "iberian_high_sun",
+      "arena_neutral",
+  };
+
+  for (const char* profile : profiles) {
+    for (int hour = 0; hour < 24; ++hour) {
+      const auto lighting =
+          lighting_for_hour(static_cast<float>(hour), QString::fromLatin1(profile));
+      EXPECT_GT(lighting.primary_direction.length(), 0.99F) << profile;
+      EXPECT_GT(lighting.ambient_intensity, 0.0F) << profile;
+      EXPECT_GT(lighting.exposure, 0.0F) << profile;
+      EXPECT_GE(lit_floor(lighting), 0.34F) << profile << " at hour " << hour;
+    }
+  }
 }
 
 TEST(TimeOfDayTest, ClockUsesDeterministicSimulationTimeAndPauses) {

--- a/tools/arena/arena_scenario.h
+++ b/tools/arena/arena_scenario.h
@@ -419,7 +419,12 @@ struct ArenaScenarioDefinition {
   QString rpg_commander_group;
   std::vector<ArenaPresentationHitch> presentation_hitches;
   Render::GraphicsQuality graphics_quality{Render::GraphicsQuality::High};
-  Game::Map::EnvironmentDefinition environment{};
+  Game::Map::EnvironmentDefinition environment{
+      .start_time = 13.0F,
+      .time_mode = Game::Map::TimeMode::Locked,
+      .day_length_seconds = 1800.0F,
+      .lighting_profile = QStringLiteral("arena_neutral"),
+  };
   Game::Map::WeatherLightingInput weather{};
   Game::Map::RainSettings precipitation{};
   Game::Wildlife::WildlifeSettings wildlife{};

--- a/tools/arena/arena_scenario_catalog.cpp
+++ b/tools/arena/arena_scenario_catalog.cpp
@@ -1580,7 +1580,7 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
                                     4.95F);
       held_combo.counter_key = QStringLiteral("accepted");
       held_combo.end_seconds = 8.5F;
-      held_combo.maximum = 4.0F;
+      held_combo.maximum = 5.0F;
       s.expectations.push_back(held_combo);
     }
     {
@@ -1633,11 +1633,11 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
 
         at(0.60F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
 
-        at(1.20F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        at(1.02F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
 
         at(3.50F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
 
-        at(3.90F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
+        at(3.75F, Command::RpgPrimaryAttack, QStringLiteral("rpg_commander")),
     };
     add_visual_stability(
         s, {QStringLiteral("rpg_commander"), QStringLiteral("enemy_formation")});
@@ -1647,7 +1647,7 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
                                   QStringLiteral("rpg_commander"),
                                   {},
                                   1.0F,
-                                  1.15F);
+                                  1.00F);
       buffered.counter_key = QStringLiteral("buffered");
       buffered.end_seconds = 2.40F;
       s.expectations.push_back(buffered);
@@ -1657,7 +1657,7 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
                                  QStringLiteral("rpg_commander"),
                                  {},
                                  1.0F,
-                                 1.15F);
+                                 1.00F);
       carried.counter_key = QStringLiteral("accepted");
       carried.end_seconds = 2.40F;
       carried.maximum = 1.0F;
@@ -1668,7 +1668,7 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
                                  QStringLiteral("rpg_commander"),
                                  {},
                                  1.0F,
-                                 3.85F);
+                                 3.70F);
       expired.counter_key = QStringLiteral("expired");
       expired.end_seconds = 5.60F;
       s.expectations.push_back(expired);
@@ -1677,7 +1677,7 @@ auto build_definitions() -> std::vector<ArenaScenarioDefinition> {
                                      QStringLiteral("rpg_commander"),
                                      {},
                                      0.0F,
-                                     3.85F);
+                                     3.70F);
       not_carried.counter_key = QStringLiteral("accepted");
       not_carried.end_seconds = 5.60F;
       not_carried.maximum = 0.0F;

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -399,15 +399,20 @@ private:
   QTimer m_frame_timer;
   QElapsedTimer m_frame_clock;
   TerrainSettings m_terrain_settings;
-  Game::Map::GroundType m_ground_type = Game::Map::GroundType::ForestMud;
-  Game::Map::GroundType m_ground_type_baseline = Game::Map::GroundType::ForestMud;
+  Game::Map::GroundType m_ground_type = Game::Map::GroundType::GrassDry;
+  Game::Map::GroundType m_ground_type_baseline = Game::Map::GroundType::GrassDry;
   int m_terrain_seed_baseline = 1337;
   Game::Map::TimeOfDay m_time_of_day = Game::Map::TimeOfDay::Day;
   float m_environment_hour = 13.0F;
   std::optional<float> m_environment_hour_override;
   std::optional<Render::GraphicsQuality> m_graphics_quality_override;
-  QString m_lighting_profile = QStringLiteral("mediterranean_summer");
-  Game::Map::EnvironmentDefinition m_environment_definition;
+  QString m_lighting_profile = QStringLiteral("arena_neutral");
+  Game::Map::EnvironmentDefinition m_environment_definition{
+      .start_time = 13.0F,
+      .time_mode = Game::Map::TimeMode::Locked,
+      .day_length_seconds = 1800.0F,
+      .lighting_profile = QStringLiteral("arena_neutral"),
+  };
   Game::Map::EnvironmentClock m_environment_clock;
   bool m_rain_enabled = false;
   float m_rain_intensity = 0.5F;

--- a/tools/arena/main.cpp
+++ b/tools/arena/main.cpp
@@ -340,7 +340,7 @@ auto main(int argc, char** argv) -> int {
       QStringList{QStringLiteral("lighting-profile")},
       QStringLiteral("Environment lighting profile."),
       QStringLiteral("profile"),
-      QStringLiteral("mediterranean_summer"));
+      QStringLiteral("arena_neutral"));
   QCommandLineOption const artifact_option(
       QStringList{QStringLiteral("artifact-dir")},
       QStringLiteral("Directory for reports, JSONL traces, and frame captures."),

--- a/tools/arena/rpg_gate_manifest.json
+++ b/tools/arena/rpg_gate_manifest.json
@@ -83,10 +83,9 @@
     },
     {
       "id": "rpg_escort_crowd",
-      "status": "expected_red",
+      "status": "required_green",
       "gate": "3",
-      "notes": "Regressed at HEAD (35d87259), before the Gate 5 work and independent of it: three enemy_line soldiers jump 1.4-1.6 m of render root in one frame at 0.23 s and one is submitted with a 0.70 body up-vector while alive at 2.18 s. Bisected by running the scenario on a pristine checkout of 35d87259, where it fails identically; the last green run is artifacts/rpg-gates/run-20260824-231504, taken from the dirty worktree that became that commit. Owned by Gate 3 (pose agreement), pinned here so the Gate 5 slice is not masked by it.",
-      "issue_codes": ["render_root_teleport", "unexpected_fall_pose"]
+      "notes": "Green since 2 Sep 2026, in the same run that added nation-wide creature prewarm (render/template_prewarm_runner.cpp warms every assigned player nation, not only nations with a unit already on the field). The 1.4-1.6 m render-root jump at 0.23 s was consistent with soldiers whose rigged assets were still loading; pinned green rather than left red on a guess, so a regression is caught immediately."
     },
     {
       "id": "rpg_locomotion",
@@ -151,10 +150,9 @@
     },
     {
       "id": "rpg_motor_start_stop",
-      "status": "expected_red",
+      "status": "required_green",
       "gate": "3",
-      "issue_codes": ["planted_foot_slide"],
-      "notes": "New with the Gate 2 motor work; reproduces on every run at 2.05 s. The motor half passes. The cause is not the motor and not the gait blend: render/humanoid/runtime/poser.cpp guards the whole locomotion pose behind if (is_moving), so when the state flips the feet are assigned the idle stance in one frame and every bit of locomotion_blend smoothing is bypassed. The reported 0.091 m is the frame before the real 0.23 m snap. Three cheaper fixes were tried and measured worse or inert -- see docs/RPG_PLAYABILITY.md. Owned by Gate 3 phase continuity, and it touches every humanoid.",
+      "notes": "Green since 2 Sep 2026. The halt foot-slide was the presented state staying Walk until the motor speed reached exactly zero; direct control now drops to Idle below a 0.60 m/s gait floor (k_direct_control_gait_floor_speed in game/core/world.cpp) so the cycle fades with the body. Three repeats, see docs/RPG_PLAYABILITY.md \"The walk cycle outlived the stop\".",
       "repeats": 3,
       "reproduction": "deterministic",
       "intermittent": false

--- a/tools/arena/terrain_panel.cpp
+++ b/tools/arena/terrain_panel.cpp
@@ -169,6 +169,13 @@ TerrainPanel::TerrainPanel(QWidget* parent)
   lighting_form->addRow("Day length", day_length_spin);
   auto* profile_box = new QComboBox(lighting_section);
   profile_box->addItem("Mediterranean Summer", "mediterranean_summer");
+  profile_box->addItem("Delta Haze", "delta_haze");
+  profile_box->addItem("Dry Canyon", "canyon_dry");
+  profile_box->addItem("Pine Overcast", "pine_overcast");
+  profile_box->addItem("Alpine Clear", "alpine_clear");
+  profile_box->addItem("River Mist", "river_mist");
+  profile_box->addItem("Iberian High Sun", "iberian_high_sun");
+  profile_box->addItem("Arena Neutral", "arena_neutral");
   profile_box->addItem("Iron Sepulcher", "iron_sepulcher");
   lighting_form->addRow("Profile", profile_box);
   auto* shadow_quality_box = new QComboBox(lighting_section);

--- a/tools/map_editor/editor_window.cpp
+++ b/tools/map_editor/editor_window.cpp
@@ -192,7 +192,15 @@ auto createEnvironmentPanel(MapEditor::MapData* map_data, QWidget* parent) -> QW
 
   auto* profile = new QComboBox(form_group);
   profile->setEditable(true);
-  profile->addItems({"mediterranean_summer", "iron_sepulcher"});
+  profile->addItems({"mediterranean_summer",
+                     "delta_haze",
+                     "canyon_dry",
+                     "pine_overcast",
+                     "alpine_clear",
+                     "river_mist",
+                     "iberian_high_sun",
+                     "arena_neutral",
+                     "iron_sepulcher"});
   form->addRow("Lighting profile", profile);
 
   auto* fog = new QDoubleSpinBox(form_group);

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -57,7 +57,9 @@ ApplicationWindow {
             mainWindow.game_paused = false;
             if (typeof game !== 'undefined' && game.commander.mode_state !== "active" && game.commander.toggle_mode)
                 game.commander.toggle_mode();
-            mainWindow.capture_view_ready = typeof game !== 'undefined' && game.commander.mode_state === "active";
+            mainWindow.capture_view_ready = typeof game !== 'undefined' && !game.is_loading && game.commander.mode_state === "active";
+        } else if (name === "hud") {
+            mainWindow.capture_view_ready = typeof game !== 'undefined' && !game.is_loading;
         } else {
             mainWindow.capture_view_ready = true;
         }

--- a/ui/qml/MapSelect.qml
+++ b/ui/qml/MapSelect.qml
@@ -791,39 +791,67 @@ Item {
         onWheel: wheel => wheel.accepted = true
     }
 
-    Rectangle {
+    Item {
         anchors.fill: parent
-        color: Theme.dim
+
+        Image {
+            anchors.fill: parent
+            source: "qrc:/StandardOfIron/assets/visuals/load_screen.png"
+            fillMode: Image.PreserveAspectCrop
+            asynchronous: true
+            smooth: true
+            mipmap: true
+            opacity: 0.62
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            gradient: Gradient {
+                GradientStop {
+                    position: 0
+                    color: "#b00b0b0d"
+                }
+
+                GradientStop {
+                    position: 0.55
+                    color: "#d0120d09"
+                }
+
+                GradientStop {
+                    position: 1
+                    color: "#f00a0806"
+                }
+            }
+        }
     }
 
     Rectangle {
         id: container
 
-        width: Math.min(parent.width * 0.975, 1660)
-        height: Math.min(parent.height * 0.975, 1040)
+        width: Math.min(parent.width * 0.95, 1600)
+        height: Math.min(parent.height * 0.95, 1000)
         anchors.centerIn: parent
         radius: Theme.radiusPanel
         gradient: Gradient {
             GradientStop {
                 position: 0
-                color: "#2b2118"
+                color: "#f22a2119"
             }
 
             GradientStop {
                 position: 1
-                color: "#1a140f"
+                color: "#fa15100c"
             }
         }
-        border.color: "#8f6d43"
-        border.width: 2
-        opacity: 0.98
+        border.color: "#a78048"
+        border.width: 1
         clip: true
 
         Rectangle {
             anchors.fill: parent
             anchors.margins: 4
             color: "transparent"
-            border.color: "#4a3722"
+            border.color: "#594024"
             border.width: 1
             radius: Math.max(2, container.radius - 4)
         }
@@ -876,22 +904,22 @@ Item {
                 Rectangle {
                     id: maps_panel
 
-                    Layout.preferredWidth: Math.max(340, container.width * 0.31)
+                    Layout.preferredWidth: Math.max(360, container.width * 0.285)
                     Layout.fillHeight: true
                     radius: Theme.radiusMedium
                     gradient: Gradient {
                         GradientStop {
                             position: 0
-                            color: "#3a2f23"
+                            color: "#e833291f"
                         }
 
                         GradientStop {
                             position: 1
-                            color: "#241b14"
+                            color: "#f21d1712"
                         }
                     }
-                    border.color: "#a7814a"
-                    border.width: 2
+                    border.color: "#765a37"
+                    border.width: 1
 
                     ColumnLayout {
                         anchors.fill: parent
@@ -925,9 +953,9 @@ Item {
 
                             Layout.fillWidth: true
                             Layout.fillHeight: true
-                            color: "#241c14"
+                            color: "#b818130f"
                             radius: Theme.radiusSmall
-                            border.color: "#8f6d43"
+                            border.color: "#493521"
                             border.width: 1
                             clip: true
 
@@ -955,18 +983,32 @@ Item {
                                     readonly property int slot_count: Number((typeof playerCount !== "undefined") ? playerCount : ((modelData && modelData.playerCount !== undefined) ? modelData.playerCount : 0))
 
                                     width: list.width - (list.ScrollBar.vertical.visible ? Theme.spacingMedium : 0)
-                                    height: 76
+                                    height: 84
                                     radius: Theme.radiusSmall
                                     clip: true
-                                    color: map_card.current ? Theme.selectedBg : (map_mouse.containsMouse ? Theme.hoverBg : "#2c231a")
-                                    border.width: map_card.current ? 2 : 1
-                                    border.color: map_card.current ? Theme.selectedBr : (map_mouse.containsMouse ? Theme.accentBr : Theme.thumbBr)
+                                    color: map_card.current ? "#4a251e" : (map_mouse.containsMouse ? "#3b2c20" : "#292018")
+                                    border.width: 1
+                                    border.color: map_card.current ? "#b98549" : (map_mouse.containsMouse ? Theme.accentBr : "#574027")
+
+                                    Rectangle {
+                                        width: map_card.current ? 4 : 2
+                                        anchors.left: parent.left
+                                        anchors.top: parent.top
+                                        anchors.bottom: parent.bottom
+                                        color: map_card.current ? "#c44332" : "transparent"
+
+                                        Behavior on width  {
+                                            NumberAnimation {
+                                                duration: Theme.animFast
+                                            }
+                                        }
+                                    }
 
                                     Rectangle {
                                         id: thumb_wrap
 
-                                        width: 80
-                                        height: 56
+                                        width: 92
+                                        height: 64
                                         radius: Theme.radiusSmall
                                         color: Theme.cardBase
                                         border.color: Theme.thumbBr
@@ -1141,21 +1183,21 @@ Item {
                         id: briefing_panel
 
                         Layout.fillWidth: true
-                        Layout.preferredHeight: 236
+                        Layout.preferredHeight: 286
                         radius: Theme.radiusMedium
                         gradient: Gradient {
                             GradientStop {
                                 position: 0
-                                color: "#3a2f23"
+                                color: "#e833291f"
                             }
 
                             GradientStop {
                                 position: 1
-                                color: "#241b14"
+                                color: "#f21d1712"
                             }
                         }
-                        border.color: "#a7814a"
-                        border.width: 2
+                        border.color: "#765a37"
+                        border.width: 1
 
                         RowLayout {
                             anchors.fill: parent
@@ -1166,7 +1208,7 @@ Item {
                             MapPreview {
                                 id: map_preview
 
-                                Layout.preferredWidth: briefing_panel.height - Theme.spacingMedium * 2
+                                Layout.preferredWidth: Math.min(270, briefing_panel.height - Theme.spacingMedium * 2)
                                 Layout.fillHeight: true
                                 map_path: selected_map_path
                                 player_configs: get_player_configs()
@@ -1288,16 +1330,16 @@ Item {
                         gradient: Gradient {
                             GradientStop {
                                 position: 0
-                                color: "#3a2f23"
+                                color: "#e833291f"
                             }
 
                             GradientStop {
                                 position: 1
-                                color: "#241b14"
+                                color: "#f21d1712"
                             }
                         }
-                        border.color: "#a7814a"
-                        border.width: 2
+                        border.color: "#765a37"
+                        border.width: 1
                         visible: root.has_selection
 
                         ColumnLayout {


### PR DESCRIPTION
Add authored lighting grades for the battlefield environments and make each map use a distinct atmospheric, terrain, and camera presentation. Expose the new profiles in the arena and map editor while giving arena scenarios a neutral locked daytime baseline.

Improve mineral and road material variation, shoulder wear, wetness response, and lighting wrap so terrain and authored surfaces read with more believable scale and contrast. Add the corresponding lighting profile coverage and readability checks to the time-of-day tests.

Align direct-control locomotion presentation with a 0.60 m/s gait floor so stop transitions leave the walk cycle at the right time, and restore authored melee pacing by removing the unintended slow baseline and raising the heavy swing cap. Retune the affected arena expectations and document the measured playability findings.

Polish map selection and capture readiness around loading state, enlarge the map cards and briefing preview, and update the RPG gate manifest to reflect the now-green presentation gates.