### PR TITLE
feat: author map dressing and deepen battlefield presentation

### DIFF
--- a/assets/maps/map_battle_cannae.json
+++ b/assets/maps/map_battle_cannae.json
@@ -2889,18 +2889,18 @@
     ],
     "undead_zones": [
         {
-            "anchor_type": "magic_shrine",
+            "anchor_type": "ruins",
             "awaken_on": [
                 "unit_enters_radius"
             ],
             "clear_reward": {
-                "iron": 100,
-                "stone": 140
+                "gold": 140,
+                "wood": 90
             },
-            "id": "pass_shrine",
-            "leash_radius": 29.42,
+            "id": "cannae_ossuary",
+            "leash_radius": 36.0,
             "owner_id": 99,
-            "radius": 16.81,
+            "radius": 20.0,
             "team_id": 99,
             "waves": [
                 {
@@ -2911,8 +2911,9 @@
                     }
                 }
             ],
-            "x": 432,
-            "z": 33
+            "x": 62,
+            "z": 548,
+            "fog_density": 0.32
         },
         {
             "anchor_type": "ruins",
@@ -2920,39 +2921,13 @@
                 "unit_enters_radius"
             ],
             "clear_reward": {
-                "gold": 130,
-                "wood": 90
-            },
-            "id": "ford_shades",
-            "leash_radius": 38.22,
-            "owner_id": 99,
-            "radius": 21.84,
-            "team_id": 99,
-            "waves": [
-                {
-                    "trigger": "initial",
-                    "units": {
-                        "grave_priest": 1,
-                        "skeleton_swordsman": 2
-                    }
-                }
-            ],
-            "x": 168,
-            "z": 473
-        },
-        {
-            "anchor_type": "magic_shrine",
-            "awaken_on": [
-                "unit_enters_radius"
-            ],
-            "clear_reward": {
-                "gold": 110,
+                "gold": 120,
                 "iron": 70
             },
-            "id": "bridge_watch",
-            "leash_radius": 35.49,
+            "id": "cannae_river_dead",
+            "leash_radius": 32.0,
             "owner_id": 99,
-            "radius": 19.11,
+            "radius": 17.0,
             "team_id": 99,
             "waves": [
                 {
@@ -2962,8 +2937,9 @@
                     }
                 }
             ],
-            "x": 395,
-            "z": 505
+            "x": 612,
+            "z": 34,
+            "fog_density": 0.28
         },
         {
             "anchor_type": "ruins",
@@ -2974,7 +2950,7 @@
                 "food": 140,
                 "gold": 180
             },
-            "id": "old_grave",
+            "id": "cannae_old_grave",
             "leash_radius": 47.89,
             "owner_id": 99,
             "radius": 26.61,
@@ -2996,7 +2972,8 @@
                 }
             ],
             "x": 96,
-            "z": 292
+            "z": 292,
+            "fog_density": 0.3
         }
     ],
     "victory": {
@@ -3113,20 +3090,6 @@
             "z": 434.97
         },
         {
-            "rotation": 0.3,
-            "scale": 1.2,
-            "type": "ruins",
-            "x": 52.09,
-            "z": 404.40000000000003
-        },
-        {
-            "rotation": 2.2,
-            "scale": 1,
-            "type": "ruins",
-            "x": 62.95,
-            "z": 417.45
-        },
-        {
             "rotation": 4.1,
             "scale": 0.9,
             "type": "ruins",
@@ -3134,32 +3097,11 @@
             "z": 392.19
         },
         {
-            "rotation": 0.8,
-            "scale": 1.1,
-            "type": "dead_tree",
-            "x": 93.33,
-            "z": 153.28
-        },
-        {
-            "rotation": 2.5,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 110.7,
-            "z": 140.24
-        },
-        {
             "rotation": 4.7,
             "scale": 0.9,
             "type": "dead_tree",
             "x": 99.85000000000001,
             "z": 179.37
-        },
-        {
-            "rotation": 1.1,
-            "scale": 1.1,
-            "type": "dead_tree",
-            "x": 97.61,
-            "z": 384.72
         },
         {
             "rotation": 3.5,
@@ -3174,48 +3116,6 @@
             "type": "weapon_rack",
             "x": 180.16,
             "z": 176.11
-        },
-        {
-            "rotation": 5,
-            "scale": 1,
-            "type": "weapon_rack",
-            "x": 182.33,
-            "z": 345.7
-        },
-        {
-            "rotation": 1.3,
-            "scale": 0.8,
-            "type": "dead_tree",
-            "x": 251.79,
-            "z": 215.25
-        },
-        {
-            "rotation": 4.2,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 258.3,
-            "z": 306.56
-        },
-        {
-            "rotation": 0.6,
-            "scale": 0.8,
-            "type": "ruins",
-            "x": 264.81,
-            "z": 260.9
-        },
-        {
-            "rotation": 0.9,
-            "scale": 1,
-            "type": "tent",
-            "x": 436.28000000000003,
-            "z": 238.08
-        },
-        {
-            "rotation": 2.8000000000000003,
-            "scale": 1,
-            "type": "tent",
-            "x": 466.67,
-            "z": 286.99
         },
         {
             "rotation": 1.6,
@@ -3253,13 +3153,6 @@
             "z": 404.40000000000003
         },
         {
-            "rotation": 1.2,
-            "scale": 0.9,
-            "type": "ruins",
-            "x": 457.99,
-            "z": 114.15
-        },
-        {
             "rotation": 3.2,
             "scale": 1,
             "type": "dead_tree",
@@ -3286,20 +3179,6 @@
             "type": "tent",
             "x": 612.1,
             "z": 146.76
-        },
-        {
-            "rotation": 2.6,
-            "scale": 1,
-            "type": "supply_cart",
-            "x": 594.74,
-            "z": 182.63
-        },
-        {
-            "rotation": 5,
-            "scale": 0.9,
-            "type": "weapon_rack",
-            "x": 621,
-            "z": 112
         },
         {
             "intensity": 1.1,
@@ -3356,15 +3235,6 @@
             "z": 381.57
         },
         {
-            "intensity": 0.85,
-            "persistent": true,
-            "radius": 2.6,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 62.95,
-            "z": 410.92
-        },
-        {
             "intensity": 0.8,
             "persistent": true,
             "radius": 2.4,
@@ -3372,12 +3242,6 @@
             "type": "firecamp",
             "x": 372.7,
             "z": 343.97
-        },
-        {
-            "scale": 1,
-            "type": "ruins",
-            "x": 96,
-            "z": 292
         },
         {
             "rotation": 138.70000000000002,
@@ -3445,15 +3309,6 @@
             "z": 366.63
         },
         {
-            "intensity": 0.92,
-            "persistent": true,
-            "radius": 3.1,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 433,
-            "z": 28.82
-        },
-        {
             "rotation": 149.3,
             "scale": 0.99,
             "type": "supply_cart",
@@ -3466,20 +3321,6 @@
             "type": "weapon_rack",
             "x": 133.46,
             "z": 422.68
-        },
-        {
-            "rotation": 138.5,
-            "scale": 1.17,
-            "type": "weapon_rack",
-            "x": 459.34000000000003,
-            "z": 362.86
-        },
-        {
-            "rotation": 239.3,
-            "scale": 1.03,
-            "type": "weapon_rack",
-            "x": 337.54,
-            "z": 107.11
         },
         {
             "rotation": 343.2,
@@ -3514,27 +3355,11 @@
             "z": 23.54
         },
         {
-            "intensity": 1.03,
-            "persistent": true,
-            "radius": 2.8000000000000003,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 390.29,
-            "z": 516.75
-        },
-        {
             "rotation": 323.7,
             "scale": 1.1,
             "type": "tent",
             "x": 96.97,
             "z": 452.45
-        },
-        {
-            "rotation": 232.1,
-            "scale": 1.1300000000000001,
-            "type": "tent",
-            "x": 553,
-            "z": 380
         },
         {
             "rotation": 62.2,
@@ -3556,15 +3381,6 @@
             "type": "tent",
             "x": 104.77,
             "z": 433.45
-        },
-        {
-            "intensity": 1.1,
-            "persistent": true,
-            "radius": 2.9,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 604.96,
-            "z": 295.56
         },
         {
             "rotation": 177.70000000000002,
@@ -3604,13 +3420,6 @@
             "type": "firecamp",
             "x": 441.71000000000004,
             "z": 59.370000000000005
-        },
-        {
-            "rotation": 195.3,
-            "scale": 1,
-            "type": "supply_cart",
-            "x": 477.44,
-            "z": 513.39
         },
         {
             "rotation": 301,
@@ -3680,13 +3489,6 @@
             "z": 453.02
         },
         {
-            "rotation": 181,
-            "scale": 0.92,
-            "type": "tent",
-            "x": 573.47,
-            "z": 223.24
-        },
-        {
             "rotation": 317.2,
             "scale": 1.16,
             "type": "tent",
@@ -3710,15 +3512,6 @@
             "z": 458.88
         },
         {
-            "intensity": 1.26,
-            "persistent": true,
-            "radius": 3.2,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 542.23,
-            "z": 234.35
-        },
-        {
             "rotation": 100.8,
             "scale": 1.1,
             "type": "tent",
@@ -3731,13 +3524,6 @@
             "type": "tent",
             "x": 426.1,
             "z": 542.05
-        },
-        {
-            "rotation": 169,
-            "scale": 1.06,
-            "type": "tent",
-            "x": 151.35,
-            "z": 455.34000000000003
         },
         {
             "intensity": 0.97,
@@ -3894,13 +3680,6 @@
             "z": 567.49
         },
         {
-            "rotation": 258.1,
-            "scale": 1.1,
-            "type": "dead_tree",
-            "x": 126.05,
-            "z": 61.07
-        },
-        {
             "rotation": 63.6,
             "scale": 1.09,
             "type": "dead_tree",
@@ -3915,25 +3694,11 @@
             "z": 531.97
         },
         {
-            "rotation": 200.20000000000002,
-            "scale": 1.05,
-            "type": "dead_tree",
-            "x": 612.63,
-            "z": 71.36
-        },
-        {
             "rotation": 354.90000000000003,
             "scale": 1.17,
             "type": "ruins",
             "x": 179.36,
             "z": 524.33
-        },
-        {
-            "rotation": 344.6,
-            "scale": 0.91,
-            "type": "dead_tree",
-            "x": 103.54,
-            "z": 630.48
         },
         {
             "rotation": 357.3,
@@ -3962,34 +3727,6 @@
             "type": "ruins",
             "x": 606.12,
             "z": 21.34
-        },
-        {
-            "rotation": 354.3,
-            "scale": 0.99,
-            "type": "dead_tree",
-            "x": 609.1800000000001,
-            "z": 558.83
-        },
-        {
-            "rotation": 278.7,
-            "scale": 0.99,
-            "type": "dead_tree",
-            "x": 95.63,
-            "z": 537.8
-        },
-        {
-            "rotation": 116.9,
-            "scale": 1.17,
-            "type": "dead_tree",
-            "x": 59.910000000000004,
-            "z": 15.56
-        },
-        {
-            "rotation": 79.3,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 369.24,
-            "z": 189.12
         },
         {
             "rotation": 99.5,
@@ -4048,13 +3785,6 @@
             "z": 331.2
         },
         {
-            "rotation": 109.8,
-            "scale": 1.08,
-            "type": "statue",
-            "x": 564.84,
-            "z": 254.78
-        },
-        {
             "rotation": 122.3,
             "scale": 0.92,
             "type": "statue",
@@ -4069,13 +3799,6 @@
             "z": 304.03000000000003
         },
         {
-            "rotation": 165,
-            "scale": 1.04,
-            "type": "abandoned_home",
-            "x": 84.22,
-            "z": 254.6
-        },
-        {
             "rotation": 268,
             "scale": 0.93,
             "type": "abandoned_home",
@@ -4083,39 +3806,11 @@
             "z": 297.12
         },
         {
-            "rotation": 166.3,
-            "scale": 1.08,
-            "type": "abandoned_home",
-            "x": 99.57000000000001,
-            "z": 266.96
-        },
-        {
             "rotation": 267.2,
             "scale": 1.04,
             "type": "abandoned_home",
             "x": 62.76,
             "z": 302.64
-        },
-        {
-            "rotation": 161.70000000000002,
-            "scale": 1.09,
-            "type": "abandoned_home",
-            "x": 57.38,
-            "z": 43.730000000000004
-        },
-        {
-            "rotation": 295,
-            "scale": 0.92,
-            "type": "abandoned_home",
-            "x": 549.65,
-            "z": 151.09
-        },
-        {
-            "rotation": 135.3,
-            "scale": 0.93,
-            "type": "abandoned_home",
-            "x": 285.69,
-            "z": 213.6
         },
         {
             "rotation": 293.90000000000003,
@@ -4130,13 +3825,6 @@
             "type": "abandoned_home",
             "x": 25.04,
             "z": 119.35000000000001
-        },
-        {
-            "rotation": 344.1,
-            "scale": 0.96,
-            "type": "abandoned_home",
-            "x": 288.06,
-            "z": 531.37
         },
         {
             "landmark": "cannae_south_sanctuary",
@@ -4457,14 +4145,6 @@
         },
         {
             "landmark": "cannae_ridge_watch",
-            "rotation": 270,
-            "scale": 1,
-            "type": "tent",
-            "x": 512.51,
-            "z": 107.71
-        },
-        {
-            "landmark": "cannae_ridge_watch",
             "rotation": 90,
             "scale": 1,
             "type": "tent",
@@ -4748,6 +4428,1951 @@
             "type": "cursed_gold_vein",
             "x": 52,
             "z": 542
+        },
+        {
+            "type": "ruins",
+            "x": 464.03,
+            "z": 261.98,
+            "scale": 1.18,
+            "rotation": 1.569,
+            "dressing": "cannae_citadel"
+        },
+        {
+            "type": "ruins",
+            "x": 459.78,
+            "z": 270.51,
+            "scale": 1.04,
+            "rotation": 2.435,
+            "dressing": "cannae_citadel"
+        },
+        {
+            "type": "ruins",
+            "x": 448.31,
+            "z": 250.93,
+            "scale": 1.23,
+            "rotation": 5.682,
+            "dressing": "cannae_citadel"
+        },
+        {
+            "type": "statue",
+            "x": 467.75,
+            "z": 266.03,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "cannae_citadel"
+        },
+        {
+            "type": "statue",
+            "x": 469.53,
+            "z": 259.75,
+            "scale": 1.0,
+            "rotation": 4.712,
+            "dressing": "cannae_citadel"
+        },
+        {
+            "type": "firecamp",
+            "x": 454.0,
+            "z": 262.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_citadel",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 445.68,
+            "z": 266.12,
+            "scale": 1.0,
+            "rotation": 0.623,
+            "dressing": "cannae_citadel"
+        },
+        {
+            "type": "boulder",
+            "x": 465.88,
+            "z": 255.89,
+            "scale": 1.03,
+            "rotation": 1.679,
+            "dressing": "cannae_citadel"
+        },
+        {
+            "type": "boulder",
+            "x": 378.51,
+            "z": 266.95,
+            "scale": 1.14,
+            "rotation": 1.871,
+            "dressing": "cannae_citadel_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 372.28,
+            "z": 268.03,
+            "scale": 0.91,
+            "rotation": 4.462,
+            "dressing": "cannae_citadel_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 386.72,
+            "z": 275.37,
+            "scale": 1.0,
+            "rotation": 1.136,
+            "dressing": "cannae_citadel_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 384.62,
+            "z": 226.4,
+            "scale": 0.96,
+            "rotation": 1.244,
+            "dressing": "cannae_citadel_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 382.27,
+            "z": 224.4,
+            "scale": 1.39,
+            "rotation": 4.22,
+            "dressing": "cannae_citadel_ramp"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 305.42,
+            "z": 334.12,
+            "scale": 0.9,
+            "rotation": 0.089,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 306.12,
+            "z": 346.54,
+            "scale": 0.92,
+            "rotation": 3.884,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 314.97,
+            "z": 334.04,
+            "scale": 1.03,
+            "rotation": 2.716,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 315.24,
+            "z": 346.13,
+            "scale": 1.02,
+            "rotation": 4.609,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 324.47,
+            "z": 334.25,
+            "scale": 0.96,
+            "rotation": 0.67,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 325.17,
+            "z": 345.78,
+            "scale": 1.0,
+            "rotation": 3.66,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 334.6,
+            "z": 333.87,
+            "scale": 1.08,
+            "rotation": 3.141,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 334.88,
+            "z": 346.67,
+            "scale": 0.98,
+            "rotation": 5.982,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 345.13,
+            "z": 333.9,
+            "scale": 1.09,
+            "rotation": 5.177,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 345.45,
+            "z": 345.75,
+            "scale": 0.92,
+            "rotation": 0.642,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 355.26,
+            "z": 333.92,
+            "scale": 1.05,
+            "rotation": 3.173,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 355.69,
+            "z": 345.56,
+            "scale": 1.0,
+            "rotation": 4.575,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 364.74,
+            "z": 333.66,
+            "scale": 0.93,
+            "rotation": 3.866,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 365.44,
+            "z": 345.4,
+            "scale": 0.98,
+            "rotation": 3.242,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 375.84,
+            "z": 334.27,
+            "scale": 0.99,
+            "rotation": 1.642,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 384.17,
+            "z": 347.79,
+            "scale": 1.04,
+            "rotation": 4.44,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 413.23,
+            "z": 328.85,
+            "scale": 0.91,
+            "rotation": 4.693,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 416.17,
+            "z": 341.05,
+            "scale": 0.97,
+            "rotation": 4.003,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 423.4,
+            "z": 326.87,
+            "scale": 1.02,
+            "rotation": 5.318,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 425.32,
+            "z": 338.8,
+            "scale": 1.06,
+            "rotation": 2.21,
+            "dressing": "cannae_aufidus_avenue"
+        },
+        {
+            "type": "boulder",
+            "x": 325.02,
+            "z": 146.56,
+            "scale": 1.01,
+            "rotation": 5.298,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 331.0,
+            "z": 145.43,
+            "scale": 1.16,
+            "rotation": 6.209,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 336.53,
+            "z": 147.09,
+            "scale": 1.32,
+            "rotation": 0.2,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 339.51,
+            "z": 147.76,
+            "scale": 0.95,
+            "rotation": 5.153,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "plant",
+            "x": 327.47,
+            "z": 146.4,
+            "scale": 1.14,
+            "rotation": 6.06,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "plant",
+            "x": 331.95,
+            "z": 147.96,
+            "scale": 1.22,
+            "rotation": 0.554,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 322.73,
+            "z": 166.13,
+            "scale": 0.85,
+            "rotation": 5.981,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 328.33,
+            "z": 166.05,
+            "scale": 1.17,
+            "rotation": 0.622,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 334.47,
+            "z": 165.31,
+            "scale": 1.3,
+            "rotation": 3.639,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 339.16,
+            "z": 165.53,
+            "scale": 1.31,
+            "rotation": 2.223,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "plant",
+            "x": 325.91,
+            "z": 165.51,
+            "scale": 1.27,
+            "rotation": 4.587,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "plant",
+            "x": 331.07,
+            "z": 166.56,
+            "scale": 0.96,
+            "rotation": 4.489,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "plant",
+            "x": 336.8,
+            "z": 166.86,
+            "scale": 0.96,
+            "rotation": 5.489,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "dead_tree",
+            "x": 334.48,
+            "z": 169.97,
+            "scale": 1.0,
+            "rotation": 1.119,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "supply_cart",
+            "x": 326.46,
+            "z": 142.49,
+            "scale": 1.0,
+            "rotation": 2.568,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "ruins",
+            "x": 343.63,
+            "z": 142.03,
+            "scale": 0.8,
+            "rotation": 1.8,
+            "dressing": "cannae_aufidus_ford"
+        },
+        {
+            "type": "ruins",
+            "x": 73.69,
+            "z": 549.31,
+            "scale": 1.11,
+            "rotation": 4.507,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "ruins",
+            "x": 69.36,
+            "z": 556.01,
+            "scale": 1.06,
+            "rotation": 0.886,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "ruins",
+            "x": 57.7,
+            "z": 557.13,
+            "scale": 1.14,
+            "rotation": 3.823,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "ruins",
+            "x": 51.08,
+            "z": 553.33,
+            "scale": 0.9,
+            "rotation": 2.999,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "ruins",
+            "x": 59.07,
+            "z": 535.91,
+            "scale": 0.87,
+            "rotation": 1.47,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "ruins",
+            "x": 67.94,
+            "z": 538.79,
+            "scale": 1.08,
+            "rotation": 4.044,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 76.43,
+            "z": 555.49,
+            "scale": 1.07,
+            "rotation": 1.437,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 47.01,
+            "z": 557.42,
+            "scale": 0.85,
+            "rotation": 5.896,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 43.14,
+            "z": 541.08,
+            "scale": 1.13,
+            "rotation": 5.223,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 76.53,
+            "z": 541.24,
+            "scale": 1.06,
+            "rotation": 1.786,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 71.97,
+            "z": 563.63,
+            "scale": 0.98,
+            "rotation": 5.907,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "statue",
+            "x": 67.9,
+            "z": 550.41,
+            "scale": 0.9,
+            "rotation": 3.208,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "statue",
+            "x": 52.84,
+            "z": 549.04,
+            "scale": 0.9,
+            "rotation": 4.754,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "boulder",
+            "x": 52.62,
+            "z": 534.65,
+            "scale": 1.01,
+            "rotation": 1.956,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "boulder",
+            "x": 78.7,
+            "z": 546.54,
+            "scale": 1.02,
+            "rotation": 4.522,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "boulder",
+            "x": 46.27,
+            "z": 553.68,
+            "scale": 0.98,
+            "rotation": 4.508,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 62.0,
+            "z": 548.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_ossuary_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 89.01,
+            "z": 577.24,
+            "scale": 1.05,
+            "rotation": 1.982,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 85.2,
+            "z": 572.86,
+            "scale": 1.02,
+            "rotation": 4.709,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 89.59,
+            "z": 570.93,
+            "scale": 0.9,
+            "rotation": 0.118,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 98.92,
+            "z": 573.96,
+            "scale": 0.97,
+            "rotation": 0.402,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 80.88,
+            "z": 569.65,
+            "scale": 1.18,
+            "rotation": 1.266,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 92.41,
+            "z": 565.98,
+            "scale": 0.93,
+            "rotation": 4.443,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 100.42,
+            "z": 569.4,
+            "scale": 0.98,
+            "rotation": 2.234,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 98.05,
+            "z": 564.28,
+            "scale": 0.7,
+            "rotation": 1.716,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 87.08,
+            "z": 565.19,
+            "scale": 0.72,
+            "rotation": 3.466,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 84.74,
+            "z": 577.3,
+            "scale": 1.19,
+            "rotation": 0.657,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 92.5,
+            "z": 574.89,
+            "scale": 1.08,
+            "rotation": 4.061,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 83.07,
+            "z": 565.33,
+            "scale": 0.99,
+            "rotation": 4.759,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 95.57,
+            "z": 567.61,
+            "scale": 0.87,
+            "rotation": 1.925,
+            "dressing": "cannae_ossuary_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 618.07,
+            "z": 33.59,
+            "scale": 0.96,
+            "rotation": 4.839,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 609.63,
+            "z": 45.14,
+            "scale": 0.82,
+            "rotation": 2.065,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 602.8,
+            "z": 32.49,
+            "scale": 1.05,
+            "rotation": 4.493,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 613.5,
+            "z": 19.08,
+            "scale": 0.87,
+            "rotation": 0.688,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 629.74,
+            "z": 40.83,
+            "scale": 1.13,
+            "rotation": 1.233,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 601.81,
+            "z": 46.69,
+            "scale": 0.87,
+            "rotation": 4.241,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 599.9,
+            "z": 24.35,
+            "scale": 1.01,
+            "rotation": 1.143,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 618.93,
+            "z": 20.97,
+            "scale": 0.97,
+            "rotation": 3.895,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 619.47,
+            "z": 38.08,
+            "scale": 0.9,
+            "rotation": 5.665,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 607.51,
+            "z": 34.76,
+            "scale": 0.9,
+            "rotation": 6.249,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 619.25,
+            "z": 42.82,
+            "scale": 0.96,
+            "rotation": 0.321,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 629.01,
+            "z": 36.58,
+            "scale": 1.25,
+            "rotation": 4.189,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 605.45,
+            "z": 47.36,
+            "scale": 0.83,
+            "rotation": 3.603,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 612.0,
+            "z": 34.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 106.36,
+            "z": 289.63,
+            "scale": 1.11,
+            "rotation": 3.007,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 103.54,
+            "z": 301.39,
+            "scale": 1.1,
+            "rotation": 0.261,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 89.3,
+            "z": 300.31,
+            "scale": 1.11,
+            "rotation": 2.24,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 83.11,
+            "z": 293.65,
+            "scale": 0.93,
+            "rotation": 2.548,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 90.75,
+            "z": 280.46,
+            "scale": 0.99,
+            "rotation": 2.148,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 102.17,
+            "z": 283.14,
+            "scale": 0.96,
+            "rotation": 6.115,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 116.75,
+            "z": 297.33,
+            "scale": 0.92,
+            "rotation": 2.312,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 80.91,
+            "z": 301.24,
+            "scale": 1.03,
+            "rotation": 3.31,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 79.57,
+            "z": 280.83,
+            "scale": 0.93,
+            "rotation": 5.446,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 108.55,
+            "z": 279.28,
+            "scale": 0.99,
+            "rotation": 3.848,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 114.76,
+            "z": 304.8,
+            "scale": 1.07,
+            "rotation": 0.775,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "statue",
+            "x": 105.92,
+            "z": 295.13,
+            "scale": 0.9,
+            "rotation": 1.86,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "statue",
+            "x": 85.93,
+            "z": 289.41,
+            "scale": 0.9,
+            "rotation": 1.797,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 84.53,
+            "z": 303.56,
+            "scale": 1.27,
+            "rotation": 0.319,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 100.01,
+            "z": 307.93,
+            "scale": 1.01,
+            "rotation": 5.341,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 87.45,
+            "z": 284.26,
+            "scale": 0.88,
+            "rotation": 2.364,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 98.39,
+            "z": 279.1,
+            "scale": 1.28,
+            "rotation": 5.119,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 96.0,
+            "z": 292.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_old_grave_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 220.96,
+            "z": 126.18,
+            "scale": 1.15,
+            "rotation": 5.253,
+            "dressing": "cannae_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 207.2,
+            "z": 123.27,
+            "scale": 1.07,
+            "rotation": 2.201,
+            "dressing": "cannae_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 205.7,
+            "z": 118.87,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_west_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 224.42,
+            "z": 119.76,
+            "scale": 1.0,
+            "rotation": 4.249,
+            "dressing": "cannae_west_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 205.76,
+            "z": 113.77,
+            "scale": 1.0,
+            "rotation": -1.202,
+            "dressing": "cannae_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 217.48,
+            "z": 143.65,
+            "scale": 1.16,
+            "rotation": 4.999,
+            "dressing": "cannae_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 202.83,
+            "z": 140.61,
+            "scale": 0.94,
+            "rotation": 0.861,
+            "dressing": "cannae_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 218.95,
+            "z": 148.04,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_west_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 447.65,
+            "z": 163.29,
+            "scale": 1.13,
+            "rotation": 5.094,
+            "dressing": "cannae_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 433.31,
+            "z": 162.3,
+            "scale": 0.91,
+            "rotation": 4.327,
+            "dressing": "cannae_east_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 430.41,
+            "z": 158.48,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_east_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 451.53,
+            "z": 156.95,
+            "scale": 1.0,
+            "rotation": 0.333,
+            "dressing": "cannae_east_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 435.25,
+            "z": 148.56,
+            "scale": 1.0,
+            "rotation": -1.179,
+            "dressing": "cannae_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 444.05,
+            "z": 180.71,
+            "scale": 1.24,
+            "rotation": 0.044,
+            "dressing": "cannae_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 431.05,
+            "z": 177.97,
+            "scale": 1.05,
+            "rotation": 1.121,
+            "dressing": "cannae_east_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 446.08,
+            "z": 185.23,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_east_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 427.35,
+            "z": 184.35,
+            "scale": 1.0,
+            "rotation": 3.557,
+            "dressing": "cannae_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 10.25,
+            "z": 449.14,
+            "scale": 1.24,
+            "rotation": 0.025,
+            "dressing": "cannae_hill_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 7.23,
+            "z": 448.8,
+            "scale": 1.22,
+            "rotation": 5.447,
+            "dressing": "cannae_hill_ramp_w"
+        },
+        {
+            "type": "dead_tree",
+            "x": 15.57,
+            "z": 454.02,
+            "scale": 1.0,
+            "rotation": 0.919,
+            "dressing": "cannae_hill_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 23.94,
+            "z": 387.73,
+            "scale": 1.15,
+            "rotation": 3.912,
+            "dressing": "cannae_hill_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 19.51,
+            "z": 385.14,
+            "scale": 1.43,
+            "rotation": 1.681,
+            "dressing": "cannae_hill_ramp_w"
+        },
+        {
+            "type": "firecamp",
+            "x": 11.96,
+            "z": 382.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_hill_ramp_w",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 150.37,
+            "z": 538.85,
+            "scale": 1.28,
+            "rotation": 4.432,
+            "dressing": "cannae_hill_ramp_s"
+        },
+        {
+            "type": "boulder",
+            "x": 152.26,
+            "z": 544.89,
+            "scale": 1.07,
+            "rotation": 5.146,
+            "dressing": "cannae_hill_ramp_s"
+        },
+        {
+            "type": "dead_tree",
+            "x": 154.53,
+            "z": 530.93,
+            "scale": 1.0,
+            "rotation": 0.841,
+            "dressing": "cannae_hill_ramp_s"
+        },
+        {
+            "type": "boulder",
+            "x": 97.82,
+            "z": 538.94,
+            "scale": 1.36,
+            "rotation": 2.384,
+            "dressing": "cannae_hill_ramp_s"
+        },
+        {
+            "type": "boulder",
+            "x": 95.27,
+            "z": 543.78,
+            "scale": 1.31,
+            "rotation": 5.357,
+            "dressing": "cannae_hill_ramp_s"
+        },
+        {
+            "type": "firecamp",
+            "x": 94.11,
+            "z": 551.76,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_hill_ramp_s",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 12.81,
+            "z": 451.48,
+            "scale": 1.0,
+            "rotation": -0.011,
+            "dressing": "cannae_west_junction"
+        },
+        {
+            "type": "statue",
+            "x": 210.54,
+            "z": 416.37,
+            "scale": 1.0,
+            "rotation": -1.305,
+            "dressing": "cannae_plain_junction"
+        },
+        {
+            "type": "olive_tree",
+            "x": 208.96,
+            "z": 422.16,
+            "scale": 1.0,
+            "rotation": 4.241,
+            "dressing": "cannae_plain_junction"
+        },
+        {
+            "type": "statue",
+            "x": 638.84,
+            "z": 341.99,
+            "scale": 1.0,
+            "rotation": -1.38,
+            "dressing": "cannae_east_junction"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 637.7,
+            "z": 347.88,
+            "scale": 1.0,
+            "rotation": 0.334,
+            "dressing": "cannae_east_junction"
+        },
+        {
+            "type": "plant",
+            "x": 33.52,
+            "z": 112.66,
+            "scale": 1.23,
+            "rotation": 3.008,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 35.24,
+            "z": 115.11,
+            "scale": 1.14,
+            "rotation": 2.231,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 64.82,
+            "z": 100.22,
+            "scale": 0.82,
+            "rotation": 0.232,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 91.44,
+            "z": 124.93,
+            "scale": 1.18,
+            "rotation": 2.797,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 93.98,
+            "z": 127.35,
+            "scale": 1.4,
+            "rotation": 2.467,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 125.32,
+            "z": 111.28,
+            "scale": 0.97,
+            "rotation": 1.48,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 150.38,
+            "z": 132.07,
+            "scale": 0.82,
+            "rotation": 2.227,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 154.18,
+            "z": 135.62,
+            "scale": 1.24,
+            "rotation": 1.905,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 182.41,
+            "z": 117.49,
+            "scale": 0.85,
+            "rotation": 4.73,
+            "dressing": "cannae_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 472.89,
+            "z": 188.53,
+            "scale": 1.27,
+            "rotation": 1.735,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 475.22,
+            "z": 191.03,
+            "scale": 1.01,
+            "rotation": 1.646,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 506.64,
+            "z": 175.4,
+            "scale": 0.99,
+            "rotation": 5.256,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 532.44,
+            "z": 199.35,
+            "scale": 1.16,
+            "rotation": 4.569,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 534.56,
+            "z": 201.47,
+            "scale": 1.35,
+            "rotation": 1.315,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 564.65,
+            "z": 184.04,
+            "scale": 1.19,
+            "rotation": 5.901,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 590.17,
+            "z": 209.41,
+            "scale": 1.23,
+            "rotation": 5.973,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 593.55,
+            "z": 212.41,
+            "scale": 0.92,
+            "rotation": 2.304,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 624.02,
+            "z": 196.46,
+            "scale": 1.12,
+            "rotation": 5.015,
+            "dressing": "cannae_lower_bank"
+        },
+        {
+            "type": "firecamp",
+            "x": 436.0,
+            "z": 447.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 451.29,
+            "z": 447.87,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 453.28,
+            "z": 444.38,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "cannae_gate_1"
+        },
+        {
+            "type": "supply_cart",
+            "x": 434.5,
+            "z": 441.0,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "cannae_gate_1"
+        },
+        {
+            "type": "statue",
+            "x": 435.0,
+            "z": 436.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_1"
+        },
+        {
+            "type": "statue",
+            "x": 446.75,
+            "z": 435.53,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "cannae_gate_1"
+        },
+        {
+            "type": "firecamp",
+            "x": 383.0,
+            "z": 467.8,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 378.05,
+            "z": 450.8,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "cannae_gate_2"
+        },
+        {
+            "type": "supply_cart",
+            "x": 377.0,
+            "z": 469.3,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "cannae_gate_2"
+        },
+        {
+            "type": "statue",
+            "x": 372.0,
+            "z": 468.8,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "cannae_gate_2"
+        },
+        {
+            "type": "statue",
+            "x": 372.89,
+            "z": 458.48,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "cannae_gate_2"
+        },
+        {
+            "type": "firecamp",
+            "x": 517.0,
+            "z": 281.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 518.0,
+            "z": 277.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "cannae_gate_3"
+        },
+        {
+            "type": "supply_cart",
+            "x": 504.75,
+            "z": 275.94,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "cannae_gate_3"
+        },
+        {
+            "type": "statue",
+            "x": 505.25,
+            "z": 270.94,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_3"
+        },
+        {
+            "type": "statue",
+            "x": 518.0,
+            "z": 270.0,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "cannae_gate_3"
+        },
+        {
+            "type": "firecamp",
+            "x": 561.0,
+            "z": 312.4,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 561.43,
+            "z": 324.72,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 565.0,
+            "z": 324.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_4"
+        },
+        {
+            "type": "supply_cart",
+            "x": 567.0,
+            "z": 310.9,
+            "scale": 1.0,
+            "rotation": 0.3,
+            "dressing": "cannae_gate_4"
+        },
+        {
+            "type": "statue",
+            "x": 572.0,
+            "z": 311.4,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "cannae_gate_4"
+        },
+        {
+            "type": "statue",
+            "x": 572.43,
+            "z": 325.72,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "cannae_gate_4"
+        },
+        {
+            "type": "firecamp",
+            "x": 514.0,
+            "z": 347.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 496.72,
+            "z": 349.62,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "cannae_gate_5"
+        },
+        {
+            "type": "supply_cart",
+            "x": 515.5,
+            "z": 353.0,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "cannae_gate_5"
+        },
+        {
+            "type": "statue",
+            "x": 515.0,
+            "z": 358.0,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "cannae_gate_5"
+        },
+        {
+            "type": "statue",
+            "x": 503.18,
+            "z": 357.28,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "cannae_gate_5"
+        },
+        {
+            "type": "firecamp",
+            "x": 487.43,
+            "z": 324.72,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 487.0,
+            "z": 312.4,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 483.0,
+            "z": 311.4,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "cannae_gate_6"
+        },
+        {
+            "type": "supply_cart",
+            "x": 482.72,
+            "z": 326.63,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "cannae_gate_6"
+        },
+        {
+            "type": "statue",
+            "x": 477.72,
+            "z": 326.13,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "cannae_gate_6"
+        },
+        {
+            "type": "statue",
+            "x": 476.0,
+            "z": 311.4,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "cannae_gate_6"
+        },
+        {
+            "type": "firecamp",
+            "x": 427.0,
+            "z": 82.7,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_7",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 427.0,
+            "z": 93.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_7",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 431.0,
+            "z": 94.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_7"
+        },
+        {
+            "type": "supply_cart",
+            "x": 433.0,
+            "z": 81.2,
+            "scale": 1.0,
+            "rotation": 0.3,
+            "dressing": "cannae_gate_7"
+        },
+        {
+            "type": "firecamp",
+            "x": 403.0,
+            "z": 119.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_8",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 402.0,
+            "z": 123.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "cannae_gate_8"
+        },
+        {
+            "type": "firecamp",
+            "x": 357.0,
+            "z": 79.1,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_9",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 357.89,
+            "z": 72.18,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "cannae_gate_9",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 353.43,
+            "z": 69.02,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "cannae_gate_9"
+        },
+        {
+            "type": "supply_cart",
+            "x": 351.0,
+            "z": 80.6,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "cannae_gate_9"
+        }
+    ],
+    "dressing": [
+        {
+            "id": "cannae_citadel",
+            "kind": "hilltop_ruin",
+            "x": 452,
+            "z": 262,
+            "facing": "west",
+            "radius": 14,
+            "ruins": 9,
+            "boulders": 4
+        },
+        {
+            "id": "cannae_citadel_ramp",
+            "kind": "ramp_mouth",
+            "x": 406,
+            "z": 254,
+            "statue": true,
+            "fire": true
+        },
+        {
+            "id": "cannae_aufidus_avenue",
+            "kind": "tree_avenue",
+            "from": [
+                300,
+                338
+            ],
+            "to": [
+                430,
+                326
+            ],
+            "tree": "cypress_tree",
+            "spacing": 10
+        },
+        {
+            "id": "cannae_aufidus_ford",
+            "kind": "ford_wreck",
+            "x": 330,
+            "z": 156,
+            "boulders": 4,
+            "plants": 4
+        },
+        {
+            "id": "cannae_ossuary_field",
+            "kind": "barrow_field",
+            "x": 62,
+            "z": 548,
+            "radius": 12,
+            "shrine": true,
+            "ruins": 7,
+            "dead_trees": 5,
+            "boulders": 4
+        },
+        {
+            "id": "cannae_ossuary_bones",
+            "kind": "boneyard",
+            "x": 92,
+            "z": 572,
+            "radius": 12,
+            "statues": 0,
+            "dead_trees": 7
+        },
+        {
+            "id": "cannae_river_barrows",
+            "kind": "barrow_field",
+            "x": 612,
+            "z": 34,
+            "radius": 11,
+            "shrine": true,
+            "ruins": 4,
+            "dead_trees": 4,
+            "boulders": 3
+        },
+        {
+            "id": "cannae_old_grave_ring",
+            "kind": "barrow_field",
+            "x": 96,
+            "z": 292,
+            "radius": 13,
+            "shrine": true,
+            "ruins": 6,
+            "dead_trees": 5,
+            "boulders": 4
+        },
+        {
+            "id": "cannae_west_bridge",
+            "kind": "bridgehead",
+            "x": 212,
+            "z": 133
+        },
+        {
+            "id": "cannae_east_bridge",
+            "kind": "bridgehead",
+            "x": 440,
+            "z": 170
+        },
+        {
+            "id": "cannae_hill_ramp_w",
+            "kind": "ramp_mouth",
+            "x": 54,
+            "z": 427,
+            "fire": true,
+            "reach": 24
+        },
+        {
+            "id": "cannae_hill_ramp_s",
+            "kind": "ramp_mouth",
+            "x": 122,
+            "z": 506,
+            "fire": true,
+            "reach": 18
+        },
+        {
+            "id": "cannae_west_junction",
+            "kind": "junction",
+            "x": 20,
+            "z": 444,
+            "style": "camp",
+            "snap": 6
+        },
+        {
+            "id": "cannae_plain_junction",
+            "kind": "junction",
+            "x": 212,
+            "z": 410,
+            "style": "milestone",
+            "tree": "olive_tree"
+        },
+        {
+            "id": "cannae_east_junction",
+            "kind": "junction",
+            "x": 640,
+            "z": 336,
+            "style": "milestone",
+            "tree": "cypress_tree"
+        },
+        {
+            "id": "cannae_upper_bank",
+            "kind": "riverbank",
+            "from": [
+                20,
+                100
+            ],
+            "to": [
+                200,
+                130
+            ],
+            "spacing": 30,
+            "kinds": [
+                "plant",
+                "boulder",
+                "plant",
+                "dead_tree"
+            ]
+        },
+        {
+            "id": "cannae_lower_bank",
+            "kind": "riverbank",
+            "from": [
+                460,
+                176
+            ],
+            "to": [
+                630,
+                210
+            ],
+            "spacing": 30,
+            "kinds": [
+                "plant",
+                "boulder",
+                "plant",
+                "dead_tree"
+            ]
+        },
+        {
+            "id": "cannae_gate_1",
+            "kind": "gate_approach",
+            "x": 442.0,
+            "z": 456.0,
+            "statues": true
+        },
+        {
+            "id": "cannae_gate_2",
+            "kind": "gate_approach",
+            "x": 392.0,
+            "z": 462.0,
+            "statues": true
+        },
+        {
+            "id": "cannae_gate_3",
+            "kind": "gate_approach",
+            "x": 512,
+            "z": 290,
+            "statues": true
+        },
+        {
+            "id": "cannae_gate_4",
+            "kind": "gate_approach",
+            "x": 552,
+            "z": 318,
+            "statues": true
+        },
+        {
+            "id": "cannae_gate_5",
+            "kind": "gate_approach",
+            "x": 508,
+            "z": 338,
+            "statues": true
+        },
+        {
+            "id": "cannae_gate_6",
+            "kind": "gate_approach",
+            "x": 496,
+            "z": 318,
+            "statues": true
+        },
+        {
+            "id": "cannae_gate_7",
+            "kind": "gate_approach",
+            "x": 418,
+            "z": 88
+        },
+        {
+            "id": "cannae_gate_8",
+            "kind": "gate_approach",
+            "x": 408,
+            "z": 110
+        },
+        {
+            "id": "cannae_gate_9",
+            "kind": "gate_approach",
+            "x": 366,
+            "z": 74
         }
     ]
 }

--- a/assets/maps/map_battle_ticino.json
+++ b/assets/maps/map_battle_ticino.json
@@ -3707,32 +3707,6 @@
     ],
     "undead_zones": [
         {
-            "anchor_type": "magic_shrine",
-            "awaken_on": [
-                "unit_enters_radius"
-            ],
-            "clear_reward": {
-                "iron": 100,
-                "stone": 140
-            },
-            "id": "pass_shrine",
-            "leash_radius": 29.42,
-            "owner_id": 99,
-            "radius": 16.81,
-            "team_id": 99,
-            "waves": [
-                {
-                    "trigger": "initial",
-                    "units": {
-                        "grave_priest": 1,
-                        "skeleton_swordsman": 2
-                    }
-                }
-            ],
-            "x": 432,
-            "z": 33
-        },
-        {
             "anchor_type": "ruins",
             "awaken_on": [
                 "unit_enters_radius"
@@ -3741,7 +3715,7 @@
                 "gold": 130,
                 "wood": 90
             },
-            "id": "ford_shades",
+            "id": "ticino_marsh_dead",
             "leash_radius": 38.22,
             "owner_id": 99,
             "radius": 21.84,
@@ -3756,7 +3730,8 @@
                 }
             ],
             "x": 168,
-            "z": 473
+            "z": 473,
+            "fog_density": 0.3
         },
         {
             "anchor_type": "magic_shrine",
@@ -3767,7 +3742,7 @@
                 "gold": 110,
                 "iron": 70
             },
-            "id": "bridge_watch",
+            "id": "ticino_bridge_shades",
             "leash_radius": 35.49,
             "owner_id": 99,
             "radius": 19.11,
@@ -3781,7 +3756,8 @@
                 }
             ],
             "x": 395,
-            "z": 505
+            "z": 505,
+            "fog_density": 0.25
         }
     ],
     "victory": {
@@ -3901,48 +3877,6 @@
             "z": 302.18
         },
         {
-            "rotation": 0.6,
-            "scale": 1.2,
-            "type": "dead_tree",
-            "x": 49.92,
-            "z": 106.45
-        },
-        {
-            "rotation": 2.3000000000000003,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 73,
-            "z": 99
-        },
-        {
-            "rotation": 4.1,
-            "scale": 1.1,
-            "type": "dead_tree",
-            "x": 41.24,
-            "z": 130.49
-        },
-        {
-            "rotation": 1.4000000000000001,
-            "scale": 0.9,
-            "type": "supply_cart",
-            "x": 156.28,
-            "z": 109.88
-        },
-        {
-            "rotation": 2.1,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 183.5,
-            "z": 110.81
-        },
-        {
-            "rotation": 4.5,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 204.03,
-            "z": 127.05
-        },
-        {
             "rotation": 0.2,
             "scale": 0.75,
             "type": "supply_cart",
@@ -3950,25 +3884,11 @@
             "z": 98.24000000000001
         },
         {
-            "rotation": 2.7,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 377.88,
-            "z": 103.96
-        },
-        {
             "rotation": 5.2,
             "scale": 0.8,
             "type": "dead_tree",
             "x": 394.06,
             "z": 118.82
-        },
-        {
-            "rotation": 1.2,
-            "scale": 1.1,
-            "type": "ruins",
-            "x": 234.53,
-            "z": 231.83
         },
         {
             "rotation": 3,
@@ -4006,13 +3926,6 @@
             "z": 302.18
         },
         {
-            "rotation": 3.6,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 197.52,
-            "z": 322.78000000000003
-        },
-        {
             "rotation": 4.1,
             "scale": 0.9,
             "type": "weapon_rack",
@@ -4032,20 +3945,6 @@
             "type": "supply_cart",
             "x": 382.37,
             "z": 240.69
-        },
-        {
-            "rotation": 1.6,
-            "scale": 0.9,
-            "type": "supply_cart",
-            "x": 185.01,
-            "z": 350.81
-        },
-        {
-            "rotation": 0.8,
-            "scale": 0.9,
-            "type": "supply_cart",
-            "x": 238.19,
-            "z": 358.13
         },
         {
             "rotation": 2.5,
@@ -4090,13 +3989,6 @@
             "z": 141.59
         },
         {
-            "rotation": 1,
-            "scale": 0.9,
-            "type": "supply_cart",
-            "x": 468.84000000000003,
-            "z": 147.66
-        },
-        {
             "rotation": 3.9,
             "scale": 0.8,
             "type": "weapon_rack",
@@ -4109,13 +4001,6 @@
             "type": "tent",
             "x": 452,
             "z": 191
-        },
-        {
-            "rotation": 2.6,
-            "scale": 1,
-            "type": "tent",
-            "x": 470,
-            "z": 243
         },
         {
             "rotation": 4,
@@ -4209,34 +4094,11 @@
             "z": 365
         },
         {
-            "rotation": 4,
-            "scale": 0.9,
-            "type": "tent",
-            "x": 581.71,
-            "z": 360.56
-        },
-        {
-            "rotation": 2.3000000000000003,
-            "scale": 1,
-            "type": "supply_cart",
-            "x": 564.35,
-            "z": 398.33
-        },
-        {
             "rotation": 5.1000000000000005,
             "scale": 0.9,
             "type": "weapon_rack",
             "x": 540.47,
             "z": 381.16
-        },
-        {
-            "intensity": 1,
-            "persistent": true,
-            "radius": 3,
-            "scale": 0.9,
-            "type": "firecamp",
-            "x": 564.35,
-            "z": 374.29
         },
         {
             "intensity": 1.1500000000000001,
@@ -4413,13 +4275,6 @@
             "z": 260.88
         },
         {
-            "rotation": 304.5,
-            "scale": 1.11,
-            "type": "tent",
-            "x": 584.25,
-            "z": 109.33
-        },
-        {
             "intensity": 1.32,
             "persistent": true,
             "radius": 2.8000000000000003,
@@ -4526,13 +4381,6 @@
             "z": 247.69
         },
         {
-            "rotation": 145.4,
-            "scale": 1.09,
-            "type": "tent",
-            "x": 597.96,
-            "z": 115.9
-        },
-        {
             "rotation": 149.3,
             "scale": 1,
             "type": "supply_cart",
@@ -4547,13 +4395,6 @@
             "type": "firecamp",
             "x": 422.09000000000003,
             "z": 381.39
-        },
-        {
-            "rotation": 156.8,
-            "scale": 0.98,
-            "type": "tent",
-            "x": 558.4300000000001,
-            "z": 106.95
         },
         {
             "rotation": 144.3,
@@ -4607,15 +4448,6 @@
             "type": "supply_cart",
             "x": 98.31,
             "z": 309.84000000000003
-        },
-        {
-            "intensity": 0.87,
-            "persistent": true,
-            "radius": 3,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 337.34000000000003,
-            "z": 329.35
         },
         {
             "rotation": 21.8,
@@ -4703,13 +4535,6 @@
             "z": 457.05
         },
         {
-            "rotation": 355,
-            "scale": 0.87,
-            "type": "dead_tree",
-            "x": 588.28,
-            "z": 484.06
-        },
-        {
             "rotation": 304.5,
             "scale": 0.97,
             "type": "ruins",
@@ -4717,39 +4542,11 @@
             "z": 469.3
         },
         {
-            "rotation": 327.90000000000003,
-            "scale": 0.93,
-            "type": "dead_tree",
-            "x": 31.310000000000002,
-            "z": 538.05
-        },
-        {
             "rotation": 358.40000000000003,
             "scale": 1.1,
             "type": "ruins",
             "x": 451.25,
             "z": 476.5
-        },
-        {
-            "rotation": 26,
-            "scale": 1.11,
-            "type": "dead_tree",
-            "x": 358.09000000000003,
-            "z": 511.36
-        },
-        {
-            "rotation": 198.5,
-            "scale": 1.07,
-            "type": "dead_tree",
-            "x": 52.370000000000005,
-            "z": 519.5
-        },
-        {
-            "rotation": 342.6,
-            "scale": 1.06,
-            "type": "dead_tree",
-            "x": 224.91,
-            "z": 314.84000000000003
         },
         {
             "rotation": 16,
@@ -4857,13 +4654,6 @@
             "z": 304.22
         },
         {
-            "rotation": 319.6,
-            "scale": 1.12,
-            "type": "abandoned_home",
-            "x": 216.99,
-            "z": 404.88
-        },
-        {
             "rotation": 213.20000000000002,
             "scale": 1.08,
             "type": "abandoned_home",
@@ -4899,13 +4689,6 @@
             "z": 272.07
         },
         {
-            "rotation": 61.9,
-            "scale": 1.11,
-            "type": "abandoned_home",
-            "x": 545.49,
-            "z": 282.99
-        },
-        {
             "rotation": 188.1,
             "scale": 1,
             "type": "abandoned_home",
@@ -4932,20 +4715,6 @@
             "type": "abandoned_home",
             "x": 521.21,
             "z": 380.08
-        },
-        {
-            "rotation": 215.6,
-            "scale": 0.97,
-            "type": "abandoned_home",
-            "x": 278.40000000000003,
-            "z": 238.45000000000002
-        },
-        {
-            "rotation": 311,
-            "scale": 1.1,
-            "type": "abandoned_home",
-            "x": 56.85,
-            "z": 187.64000000000001
         },
         {
             "rotation": 318.5,
@@ -5535,6 +5304,1687 @@
             "type": "cursed_gold_vein",
             "x": 582,
             "z": 292
+        },
+        {
+            "type": "boulder",
+            "x": 486.71,
+            "z": 338.06,
+            "scale": 1.25,
+            "rotation": 3.187,
+            "dressing": "ticino_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 485.47,
+            "z": 345.33,
+            "scale": 0.86,
+            "rotation": 1.525,
+            "dressing": "ticino_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 471.08,
+            "z": 320.73,
+            "scale": 0.93,
+            "rotation": 5.748,
+            "dressing": "ticino_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 470.96,
+            "z": 325.67,
+            "scale": 0.91,
+            "rotation": 3.465,
+            "dressing": "ticino_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 467.95,
+            "z": 329.39,
+            "scale": 1.07,
+            "rotation": 3.264,
+            "dressing": "ticino_ford"
+        },
+        {
+            "type": "plant",
+            "x": 469.21,
+            "z": 327.29,
+            "scale": 1.04,
+            "rotation": 1.961,
+            "dressing": "ticino_ford"
+        },
+        {
+            "type": "dead_tree",
+            "x": 467.74,
+            "z": 323.13,
+            "scale": 1.0,
+            "rotation": 3.603,
+            "dressing": "ticino_ford"
+        },
+        {
+            "type": "ruins",
+            "x": 485.02,
+            "z": 353.52,
+            "scale": 0.8,
+            "rotation": 4.886,
+            "dressing": "ticino_ford"
+        },
+        {
+            "type": "plant",
+            "x": 522.57,
+            "z": 226.51,
+            "scale": 1.01,
+            "rotation": 2.969,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 554.08,
+            "z": 236.98,
+            "scale": 1.02,
+            "rotation": 1.527,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 544.15,
+            "z": 265.59,
+            "scale": 1.14,
+            "rotation": 0.868,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 542.82,
+            "z": 270.38,
+            "scale": 1.01,
+            "rotation": 5.748,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 576.18,
+            "z": 277.87,
+            "scale": 1.03,
+            "rotation": 1.713,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 560.69,
+            "z": 305.11,
+            "scale": 0.81,
+            "rotation": 5.463,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 558.59,
+            "z": 309.45,
+            "scale": 1.02,
+            "rotation": 5.52,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 578.49,
+            "z": 335.04,
+            "scale": 1.27,
+            "rotation": 6.082,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 542.96,
+            "z": 333.84,
+            "scale": 0.85,
+            "rotation": 5.74,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 540.86,
+            "z": 336.07,
+            "scale": 1.19,
+            "rotation": 5.055,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 544.24,
+            "z": 363.31,
+            "scale": 0.86,
+            "rotation": 1.035,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 513.04,
+            "z": 354.47,
+            "scale": 1.12,
+            "rotation": 0.088,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 510.73,
+            "z": 354.41,
+            "scale": 1.28,
+            "rotation": 3.741,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 515.75,
+            "z": 387.89,
+            "scale": 0.97,
+            "rotation": 3.939,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 485.77,
+            "z": 376.15,
+            "scale": 0.86,
+            "rotation": 5.76,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "plant",
+            "x": 483.36,
+            "z": 375.97,
+            "scale": 0.98,
+            "rotation": 4.081,
+            "dressing": "ticino_ford_bank"
+        },
+        {
+            "type": "firecamp",
+            "x": 358.81,
+            "z": 223.82,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_insubres_fort",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 363.87,
+            "z": 232.52,
+            "scale": 1.0,
+            "rotation": 2.953,
+            "dressing": "ticino_insubres_fort"
+        },
+        {
+            "type": "dead_tree",
+            "x": 356.78,
+            "z": 230.08,
+            "scale": 1.0,
+            "rotation": 2.596,
+            "dressing": "ticino_insubres_fort"
+        },
+        {
+            "type": "boulder",
+            "x": 320.27,
+            "z": 237.13,
+            "scale": 1.36,
+            "rotation": 3.14,
+            "dressing": "ticino_insubres_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 314.27,
+            "z": 239.13,
+            "scale": 1.25,
+            "rotation": 5.086,
+            "dressing": "ticino_insubres_ramp_w"
+        },
+        {
+            "type": "dead_tree",
+            "x": 328.27,
+            "z": 241.13,
+            "scale": 1.0,
+            "rotation": 1.816,
+            "dressing": "ticino_insubres_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 320.27,
+            "z": 216.13,
+            "scale": 1.5,
+            "rotation": 6.22,
+            "dressing": "ticino_insubres_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 314.27,
+            "z": 214.13,
+            "scale": 1.3,
+            "rotation": 3.267,
+            "dressing": "ticino_insubres_ramp_w"
+        },
+        {
+            "type": "statue",
+            "x": 310.27,
+            "z": 215.13,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "ticino_insubres_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 398.87,
+            "z": 210.96,
+            "scale": 1.37,
+            "rotation": 2.97,
+            "dressing": "ticino_insubres_ramp_e"
+        },
+        {
+            "type": "boulder",
+            "x": 404.56,
+            "z": 208.2,
+            "scale": 1.3,
+            "rotation": 0.221,
+            "dressing": "ticino_insubres_ramp_e"
+        },
+        {
+            "type": "dead_tree",
+            "x": 390.42,
+            "z": 208.04,
+            "scale": 1.0,
+            "rotation": 4.01,
+            "dressing": "ticino_insubres_ramp_e"
+        },
+        {
+            "type": "boulder",
+            "x": 401.61,
+            "z": 231.78,
+            "scale": 1.29,
+            "rotation": 4.465,
+            "dressing": "ticino_insubres_ramp_e"
+        },
+        {
+            "type": "boulder",
+            "x": 407.82,
+            "z": 232.98,
+            "scale": 1.31,
+            "rotation": 0.173,
+            "dressing": "ticino_insubres_ramp_e"
+        },
+        {
+            "type": "ruins",
+            "x": 179.68,
+            "z": 470.11,
+            "scale": 0.82,
+            "rotation": 5.896,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 174.07,
+            "z": 483.41,
+            "scale": 1.14,
+            "rotation": 4.215,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 164.22,
+            "z": 482.4,
+            "scale": 1.15,
+            "rotation": 0.893,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 156.59,
+            "z": 475.7,
+            "scale": 0.84,
+            "rotation": 1.115,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 154.53,
+            "z": 469.09,
+            "scale": 0.84,
+            "rotation": 3.9,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 166.16,
+            "z": 461.41,
+            "scale": 0.96,
+            "rotation": 5.417,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 174.29,
+            "z": 465.62,
+            "scale": 0.98,
+            "rotation": 0.956,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 177.26,
+            "z": 489.27,
+            "scale": 0.98,
+            "rotation": 1.417,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 155.04,
+            "z": 484.36,
+            "scale": 1.01,
+            "rotation": 2.532,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 157.47,
+            "z": 460.6,
+            "scale": 0.9,
+            "rotation": 4.652,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 177.12,
+            "z": 456.74,
+            "scale": 0.99,
+            "rotation": 3.062,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 181.3,
+            "z": 485.87,
+            "scale": 1.03,
+            "rotation": 4.267,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 161.53,
+            "z": 488.81,
+            "scale": 1.13,
+            "rotation": 2.851,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 175.81,
+            "z": 472.52,
+            "scale": 0.9,
+            "rotation": 5.422,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 159.24,
+            "z": 469.08,
+            "scale": 0.9,
+            "rotation": 1.775,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 161.43,
+            "z": 462.22,
+            "scale": 0.9,
+            "rotation": 0.596,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 168.27,
+            "z": 487.84,
+            "scale": 1.28,
+            "rotation": 0.169,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 182.64,
+            "z": 473.49,
+            "scale": 1.0,
+            "rotation": 4.789,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 168.0,
+            "z": 473.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_marsh_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 142.35,
+            "z": 504.46,
+            "scale": 0.91,
+            "rotation": 5.633,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 145.31,
+            "z": 495.8,
+            "scale": 1.09,
+            "rotation": 1.984,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 147.32,
+            "z": 507.88,
+            "scale": 0.87,
+            "rotation": 0.747,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 145.51,
+            "z": 490.5,
+            "scale": 0.85,
+            "rotation": 3.908,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 132.37,
+            "z": 493.08,
+            "scale": 0.9,
+            "rotation": 2.926,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 148.58,
+            "z": 499.53,
+            "scale": 0.94,
+            "rotation": 4.652,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 134.79,
+            "z": 497.33,
+            "scale": 1.02,
+            "rotation": 3.947,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 130.04,
+            "z": 500.41,
+            "scale": 0.92,
+            "rotation": 3.248,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 137.83,
+            "z": 491.31,
+            "scale": 0.82,
+            "rotation": 2.677,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 128.84,
+            "z": 492.08,
+            "scale": 0.84,
+            "rotation": 5.818,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 149.78,
+            "z": 510.5,
+            "scale": 1.03,
+            "rotation": 1.878,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 127.73,
+            "z": 494.57,
+            "scale": 1.09,
+            "rotation": 1.353,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 132.72,
+            "z": 502.59,
+            "scale": 0.84,
+            "rotation": 4.189,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 145.17,
+            "z": 510.84,
+            "scale": 0.74,
+            "rotation": 6.15,
+            "dressing": "ticino_marsh_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 402.84,
+            "z": 506.78,
+            "scale": 1.12,
+            "rotation": 4.239,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 398.54,
+            "z": 513.47,
+            "scale": 1.03,
+            "rotation": 3.718,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 387.62,
+            "z": 508.3,
+            "scale": 1.17,
+            "rotation": 1.714,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 388.17,
+            "z": 498.56,
+            "scale": 0.86,
+            "rotation": 4.882,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 396.9,
+            "z": 494.97,
+            "scale": 1.2,
+            "rotation": 5.455,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 404.51,
+            "z": 517.46,
+            "scale": 1.13,
+            "rotation": 5.526,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 382.02,
+            "z": 512.27,
+            "scale": 0.91,
+            "rotation": 1.04,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 387.59,
+            "z": 491.15,
+            "scale": 0.94,
+            "rotation": 4.226,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 409.26,
+            "z": 498.35,
+            "scale": 1.13,
+            "rotation": 2.913,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 401.54,
+            "z": 501.39,
+            "scale": 0.9,
+            "rotation": 1.403,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 391.02,
+            "z": 493.26,
+            "scale": 0.99,
+            "rotation": 2.625,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 408.27,
+            "z": 505.14,
+            "scale": 1.22,
+            "rotation": 3.512,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 395.0,
+            "z": 505.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_bridge_barrows"
+        },
+        {
+            "type": "olive_tree",
+            "x": 305.53,
+            "z": 282.74,
+            "scale": 1.04,
+            "rotation": 1.621,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 304.51,
+            "z": 296.15,
+            "scale": 0.97,
+            "rotation": 5.458,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 316.47,
+            "z": 283.79,
+            "scale": 0.99,
+            "rotation": 4.262,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 315.07,
+            "z": 297.33,
+            "scale": 1.01,
+            "rotation": 5.067,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 327.91,
+            "z": 284.99,
+            "scale": 1.07,
+            "rotation": 3.255,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 326.62,
+            "z": 298.65,
+            "scale": 1.03,
+            "rotation": 4.735,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 339.16,
+            "z": 285.49,
+            "scale": 1.05,
+            "rotation": 0.486,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 337.34,
+            "z": 298.6,
+            "scale": 0.93,
+            "rotation": 5.588,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 349.13,
+            "z": 286.78,
+            "scale": 1.09,
+            "rotation": 2.682,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 348.02,
+            "z": 299.35,
+            "scale": 0.97,
+            "rotation": 4.583,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 371.76,
+            "z": 289.08,
+            "scale": 1.07,
+            "rotation": 5.096,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 370.87,
+            "z": 301.31,
+            "scale": 1.01,
+            "rotation": 5.22,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 382.78,
+            "z": 289.94,
+            "scale": 0.91,
+            "rotation": 4.546,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 380.99,
+            "z": 302.17,
+            "scale": 1.09,
+            "rotation": 1.956,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 393.99,
+            "z": 289.81,
+            "scale": 0.94,
+            "rotation": 6.1,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "olive_tree",
+            "x": 392.89,
+            "z": 304.09,
+            "scale": 0.98,
+            "rotation": 5.262,
+            "dressing": "ticino_via_avenue"
+        },
+        {
+            "type": "boulder",
+            "x": 520.59,
+            "z": 222.09,
+            "scale": 1.08,
+            "rotation": 4.168,
+            "dressing": "ticino_north_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 530.15,
+            "z": 234.43,
+            "scale": 1.23,
+            "rotation": 5.261,
+            "dressing": "ticino_north_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 528.01,
+            "z": 237.56,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_north_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 513.94,
+            "z": 225.01,
+            "scale": 1.0,
+            "rotation": 0.226,
+            "dressing": "ticino_north_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 524.77,
+            "z": 241.49,
+            "scale": 1.0,
+            "rotation": 2.515,
+            "dressing": "ticino_north_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 537.57,
+            "z": 208.11,
+            "scale": 1.0,
+            "rotation": 0.509,
+            "dressing": "ticino_north_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 546.82,
+            "z": 219.48,
+            "scale": 0.85,
+            "rotation": 3.934,
+            "dressing": "ticino_north_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 539.23,
+            "z": 203.81,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_north_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 552.11,
+            "z": 216.18,
+            "scale": 1.0,
+            "rotation": 3.32,
+            "dressing": "ticino_north_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 415.95,
+            "z": 77.84,
+            "scale": 1.14,
+            "rotation": 5.333,
+            "dressing": "ticino_road_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 402.06,
+            "z": 78.02,
+            "scale": 1.14,
+            "rotation": 0.356,
+            "dressing": "ticino_road_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 399.37,
+            "z": 74.05,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_road_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 417.83,
+            "z": 70.82,
+            "scale": 1.0,
+            "rotation": 1.943,
+            "dressing": "ticino_road_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 398.31,
+            "z": 69.06,
+            "scale": 1.0,
+            "rotation": -1.652,
+            "dressing": "ticino_road_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 402.22,
+            "z": 90.78,
+            "scale": 0.87,
+            "rotation": 2.384,
+            "dressing": "ticino_road_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 417.76,
+            "z": 97.86,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_road_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 398.45,
+            "z": 96.27,
+            "scale": 1.0,
+            "rotation": 1.337,
+            "dressing": "ticino_road_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 345.53,
+            "z": 414.82,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 362.59,
+            "z": 416.02,
+            "scale": 1.0,
+            "rotation": 1.735,
+            "dressing": "ticino_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 360.04,
+            "z": 434.39,
+            "scale": 1.24,
+            "rotation": 0.285,
+            "dressing": "ticino_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 345.93,
+            "z": 432.77,
+            "scale": 1.29,
+            "rotation": 2.311,
+            "dressing": "ticino_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 361.7,
+            "z": 438.61,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 342.05,
+            "z": 438.73,
+            "scale": 1.0,
+            "rotation": 2.684,
+            "dressing": "ticino_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 220.57,
+            "z": 92.86,
+            "scale": 1.2,
+            "rotation": 5.592,
+            "dressing": "ticino_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 237.65,
+            "z": 97.77,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_west_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 218.76,
+            "z": 99.88,
+            "scale": 1.0,
+            "rotation": 0.756,
+            "dressing": "ticino_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 220.21,
+            "z": 80.1,
+            "scale": 1.22,
+            "rotation": 1.809,
+            "dressing": "ticino_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 234.7,
+            "z": 79.92,
+            "scale": 0.98,
+            "rotation": 3.963,
+            "dressing": "ticino_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 217.96,
+            "z": 76.13,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_west_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 236.42,
+            "z": 72.9,
+            "scale": 1.0,
+            "rotation": 0.24,
+            "dressing": "ticino_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 138.99,
+            "z": 281.55,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_camp_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "supply_cart",
+            "x": 145.06,
+            "z": 283.12,
+            "scale": 1.0,
+            "rotation": -0.494,
+            "dressing": "ticino_camp_junction"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 135.48,
+            "z": 284.45,
+            "scale": 1.0,
+            "rotation": -0.494,
+            "dressing": "ticino_camp_junction"
+        },
+        {
+            "type": "statue",
+            "x": 592.0,
+            "z": 237.5,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "ticino_reserve_junction"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 592.0,
+            "z": 243.5,
+            "scale": 1.0,
+            "rotation": 3.413,
+            "dressing": "ticino_reserve_junction"
+        },
+        {
+            "type": "statue",
+            "x": 253.09,
+            "z": 20.86,
+            "scale": 1.0,
+            "rotation": 1.736,
+            "dressing": "ticino_north_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 244.12,
+            "z": 19.5,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_north_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "ruins",
+            "x": 257.32,
+            "z": 19.6,
+            "scale": 0.8,
+            "rotation": 0.458,
+            "dressing": "ticino_north_junction"
+        },
+        {
+            "type": "boulder",
+            "x": 472.14,
+            "z": 36.19,
+            "scale": 0.93,
+            "rotation": 2.31,
+            "dressing": "ticino_river_bank"
+        },
+        {
+            "type": "plant",
+            "x": 486.47,
+            "z": 66.12,
+            "scale": 0.95,
+            "rotation": 1.358,
+            "dressing": "ticino_river_bank"
+        },
+        {
+            "type": "plant",
+            "x": 488.81,
+            "z": 66.79,
+            "scale": 1.11,
+            "rotation": 4.262,
+            "dressing": "ticino_river_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 471.02,
+            "z": 104.77,
+            "scale": 1.2,
+            "rotation": 4.409,
+            "dressing": "ticino_river_bank"
+        },
+        {
+            "type": "plant",
+            "x": 508.97,
+            "z": 126.0,
+            "scale": 1.06,
+            "rotation": 5.578,
+            "dressing": "ticino_river_bank"
+        },
+        {
+            "type": "plant",
+            "x": 511.2,
+            "z": 127.58,
+            "scale": 1.23,
+            "rotation": 4.735,
+            "dressing": "ticino_river_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 491.5,
+            "z": 165.77,
+            "scale": 0.84,
+            "rotation": 1.999,
+            "dressing": "ticino_river_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 521.49,
+            "z": 190.2,
+            "scale": 0.85,
+            "rotation": 2.983,
+            "dressing": "ticino_river_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 473.39,
+            "z": 434.97,
+            "scale": 1.19,
+            "rotation": 5.72,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "plant",
+            "x": 495.17,
+            "z": 470.79,
+            "scale": 1.25,
+            "rotation": 3.403,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "plant",
+            "x": 495.73,
+            "z": 474.32,
+            "scale": 1.39,
+            "rotation": 1.729,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "dead_tree",
+            "x": 468.24,
+            "z": 504.83,
+            "scale": 1.12,
+            "rotation": 5.467,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "plant",
+            "x": 496.06,
+            "z": 536.02,
+            "scale": 0.96,
+            "rotation": 1.581,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "plant",
+            "x": 497.54,
+            "z": 538.09,
+            "scale": 1.17,
+            "rotation": 5.98,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "boulder",
+            "x": 479.35,
+            "z": 573.69,
+            "scale": 1.08,
+            "rotation": 3.484,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "boulder",
+            "x": 501.64,
+            "z": 607.6,
+            "scale": 0.87,
+            "rotation": 5.122,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "plant",
+            "x": 473.9,
+            "z": 636.82,
+            "scale": 1.02,
+            "rotation": 1.033,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "plant",
+            "x": 473.04,
+            "z": 641.39,
+            "scale": 1.31,
+            "rotation": 1.88,
+            "dressing": "ticino_river_bank_s"
+        },
+        {
+            "type": "firecamp",
+            "x": 612.7,
+            "z": 135.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 623.3,
+            "z": 135.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 624.3,
+            "z": 131.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "ticino_gate_1"
+        },
+        {
+            "type": "supply_cart",
+            "x": 611.2,
+            "z": 129.0,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "ticino_gate_1"
+        },
+        {
+            "type": "statue",
+            "x": 611.7,
+            "z": 124.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_gate_1"
+        },
+        {
+            "type": "statue",
+            "x": 624.3,
+            "z": 124.0,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "ticino_gate_1"
+        },
+        {
+            "type": "firecamp",
+            "x": 616.83,
+            "z": 199.28,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 603.98,
+            "z": 198.82,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 602.17,
+            "z": 206.72,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "ticino_gate_2"
+        },
+        {
+            "type": "supply_cart",
+            "x": 620.08,
+            "z": 206.11,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "ticino_gate_2"
+        },
+        {
+            "type": "statue",
+            "x": 603.7,
+            "z": 212.0,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "ticino_gate_2"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 476.28,
+            "z": 287.11,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_gate_3"
+        },
+        {
+            "type": "statue",
+            "x": 480.43,
+            "z": 289.12,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "ticino_gate_3"
+        },
+        {
+            "type": "firecamp",
+            "x": 421.0,
+            "z": 335.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 411.0,
+            "z": 335.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "ticino_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 410.0,
+            "z": 339.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "ticino_gate_4"
+        },
+        {
+            "type": "supply_cart",
+            "x": 422.5,
+            "z": 341.0,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "ticino_gate_4"
+        },
+        {
+            "type": "statue",
+            "x": 422.0,
+            "z": 346.0,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "ticino_gate_4"
+        },
+        {
+            "type": "statue",
+            "x": 410.0,
+            "z": 346.0,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "ticino_gate_4"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 388.19,
+            "z": 291.08,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "ticino_gate_5"
+        },
+        {
+            "type": "supply_cart",
+            "x": 385.89,
+            "z": 308.88,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "ticino_gate_5"
+        },
+        {
+            "type": "statue",
+            "x": 380.89,
+            "z": 308.38,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "ticino_gate_5"
+        }
+    ],
+    "dressing": [
+        {
+            "id": "ticino_ford",
+            "kind": "ford_wreck",
+            "x": 484,
+            "z": 330,
+            "boulders": 4,
+            "plants": 4
+        },
+        {
+            "id": "ticino_ford_bank",
+            "kind": "riverbank",
+            "from": [
+                483,
+                250
+            ],
+            "to": [
+                486,
+                400
+            ],
+            "spacing": 22,
+            "kinds": [
+                "plant",
+                "boulder",
+                "plant",
+                "dead_tree"
+            ]
+        },
+        {
+            "id": "ticino_insubres_fort",
+            "kind": "hilltop_ruin",
+            "x": 360,
+            "z": 226,
+            "facing": "south",
+            "radius": 12,
+            "ruins": 7
+        },
+        {
+            "id": "ticino_insubres_ramp_w",
+            "kind": "ramp_mouth",
+            "x": 334,
+            "z": 227,
+            "statue": true
+        },
+        {
+            "id": "ticino_insubres_ramp_e",
+            "kind": "ramp_mouth",
+            "x": 386,
+            "z": 223
+        },
+        {
+            "id": "ticino_marsh_barrows",
+            "kind": "barrow_field",
+            "x": 168,
+            "z": 473,
+            "radius": 12,
+            "shrine": true,
+            "ruins": 7,
+            "dead_trees": 6,
+            "boulders": 3
+        },
+        {
+            "id": "ticino_marsh_bones",
+            "kind": "boneyard",
+            "x": 140,
+            "z": 500,
+            "radius": 12,
+            "statues": 0,
+            "dead_trees": 8,
+            "ruins": 2
+        },
+        {
+            "id": "ticino_bridge_barrows",
+            "kind": "barrow_field",
+            "x": 395,
+            "z": 505,
+            "radius": 10,
+            "shrine": true,
+            "ruins": 5,
+            "dead_trees": 4,
+            "statues": 1
+        },
+        {
+            "id": "ticino_via_avenue",
+            "kind": "tree_avenue",
+            "from": [
+                300,
+                286
+            ],
+            "to": [
+                400,
+                297
+            ],
+            "tree": "olive_tree",
+            "spacing": 11
+        },
+        {
+            "id": "ticino_north_bridge",
+            "kind": "bridgehead",
+            "x": 533,
+            "z": 220
+        },
+        {
+            "id": "ticino_road_bridge",
+            "kind": "bridgehead",
+            "x": 409,
+            "z": 84
+        },
+        {
+            "id": "ticino_south_bridge",
+            "kind": "bridgehead",
+            "x": 353,
+            "z": 428,
+            "cart": false
+        },
+        {
+            "id": "ticino_west_bridge",
+            "kind": "bridgehead",
+            "x": 227,
+            "z": 86,
+            "cart": false
+        },
+        {
+            "id": "ticino_camp_junction",
+            "kind": "junction",
+            "x": 136,
+            "z": 276,
+            "style": "camp"
+        },
+        {
+            "id": "ticino_reserve_junction",
+            "kind": "junction",
+            "x": 592,
+            "z": 232,
+            "style": "milestone",
+            "tree": "cypress_tree"
+        },
+        {
+            "id": "ticino_north_junction",
+            "kind": "junction",
+            "x": 262,
+            "z": 12,
+            "style": "shrine"
+        },
+        {
+            "id": "ticino_river_bank",
+            "kind": "riverbank",
+            "from": [
+                483,
+                20
+            ],
+            "to": [
+                483,
+                230
+            ],
+            "spacing": 34
+        },
+        {
+            "id": "ticino_river_bank_s",
+            "kind": "riverbank",
+            "from": [
+                486,
+                420
+            ],
+            "to": [
+                486,
+                640
+            ],
+            "spacing": 34
+        },
+        {
+            "id": "ticino_gate_1",
+            "kind": "gate_approach",
+            "x": 618.0,
+            "z": 144.0,
+            "statues": true
+        },
+        {
+            "id": "ticino_gate_2",
+            "kind": "gate_approach",
+            "x": 610.0,
+            "z": 192.0,
+            "statues": true
+        },
+        {
+            "id": "ticino_gate_3",
+            "kind": "gate_approach",
+            "x": 460,
+            "z": 282,
+            "statues": true
+        },
+        {
+            "id": "ticino_gate_4",
+            "kind": "gate_approach",
+            "x": 416,
+            "z": 326,
+            "statues": true
+        },
+        {
+            "id": "ticino_gate_5",
+            "kind": "gate_approach",
+            "x": 400,
+            "z": 298,
+            "statues": true
         }
     ]
 }

--- a/assets/maps/map_battle_trasimene.json
+++ b/assets/maps/map_battle_trasimene.json
@@ -3256,7 +3256,7 @@
                 "food": 120,
                 "gold": 150
             },
-            "id": "frozen_dead",
+            "id": "trasimene_drowned_dead",
             "leash_radius": 43,
             "owner_id": 99,
             "radius": 24.19,
@@ -3277,7 +3277,8 @@
                 }
             ],
             "x": 64,
-            "z": 322
+            "z": 322,
+            "fog_density": 0.3
         },
         {
             "anchor_type": "magic_shrine",
@@ -3288,7 +3289,7 @@
                 "gold": 160,
                 "iron": 60
             },
-            "id": "lake_altar",
+            "id": "trasimene_lake_altar",
             "leash_radius": 22,
             "owner_id": 99,
             "radius": 10,
@@ -3303,7 +3304,8 @@
                 }
             ],
             "x": 625,
-            "z": 321
+            "z": 321,
+            "fog_density": 0.25
         }
     ],
     "victory": {
@@ -3454,27 +3456,6 @@
             "z": 232
         },
         {
-            "rotation": 2.9,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 145,
-            "z": 407
-        },
-        {
-            "rotation": 4.8,
-            "scale": 1.1,
-            "type": "dead_tree",
-            "x": 300.08,
-            "z": 224.72
-        },
-        {
-            "rotation": 0.7000000000000001,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 343.38,
-            "z": 431.03
-        },
-        {
             "rotation": 5.1000000000000005,
             "scale": 0.9,
             "type": "dead_tree",
@@ -3487,13 +3468,6 @@
             "type": "dead_tree",
             "x": 535,
             "z": 415
-        },
-        {
-            "rotation": 0.8,
-            "scale": 1.1,
-            "type": "ruins",
-            "x": 615,
-            "z": 350
         },
         {
             "rotation": 2.4,
@@ -3587,15 +3561,6 @@
             "z": 553.4
         },
         {
-            "intensity": 0.97,
-            "persistent": true,
-            "radius": 3.2,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 102.34,
-            "z": 263.08
-        },
-        {
             "rotation": 332.1,
             "scale": 0.98,
             "type": "supply_cart",
@@ -3619,25 +3584,11 @@
             "z": 110.26
         },
         {
-            "rotation": 33.2,
-            "scale": 0.96,
-            "type": "weapon_rack",
-            "x": 632.45,
-            "z": 180.23
-        },
-        {
             "rotation": 178.5,
             "scale": 1.12,
             "type": "supply_cart",
             "x": 232.94,
             "z": 540.94
-        },
-        {
-            "rotation": 82.10000000000001,
-            "scale": 1.06,
-            "type": "weapon_rack",
-            "x": 87.33,
-            "z": 96.18
         },
         {
             "rotation": 77.7,
@@ -3665,27 +3616,11 @@
             "z": 121.14
         },
         {
-            "rotation": 7.1000000000000005,
-            "scale": 0.89,
-            "type": "tent",
-            "x": 531.04,
-            "z": 113.87
-        },
-        {
             "rotation": 263.4,
             "scale": 0.96,
             "type": "weapon_rack",
             "x": 288.72,
             "z": 499.08
-        },
-        {
-            "intensity": 1.07,
-            "persistent": true,
-            "radius": 3.6,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 143,
-            "z": 236.07
         },
         {
             "intensity": 0.9,
@@ -3704,13 +3639,6 @@
             "z": 517.21
         },
         {
-            "rotation": 92.7,
-            "scale": 0.92,
-            "type": "tent",
-            "x": 159.07,
-            "z": 211.9
-        },
-        {
             "intensity": 1.19,
             "persistent": true,
             "radius": 3.1,
@@ -3725,20 +3653,6 @@
             "type": "weapon_rack",
             "x": 248.02,
             "z": 567.79
-        },
-        {
-            "rotation": 127.5,
-            "scale": 0.89,
-            "type": "tent",
-            "x": 26.07,
-            "z": 110.79
-        },
-        {
-            "rotation": 74,
-            "scale": 1.16,
-            "type": "tent",
-            "x": 599.09,
-            "z": 205.04
         },
         {
             "intensity": 1.07,
@@ -3815,13 +3729,6 @@
             "z": 535.71
         },
         {
-            "rotation": 54.5,
-            "scale": 1.1400000000000001,
-            "type": "supply_cart",
-            "x": 35.49,
-            "z": 90.86
-        },
-        {
             "intensity": 1.34,
             "persistent": true,
             "radius": 2.8000000000000003,
@@ -3886,13 +3793,6 @@
             "z": 551.89
         },
         {
-            "rotation": 355.1,
-            "scale": 0.86,
-            "type": "tent",
-            "x": 77.56,
-            "z": 271.45
-        },
-        {
             "rotation": 343.1,
             "scale": 1.08,
             "type": "tent",
@@ -3928,13 +3828,6 @@
             "type": "firecamp",
             "x": 228.34,
             "z": 566.23
-        },
-        {
-            "rotation": 154,
-            "scale": 1.11,
-            "type": "tent",
-            "x": 55.01,
-            "z": 270.63
         },
         {
             "rotation": 343.40000000000003,
@@ -3974,13 +3867,6 @@
             "type": "firecamp",
             "x": 301.79,
             "z": 602.16
-        },
-        {
-            "rotation": 293.8,
-            "scale": 1.03,
-            "type": "tent",
-            "x": 30.150000000000002,
-            "z": 259.63
         },
         {
             "rotation": 313.2,
@@ -4050,15 +3936,6 @@
             "z": 463.64
         },
         {
-            "intensity": 1.2,
-            "persistent": true,
-            "radius": 3.5,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 172.26,
-            "z": 268.48
-        },
-        {
             "intensity": 1.29,
             "persistent": true,
             "radius": 3,
@@ -4105,20 +3982,6 @@
             "type": "supply_cart",
             "x": 213.32,
             "z": 147.75
-        },
-        {
-            "rotation": 50.4,
-            "scale": 0.96,
-            "type": "supply_cart",
-            "x": 168.82,
-            "z": 322.22
-        },
-        {
-            "rotation": 297,
-            "scale": 0.97,
-            "type": "dead_tree",
-            "x": 407.56,
-            "z": 205.03
         },
         {
             "rotation": 12.9,
@@ -4191,39 +4054,11 @@
             "z": 303.79
         },
         {
-            "rotation": 274.40000000000003,
-            "scale": 0.92,
-            "type": "dead_tree",
-            "x": 388,
-            "z": 303
-        },
-        {
             "rotation": 12.4,
             "scale": 0.97,
             "type": "ruins",
             "x": 116.94,
             "z": 312.35
-        },
-        {
-            "rotation": 255.4,
-            "scale": 0.9500000000000001,
-            "type": "dead_tree",
-            "x": 581.74,
-            "z": 423.17
-        },
-        {
-            "rotation": 142.5,
-            "scale": 1.06,
-            "type": "dead_tree",
-            "x": 27.1,
-            "z": 561.57
-        },
-        {
-            "rotation": 225.20000000000002,
-            "scale": 1.03,
-            "type": "dead_tree",
-            "x": 461.3,
-            "z": 343.72
         },
         {
             "rotation": 275.6,
@@ -4240,53 +4075,11 @@
             "z": 280.59000000000003
         },
         {
-            "rotation": 268,
-            "scale": 0.9500000000000001,
-            "type": "ruins",
-            "x": 586.99,
-            "z": 268.8
-        },
-        {
-            "rotation": 164.9,
-            "scale": 1.06,
-            "type": "dead_tree",
-            "x": 546.97,
-            "z": 578.46
-        },
-        {
-            "rotation": 118.3,
-            "scale": 0.92,
-            "type": "dead_tree",
-            "x": 458.01,
-            "z": 113.57000000000001
-        },
-        {
             "rotation": 142.20000000000002,
             "scale": 0.91,
             "type": "dead_tree",
             "x": 268.53000000000003,
             "z": 123.29
-        },
-        {
-            "rotation": 206.9,
-            "scale": 1.12,
-            "type": "dead_tree",
-            "x": 603.72,
-            "z": 556.58
-        },
-        {
-            "rotation": 60.9,
-            "scale": 1.05,
-            "type": "ruins",
-            "x": 587.25,
-            "z": 287.89
-        },
-        {
-            "rotation": 21.7,
-            "scale": 0.87,
-            "type": "dead_tree",
-            "x": 585.28,
-            "z": 260.15
         },
         {
             "rotation": 99.5,
@@ -4301,13 +4094,6 @@
             "type": "ruins",
             "x": 212.87,
             "z": 470.72
-        },
-        {
-            "rotation": 107.7,
-            "scale": 1.1,
-            "type": "dead_tree",
-            "x": 366.35,
-            "z": 120.18
         },
         {
             "rotation": 248.20000000000002,
@@ -4394,39 +4180,11 @@
             "z": 312.22
         },
         {
-            "rotation": 101.2,
-            "scale": 1,
-            "type": "abandoned_home",
-            "x": 416.13,
-            "z": 269.7
-        },
-        {
-            "rotation": 91.10000000000001,
-            "scale": 0.96,
-            "type": "abandoned_home",
-            "x": 432.68,
-            "z": 264.47
-        },
-        {
-            "rotation": 135.4,
-            "scale": 0.98,
-            "type": "abandoned_home",
-            "x": 487.1,
-            "z": 633.57
-        },
-        {
             "rotation": 47.300000000000004,
             "scale": 1,
             "type": "abandoned_home",
             "x": 633.98,
             "z": 353.97
-        },
-        {
-            "rotation": 333,
-            "scale": 1.06,
-            "type": "abandoned_home",
-            "x": 565.62,
-            "z": 433.98
         },
         {
             "rotation": 169.3,
@@ -4929,6 +4687,1989 @@
             "type": "cursed_gold_vein",
             "x": 442,
             "z": 592
+        },
+        {
+            "type": "abandoned_home",
+            "x": 333.5,
+            "z": 130.26,
+            "scale": 1.02,
+            "rotation": -1.66,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "abandoned_home",
+            "x": 344.5,
+            "z": 133.64,
+            "scale": 1.05,
+            "rotation": -1.436,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "abandoned_home",
+            "x": 355.5,
+            "z": 132.74,
+            "scale": 0.9,
+            "rotation": -1.752,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "abandoned_home",
+            "x": 366.5,
+            "z": 132.3,
+            "scale": 0.9,
+            "rotation": -1.473,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "supply_cart",
+            "x": 345.14,
+            "z": 124.36,
+            "scale": 1.0,
+            "rotation": 0.228,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "supply_cart",
+            "x": 354.77,
+            "z": 124.81,
+            "scale": 1.0,
+            "rotation": 0.038,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "supply_cart",
+            "x": 364.0,
+            "z": 123.71,
+            "scale": 1.0,
+            "rotation": 0.355,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "ruins",
+            "x": 375.0,
+            "z": 125.0,
+            "scale": 0.85,
+            "rotation": 0.529,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "dead_tree",
+            "x": 328.0,
+            "z": 139.0,
+            "scale": 1.0,
+            "rotation": 3.397,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "firecamp",
+            "x": 350.0,
+            "z": 127.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_fishing_village",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "plant",
+            "x": 362.35,
+            "z": 117.49,
+            "scale": 1.32,
+            "rotation": 2.042,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "plant",
+            "x": 354.56,
+            "z": 118.49,
+            "scale": 1.27,
+            "rotation": 5.721,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "plant",
+            "x": 342.3,
+            "z": 117.98,
+            "scale": 0.92,
+            "rotation": 2.29,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "plant",
+            "x": 328.09,
+            "z": 118.76,
+            "scale": 1.15,
+            "rotation": 1.322,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "plant",
+            "x": 329.95,
+            "z": 117.94,
+            "scale": 1.35,
+            "rotation": 5.405,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "plant",
+            "x": 335.01,
+            "z": 117.75,
+            "scale": 1.31,
+            "rotation": 2.682,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "plant",
+            "x": 351.0,
+            "z": 119.1,
+            "scale": 1.2,
+            "rotation": 2.48,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "boulder",
+            "x": 369.63,
+            "z": 118.93,
+            "scale": 0.64,
+            "rotation": 6.039,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "boulder",
+            "x": 348.23,
+            "z": 120.41,
+            "scale": 0.66,
+            "rotation": 3.427,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "boulder",
+            "x": 364.37,
+            "z": 117.59,
+            "scale": 0.7,
+            "rotation": 4.893,
+            "dressing": "trasimene_fishing_village"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 235.74,
+            "z": 163.14,
+            "scale": 1.08,
+            "rotation": 5.307,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 244.77,
+            "z": 162.75,
+            "scale": 1.1,
+            "rotation": 0.656,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 255.3,
+            "z": 161.66,
+            "scale": 1.04,
+            "rotation": 2.296,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 265.42,
+            "z": 160.53,
+            "scale": 1.04,
+            "rotation": 5.909,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 275.41,
+            "z": 158.92,
+            "scale": 0.94,
+            "rotation": 0.101,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 284.64,
+            "z": 158.92,
+            "scale": 1.06,
+            "rotation": 2.27,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 314.53,
+            "z": 156.26,
+            "scale": 1.07,
+            "rotation": 0.375,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 325.14,
+            "z": 154.55,
+            "scale": 1.04,
+            "rotation": 5.029,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 335.37,
+            "z": 153.67,
+            "scale": 1.03,
+            "rotation": 1.368,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 345.08,
+            "z": 152.63,
+            "scale": 1.05,
+            "rotation": 3.272,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 355.26,
+            "z": 152.16,
+            "scale": 0.94,
+            "rotation": 4.222,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 365.3,
+            "z": 151.55,
+            "scale": 1.1,
+            "rotation": 5.373,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 374.51,
+            "z": 150.39,
+            "scale": 0.97,
+            "rotation": 0.754,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 384.41,
+            "z": 149.57,
+            "scale": 0.96,
+            "rotation": 2.973,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 404.29,
+            "z": 147.84,
+            "scale": 1.09,
+            "rotation": 6.21,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 412.94,
+            "z": 144.78,
+            "scale": 1.01,
+            "rotation": 0.558,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 424.06,
+            "z": 145.76,
+            "scale": 0.91,
+            "rotation": 5.923,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 434.29,
+            "z": 142.66,
+            "scale": 0.99,
+            "rotation": 3.538,
+            "dressing": "trasimene_shore_avenue"
+        },
+        {
+            "type": "statue",
+            "x": 258.87,
+            "z": 156.71,
+            "scale": 1.15,
+            "rotation": 1.571,
+            "dressing": "trasimene_malpasso"
+        },
+        {
+            "type": "boulder",
+            "x": 251.16,
+            "z": 157.54,
+            "scale": 0.91,
+            "rotation": 2.376,
+            "dressing": "trasimene_malpasso"
+        },
+        {
+            "type": "boulder",
+            "x": 256.81,
+            "z": 155.14,
+            "scale": 0.71,
+            "rotation": 0.822,
+            "dressing": "trasimene_malpasso"
+        },
+        {
+            "type": "boulder",
+            "x": 260.1,
+            "z": 154.57,
+            "scale": 0.75,
+            "rotation": 3.411,
+            "dressing": "trasimene_malpasso"
+        },
+        {
+            "type": "ruins",
+            "x": 632.44,
+            "z": 320.99,
+            "scale": 0.89,
+            "rotation": 1.35,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 628.37,
+            "z": 328.36,
+            "scale": 1.14,
+            "rotation": 4.823,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 617.75,
+            "z": 324.3,
+            "scale": 0.84,
+            "rotation": 3.564,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 619.27,
+            "z": 316.63,
+            "scale": 1.12,
+            "rotation": 6.126,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 627.27,
+            "z": 314.58,
+            "scale": 0.85,
+            "rotation": 0.78,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 634.95,
+            "z": 329.69,
+            "scale": 1.02,
+            "rotation": 3.655,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 617.47,
+            "z": 329.68,
+            "scale": 0.86,
+            "rotation": 4.409,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "statue",
+            "x": 633.27,
+            "z": 325.51,
+            "scale": 0.9,
+            "rotation": 0.044,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "statue",
+            "x": 614.66,
+            "z": 320.45,
+            "scale": 0.9,
+            "rotation": 1.407,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 621.15,
+            "z": 328.28,
+            "scale": 1.25,
+            "rotation": 5.623,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 626.61,
+            "z": 309.79,
+            "scale": 1.2,
+            "rotation": 5.907,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 629.61,
+            "z": 308.05,
+            "scale": 1.24,
+            "rotation": 1.542,
+            "dressing": "trasimene_altar_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 77.35,
+            "z": 324.53,
+            "scale": 0.85,
+            "rotation": 5.585,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 69.69,
+            "z": 331.77,
+            "scale": 1.07,
+            "rotation": 3.932,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 63.0,
+            "z": 336.36,
+            "scale": 1.11,
+            "rotation": 2.076,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 52.19,
+            "z": 328.16,
+            "scale": 1.06,
+            "rotation": 4.247,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 53.9,
+            "z": 317.75,
+            "scale": 1.19,
+            "rotation": 0.211,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 60.66,
+            "z": 311.82,
+            "scale": 0.84,
+            "rotation": 0.937,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 70.79,
+            "z": 311.63,
+            "scale": 1.03,
+            "rotation": 4.92,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 78.89,
+            "z": 334.89,
+            "scale": 0.92,
+            "rotation": 4.844,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 54.52,
+            "z": 337.47,
+            "scale": 1.01,
+            "rotation": 0.966,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 44.96,
+            "z": 313.88,
+            "scale": 0.85,
+            "rotation": 5.092,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 77.48,
+            "z": 313.17,
+            "scale": 1.1,
+            "rotation": 3.184,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 81.61,
+            "z": 338.67,
+            "scale": 0.91,
+            "rotation": 0.252,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 58.29,
+            "z": 341.34,
+            "scale": 1.06,
+            "rotation": 3.037,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 73.48,
+            "z": 327.02,
+            "scale": 0.9,
+            "rotation": 1.214,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 56.89,
+            "z": 322.96,
+            "scale": 0.9,
+            "rotation": 3.746,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 57.84,
+            "z": 334.41,
+            "scale": 1.1,
+            "rotation": 2.673,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 68.92,
+            "z": 337.66,
+            "scale": 1.25,
+            "rotation": 2.485,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 74.84,
+            "z": 333.47,
+            "scale": 0.97,
+            "rotation": 1.234,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 63.41,
+            "z": 330.29,
+            "scale": 0.93,
+            "rotation": 3.969,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 64.0,
+            "z": 322.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_drowned_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 502.4,
+            "z": 397.59,
+            "scale": 1.1,
+            "rotation": 0.0,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "firecamp",
+            "x": 504.75,
+            "z": 402.06,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_olive_grove",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "olive_tree",
+            "x": 513.57,
+            "z": 400.6,
+            "scale": 1.03,
+            "rotation": 4.265,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "olive_tree",
+            "x": 510.25,
+            "z": 409.55,
+            "scale": 0.97,
+            "rotation": 5.411,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "olive_tree",
+            "x": 493.88,
+            "z": 412.37,
+            "scale": 0.99,
+            "rotation": 4.283,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "olive_tree",
+            "x": 489.34,
+            "z": 406.4,
+            "scale": 0.97,
+            "rotation": 2.451,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "olive_tree",
+            "x": 486.14,
+            "z": 401.53,
+            "scale": 1.05,
+            "rotation": 1.285,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "olive_tree",
+            "x": 488.13,
+            "z": 394.27,
+            "scale": 1.01,
+            "rotation": 3.679,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "olive_tree",
+            "x": 497.35,
+            "z": 384.88,
+            "scale": 0.99,
+            "rotation": 0.535,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "olive_tree",
+            "x": 502.86,
+            "z": 387.58,
+            "scale": 1.08,
+            "rotation": 0.006,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "olive_tree",
+            "x": 509.01,
+            "z": 391.41,
+            "scale": 0.91,
+            "rotation": 0.854,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "boulder",
+            "x": 506.14,
+            "z": 404.65,
+            "scale": 0.92,
+            "rotation": 4.168,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "boulder",
+            "x": 507.51,
+            "z": 402.12,
+            "scale": 0.8,
+            "rotation": 4.834,
+            "dressing": "trasimene_olive_grove"
+        },
+        {
+            "type": "boulder",
+            "x": 196.46,
+            "z": 169.14,
+            "scale": 1.04,
+            "rotation": 5.375,
+            "dressing": "trasimene_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 199.46,
+            "z": 182.81,
+            "scale": 1.03,
+            "rotation": 6.245,
+            "dressing": "trasimene_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 195.98,
+            "z": 185.63,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_west_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 189.09,
+            "z": 168.21,
+            "scale": 1.0,
+            "rotation": 4.066,
+            "dressing": "trasimene_west_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 191.31,
+            "z": 187.68,
+            "scale": 1.0,
+            "rotation": 2.912,
+            "dressing": "trasimene_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 210.95,
+            "z": 165.2,
+            "scale": 0.95,
+            "rotation": 3.495,
+            "dressing": "trasimene_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 214.03,
+            "z": 179.21,
+            "scale": 1.28,
+            "rotation": 2.787,
+            "dressing": "trasimene_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 214.38,
+            "z": 162.15,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_west_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 221.27,
+            "z": 179.57,
+            "scale": 1.0,
+            "rotation": 3.822,
+            "dressing": "trasimene_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 458.9,
+            "z": 142.81,
+            "scale": 1.06,
+            "rotation": 0.479,
+            "dressing": "trasimene_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 457.66,
+            "z": 156.08,
+            "scale": 1.21,
+            "rotation": 1.007,
+            "dressing": "trasimene_east_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 453.41,
+            "z": 158.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_east_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 452.14,
+            "z": 139.9,
+            "scale": 1.0,
+            "rotation": 4.557,
+            "dressing": "trasimene_east_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 448.34,
+            "z": 159.13,
+            "scale": 1.0,
+            "rotation": -2.98,
+            "dressing": "trasimene_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 473.82,
+            "z": 144.37,
+            "scale": 1.25,
+            "rotation": 0.594,
+            "dressing": "trasimene_east_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 478.08,
+            "z": 141.81,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_east_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 479.35,
+            "z": 160.51,
+            "scale": 1.0,
+            "rotation": 1.267,
+            "dressing": "trasimene_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 195.05,
+            "z": 394.55,
+            "scale": 0.91,
+            "rotation": 5.05,
+            "dressing": "trasimene_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 183.89,
+            "z": 410.68,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 189.06,
+            "z": 390.58,
+            "scale": 1.0,
+            "rotation": 5.352,
+            "dressing": "trasimene_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 209.08,
+            "z": 399.85,
+            "scale": 0.84,
+            "rotation": 5.675,
+            "dressing": "trasimene_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 203.93,
+            "z": 413.71,
+            "scale": 0.85,
+            "rotation": 5.237,
+            "dressing": "trasimene_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 213.6,
+            "z": 399.17,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 505.03,
+            "z": 279.39,
+            "scale": 0.95,
+            "rotation": 2.649,
+            "dressing": "trasimene_ridge_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 499.81,
+            "z": 266.05,
+            "scale": 1.28,
+            "rotation": 4.675,
+            "dressing": "trasimene_ridge_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 502.04,
+            "z": 263.62,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_ridge_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 509.93,
+            "z": 281.24,
+            "scale": 1.0,
+            "rotation": 4.497,
+            "dressing": "trasimene_ridge_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 490.96,
+            "z": 284.61,
+            "scale": 1.27,
+            "rotation": 5.827,
+            "dressing": "trasimene_ridge_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 485.97,
+            "z": 271.84,
+            "scale": 1.2,
+            "rotation": 1.229,
+            "dressing": "trasimene_ridge_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 488.29,
+            "z": 288.76,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_ridge_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 478.76,
+            "z": 272.62,
+            "scale": 1.0,
+            "rotation": 2.926,
+            "dressing": "trasimene_ridge_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 331.05,
+            "z": 255.79,
+            "scale": 1.37,
+            "rotation": 2.39,
+            "dressing": "trasimene_north_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 335.07,
+            "z": 260.68,
+            "scale": 1.47,
+            "rotation": 2.226,
+            "dressing": "trasimene_north_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 331.93,
+            "z": 246.89,
+            "scale": 1.0,
+            "rotation": 1.074,
+            "dressing": "trasimene_north_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 307.7,
+            "z": 264.72,
+            "scale": 1.38,
+            "rotation": 2.09,
+            "dressing": "trasimene_north_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 307.98,
+            "z": 271.04,
+            "scale": 1.27,
+            "rotation": 3.158,
+            "dressing": "trasimene_north_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 310.34,
+            "z": 274.41,
+            "scale": 1.0,
+            "rotation": -1.936,
+            "dressing": "trasimene_north_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 376.6,
+            "z": 484.83,
+            "scale": 0.9,
+            "rotation": 3.009,
+            "dressing": "trasimene_ambush_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 379.96,
+            "z": 490.19,
+            "scale": 1.41,
+            "rotation": 6.176,
+            "dressing": "trasimene_ambush_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 378.59,
+            "z": 476.11,
+            "scale": 1.0,
+            "rotation": 2.831,
+            "dressing": "trasimene_ambush_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 346.48,
+            "z": 492.17,
+            "scale": 1.5,
+            "rotation": 4.066,
+            "dressing": "trasimene_ambush_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 345.96,
+            "z": 498.48,
+            "scale": 1.19,
+            "rotation": 4.747,
+            "dressing": "trasimene_ambush_ramp"
+        },
+        {
+            "type": "firecamp",
+            "x": 346.88,
+            "z": 506.49,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_ambush_ramp",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 185.86,
+            "z": 278.41,
+            "scale": 1.4,
+            "rotation": 3.036,
+            "dressing": "trasimene_column_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 192.16,
+            "z": 278.97,
+            "scale": 1.3,
+            "rotation": 4.709,
+            "dressing": "trasimene_column_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 180.13,
+            "z": 271.54,
+            "scale": 1.0,
+            "rotation": 2.01,
+            "dressing": "trasimene_column_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 175.07,
+            "z": 303.16,
+            "scale": 0.99,
+            "rotation": 0.893,
+            "dressing": "trasimene_column_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 179.76,
+            "z": 307.39,
+            "scale": 1.34,
+            "rotation": 3.41,
+            "dressing": "trasimene_column_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 293.25,
+            "z": 169.57,
+            "scale": 1.0,
+            "rotation": 0.656,
+            "dressing": "trasimene_via_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 294.04,
+            "z": 470.65,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_camp_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "supply_cart",
+            "x": 292.59,
+            "z": 475.83,
+            "scale": 1.0,
+            "rotation": 1.463,
+            "dressing": "trasimene_camp_junction"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 291.62,
+            "z": 466.89,
+            "scale": 1.0,
+            "rotation": 1.463,
+            "dressing": "trasimene_camp_junction"
+        },
+        {
+            "type": "statue",
+            "x": 405.1,
+            "z": 160.86,
+            "scale": 1.0,
+            "rotation": -1.664,
+            "dressing": "trasimene_shore_junction"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 405.65,
+            "z": 166.83,
+            "scale": 1.0,
+            "rotation": 2.081,
+            "dressing": "trasimene_shore_junction"
+        },
+        {
+            "type": "plant",
+            "x": 184.2,
+            "z": 624.72,
+            "scale": 1.17,
+            "rotation": 4.942,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 186.71,
+            "z": 622.39,
+            "scale": 0.98,
+            "rotation": 1.418,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 176.77,
+            "z": 584.57,
+            "scale": 0.99,
+            "rotation": 1.893,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 198.53,
+            "z": 549.88,
+            "scale": 1.03,
+            "rotation": 2.382,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 174.17,
+            "z": 519.87,
+            "scale": 0.94,
+            "rotation": 6.235,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 171.27,
+            "z": 517.02,
+            "scale": 1.36,
+            "rotation": 4.627,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 179.92,
+            "z": 483.43,
+            "scale": 1.25,
+            "rotation": 4.179,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 202.12,
+            "z": 417.56,
+            "scale": 0.96,
+            "rotation": 5.923,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 200.01,
+            "z": 378.24,
+            "scale": 0.89,
+            "rotation": 5.846,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 198.03,
+            "z": 374.96,
+            "scale": 0.98,
+            "rotation": 2.277,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 224.6,
+            "z": 348.31,
+            "scale": 1.07,
+            "rotation": 3.982,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 228.09,
+            "z": 346.89,
+            "scale": 1.08,
+            "rotation": 6.089,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 222.54,
+            "z": 309.99,
+            "scale": 1.21,
+            "rotation": 2.173,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 233.86,
+            "z": 277.15,
+            "scale": 0.81,
+            "rotation": 3.11,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 210.99,
+            "z": 244.94,
+            "scale": 1.11,
+            "rotation": 0.462,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 209.33,
+            "z": 241.24,
+            "scale": 1.39,
+            "rotation": 2.412,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 218.86,
+            "z": 205.48,
+            "scale": 0.94,
+            "rotation": 2.406,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 220.69,
+            "z": 202.12,
+            "scale": 0.99,
+            "rotation": 1.296,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 204.88,
+            "z": 136.23,
+            "scale": 1.2,
+            "rotation": 2.427,
+            "dressing": "trasimene_west_bank"
+        },
+        {
+            "type": "plant",
+            "x": 540.99,
+            "z": 620.39,
+            "scale": 1.29,
+            "rotation": 2.547,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 541.22,
+            "z": 617.04,
+            "scale": 0.99,
+            "rotation": 4.183,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 511.65,
+            "z": 590.91,
+            "scale": 1.02,
+            "rotation": 5.292,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 519.23,
+            "z": 555.94,
+            "scale": 0.89,
+            "rotation": 1.359,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 523.09,
+            "z": 552.84,
+            "scale": 1.22,
+            "rotation": 2.303,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 509.83,
+            "z": 517.45,
+            "scale": 1.15,
+            "rotation": 2.356,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 532.88,
+            "z": 485.67,
+            "scale": 1.05,
+            "rotation": 4.137,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 536.14,
+            "z": 483.08,
+            "scale": 1.01,
+            "rotation": 4.955,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 513.66,
+            "z": 451.78,
+            "scale": 0.81,
+            "rotation": 1.855,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 512.86,
+            "z": 415.03,
+            "scale": 0.85,
+            "rotation": 0.665,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 483.45,
+            "z": 387.1,
+            "scale": 1.05,
+            "rotation": 5.654,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 496.64,
+            "z": 351.01,
+            "scale": 0.92,
+            "rotation": 3.038,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 498.44,
+            "z": 347.06,
+            "scale": 1.35,
+            "rotation": 5.118,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 483.46,
+            "z": 311.89,
+            "scale": 1.29,
+            "rotation": 3.981,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 504.82,
+            "z": 273.37,
+            "scale": 1.25,
+            "rotation": 1.979,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 505.09,
+            "z": 271.15,
+            "scale": 1.18,
+            "rotation": 3.403,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 475.69,
+            "z": 245.52,
+            "scale": 1.27,
+            "rotation": 0.077,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 475.53,
+            "z": 208.4,
+            "scale": 0.96,
+            "rotation": 5.995,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 477.24,
+            "z": 204.73,
+            "scale": 1.28,
+            "rotation": 3.616,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 454.42,
+            "z": 175.62,
+            "scale": 1.01,
+            "rotation": 0.147,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 474.26,
+            "z": 141.72,
+            "scale": 0.88,
+            "rotation": 0.52,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "plant",
+            "x": 477.32,
+            "z": 138.48,
+            "scale": 0.94,
+            "rotation": 4.899,
+            "dressing": "trasimene_east_bank"
+        },
+        {
+            "type": "firecamp",
+            "x": 563.0,
+            "z": 148.25,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 563.0,
+            "z": 135.75,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 559.0,
+            "z": 134.75,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "trasimene_gate_1"
+        },
+        {
+            "type": "supply_cart",
+            "x": 560.02,
+            "z": 153.09,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "trasimene_gate_1"
+        },
+        {
+            "type": "statue",
+            "x": 551.25,
+            "z": 150.19,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "trasimene_gate_1"
+        },
+        {
+            "type": "statue",
+            "x": 552.0,
+            "z": 134.75,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "trasimene_gate_1"
+        },
+        {
+            "type": "firecamp",
+            "x": 637.0,
+            "z": 128.7,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 637.0,
+            "z": 139.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 641.0,
+            "z": 140.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_2"
+        },
+        {
+            "type": "supply_cart",
+            "x": 643.43,
+            "z": 128.32,
+            "scale": 1.0,
+            "rotation": 0.3,
+            "dressing": "trasimene_gate_2"
+        },
+        {
+            "type": "statue",
+            "x": 644.71,
+            "z": 139.43,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "trasimene_gate_2"
+        },
+        {
+            "type": "firecamp",
+            "x": 278.5,
+            "z": 525.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 289.5,
+            "z": 525.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 290.5,
+            "z": 521.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "trasimene_gate_3"
+        },
+        {
+            "type": "supply_cart",
+            "x": 276.82,
+            "z": 520.19,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "trasimene_gate_3"
+        },
+        {
+            "type": "tent",
+            "x": 269.21,
+            "z": 515.13,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "trasimene_gate_3"
+        },
+        {
+            "type": "firecamp",
+            "x": 317.28,
+            "z": 537.17,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 324.12,
+            "z": 549.87,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_4"
+        },
+        {
+            "type": "supply_cart",
+            "x": 324.11,
+            "z": 533.92,
+            "scale": 1.0,
+            "rotation": 0.3,
+            "dressing": "trasimene_gate_4"
+        },
+        {
+            "type": "tent",
+            "x": 328.87,
+            "z": 529.41,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "trasimene_gate_4"
+        },
+        {
+            "type": "firecamp",
+            "x": 301.48,
+            "z": 578.28,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 289.13,
+            "z": 580.12,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 289.95,
+            "z": 583.47,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "trasimene_gate_5"
+        },
+        {
+            "type": "supply_cart",
+            "x": 304.14,
+            "z": 581.98,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "trasimene_gate_5"
+        },
+        {
+            "type": "tent",
+            "x": 308.59,
+            "z": 588.87,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "trasimene_gate_5"
+        },
+        {
+            "type": "firecamp",
+            "x": 253.0,
+            "z": 547.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 252.13,
+            "z": 539.99,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trasimene_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 247.47,
+            "z": 537.42,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "trasimene_gate_6"
+        },
+        {
+            "type": "supply_cart",
+            "x": 247.0,
+            "z": 548.8,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "trasimene_gate_6"
+        },
+        {
+            "type": "tent",
+            "x": 244.89,
+            "z": 556.58,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "trasimene_gate_6"
+        }
+    ],
+    "dressing": [
+        {
+            "id": "trasimene_fishing_village",
+            "kind": "shore_hamlet",
+            "x": 350,
+            "z": 132,
+            "facing": "north",
+            "homes": 4,
+            "carts": 3,
+            "plants": 7
+        },
+        {
+            "id": "trasimene_shore_avenue",
+            "kind": "tree_avenue",
+            "from": [
+                230,
+                160
+            ],
+            "to": [
+                440,
+                150
+            ],
+            "tree": "cypress_tree",
+            "spacing": 10,
+            "sides": "left"
+        },
+        {
+            "id": "trasimene_malpasso",
+            "kind": "cairn",
+            "x": 258,
+            "z": 160,
+            "facing": "south",
+            "boulders": 7,
+            "radius": 5,
+            "fire": true
+        },
+        {
+            "id": "trasimene_altar_ring",
+            "kind": "barrow_field",
+            "x": 625,
+            "z": 321,
+            "radius": 9,
+            "ruins": 5,
+            "dead_trees": 3,
+            "statues": 2,
+            "boulders": 3
+        },
+        {
+            "id": "trasimene_drowned_barrows",
+            "kind": "barrow_field",
+            "x": 64,
+            "z": 322,
+            "radius": 13,
+            "shrine": true,
+            "ruins": 7,
+            "dead_trees": 6,
+            "boulders": 4
+        },
+        {
+            "id": "trasimene_olive_grove",
+            "kind": "sacred_grove",
+            "x": 500,
+            "z": 400,
+            "tree": "olive_tree",
+            "count": 10,
+            "radius": 13,
+            "centre": "statue"
+        },
+        {
+            "id": "trasimene_west_bridge",
+            "kind": "bridgehead",
+            "x": 205,
+            "z": 174
+        },
+        {
+            "id": "trasimene_east_bridge",
+            "kind": "bridgehead",
+            "x": 466,
+            "z": 150
+        },
+        {
+            "id": "trasimene_south_bridge",
+            "kind": "bridgehead",
+            "x": 200,
+            "z": 404,
+            "cart": false
+        },
+        {
+            "id": "trasimene_ridge_bridge",
+            "kind": "bridgehead",
+            "x": 495,
+            "z": 276,
+            "cart": false
+        },
+        {
+            "id": "trasimene_north_ramp",
+            "kind": "ramp_mouth",
+            "x": 308,
+            "z": 243,
+            "statue": true
+        },
+        {
+            "id": "trasimene_ambush_ramp",
+            "kind": "ramp_mouth",
+            "x": 351,
+            "z": 466,
+            "fire": true
+        },
+        {
+            "id": "trasimene_column_ramp",
+            "kind": "ramp_mouth",
+            "x": 159,
+            "z": 283
+        },
+        {
+            "id": "trasimene_via_junction",
+            "kind": "junction",
+            "x": 300,
+            "z": 168,
+            "style": "shrine"
+        },
+        {
+            "id": "trasimene_camp_junction",
+            "kind": "junction",
+            "x": 300,
+            "z": 470,
+            "style": "camp",
+            "snap": 6
+        },
+        {
+            "id": "trasimene_shore_junction",
+            "kind": "junction",
+            "x": 420,
+            "z": 150,
+            "style": "milestone",
+            "tree": "cypress_tree"
+        },
+        {
+            "id": "trasimene_west_bank",
+            "kind": "riverbank",
+            "from": [
+                186,
+                120
+            ],
+            "to": [
+                172,
+                640
+            ],
+            "spacing": 36,
+            "kinds": [
+                "plant",
+                "boulder",
+                "dead_tree",
+                "plant"
+            ]
+        },
+        {
+            "id": "trasimene_east_bank",
+            "kind": "riverbank",
+            "from": [
+                472,
+                120
+            ],
+            "to": [
+                538,
+                640
+            ],
+            "spacing": 36,
+            "kinds": [
+                "plant",
+                "boulder",
+                "plant",
+                "dead_tree"
+            ]
+        },
+        {
+            "id": "trasimene_gate_1",
+            "kind": "gate_approach",
+            "x": 572.0,
+            "z": 142.0,
+            "statues": true
+        },
+        {
+            "id": "trasimene_gate_2",
+            "kind": "gate_approach",
+            "x": 628.0,
+            "z": 134.0,
+            "statues": true
+        },
+        {
+            "id": "trasimene_gate_3",
+            "kind": "gate_approach",
+            "x": 284,
+            "z": 534,
+            "tents": 2
+        },
+        {
+            "id": "trasimene_gate_4",
+            "kind": "gate_approach",
+            "x": 310,
+            "z": 544,
+            "tents": 2
+        },
+        {
+            "id": "trasimene_gate_5",
+            "kind": "gate_approach",
+            "x": 294,
+            "z": 570,
+            "tents": 2
+        },
+        {
+            "id": "trasimene_gate_6",
+            "kind": "gate_approach",
+            "x": 262,
+            "z": 542,
+            "tents": 2
         }
     ]
 }

--- a/assets/maps/map_battle_trebia.json
+++ b/assets/maps/map_battle_trebia.json
@@ -160,7 +160,7 @@
     "environment": {
         "day_length_seconds": 1800,
         "fog_density": 0.02,
-        "lighting_profile": "mediterranean_summer",
+        "lighting_profile": "river_mist",
         "start_time": 6.5,
         "time_mode": "locked"
     },
@@ -4223,7 +4223,7 @@
                 "food": 120,
                 "gold": 150
             },
-            "id": "frozen_dead",
+            "id": "trebia_frozen_dead",
             "leash_radius": 43,
             "owner_id": 99,
             "radius": 24.19,
@@ -4244,7 +4244,8 @@
                 }
             ],
             "x": 128,
-            "z": 292
+            "z": 292,
+            "fog_density": 0.35
         }
     ],
     "victory": {
@@ -4343,20 +4344,6 @@
     },
     "world_props": [
         {
-            "rotation": 0.5,
-            "scale": 1,
-            "type": "tent",
-            "x": 234.94,
-            "z": 468.89
-        },
-        {
-            "rotation": 2.8000000000000003,
-            "scale": 1,
-            "type": "tent",
-            "x": 281.47,
-            "z": 468.89
-        },
-        {
             "rotation": 1.2,
             "scale": 1,
             "type": "supply_cart",
@@ -4376,13 +4363,6 @@
             "type": "tent",
             "x": 244.8,
             "z": 47.46
-        },
-        {
-            "rotation": 4,
-            "scale": 1,
-            "type": "tent",
-            "x": 282.77,
-            "z": 47.01
         },
         {
             "rotation": 2.2,
@@ -4413,53 +4393,11 @@
             "z": 260.9
         },
         {
-            "rotation": 0.5,
-            "scale": 1.2,
-            "type": "dead_tree",
-            "x": 123.29,
-            "z": 211.16
-        },
-        {
-            "rotation": 2.2,
-            "scale": 1.1,
-            "type": "dead_tree",
-            "x": 148.87,
-            "z": 223.58
-        },
-        {
-            "rotation": 1.2,
-            "scale": 1.2,
-            "type": "dead_tree",
-            "x": 360,
-            "z": 200
-        },
-        {
-            "rotation": 3,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 386.14,
-            "z": 223.58
-        },
-        {
-            "rotation": 4.7,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 211.68,
-            "z": 254.63
-        },
-        {
             "rotation": 6.2,
             "scale": 1.1,
             "type": "dead_tree",
             "x": 295.42,
             "z": 254.63
-        },
-        {
-            "rotation": 1.7,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 97.7,
-            "z": 329.16
         },
         {
             "rotation": 3.9,
@@ -4504,13 +4442,6 @@
             "z": 131.57
         },
         {
-            "rotation": 0.5,
-            "scale": 0.9,
-            "type": "weapon_rack",
-            "x": 567.58,
-            "z": 71.42
-        },
-        {
             "intensity": 1,
             "persistent": true,
             "radius": 3,
@@ -4518,15 +4449,6 @@
             "type": "firecamp",
             "x": 581.54,
             "z": 105.58
-        },
-        {
-            "intensity": 1.25,
-            "persistent": true,
-            "radius": 3.8000000000000003,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 239.59,
-            "z": 456.47
         },
         {
             "intensity": 1.1500000000000001,
@@ -4556,15 +4478,6 @@
             "z": 55.89
         },
         {
-            "intensity": 0.8,
-            "persistent": true,
-            "radius": 2.5,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 293.1,
-            "z": 55.89
-        },
-        {
             "intensity": 0.35000000000000003,
             "persistent": true,
             "radius": 1.8,
@@ -4572,12 +4485,6 @@
             "type": "firecamp",
             "x": 111.66,
             "z": 347.79
-        },
-        {
-            "scale": 1,
-            "type": "ruins",
-            "x": 128,
-            "z": 292
         },
         {
             "rotation": 55.300000000000004,
@@ -4613,15 +4520,6 @@
             "type": "tent",
             "x": 146.09,
             "z": 108.76
-        },
-        {
-            "intensity": 1.28,
-            "persistent": true,
-            "radius": 2.7,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 630.26,
-            "z": 63.940000000000005
         },
         {
             "rotation": 182.6,
@@ -4684,15 +4582,6 @@
             "type": "supply_cart",
             "x": 90.55,
             "z": 72.74
-        },
-        {
-            "intensity": 1.23,
-            "persistent": true,
-            "radius": 2.9,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 486.63,
-            "z": 125.07000000000001
         },
         {
             "rotation": 129.8,
@@ -4803,13 +4692,6 @@
             "z": 63.04
         },
         {
-            "rotation": 34.5,
-            "scale": 1.06,
-            "type": "supply_cart",
-            "x": 539.26,
-            "z": 38.33
-        },
-        {
             "intensity": 1.1400000000000001,
             "persistent": true,
             "radius": 3.3000000000000003,
@@ -4851,32 +4733,11 @@
             "z": 29.73
         },
         {
-            "rotation": 249.6,
-            "scale": 1.04,
-            "type": "tent",
-            "x": 624.26,
-            "z": 44.82
-        },
-        {
             "rotation": 247.70000000000002,
             "scale": 0.88,
             "type": "tent",
             "x": 346.19,
             "z": 477.2
-        },
-        {
-            "rotation": 2.9,
-            "scale": 1.1400000000000001,
-            "type": "tent",
-            "x": 102.5,
-            "z": 17.18
-        },
-        {
-            "rotation": 11.6,
-            "scale": 1.04,
-            "type": "tent",
-            "x": 509.64,
-            "z": 61.83
         },
         {
             "rotation": 127,
@@ -4893,13 +4754,6 @@
             "z": 107.34
         },
         {
-            "rotation": 273,
-            "scale": 1.1,
-            "type": "supply_cart",
-            "x": 580.61,
-            "z": 207.15
-        },
-        {
             "intensity": 1.06,
             "persistent": true,
             "radius": 3.3000000000000003,
@@ -4914,13 +4768,6 @@
             "type": "supply_cart",
             "x": 80.43,
             "z": 66.93
-        },
-        {
-            "rotation": 246.6,
-            "scale": 1.01,
-            "type": "weapon_rack",
-            "x": 607.22,
-            "z": 49.36
         },
         {
             "rotation": 309,
@@ -4981,13 +4828,6 @@
             "type": "weapon_rack",
             "x": 90.82000000000001,
             "z": 54.96
-        },
-        {
-            "rotation": 70.60000000000001,
-            "scale": 1.01,
-            "type": "tent",
-            "x": 582.85,
-            "z": 22.59
         },
         {
             "rotation": 251.5,
@@ -5114,20 +4954,6 @@
             "z": 346.68
         },
         {
-            "rotation": 302.90000000000003,
-            "scale": 1.16,
-            "type": "dead_tree",
-            "x": 585.59,
-            "z": 579.62
-        },
-        {
-            "rotation": 194.9,
-            "scale": 1.08,
-            "type": "dead_tree",
-            "x": 439.73,
-            "z": 356.41
-        },
-        {
             "rotation": 252.8,
             "scale": 1.06,
             "type": "ruins",
@@ -5140,13 +4966,6 @@
             "type": "dead_tree",
             "x": 240.56,
             "z": 126.15
-        },
-        {
-            "rotation": 198.20000000000002,
-            "scale": 0.92,
-            "type": "dead_tree",
-            "x": 557.7,
-            "z": 595.3000000000001
         },
         {
             "rotation": 173.20000000000002,
@@ -5233,13 +5052,6 @@
             "z": 618.11
         },
         {
-            "rotation": 74.5,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 434.64,
-            "z": 530.79
-        },
-        {
             "rotation": 66.9,
             "scale": 0.93,
             "type": "dead_tree",
@@ -5275,25 +5087,11 @@
             "z": 306.39
         },
         {
-            "rotation": 322.2,
-            "scale": 1,
-            "type": "ruins",
-            "x": 38.64,
-            "z": 499.03000000000003
-        },
-        {
             "rotation": 141.5,
             "scale": 0.92,
             "type": "dead_tree",
             "x": 608.12,
             "z": 365.57
-        },
-        {
-            "rotation": 359.7,
-            "scale": 1.08,
-            "type": "ruins",
-            "x": 45.51,
-            "z": 512.85
         },
         {
             "rotation": 147,
@@ -5310,13 +5108,6 @@
             "z": 121.15
         },
         {
-            "rotation": 157.3,
-            "scale": 1.05,
-            "type": "statue",
-            "x": 633.87,
-            "z": 136.19
-        },
-        {
             "rotation": 332.6,
             "scale": 1.05,
             "type": "statue",
@@ -5331,34 +5122,6 @@
             "z": 110.12
         },
         {
-            "rotation": 132.9,
-            "scale": 1.03,
-            "type": "abandoned_home",
-            "x": 164.22,
-            "z": 264.44
-        },
-        {
-            "rotation": 39.800000000000004,
-            "scale": 1.02,
-            "type": "abandoned_home",
-            "x": 145.59,
-            "z": 259.27
-        },
-        {
-            "rotation": 96.3,
-            "scale": 0.91,
-            "type": "abandoned_home",
-            "x": 115.38,
-            "z": 314.36
-        },
-        {
-            "rotation": 203.1,
-            "scale": 1.09,
-            "type": "abandoned_home",
-            "x": 164.39000000000001,
-            "z": 311.95
-        },
-        {
             "rotation": 247.20000000000002,
             "scale": 0.98,
             "type": "abandoned_home",
@@ -5371,20 +5134,6 @@
             "type": "abandoned_home",
             "x": 176.52,
             "z": 196.14000000000001
-        },
-        {
-            "rotation": 254.4,
-            "scale": 1.07,
-            "type": "abandoned_home",
-            "x": 28.310000000000002,
-            "z": 146.83
-        },
-        {
-            "rotation": 150.4,
-            "scale": 1.06,
-            "type": "abandoned_home",
-            "x": 462.86,
-            "z": 628.59
         },
         {
             "rotation": 41.9,
@@ -5547,14 +5296,6 @@
             "type": "ruins",
             "x": 398.3,
             "z": 263.1
-        },
-        {
-            "landmark": "trebia_ridge_sanctuary",
-            "rotation": 180,
-            "scale": 0.9,
-            "type": "ruins",
-            "x": 399.7,
-            "z": 272.2
         },
         {
             "landmark": "trebia_ridge_sanctuary",
@@ -5897,6 +5638,1600 @@
             "type": "cursed_gold_vein",
             "x": 352,
             "z": 362
+        },
+        {
+            "type": "boulder",
+            "x": 342.25,
+            "z": 256.96,
+            "scale": 1.26,
+            "rotation": 1.68,
+            "dressing": "trebia_frozen_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 346.74,
+            "z": 255.12,
+            "scale": 0.89,
+            "rotation": 3.864,
+            "dressing": "trebia_frozen_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 351.63,
+            "z": 252.0,
+            "scale": 0.87,
+            "rotation": 1.571,
+            "dressing": "trebia_frozen_ford"
+        },
+        {
+            "type": "boulder",
+            "x": 355.18,
+            "z": 252.25,
+            "scale": 1.27,
+            "rotation": 4.198,
+            "dressing": "trebia_frozen_ford"
+        },
+        {
+            "type": "dead_tree",
+            "x": 353.56,
+            "z": 256.31,
+            "scale": 1.0,
+            "rotation": 1.126,
+            "dressing": "trebia_frozen_ford"
+        },
+        {
+            "type": "ruins",
+            "x": 340.84,
+            "z": 213.67,
+            "scale": 0.8,
+            "rotation": 2.525,
+            "dressing": "trebia_frozen_ford"
+        },
+        {
+            "type": "dead_tree",
+            "x": 25.93,
+            "z": 228.58,
+            "scale": 0.81,
+            "rotation": 4.472,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 17.01,
+            "z": 186.59,
+            "scale": 1.0,
+            "rotation": 0.06,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 58.67,
+            "z": 177.32,
+            "scale": 1.04,
+            "rotation": 5.643,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 51.67,
+            "z": 135.8,
+            "scale": 1.2,
+            "rotation": 1.396,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 50.65,
+            "z": 133.5,
+            "scale": 1.38,
+            "rotation": 1.586,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 88.62,
+            "z": 126.3,
+            "scale": 0.96,
+            "rotation": 5.959,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 82.17,
+            "z": 86.17,
+            "scale": 0.98,
+            "rotation": 5.875,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 115.68,
+            "z": 90.59,
+            "scale": 1.25,
+            "rotation": 5.541,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 150.78,
+            "z": 109.03,
+            "scale": 1.07,
+            "rotation": 2.383,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 150.24,
+            "z": 113.35,
+            "scale": 1.36,
+            "rotation": 2.205,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 179.5,
+            "z": 163.43,
+            "scale": 1.06,
+            "rotation": 6.085,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 208.94,
+            "z": 183.61,
+            "scale": 1.1,
+            "rotation": 1.115,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 179.44,
+            "z": 210.84,
+            "scale": 1.04,
+            "rotation": 4.91,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 227.2,
+            "z": 254.6,
+            "scale": 1.24,
+            "rotation": 3.508,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 261.78,
+            "z": 225.39,
+            "scale": 1.0,
+            "rotation": 0.996,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 287.12,
+            "z": 256.63,
+            "scale": 0.81,
+            "rotation": 0.868,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 312.13,
+            "z": 227.08,
+            "scale": 1.16,
+            "rotation": 6.156,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 350.51,
+            "z": 241.31,
+            "scale": 1.15,
+            "rotation": 5.618,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 354.68,
+            "z": 240.58,
+            "scale": 1.07,
+            "rotation": 3.763,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 365.37,
+            "z": 199.94,
+            "scale": 0.96,
+            "rotation": 3.778,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 399.23,
+            "z": 217.25,
+            "scale": 1.02,
+            "rotation": 2.05,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 439.51,
+            "z": 199.39,
+            "scale": 0.81,
+            "rotation": 5.059,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 430.32,
+            "z": 239.31,
+            "scale": 1.24,
+            "rotation": 4.248,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 467.41,
+            "z": 223.77,
+            "scale": 1.11,
+            "rotation": 5.147,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 469.65,
+            "z": 222.66,
+            "scale": 1.19,
+            "rotation": 0.963,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 496.5,
+            "z": 253.29,
+            "scale": 0.81,
+            "rotation": 2.563,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 526.36,
+            "z": 225.15,
+            "scale": 0.95,
+            "rotation": 0.564,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 555.37,
+            "z": 257.59,
+            "scale": 0.83,
+            "rotation": 3.426,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 586.07,
+            "z": 226.86,
+            "scale": 1.19,
+            "rotation": 3.838,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 614.75,
+            "z": 255.46,
+            "scale": 0.9,
+            "rotation": 1.82,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "plant",
+            "x": 619.13,
+            "z": 258.07,
+            "scale": 1.08,
+            "rotation": 0.303,
+            "dressing": "trebia_frozen_bank"
+        },
+        {
+            "type": "ruins",
+            "x": 277.79,
+            "z": 91.2,
+            "scale": 1.01,
+            "rotation": 1.509,
+            "dressing": "trebia_oppidum"
+        },
+        {
+            "type": "ruins",
+            "x": 252.44,
+            "z": 96.05,
+            "scale": 0.99,
+            "rotation": 4.228,
+            "dressing": "trebia_oppidum"
+        },
+        {
+            "type": "ruins",
+            "x": 251.43,
+            "z": 87.09,
+            "scale": 1.18,
+            "rotation": 5.06,
+            "dressing": "trebia_oppidum"
+        },
+        {
+            "type": "ruins",
+            "x": 271.47,
+            "z": 83.79,
+            "scale": 0.91,
+            "rotation": 6.978,
+            "dressing": "trebia_oppidum"
+        },
+        {
+            "type": "firecamp",
+            "x": 265.0,
+            "z": 90.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_oppidum",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 271.75,
+            "z": 98.0,
+            "scale": 1.0,
+            "rotation": 2.606,
+            "dressing": "trebia_oppidum"
+        },
+        {
+            "type": "dead_tree",
+            "x": 258.25,
+            "z": 98.0,
+            "scale": 1.0,
+            "rotation": 2.152,
+            "dressing": "trebia_oppidum"
+        },
+        {
+            "type": "dead_tree",
+            "x": 244.93,
+            "z": 96.81,
+            "scale": 1.0,
+            "rotation": 0.703,
+            "dressing": "trebia_oppidum"
+        },
+        {
+            "type": "boulder",
+            "x": 246.75,
+            "z": 83.61,
+            "scale": 0.89,
+            "rotation": 0.141,
+            "dressing": "trebia_oppidum"
+        },
+        {
+            "type": "boulder",
+            "x": 283.81,
+            "z": 15.07,
+            "scale": 1.33,
+            "rotation": 0.179,
+            "dressing": "trebia_oppidum_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 284.77,
+            "z": 8.81,
+            "scale": 1.04,
+            "rotation": 2.483,
+            "dressing": "trebia_oppidum_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 274.19,
+            "z": 17.97,
+            "scale": 1.0,
+            "rotation": 6.177,
+            "dressing": "trebia_oppidum_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 314.53,
+            "z": 29.9,
+            "scale": 0.99,
+            "rotation": 3.263,
+            "dressing": "trebia_oppidum_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 319.48,
+            "z": 26.59,
+            "scale": 1.04,
+            "rotation": 0.225,
+            "dressing": "trebia_oppidum_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 320.41,
+            "z": 22.57,
+            "scale": 1.0,
+            "rotation": 2.044,
+            "dressing": "trebia_oppidum_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 191.37,
+            "z": 108.64,
+            "scale": 0.96,
+            "rotation": 1.535,
+            "dressing": "trebia_oppidum_ramp_w"
+        },
+        {
+            "type": "dead_tree",
+            "x": 199.76,
+            "z": 111.75,
+            "scale": 1.0,
+            "rotation": 1.738,
+            "dressing": "trebia_oppidum_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 187.53,
+            "z": 84.23,
+            "scale": 1.39,
+            "rotation": 4.181,
+            "dressing": "trebia_oppidum_ramp_w"
+        },
+        {
+            "type": "boulder",
+            "x": 182.47,
+            "z": 82.46,
+            "scale": 0.91,
+            "rotation": 4.852,
+            "dressing": "trebia_oppidum_ramp_w"
+        },
+        {
+            "type": "ruins",
+            "x": 139.66,
+            "z": 291.87,
+            "scale": 1.04,
+            "rotation": 3.261,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 133.2,
+            "z": 303.39,
+            "scale": 0.9,
+            "rotation": 0.67,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 125.91,
+            "z": 302.76,
+            "scale": 0.88,
+            "rotation": 3.225,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 138.45,
+            "z": 283.4,
+            "scale": 1.15,
+            "rotation": 1.979,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 137.69,
+            "z": 307.01,
+            "scale": 0.89,
+            "rotation": 4.223,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 143.48,
+            "z": 278.0,
+            "scale": 1.14,
+            "rotation": 0.141,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 133.77,
+            "z": 309.46,
+            "scale": 0.94,
+            "rotation": 5.169,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 135.97,
+            "z": 295.31,
+            "scale": 0.9,
+            "rotation": 4.543,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 128.85,
+            "z": 306.41,
+            "scale": 1.07,
+            "rotation": 0.738,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 132.15,
+            "z": 273.63,
+            "scale": 1.09,
+            "rotation": 1.272,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 121.38,
+            "z": 303.59,
+            "scale": 0.92,
+            "rotation": 1.627,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 128.0,
+            "z": 292.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_frozen_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 98.87,
+            "z": 333.29,
+            "scale": 1.1,
+            "rotation": 0.566,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 88.59,
+            "z": 323.5,
+            "scale": 0.97,
+            "rotation": 4.508,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 103.99,
+            "z": 315.1,
+            "scale": 0.88,
+            "rotation": 0.452,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 98.16,
+            "z": 314.84,
+            "scale": 1.16,
+            "rotation": 0.124,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 96.84,
+            "z": 326.09,
+            "scale": 1.16,
+            "rotation": 2.487,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 111.14,
+            "z": 321.21,
+            "scale": 1.02,
+            "rotation": 5.528,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 102.49,
+            "z": 319.32,
+            "scale": 0.9,
+            "rotation": 3.02,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 100.09,
+            "z": 329.78,
+            "scale": 0.69,
+            "rotation": 5.889,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 100.59,
+            "z": 326.98,
+            "scale": 0.75,
+            "rotation": 6.17,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 102.49,
+            "z": 328.83,
+            "scale": 0.74,
+            "rotation": 4.575,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 102.08,
+            "z": 323.47,
+            "scale": 0.7,
+            "rotation": 3.877,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 103.09,
+            "z": 325.8,
+            "scale": 1.0,
+            "rotation": 4.665,
+            "dressing": "trebia_frozen_bones"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 487.97,
+            "z": 88.45,
+            "scale": 0.99,
+            "rotation": 2.668,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 484.82,
+            "z": 100.19,
+            "scale": 0.94,
+            "rotation": 3.537,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 497.68,
+            "z": 90.86,
+            "scale": 1.05,
+            "rotation": 0.163,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 494.28,
+            "z": 102.89,
+            "scale": 0.94,
+            "rotation": 3.972,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 506.71,
+            "z": 94.15,
+            "scale": 0.98,
+            "rotation": 1.911,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 503.92,
+            "z": 105.56,
+            "scale": 1.06,
+            "rotation": 1.465,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 515.92,
+            "z": 96.12,
+            "scale": 1.08,
+            "rotation": 5.566,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 512.71,
+            "z": 108.8,
+            "scale": 1.02,
+            "rotation": 1.072,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 525.59,
+            "z": 99.97,
+            "scale": 1.08,
+            "rotation": 4.906,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 522.91,
+            "z": 111.46,
+            "scale": 1.07,
+            "rotation": 2.723,
+            "dressing": "trebia_placentia_avenue"
+        },
+        {
+            "type": "boulder",
+            "x": 265.88,
+            "z": 226.13,
+            "scale": 1.02,
+            "rotation": 2.226,
+            "dressing": "trebia_centre_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 249.34,
+            "z": 226.4,
+            "scale": 1.16,
+            "rotation": 4.015,
+            "dressing": "trebia_centre_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 247.06,
+            "z": 222.33,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_centre_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 265.65,
+            "z": 219.91,
+            "scale": 1.0,
+            "rotation": 0.619,
+            "dressing": "trebia_centre_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 245.47,
+            "z": 218.24,
+            "scale": 1.0,
+            "rotation": -1.53,
+            "dressing": "trebia_centre_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 264.49,
+            "z": 253.7,
+            "scale": 1.11,
+            "rotation": 4.223,
+            "dressing": "trebia_centre_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 248.45,
+            "z": 253.99,
+            "scale": 0.93,
+            "rotation": 2.508,
+            "dressing": "trebia_centre_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 267.34,
+            "z": 256.09,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_centre_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 246.36,
+            "z": 260.92,
+            "scale": 1.0,
+            "rotation": 3.518,
+            "dressing": "trebia_centre_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 488.34,
+            "z": 225.98,
+            "scale": 1.15,
+            "rotation": 1.739,
+            "dressing": "trebia_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 473.89,
+            "z": 225.76,
+            "scale": 0.87,
+            "rotation": 4.767,
+            "dressing": "trebia_east_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 471.33,
+            "z": 220.61,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_east_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "supply_cart",
+            "x": 469.66,
+            "z": 216.53,
+            "scale": 1.0,
+            "rotation": -1.451,
+            "dressing": "trebia_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 488.15,
+            "z": 253.57,
+            "scale": 0.84,
+            "rotation": 5.141,
+            "dressing": "trebia_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 473.5,
+            "z": 253.35,
+            "scale": 1.26,
+            "rotation": 3.953,
+            "dressing": "trebia_east_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 490.24,
+            "z": 257.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_east_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 470.76,
+            "z": 259.57,
+            "scale": 1.0,
+            "rotation": 6.035,
+            "dressing": "trebia_east_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 123.96,
+            "z": 89.37,
+            "scale": 1.04,
+            "rotation": 1.852,
+            "dressing": "trebia_camp_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 140.8,
+            "z": 92.69,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_camp_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 121.17,
+            "z": 61.91,
+            "scale": 1.05,
+            "rotation": 3.421,
+            "dressing": "trebia_camp_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 118.16,
+            "z": 58.22,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_camp_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 522.51,
+            "z": 182.48,
+            "scale": 1.12,
+            "rotation": 5.346,
+            "dressing": "trebia_placentia_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 508.64,
+            "z": 182.48,
+            "scale": 0.99,
+            "rotation": 1.345,
+            "dressing": "trebia_placentia_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 506.5,
+            "z": 178.48,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_placentia_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 527.25,
+            "z": 175.95,
+            "scale": 1.0,
+            "rotation": 2.845,
+            "dressing": "trebia_placentia_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 523.14,
+            "z": 196.36,
+            "scale": 0.9,
+            "rotation": 5.401,
+            "dressing": "trebia_placentia_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 509.32,
+            "z": 196.36,
+            "scale": 1.21,
+            "rotation": 1.706,
+            "dressing": "trebia_placentia_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 525.5,
+            "z": 200.36,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_placentia_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 436.63,
+            "z": 292.34,
+            "scale": 0.84,
+            "rotation": 3.399,
+            "dressing": "trebia_ford_bridge"
+        },
+        {
+            "type": "dead_tree",
+            "x": 430.51,
+            "z": 288.19,
+            "scale": 1.0,
+            "rotation": 1.853,
+            "dressing": "trebia_ford_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 446.93,
+            "z": 295.36,
+            "scale": 1.14,
+            "rotation": 5.416,
+            "dressing": "trebia_ford_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 444.57,
+            "z": 308.4,
+            "scale": 1.26,
+            "rotation": 1.122,
+            "dressing": "trebia_ford_bridge"
+        },
+        {
+            "type": "dead_tree",
+            "x": 450.73,
+            "z": 312.43,
+            "scale": 1.0,
+            "rotation": 5.532,
+            "dressing": "trebia_ford_bridge"
+        },
+        {
+            "type": "dead_tree",
+            "x": 237.02,
+            "z": 382.7,
+            "scale": 1.0,
+            "rotation": 1.474,
+            "dressing": "trebia_camp_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 279.32,
+            "z": 366.27,
+            "scale": 1.08,
+            "rotation": 1.139,
+            "dressing": "trebia_camp_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 280.1,
+            "z": 359.99,
+            "scale": 1.16,
+            "rotation": 0.942,
+            "dressing": "trebia_camp_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 278.32,
+            "z": 356.27,
+            "scale": 1.0,
+            "rotation": 1.371,
+            "dressing": "trebia_camp_ramp"
+        },
+        {
+            "type": "firecamp",
+            "x": 279.49,
+            "z": 351.95,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_camp_ramp",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 309.36,
+            "z": 301.62,
+            "scale": 1.09,
+            "rotation": 3.197,
+            "dressing": "trebia_ambush_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 304.96,
+            "z": 298.97,
+            "scale": 1.32,
+            "rotation": 0.122,
+            "dressing": "trebia_ambush_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 321.44,
+            "z": 284.54,
+            "scale": 1.33,
+            "rotation": 2.542,
+            "dressing": "trebia_ambush_ramp"
+        },
+        {
+            "type": "firecamp",
+            "x": 296.47,
+            "z": 494.43,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_camp_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "supply_cart",
+            "x": 290.45,
+            "z": 493.23,
+            "scale": 1.0,
+            "rotation": 2.577,
+            "dressing": "trebia_camp_junction"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 298.77,
+            "z": 490.59,
+            "scale": 1.0,
+            "rotation": 2.577,
+            "dressing": "trebia_camp_junction"
+        },
+        {
+            "type": "statue",
+            "x": 442.99,
+            "z": 384.97,
+            "scale": 1.0,
+            "rotation": -2.113,
+            "dressing": "trebia_west_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 448.31,
+            "z": 384.1,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_west_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "ruins",
+            "x": 439.4,
+            "z": 390.63,
+            "scale": 0.8,
+            "rotation": 2.652,
+            "dressing": "trebia_west_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 122.06,
+            "z": 58.95,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 123.0,
+            "z": 48.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 119.0,
+            "z": 47.3,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "trebia_gate_1"
+        },
+        {
+            "type": "supply_cart",
+            "x": 116.82,
+            "z": 62.39,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "trebia_gate_1"
+        },
+        {
+            "type": "firecamp",
+            "x": 175.0,
+            "z": 40.4,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 175.0,
+            "z": 51.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 179.0,
+            "z": 52.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_2"
+        },
+        {
+            "type": "supply_cart",
+            "x": 181.0,
+            "z": 38.9,
+            "scale": 1.0,
+            "rotation": 0.3,
+            "dressing": "trebia_gate_2"
+        },
+        {
+            "type": "firecamp",
+            "x": 565.9,
+            "z": 153.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 554.1,
+            "z": 153.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 553.1,
+            "z": 157.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "trebia_gate_3"
+        },
+        {
+            "type": "supply_cart",
+            "x": 567.4,
+            "z": 159.0,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "trebia_gate_3"
+        },
+        {
+            "type": "statue",
+            "x": 566.9,
+            "z": 164.0,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "trebia_gate_3"
+        },
+        {
+            "type": "statue",
+            "x": 553.1,
+            "z": 164.0,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "trebia_gate_3"
+        },
+        {
+            "type": "firecamp",
+            "x": 529.0,
+            "z": 119.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 529.89,
+            "z": 111.68,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "supply_cart",
+            "x": 523.0,
+            "z": 121.1,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "trebia_gate_4"
+        },
+        {
+            "type": "statue",
+            "x": 518.0,
+            "z": 120.6,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "trebia_gate_4"
+        },
+        {
+            "type": "firecamp",
+            "x": 289.0,
+            "z": 525.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 289.0,
+            "z": 514.7,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 285.0,
+            "z": 513.7,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "trebia_gate_5"
+        },
+        {
+            "type": "supply_cart",
+            "x": 283.0,
+            "z": 526.8,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "trebia_gate_5"
+        },
+        {
+            "type": "tent",
+            "x": 280.43,
+            "z": 532.42,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "trebia_gate_5"
+        },
+        {
+            "type": "tent",
+            "x": 283.02,
+            "z": 539.64,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "trebia_gate_5"
+        },
+        {
+            "type": "firecamp",
+            "x": 318.1,
+            "z": 495.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "trebia_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 321.35,
+            "z": 491.47,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "trebia_gate_6"
+        },
+        {
+            "type": "supply_cart",
+            "x": 304.4,
+            "z": 489.0,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "trebia_gate_6"
+        },
+        {
+            "type": "tent",
+            "x": 298.96,
+            "z": 485.25,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "trebia_gate_6"
+        },
+        {
+            "type": "tent",
+            "x": 291.62,
+            "z": 486.89,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "trebia_gate_6"
+        }
+    ],
+    "dressing": [
+        {
+            "id": "trebia_frozen_ford",
+            "kind": "ford_wreck",
+            "x": 340,
+            "z": 242,
+            "boulders": 4,
+            "plants": 2
+        },
+        {
+            "id": "trebia_frozen_bank",
+            "kind": "riverbank",
+            "from": [
+                20,
+                242
+            ],
+            "to": [
+                630,
+                242
+            ],
+            "spacing": 30,
+            "kinds": [
+                "dead_tree",
+                "boulder",
+                "dead_tree",
+                "plant",
+                "boulder"
+            ]
+        },
+        {
+            "id": "trebia_oppidum",
+            "kind": "hilltop_ruin",
+            "x": 265,
+            "z": 92,
+            "facing": "south",
+            "radius": 15,
+            "ruins": 9,
+            "dead_trees": 3
+        },
+        {
+            "id": "trebia_oppidum_ramp",
+            "kind": "ramp_mouth",
+            "x": 283,
+            "z": 53,
+            "statue": true
+        },
+        {
+            "id": "trebia_oppidum_ramp_w",
+            "kind": "ramp_mouth",
+            "x": 192,
+            "z": 96
+        },
+        {
+            "id": "trebia_frozen_barrows",
+            "kind": "barrow_field",
+            "x": 128,
+            "z": 292,
+            "radius": 13,
+            "shrine": true,
+            "ruins": 7,
+            "dead_trees": 7,
+            "boulders": 4
+        },
+        {
+            "id": "trebia_frozen_bones",
+            "kind": "boneyard",
+            "x": 100,
+            "z": 322,
+            "radius": 12,
+            "dead_trees": 8,
+            "ruins": 2,
+            "statues": 0
+        },
+        {
+            "id": "trebia_placentia_avenue",
+            "kind": "tree_avenue",
+            "from": [
+                470,
+                132
+            ],
+            "to": [
+                530,
+                122
+            ],
+            "tree": "cypress_tree",
+            "spacing": 10
+        },
+        {
+            "id": "trebia_centre_bridge",
+            "kind": "bridgehead",
+            "x": 256,
+            "z": 240
+        },
+        {
+            "id": "trebia_east_bridge",
+            "kind": "bridgehead",
+            "x": 481,
+            "z": 240
+        },
+        {
+            "id": "trebia_camp_bridge",
+            "kind": "bridgehead",
+            "x": 130,
+            "z": 75,
+            "cart": false
+        },
+        {
+            "id": "trebia_placentia_bridge",
+            "kind": "bridgehead",
+            "x": 516,
+            "z": 189,
+            "cart": false
+        },
+        {
+            "id": "trebia_ford_bridge",
+            "kind": "bridgehead",
+            "x": 440,
+            "z": 300,
+            "cart": false
+        },
+        {
+            "id": "trebia_camp_ramp",
+            "kind": "ramp_mouth",
+            "x": 258,
+            "z": 397,
+            "statue": true,
+            "fire": true
+        },
+        {
+            "id": "trebia_ambush_ramp",
+            "kind": "ramp_mouth",
+            "x": 333,
+            "z": 320
+        },
+        {
+            "id": "trebia_camp_junction",
+            "kind": "junction",
+            "x": 300,
+            "z": 500,
+            "style": "camp"
+        },
+        {
+            "id": "trebia_winter_junction",
+            "kind": "junction",
+            "x": 300,
+            "z": 28,
+            "style": "milestone",
+            "tree": "pine_tree"
+        },
+        {
+            "id": "trebia_west_junction",
+            "kind": "junction",
+            "x": 440,
+            "z": 380,
+            "style": "shrine"
+        },
+        {
+            "id": "trebia_gate_1",
+            "kind": "gate_approach",
+            "x": 132.0,
+            "z": 54.0
+        },
+        {
+            "id": "trebia_gate_2",
+            "kind": "gate_approach",
+            "x": 166.0,
+            "z": 46.0
+        },
+        {
+            "id": "trebia_gate_3",
+            "kind": "gate_approach",
+            "x": 560.0,
+            "z": 144.0,
+            "statues": true
+        },
+        {
+            "id": "trebia_gate_4",
+            "kind": "gate_approach",
+            "x": 538.0,
+            "z": 114.0,
+            "statues": true
+        },
+        {
+            "id": "trebia_gate_5",
+            "kind": "gate_approach",
+            "x": 298,
+            "z": 520,
+            "tents": 2
+        },
+        {
+            "id": "trebia_gate_6",
+            "kind": "gate_approach",
+            "x": 312,
+            "z": 504,
+            "tents": 2
         }
     ]
 }

--- a/assets/maps/map_battle_zama.json
+++ b/assets/maps/map_battle_zama.json
@@ -4736,7 +4736,7 @@
                 "gold": 220,
                 "iron": 120
             },
-            "id": "desert_shrine",
+            "id": "zama_desert_shrine",
             "leash_radius": 42.32,
             "owner_id": 99,
             "radius": 24.18,
@@ -4751,7 +4751,8 @@
                 }
             ],
             "x": 108,
-            "z": 173
+            "z": 173,
+            "fog_density": 0.3
         },
         {
             "anchor_type": "ruins",
@@ -4787,7 +4788,8 @@
                 }
             ],
             "x": 119,
-            "z": 609
+            "z": 609,
+            "fog_density": 0.35
         }
     ],
     "victory": {
@@ -4866,20 +4868,6 @@
     },
     "world_props": [
         {
-            "rotation": 0.5,
-            "scale": 1,
-            "type": "tent",
-            "x": 67.63,
-            "z": 277.28000000000003
-        },
-        {
-            "rotation": 2.8000000000000003,
-            "scale": 1,
-            "type": "tent",
-            "x": 67.63,
-            "z": 350.25
-        },
-        {
             "rotation": 1.2,
             "scale": 1,
             "type": "supply_cart",
@@ -4936,13 +4924,6 @@
             "z": 423.21000000000004
         },
         {
-            "rotation": 1.8,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 378.21,
-            "z": 452.40000000000003
-        },
-        {
             "rotation": 5,
             "scale": 1,
             "type": "dead_tree",
@@ -4957,20 +4938,6 @@
             "z": 258.82
         },
         {
-            "rotation": 3.2,
-            "scale": 1,
-            "type": "tent",
-            "x": 550.67,
-            "z": 347.44
-        },
-        {
-            "rotation": 2.1,
-            "scale": 1,
-            "type": "supply_cart",
-            "x": 576.09,
-            "z": 293.24
-        },
-        {
             "rotation": 4.4,
             "scale": 1,
             "type": "weapon_rack",
@@ -4978,25 +4945,11 @@
             "z": 340.33
         },
         {
-            "rotation": 0.4,
-            "scale": 1.1,
-            "type": "ruins",
-            "x": 588.61,
-            "z": 138.64000000000001
-        },
-        {
             "rotation": 2.1,
             "scale": 1,
             "type": "ruins",
             "x": 606.14,
             "z": 164.18
-        },
-        {
-            "rotation": 1.2,
-            "scale": 0.9,
-            "type": "tent",
-            "x": 686.29,
-            "z": 138.64000000000001
         },
         {
             "rotation": 2.6,
@@ -5011,38 +4964,6 @@
             "type": "weapon_rack",
             "x": 731.37,
             "z": 134.99
-        },
-        {
-            "intensity": 1.1,
-            "persistent": true,
-            "radius": 3,
-            "scale": 0.9,
-            "type": "firecamp",
-            "x": 706.33,
-            "z": 149.58
-        },
-        {
-            "rotation": 1,
-            "scale": 0.9,
-            "type": "tent",
-            "x": 693.8000000000001,
-            "z": 580.1
-        },
-        {
-            "rotation": 2.7,
-            "scale": 1,
-            "type": "supply_cart",
-            "x": 716.34,
-            "z": 627.53
-        },
-        {
-            "intensity": 1,
-            "persistent": true,
-            "radius": 3,
-            "scale": 0.9,
-            "type": "firecamp",
-            "x": 716.34,
-            "z": 591.04
         },
         {
             "rotation": 0.4,
@@ -5110,13 +5031,6 @@
             "z": 231
         },
         {
-            "rotation": 98.5,
-            "scale": 0.98,
-            "type": "dead_tree",
-            "x": 360.3,
-            "z": 246.01000000000002
-        },
-        {
             "rotation": 256.3,
             "scale": 0.87,
             "type": "dead_tree",
@@ -5174,20 +5088,6 @@
             "z": 423.82
         },
         {
-            "rotation": 67.4,
-            "scale": 1.08,
-            "type": "tent",
-            "x": 649.88,
-            "z": 177.95000000000002
-        },
-        {
-            "rotation": 186.3,
-            "scale": 1.1300000000000001,
-            "type": "tent",
-            "x": 615.27,
-            "z": 670.37
-        },
-        {
             "rotation": 16.8,
             "scale": 1.11,
             "type": "supply_cart",
@@ -5200,15 +5100,6 @@
             "type": "weapon_rack",
             "x": 540.85,
             "z": 367.74
-        },
-        {
-            "intensity": 1.26,
-            "persistent": true,
-            "radius": 2.7,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 768.34,
-            "z": 226.72
         },
         {
             "intensity": 0.87,
@@ -5234,20 +5125,6 @@
             "z": 335.22
         },
         {
-            "rotation": 12.5,
-            "scale": 1.16,
-            "type": "supply_cart",
-            "x": 661.5500000000001,
-            "z": 145.84
-        },
-        {
-            "rotation": 335.8,
-            "scale": 1.1500000000000001,
-            "type": "tent",
-            "x": 527.19,
-            "z": 691.27
-        },
-        {
             "rotation": 52.9,
             "scale": 1.06,
             "type": "weapon_rack",
@@ -5269,13 +5146,6 @@
             "type": "weapon_rack",
             "x": 676.86,
             "z": 250.87
-        },
-        {
-            "rotation": 52.1,
-            "scale": 1.05,
-            "type": "tent",
-            "x": 503.43,
-            "z": 641.24
         },
         {
             "rotation": 3.4,
@@ -5306,25 +5176,11 @@
             "z": 236.03
         },
         {
-            "rotation": 251.70000000000002,
-            "scale": 0.99,
-            "type": "tent",
-            "x": 629.0600000000001,
-            "z": 639.7
-        },
-        {
             "rotation": 256.3,
             "scale": 0.98,
             "type": "supply_cart",
             "x": 410.89,
             "z": 100.3
-        },
-        {
-            "rotation": 63.5,
-            "scale": 1.1300000000000001,
-            "type": "tent",
-            "x": 170.67000000000002,
-            "z": 328.59000000000003
         },
         {
             "rotation": 209.8,
@@ -5353,22 +5209,6 @@
             "type": "supply_cart",
             "x": 207.61,
             "z": 411.63
-        },
-        {
-            "rotation": 356.7,
-            "scale": 1.1,
-            "type": "weapon_rack",
-            "x": 646.69,
-            "z": 495.82
-        },
-        {
-            "intensity": 1.08,
-            "persistent": true,
-            "radius": 3.1,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 727.44,
-            "z": 250.59
         },
         {
             "rotation": 116.5,
@@ -5426,24 +5266,6 @@
             "z": 318.5
         },
         {
-            "intensity": 1.22,
-            "persistent": true,
-            "radius": 3.4,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 656.83,
-            "z": 198.77
-        },
-        {
-            "intensity": 1.35,
-            "persistent": true,
-            "radius": 3.3000000000000003,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 611.76,
-            "z": 636.33
-        },
-        {
             "intensity": 1.17,
             "persistent": true,
             "radius": 2.9,
@@ -5481,13 +5303,6 @@
             "type": "tent",
             "x": 145.81,
             "z": 360.39
-        },
-        {
-            "rotation": 214.3,
-            "scale": 1.11,
-            "type": "tent",
-            "x": 703.35,
-            "z": 455.74
         },
         {
             "rotation": 79.4,
@@ -5543,22 +5358,6 @@
             "z": 411.83
         },
         {
-            "intensity": 0.87,
-            "persistent": true,
-            "radius": 3.1,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 556.86,
-            "z": 370.39
-        },
-        {
-            "rotation": 319.7,
-            "scale": 0.9500000000000001,
-            "type": "supply_cart",
-            "x": 750.99,
-            "z": 152.04
-        },
-        {
             "rotation": 212.5,
             "scale": 1,
             "type": "tent",
@@ -5610,15 +5409,6 @@
             "type": "supply_cart",
             "x": 69.61,
             "z": 561.46
-        },
-        {
-            "intensity": 1.12,
-            "persistent": true,
-            "radius": 3.4,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 397.31,
-            "z": 518.88
         },
         {
             "rotation": 345.90000000000003,
@@ -5699,33 +5489,6 @@
             "z": 467.02
         },
         {
-            "intensity": 0.97,
-            "persistent": true,
-            "radius": 3.1,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 639.35,
-            "z": 200.11
-        },
-        {
-            "intensity": 1.19,
-            "persistent": true,
-            "radius": 3,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 257.88,
-            "z": 318.87
-        },
-        {
-            "intensity": 1.02,
-            "persistent": true,
-            "radius": 2.6,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 269.04,
-            "z": 394.93
-        },
-        {
             "rotation": 170.8,
             "scale": 0.93,
             "type": "ruins",
@@ -5768,13 +5531,6 @@
             "z": 779.8000000000001
         },
         {
-            "rotation": 111.60000000000001,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 129.65,
-            "z": 227.01
-        },
-        {
             "rotation": 179.3,
             "scale": 0.92,
             "type": "ruins",
@@ -5787,20 +5543,6 @@
             "type": "ruins",
             "x": 546.14,
             "z": 60.550000000000004
-        },
-        {
-            "rotation": 203.5,
-            "scale": 1.05,
-            "type": "dead_tree",
-            "x": 170.24,
-            "z": 233.93
-        },
-        {
-            "rotation": 208.6,
-            "scale": 1.04,
-            "type": "dead_tree",
-            "x": 730.7,
-            "z": 84.62
         },
         {
             "rotation": 335.1,
@@ -5824,13 +5566,6 @@
             "z": 44.46
         },
         {
-            "rotation": 279.7,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 768.0500000000001,
-            "z": 554.44
-        },
-        {
             "rotation": 213.20000000000002,
             "scale": 1.17,
             "type": "dead_tree",
@@ -5852,25 +5587,11 @@
             "z": 308.02
         },
         {
-            "rotation": 324,
-            "scale": 0.92,
-            "type": "dead_tree",
-            "x": 134.91,
-            "z": 198.02
-        },
-        {
             "rotation": 305.6,
             "scale": 1.05,
             "type": "ruins",
             "x": 325.1,
             "z": 278.90000000000003
-        },
-        {
-            "rotation": 22.3,
-            "scale": 0.98,
-            "type": "dead_tree",
-            "x": 531.42,
-            "z": 772.86
         },
         {
             "rotation": 189.4,
@@ -5887,41 +5608,6 @@
             "z": 274.75
         },
         {
-            "rotation": 357.3,
-            "scale": 1.03,
-            "type": "dead_tree",
-            "x": 380.15000000000003,
-            "z": 344.83
-        },
-        {
-            "rotation": 237.9,
-            "scale": 1.06,
-            "type": "ruins",
-            "x": 128.74,
-            "z": 708.49
-        },
-        {
-            "rotation": 253.4,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 361.11,
-            "z": 643.2
-        },
-        {
-            "rotation": 112.60000000000001,
-            "scale": 1.18,
-            "type": "dead_tree",
-            "x": 149.5,
-            "z": 113.22
-        },
-        {
-            "rotation": 99.7,
-            "scale": 1.1300000000000001,
-            "type": "dead_tree",
-            "x": 22.32,
-            "z": 267.43
-        },
-        {
             "rotation": 41.7,
             "scale": 1.1,
             "type": "dead_tree",
@@ -5934,13 +5620,6 @@
             "type": "ruins",
             "x": 115.4,
             "z": 700.85
-        },
-        {
-            "rotation": 21.3,
-            "scale": 1.05,
-            "type": "dead_tree",
-            "x": 587.47,
-            "z": 107.63
         },
         {
             "rotation": 161.20000000000002,
@@ -5964,34 +5643,6 @@
             "z": 400.83
         },
         {
-            "rotation": 313.7,
-            "scale": 0.97,
-            "type": "abandoned_home",
-            "x": 315.14,
-            "z": 224.02
-        },
-        {
-            "rotation": 22.7,
-            "scale": 0.9,
-            "type": "abandoned_home",
-            "x": 398.02,
-            "z": 252.43
-        },
-        {
-            "rotation": 238.20000000000002,
-            "scale": 0.96,
-            "type": "abandoned_home",
-            "x": 376.77,
-            "z": 263.38
-        },
-        {
-            "rotation": 110.2,
-            "scale": 0.9,
-            "type": "abandoned_home",
-            "x": 102.62,
-            "z": 582.1
-        },
-        {
             "rotation": 0.1,
             "scale": 0.98,
             "type": "abandoned_home",
@@ -6004,13 +5655,6 @@
             "type": "abandoned_home",
             "x": 65.41,
             "z": 619.45
-        },
-        {
-            "rotation": 107,
-            "scale": 1,
-            "type": "abandoned_home",
-            "x": 25.46,
-            "z": 563.7
         },
         {
             "rotation": 35.5,
@@ -6027,32 +5671,11 @@
             "z": 468.69
         },
         {
-            "rotation": 25.6,
-            "scale": 1.03,
-            "type": "abandoned_home",
-            "x": 112.29,
-            "z": 433.18
-        },
-        {
-            "rotation": 60.5,
-            "scale": 0.99,
-            "type": "abandoned_home",
-            "x": 569.87,
-            "z": 31.17
-        },
-        {
             "rotation": 117.7,
             "scale": 1.12,
             "type": "abandoned_home",
             "x": 217.76,
             "z": 232.69
-        },
-        {
-            "rotation": 126.8,
-            "scale": 1.12,
-            "type": "abandoned_home",
-            "x": 316.41,
-            "z": 240.25
         },
         {
             "landmark": "zama_west_sanctuary",
@@ -6718,6 +6341,1900 @@
             "type": "cursed_gold_vein",
             "x": 337,
             "z": 350
+        },
+        {
+            "type": "ruins",
+            "x": 300.0,
+            "z": 498.0,
+            "scale": 0.8,
+            "rotation": 0.0,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 312.06,
+            "z": 500.55,
+            "scale": 0.85,
+            "rotation": 0.685,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 307.51,
+            "z": 504.01,
+            "scale": 1.04,
+            "rotation": 0.241,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 299.74,
+            "z": 508.44,
+            "scale": 0.98,
+            "rotation": 3.44,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 295.75,
+            "z": 508.63,
+            "scale": 1.01,
+            "rotation": 5.081,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 289.26,
+            "z": 505.06,
+            "scale": 0.86,
+            "rotation": 2.42,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 292.25,
+            "z": 490.64,
+            "scale": 1.04,
+            "rotation": 3.856,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 295.8,
+            "z": 489.8,
+            "scale": 1.06,
+            "rotation": 3.294,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 304.3,
+            "z": 488.9,
+            "scale": 1.04,
+            "rotation": 4.455,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 310.54,
+            "z": 491.44,
+            "scale": 0.98,
+            "rotation": 1.809,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 308.88,
+            "z": 495.65,
+            "scale": 1.0,
+            "rotation": 1.731,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 308.88,
+            "z": 500.09,
+            "scale": 1.08,
+            "rotation": 3.984,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "supply_cart",
+            "x": 297.0,
+            "z": 481.0,
+            "scale": 1.0,
+            "rotation": -1.45,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "boulder",
+            "x": 295.42,
+            "z": 502.61,
+            "scale": 0.74,
+            "rotation": 4.488,
+            "dressing": "zama_oasis"
+        },
+        {
+            "type": "palm_tree",
+            "x": 197.55,
+            "z": 537.67,
+            "scale": 0.95,
+            "rotation": 3.65,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 225.99,
+            "z": 533.83,
+            "scale": 1.02,
+            "rotation": 2.91,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 230.94,
+            "z": 532.26,
+            "scale": 1.01,
+            "rotation": 3.418,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 244.2,
+            "z": 557.41,
+            "scale": 0.85,
+            "rotation": 0.813,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 272.05,
+            "z": 557.22,
+            "scale": 0.94,
+            "rotation": 2.82,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 276.99,
+            "z": 558.07,
+            "scale": 1.25,
+            "rotation": 0.716,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "palm_tree",
+            "x": 291.01,
+            "z": 579.7,
+            "scale": 0.86,
+            "rotation": 1.435,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 316.93,
+            "z": 577.57,
+            "scale": 1.2,
+            "rotation": 0.195,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 319.75,
+            "z": 574.56,
+            "scale": 1.22,
+            "rotation": 4.064,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 343.3,
+            "z": 586.01,
+            "scale": 1.29,
+            "rotation": 5.688,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 367.86,
+            "z": 568.06,
+            "scale": 0.82,
+            "rotation": 3.221,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 371.62,
+            "z": 566.83,
+            "scale": 1.02,
+            "rotation": 3.679,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "palm_tree",
+            "x": 397.44,
+            "z": 579.77,
+            "scale": 0.94,
+            "rotation": 0.916,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 421.3,
+            "z": 563.31,
+            "scale": 1.07,
+            "rotation": 6.212,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "plant",
+            "x": 423.21,
+            "z": 562.58,
+            "scale": 1.16,
+            "rotation": 3.84,
+            "dressing": "zama_oasis_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 119.06,
+            "z": 624.89,
+            "scale": 1.11,
+            "rotation": 5.369,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 115.36,
+            "z": 602.07,
+            "scale": 1.03,
+            "rotation": 6.091,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 107.93,
+            "z": 604.1,
+            "scale": 1.06,
+            "rotation": 3.256,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 109.55,
+            "z": 618.23,
+            "scale": 0.98,
+            "rotation": 1.853,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 99.4,
+            "z": 602.28,
+            "scale": 0.99,
+            "rotation": 0.425,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 98.23,
+            "z": 608.8,
+            "scale": 1.14,
+            "rotation": 5.847,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 126.28,
+            "z": 608.56,
+            "scale": 1.16,
+            "rotation": 3.802,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 108.57,
+            "z": 623.13,
+            "scale": 1.0,
+            "rotation": 1.858,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 133.37,
+            "z": 623.95,
+            "scale": 1.05,
+            "rotation": 1.903,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 140.56,
+            "z": 612.34,
+            "scale": 1.15,
+            "rotation": 3.686,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 115.31,
+            "z": 596.68,
+            "scale": 1.07,
+            "rotation": 0.4,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "dead_tree",
+            "x": 108.08,
+            "z": 599.05,
+            "scale": 1.0,
+            "rotation": 3.776,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "ruins",
+            "x": 107.42,
+            "z": 610.77,
+            "scale": 0.97,
+            "rotation": 0.049,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "ruins",
+            "x": 125.08,
+            "z": 598.93,
+            "scale": 0.98,
+            "rotation": 3.804,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "ruins",
+            "x": 116.09,
+            "z": 590.94,
+            "scale": 0.81,
+            "rotation": 4.939,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "ruins",
+            "x": 104.06,
+            "z": 618.04,
+            "scale": 0.8,
+            "rotation": 0.171,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "boulder",
+            "x": 139.85,
+            "z": 608.16,
+            "scale": 0.76,
+            "rotation": 4.832,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "boulder",
+            "x": 124.12,
+            "z": 604.5,
+            "scale": 1.01,
+            "rotation": 0.869,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "boulder",
+            "x": 118.25,
+            "z": 605.84,
+            "scale": 0.85,
+            "rotation": 5.836,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "boulder",
+            "x": 127.12,
+            "z": 603.83,
+            "scale": 1.05,
+            "rotation": 4.51,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "boulder",
+            "x": 103.43,
+            "z": 606.94,
+            "scale": 1.05,
+            "rotation": 2.521,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "boulder",
+            "x": 110.25,
+            "z": 587.95,
+            "scale": 0.97,
+            "rotation": 1.7,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "boulder",
+            "x": 104.64,
+            "z": 596.86,
+            "scale": 1.14,
+            "rotation": 4.927,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "boulder",
+            "x": 96.36,
+            "z": 599.99,
+            "scale": 0.68,
+            "rotation": 0.125,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "statue",
+            "x": 117.65,
+            "z": 609.41,
+            "scale": 0.9,
+            "rotation": 1.75,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "statue",
+            "x": 116.22,
+            "z": 607.03,
+            "scale": 0.9,
+            "rotation": 1.418,
+            "dressing": "zama_field_of_the_dead"
+        },
+        {
+            "type": "ruins",
+            "x": 133.11,
+            "z": 606.07,
+            "scale": 1.19,
+            "rotation": 0.891,
+            "dressing": "zama_vanguard_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 124.65,
+            "z": 621.63,
+            "scale": 0.91,
+            "rotation": 3.851,
+            "dressing": "zama_vanguard_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 116.35,
+            "z": 617.43,
+            "scale": 1.11,
+            "rotation": 5.154,
+            "dressing": "zama_vanguard_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 119.76,
+            "z": 172.11,
+            "scale": 1.02,
+            "rotation": 5.085,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 111.58,
+            "z": 182.88,
+            "scale": 0.98,
+            "rotation": 1.994,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 101.87,
+            "z": 184.3,
+            "scale": 1.17,
+            "rotation": 1.177,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 94.82,
+            "z": 175.77,
+            "scale": 0.97,
+            "rotation": 3.685,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 100.15,
+            "z": 163.22,
+            "scale": 1.04,
+            "rotation": 0.632,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 115.85,
+            "z": 164.54,
+            "scale": 0.9,
+            "rotation": 2.305,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 117.26,
+            "z": 190.73,
+            "scale": 1.09,
+            "rotation": 0.957,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 91.37,
+            "z": 181.64,
+            "scale": 0.98,
+            "rotation": 2.858,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 99.82,
+            "z": 155.24,
+            "scale": 1.01,
+            "rotation": 1.555,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 122.99,
+            "z": 161.81,
+            "scale": 0.97,
+            "rotation": 0.782,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 122.12,
+            "z": 187.11,
+            "scale": 1.07,
+            "rotation": 4.588,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 119.26,
+            "z": 177.13,
+            "scale": 0.9,
+            "rotation": 3.22,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 99.43,
+            "z": 173.77,
+            "scale": 0.9,
+            "rotation": 3.277,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 111.41,
+            "z": 161.86,
+            "scale": 1.03,
+            "rotation": 2.582,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 109.32,
+            "z": 157.96,
+            "scale": 1.07,
+            "rotation": 3.865,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 121.64,
+            "z": 167.15,
+            "scale": 0.92,
+            "rotation": 0.509,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 108.0,
+            "z": 173.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_desert_barrows"
+        },
+        {
+            "type": "palm_tree",
+            "x": 519.09,
+            "z": 264.57,
+            "scale": 0.95,
+            "rotation": 4.404,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 521.68,
+            "z": 278.24,
+            "scale": 1.06,
+            "rotation": 0.21,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 528.89,
+            "z": 262.06,
+            "scale": 1.0,
+            "rotation": 2.177,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 541.76,
+            "z": 270.7,
+            "scale": 1.08,
+            "rotation": 0.327,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 550.78,
+            "z": 255.49,
+            "scale": 0.93,
+            "rotation": 3.0,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 560.8,
+            "z": 252.04,
+            "scale": 0.93,
+            "rotation": 2.928,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 573.17,
+            "z": 252.1,
+            "scale": 0.95,
+            "rotation": 0.658,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 584.48,
+            "z": 251.6,
+            "scale": 0.96,
+            "rotation": 2.243,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 585.18,
+            "z": 264.91,
+            "scale": 0.97,
+            "rotation": 0.785,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 598.78,
+            "z": 258.43,
+            "scale": 0.99,
+            "rotation": 3.901,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 590.29,
+            "z": 266.99,
+            "scale": 1.03,
+            "rotation": 3.742,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 606.87,
+            "z": 265.72,
+            "scale": 1.0,
+            "rotation": 0.055,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 597.59,
+            "z": 275.0,
+            "scale": 1.02,
+            "rotation": 2.454,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 613.94,
+            "z": 274.06,
+            "scale": 0.9,
+            "rotation": 6.239,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 604.46,
+            "z": 282.9,
+            "scale": 0.97,
+            "rotation": 3.759,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 622.2,
+            "z": 284.89,
+            "scale": 1.1,
+            "rotation": 0.785,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 609.69,
+            "z": 289.52,
+            "scale": 0.96,
+            "rotation": 5.656,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 625.72,
+            "z": 294.21,
+            "scale": 0.98,
+            "rotation": 5.625,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 614.66,
+            "z": 299.74,
+            "scale": 1.03,
+            "rotation": 5.634,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 631.38,
+            "z": 305.04,
+            "scale": 1.09,
+            "rotation": 4.704,
+            "dressing": "zama_scipio_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 67.21,
+            "z": 393.85,
+            "scale": 0.9,
+            "rotation": 3.421,
+            "dressing": "zama_camp_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 78.9,
+            "z": 392.3,
+            "scale": 0.92,
+            "rotation": 0.693,
+            "dressing": "zama_camp_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 90.53,
+            "z": 390.96,
+            "scale": 1.02,
+            "rotation": 6.135,
+            "dressing": "zama_camp_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 102.62,
+            "z": 389.49,
+            "scale": 1.02,
+            "rotation": 5.278,
+            "dressing": "zama_camp_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 114.54,
+            "z": 387.82,
+            "scale": 1.02,
+            "rotation": 0.514,
+            "dressing": "zama_camp_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 126.56,
+            "z": 385.41,
+            "scale": 0.95,
+            "rotation": 5.291,
+            "dressing": "zama_camp_avenue"
+        },
+        {
+            "type": "palm_tree",
+            "x": 150.53,
+            "z": 382.95,
+            "scale": 1.06,
+            "rotation": 4.331,
+            "dressing": "zama_camp_avenue"
+        },
+        {
+            "type": "abandoned_home",
+            "x": 322.0,
+            "z": 104.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "boulder",
+            "x": 314.03,
+            "z": 104.64,
+            "scale": 0.91,
+            "rotation": 4.183,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "boulder",
+            "x": 315.09,
+            "z": 99.97,
+            "scale": 0.73,
+            "rotation": 4.17,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "boulder",
+            "x": 319.33,
+            "z": 96.46,
+            "scale": 0.8,
+            "rotation": 0.052,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "boulder",
+            "x": 324.53,
+            "z": 96.41,
+            "scale": 0.79,
+            "rotation": 5.522,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "boulder",
+            "x": 328.07,
+            "z": 98.79,
+            "scale": 0.91,
+            "rotation": 1.741,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "boulder",
+            "x": 330.0,
+            "z": 103.81,
+            "scale": 0.74,
+            "rotation": 1.359,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "dead_tree",
+            "x": 315.28,
+            "z": 96.47,
+            "scale": 1.0,
+            "rotation": 2.0,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "supply_cart",
+            "x": 326.0,
+            "z": 109.0,
+            "scale": 1.0,
+            "rotation": 1.971,
+            "dressing": "zama_kraal_fold"
+        },
+        {
+            "type": "boulder",
+            "x": 455.85,
+            "z": 554.05,
+            "scale": 0.9,
+            "rotation": 3.68,
+            "dressing": "zama_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 438.16,
+            "z": 553.95,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 455.45,
+            "z": 546.86,
+            "scale": 1.0,
+            "rotation": 2.127,
+            "dressing": "zama_south_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 435.08,
+            "z": 551.0,
+            "scale": 1.0,
+            "rotation": -1.875,
+            "dressing": "zama_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 459.22,
+            "z": 565.78,
+            "scale": 1.21,
+            "rotation": 3.686,
+            "dressing": "zama_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 445.3,
+            "z": 569.97,
+            "scale": 0.85,
+            "rotation": 0.743,
+            "dressing": "zama_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 462.61,
+            "z": 568.93,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 445.76,
+            "z": 577.14,
+            "scale": 1.0,
+            "rotation": 3.005,
+            "dressing": "zama_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 584.25,
+            "z": 537.77,
+            "scale": 0.87,
+            "rotation": 5.296,
+            "dressing": "zama_rearguard_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 598.41,
+            "z": 536.21,
+            "scale": 1.21,
+            "rotation": 3.843,
+            "dressing": "zama_rearguard_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 601.59,
+            "z": 539.88,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_rearguard_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 583.53,
+            "z": 544.89,
+            "scale": 1.0,
+            "rotation": 1.635,
+            "dressing": "zama_rearguard_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 603.13,
+            "z": 544.74,
+            "scale": 1.0,
+            "rotation": 1.429,
+            "dressing": "zama_rearguard_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 583.28,
+            "z": 525.61,
+            "scale": 0.91,
+            "rotation": 4.228,
+            "dressing": "zama_rearguard_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 597.47,
+            "z": 524.04,
+            "scale": 1.12,
+            "rotation": 2.096,
+            "dressing": "zama_rearguard_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 580.49,
+            "z": 521.89,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_rearguard_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 598.55,
+            "z": 516.88,
+            "scale": 1.0,
+            "rotation": 1.191,
+            "dressing": "zama_rearguard_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 55.67,
+            "z": 468.76,
+            "scale": 0.84,
+            "rotation": 0.466,
+            "dressing": "zama_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 43.04,
+            "z": 463.71,
+            "scale": 0.96,
+            "rotation": 3.41,
+            "dressing": "zama_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 42.15,
+            "z": 459.04,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_west_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 50.96,
+            "z": 481.29,
+            "scale": 1.13,
+            "rotation": 3.838,
+            "dressing": "zama_west_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 51.85,
+            "z": 485.96,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_west_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 33.99,
+            "z": 482.99,
+            "scale": 1.0,
+            "rotation": 1.626,
+            "dressing": "zama_west_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 546.0,
+            "z": 412.5,
+            "scale": 0.96,
+            "rotation": 5.786,
+            "dressing": "zama_scipio_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 540.0,
+            "z": 414.5,
+            "scale": 1.39,
+            "rotation": 4.855,
+            "dressing": "zama_scipio_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 554.0,
+            "z": 416.5,
+            "scale": 1.0,
+            "rotation": 3.403,
+            "dressing": "zama_scipio_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 545.53,
+            "z": 381.75,
+            "scale": 0.94,
+            "rotation": 0.583,
+            "dressing": "zama_scipio_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 538.88,
+            "z": 377.93,
+            "scale": 1.36,
+            "rotation": 2.372,
+            "dressing": "zama_scipio_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 536.0,
+            "z": 378.5,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "zama_scipio_ramp"
+        },
+        {
+            "type": "firecamp",
+            "x": 532.0,
+            "z": 376.5,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_scipio_ramp",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 452.5,
+            "z": 251.0,
+            "scale": 1.45,
+            "rotation": 4.027,
+            "dressing": "zama_north_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 454.5,
+            "z": 257.0,
+            "scale": 0.98,
+            "rotation": 2.615,
+            "dressing": "zama_north_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 456.5,
+            "z": 243.0,
+            "scale": 1.0,
+            "rotation": 1.625,
+            "dressing": "zama_north_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 419.5,
+            "z": 251.0,
+            "scale": 1.43,
+            "rotation": 2.533,
+            "dressing": "zama_north_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 417.5,
+            "z": 257.0,
+            "scale": 0.9,
+            "rotation": 0.275,
+            "dressing": "zama_north_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 418.5,
+            "z": 261.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "zama_north_ramp"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 174.99,
+            "z": 381.68,
+            "scale": 1.0,
+            "rotation": -0.134,
+            "dressing": "zama_camp_junction"
+        },
+        {
+            "type": "statue",
+            "x": 521.82,
+            "z": 350.14,
+            "scale": 1.0,
+            "rotation": -1.859,
+            "dressing": "zama_scipio_junction"
+        },
+        {
+            "type": "palm_tree",
+            "x": 523.96,
+            "z": 357.01,
+            "scale": 1.0,
+            "rotation": 3.613,
+            "dressing": "zama_scipio_junction"
+        },
+        {
+            "type": "statue",
+            "x": 5.12,
+            "z": 402.91,
+            "scale": 1.0,
+            "rotation": -1.705,
+            "dressing": "zama_west_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 7.91,
+            "z": 404.94,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_west_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "palm_tree",
+            "x": 55.39,
+            "z": 149.24,
+            "scale": 0.94,
+            "rotation": 3.188,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 87.05,
+            "z": 122.29,
+            "scale": 0.8,
+            "rotation": 3.521,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 127.5,
+            "z": 117.09,
+            "scale": 1.05,
+            "rotation": 3.461,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 130.3,
+            "z": 119.02,
+            "scale": 1.39,
+            "rotation": 0.414,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 159.86,
+            "z": 95.43,
+            "scale": 1.03,
+            "rotation": 0.473,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "palm_tree",
+            "x": 203.09,
+            "z": 93.24,
+            "scale": 1.1,
+            "rotation": 0.776,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 234.2,
+            "z": 70.1,
+            "scale": 1.29,
+            "rotation": 1.142,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 274.7,
+            "z": 61.22,
+            "scale": 1.13,
+            "rotation": 4.114,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 277.99,
+            "z": 60.44,
+            "scale": 1.34,
+            "rotation": 0.955,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 310.72,
+            "z": 35.08,
+            "scale": 0.91,
+            "rotation": 2.59,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "palm_tree",
+            "x": 351.91,
+            "z": 48.97,
+            "scale": 1.12,
+            "rotation": 2.339,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 392.35,
+            "z": 40.59,
+            "scale": 1.12,
+            "rotation": 0.958,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 426.08,
+            "z": 62.25,
+            "scale": 1.19,
+            "rotation": 4.38,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 428.88,
+            "z": 65.32,
+            "scale": 0.92,
+            "rotation": 5.585,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 467.87,
+            "z": 61.37,
+            "scale": 1.21,
+            "rotation": 1.339,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "palm_tree",
+            "x": 503.91,
+            "z": 82.96,
+            "scale": 0.86,
+            "rotation": 0.129,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 545.79,
+            "z": 74.11,
+            "scale": 1.12,
+            "rotation": 1.587,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 583.74,
+            "z": 90.57,
+            "scale": 1.13,
+            "rotation": 5.066,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 587.03,
+            "z": 94.18,
+            "scale": 1.17,
+            "rotation": 3.27,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 626.22,
+            "z": 84.64,
+            "scale": 1.3,
+            "rotation": 0.495,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "palm_tree",
+            "x": 663.04,
+            "z": 103.75,
+            "scale": 1.06,
+            "rotation": 4.626,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 703.31,
+            "z": 102.41,
+            "scale": 0.96,
+            "rotation": 0.125,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 738.34,
+            "z": 126.6,
+            "scale": 0.99,
+            "rotation": 5.823,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "plant",
+            "x": 741.96,
+            "z": 129.98,
+            "scale": 1.39,
+            "rotation": 4.33,
+            "dressing": "zama_north_bank"
+        },
+        {
+            "type": "firecamp",
+            "x": 630.3,
+            "z": 375.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 641.7,
+            "z": 375.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 642.7,
+            "z": 371.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "zama_gate_1"
+        },
+        {
+            "type": "supply_cart",
+            "x": 628.8,
+            "z": 369.0,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "zama_gate_1"
+        },
+        {
+            "type": "statue",
+            "x": 629.73,
+            "z": 365.12,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_1"
+        },
+        {
+            "type": "statue",
+            "x": 643.13,
+            "z": 365.12,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "zama_gate_1"
+        },
+        {
+            "type": "firecamp",
+            "x": 711.7,
+            "z": 227.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 700.3,
+            "z": 227.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 699.3,
+            "z": 231.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "zama_gate_2"
+        },
+        {
+            "type": "supply_cart",
+            "x": 713.2,
+            "z": 233.0,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "zama_gate_2"
+        },
+        {
+            "type": "firecamp",
+            "x": 449.47,
+            "z": 211.88,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 436.67,
+            "z": 215.88,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "zama_gate_3"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 425.81,
+            "z": 194.13,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "zama_gate_4"
+        },
+        {
+            "type": "supply_cart",
+            "x": 447.8,
+            "z": 196.05,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "zama_gate_4"
+        },
+        {
+            "type": "firecamp",
+            "x": 559.0,
+            "z": 605.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 569.43,
+            "z": 606.12,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 570.0,
+            "z": 601.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "zama_gate_5"
+        },
+        {
+            "type": "supply_cart",
+            "x": 557.5,
+            "z": 599.0,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "zama_gate_5"
+        },
+        {
+            "type": "firecamp",
+            "x": 561.3,
+            "z": 667.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 550.7,
+            "z": 667.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 549.7,
+            "z": 671.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "zama_gate_6"
+        },
+        {
+            "type": "supply_cart",
+            "x": 562.8,
+            "z": 673.0,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "zama_gate_6"
+        },
+        {
+            "type": "firecamp",
+            "x": 519.0,
+            "z": 627.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_7",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 518.28,
+            "z": 614.82,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "zama_gate_7",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 515.47,
+            "z": 613.75,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "zama_gate_7"
+        },
+        {
+            "type": "supply_cart",
+            "x": 513.0,
+            "z": 628.5,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "zama_gate_7"
+        }
+    ],
+    "dressing": [
+        {
+            "id": "zama_oasis",
+            "kind": "oasis",
+            "x": 300,
+            "z": 498,
+            "facing": "north",
+            "palms": 11,
+            "radius": 13,
+            "tents": 2
+        },
+        {
+            "id": "zama_oasis_bank",
+            "kind": "riverbank",
+            "from": [
+                200,
+                462
+            ],
+            "to": [
+                420,
+                478
+            ],
+            "spacing": 26,
+            "kinds": [
+                "palm_tree",
+                "plant",
+                "boulder",
+                "plant"
+            ]
+        },
+        {
+            "id": "zama_field_of_the_dead",
+            "kind": "boneyard",
+            "x": 119,
+            "z": 609,
+            "radius": 22,
+            "dead_trees": 12,
+            "ruins": 5,
+            "boulders": 8,
+            "statues": 2
+        },
+        {
+            "id": "zama_vanguard_ring",
+            "kind": "barrow_field",
+            "x": 119,
+            "z": 609,
+            "radius": 15,
+            "ruins": 6,
+            "dead_trees": 0,
+            "statues": 0,
+            "boulders": 0
+        },
+        {
+            "id": "zama_desert_barrows",
+            "kind": "barrow_field",
+            "x": 108,
+            "z": 173,
+            "radius": 13,
+            "shrine": true,
+            "ruins": 6,
+            "dead_trees": 5,
+            "boulders": 5
+        },
+        {
+            "id": "zama_scipio_avenue",
+            "kind": "tree_avenue",
+            "from": [
+                536,
+                342
+            ],
+            "to": [
+                596,
+                334
+            ],
+            "tree": "palm_tree",
+            "spacing": 11
+        },
+        {
+            "id": "zama_camp_avenue",
+            "kind": "tree_avenue",
+            "from": [
+                60,
+                388
+            ],
+            "to": [
+                160,
+                376
+            ],
+            "tree": "palm_tree",
+            "spacing": 12,
+            "sides": "right"
+        },
+        {
+            "id": "zama_kraal_fold",
+            "kind": "sheepfold",
+            "x": 322,
+            "z": 104,
+            "facing": "south"
+        },
+        {
+            "id": "zama_south_bridge",
+            "kind": "bridgehead",
+            "x": 450,
+            "z": 562
+        },
+        {
+            "id": "zama_rearguard_bridge",
+            "kind": "bridgehead",
+            "x": 591,
+            "z": 530
+        },
+        {
+            "id": "zama_west_bridge",
+            "kind": "bridgehead",
+            "x": 47,
+            "z": 472,
+            "cart": false
+        },
+        {
+            "id": "zama_scipio_ramp",
+            "kind": "ramp_mouth",
+            "x": 566,
+            "z": 396,
+            "statue": true,
+            "fire": true
+        },
+        {
+            "id": "zama_north_ramp",
+            "kind": "ramp_mouth",
+            "x": 436,
+            "z": 237,
+            "statue": true
+        },
+        {
+            "id": "zama_camp_junction",
+            "kind": "junction",
+            "x": 180,
+            "z": 372,
+            "style": "camp"
+        },
+        {
+            "id": "zama_scipio_junction",
+            "kind": "junction",
+            "x": 520,
+            "z": 344,
+            "style": "milestone",
+            "tree": "palm_tree",
+            "snap": 6
+        },
+        {
+            "id": "zama_west_junction",
+            "kind": "junction",
+            "x": 8,
+            "z": 396,
+            "style": "shrine"
+        },
+        {
+            "id": "zama_north_bank",
+            "kind": "riverbank",
+            "from": [
+                40,
+                166
+            ],
+            "to": [
+                760,
+                133
+            ],
+            "spacing": 40,
+            "kinds": [
+                "palm_tree",
+                "boulder",
+                "plant",
+                "boulder"
+            ]
+        },
+        {
+            "id": "zama_gate_1",
+            "kind": "gate_approach",
+            "x": 636.0,
+            "z": 384.0,
+            "statues": true
+        },
+        {
+            "id": "zama_gate_2",
+            "kind": "gate_approach",
+            "x": 706.0,
+            "z": 218.0
+        },
+        {
+            "id": "zama_gate_3",
+            "kind": "gate_approach",
+            "x": 444.0,
+            "z": 204.0,
+            "statues": true
+        },
+        {
+            "id": "zama_gate_4",
+            "kind": "gate_approach",
+            "x": 436.0,
+            "z": 182.0,
+            "statues": true
+        },
+        {
+            "id": "zama_gate_5",
+            "kind": "gate_approach",
+            "x": 564,
+            "z": 614
+        },
+        {
+            "id": "zama_gate_6",
+            "kind": "gate_approach",
+            "x": 556,
+            "z": 658
+        },
+        {
+            "id": "zama_gate_7",
+            "kind": "gate_approach",
+            "x": 528,
+            "z": 622
         }
     ]
 }

--- a/assets/maps/map_campania_campaign.json
+++ b/assets/maps/map_campania_campaign.json
@@ -5207,32 +5207,6 @@
     ],
     "undead_zones": [
         {
-            "anchor_type": "magic_shrine",
-            "awaken_on": [
-                "unit_enters_radius"
-            ],
-            "clear_reward": {
-                "iron": 100,
-                "stone": 140
-            },
-            "id": "pass_shrine",
-            "leash_radius": 29.42,
-            "owner_id": 99,
-            "radius": 16.81,
-            "team_id": 99,
-            "waves": [
-                {
-                    "trigger": "initial",
-                    "units": {
-                        "grave_priest": 1,
-                        "skeleton_swordsman": 2
-                    }
-                }
-            ],
-            "x": 432,
-            "z": 33
-        },
-        {
             "anchor_type": "ruins",
             "awaken_on": [
                 "unit_enters_radius"
@@ -5241,10 +5215,10 @@
                 "gold": 130,
                 "wood": 90
             },
-            "id": "ford_shades",
-            "leash_radius": 38.22,
+            "id": "campania_river_dead",
+            "leash_radius": 32.0,
             "owner_id": 99,
-            "radius": 21.84,
+            "radius": 18.0,
             "team_id": 99,
             "waves": [
                 {
@@ -5255,11 +5229,12 @@
                     }
                 }
             ],
-            "x": 394,
-            "z": 207
+            "x": 585,
+            "z": 52,
+            "fog_density": 0.3
         },
         {
-            "anchor_type": "magic_shrine",
+            "anchor_type": "ruins",
             "awaken_on": [
                 "unit_enters_radius"
             ],
@@ -5267,7 +5242,7 @@
                 "gold": 110,
                 "iron": 70
             },
-            "id": "bridge_watch",
+            "id": "campania_coast_barrow",
             "leash_radius": 35.49,
             "owner_id": 99,
             "radius": 19.11,
@@ -5281,7 +5256,8 @@
                 }
             ],
             "x": 162,
-            "z": 586
+            "z": 586,
+            "fog_density": 0.28
         },
         {
             "anchor_type": "ruins",
@@ -5292,7 +5268,7 @@
                 "food": 140,
                 "gold": 180
             },
-            "id": "old_grave",
+            "id": "campania_old_grave",
             "leash_radius": 47.89,
             "owner_id": 99,
             "radius": 26.61,
@@ -5314,7 +5290,8 @@
                 }
             ],
             "x": 28,
-            "z": 277
+            "z": 277,
+            "fog_density": 0.3
         },
         {
             "anchor_type": "ruins",
@@ -5341,7 +5318,8 @@
                 }
             ],
             "x": 611,
-            "z": 392
+            "z": 392,
+            "fog_density": 0.32
         }
     ],
     "victory": {
@@ -5481,27 +5459,6 @@
             "z": 302.12
         },
         {
-            "rotation": 0.8,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 88.39,
-            "z": 330.32
-        },
-        {
-            "rotation": 3.1,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 111.66,
-            "z": 339.62
-        },
-        {
-            "rotation": 2.6,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 409.46,
-            "z": 338.77
-        },
-        {
             "rotation": 5.4,
             "scale": 0.9,
             "type": "dead_tree",
@@ -5514,13 +5471,6 @@
             "type": "dead_tree",
             "x": 172.14000000000001,
             "z": 167.48
-        },
-        {
-            "rotation": 4.1,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 394,
-            "z": 22
         },
         {
             "rotation": 0.3,
@@ -5579,32 +5529,11 @@
             "z": 269.84000000000003
         },
         {
-            "rotation": 1.1,
-            "scale": 0.9,
-            "type": "tent",
-            "x": 579.22,
-            "z": 255.88
-        },
-        {
-            "rotation": 4.2,
-            "scale": 0.9,
-            "type": "tent",
-            "x": 621.09,
-            "z": 258.2
-        },
-        {
             "rotation": 2.6,
             "scale": 1,
             "type": "supply_cart",
             "x": 600.15,
             "z": 293.1
-        },
-        {
-            "rotation": 5,
-            "scale": 0.9,
-            "type": "weapon_rack",
-            "x": 628.0600000000001,
-            "z": 244.25
         },
         {
             "intensity": 1.1500000000000001,
@@ -5621,13 +5550,6 @@
             "type": "ruins",
             "x": 97.7,
             "z": 532.69
-        },
-        {
-            "rotation": 3.5,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 111.66,
-            "z": 521.0600000000001
         },
         {
             "intensity": 1.25,
@@ -5733,13 +5655,6 @@
             "z": 243.64000000000001
         },
         {
-            "rotation": 345.40000000000003,
-            "scale": 1,
-            "type": "ruins",
-            "x": 115.58,
-            "z": 250
-        },
-        {
             "rotation": 84.7,
             "scale": 1.1400000000000001,
             "type": "dead_tree",
@@ -5754,32 +5669,11 @@
             "z": 147.86
         },
         {
-            "rotation": 295.8,
-            "scale": 0.9500000000000001,
-            "type": "weapon_rack",
-            "x": 133.37,
-            "z": 122.68
-        },
-        {
-            "rotation": 61.5,
-            "scale": 1.06,
-            "type": "supply_cart",
-            "x": 424.28000000000003,
-            "z": 111.43
-        },
-        {
             "rotation": 19.7,
             "scale": 1.02,
             "type": "weapon_rack",
             "x": 133.37,
             "z": 494.26
-        },
-        {
-            "rotation": 86.4,
-            "scale": 1.06,
-            "type": "tent",
-            "x": 442.77,
-            "z": 558.0500000000001
         },
         {
             "intensity": 1.21,
@@ -5796,13 +5690,6 @@
             "type": "tent",
             "x": 237.69,
             "z": 258.78
-        },
-        {
-            "rotation": 173.70000000000002,
-            "scale": 1.1,
-            "type": "tent",
-            "x": 61.54,
-            "z": 21.5
         },
         {
             "rotation": 234.1,
@@ -5840,13 +5727,6 @@
             "type": "supply_cart",
             "x": 251.72,
             "z": 303.31
-        },
-        {
-            "rotation": 21.5,
-            "scale": 1.07,
-            "type": "tent",
-            "x": 38.27,
-            "z": 45.21
         },
         {
             "rotation": 204.20000000000002,
@@ -5953,15 +5833,6 @@
             "z": 382.46000000000004
         },
         {
-            "intensity": 1.35,
-            "persistent": true,
-            "radius": 3.1,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 443.18,
-            "z": 531.9300000000001
-        },
-        {
             "rotation": 352.1,
             "scale": 1.03,
             "type": "tent",
@@ -5981,15 +5852,6 @@
             "type": "tent",
             "x": 168.34,
             "z": 59.27
-        },
-        {
-            "intensity": 1.22,
-            "persistent": true,
-            "radius": 3.1,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 465.01,
-            "z": 74.3
         },
         {
             "intensity": 0.9,
@@ -6031,13 +5893,6 @@
             "z": 109.3
         },
         {
-            "rotation": 345.1,
-            "scale": 0.91,
-            "type": "tent",
-            "x": 441.84000000000003,
-            "z": 94.99
-        },
-        {
             "intensity": 1.1400000000000001,
             "persistent": true,
             "radius": 2.6,
@@ -6072,27 +5927,11 @@
             "z": 159.79
         },
         {
-            "rotation": 97.4,
-            "scale": 1.1300000000000001,
-            "type": "weapon_rack",
-            "x": 113.7,
-            "z": 126.53
-        },
-        {
             "rotation": 337.40000000000003,
             "scale": 0.91,
             "type": "tent",
             "x": 496.35,
             "z": 83.98
-        },
-        {
-            "intensity": 1.26,
-            "persistent": true,
-            "radius": 3.3000000000000003,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 31.54,
-            "z": 399.01
         },
         {
             "rotation": 264.1,
@@ -6139,13 +5978,6 @@
             "type": "supply_cart",
             "x": 91.7,
             "z": 392.43
-        },
-        {
-            "rotation": 74,
-            "scale": 1.02,
-            "type": "tent",
-            "x": 448.09000000000003,
-            "z": 507.24
         },
         {
             "rotation": 169.5,
@@ -6221,13 +6053,6 @@
             "z": 203.70000000000002
         },
         {
-            "rotation": 78.2,
-            "scale": 0.97,
-            "type": "supply_cart",
-            "x": 393.28000000000003,
-            "z": 443.44
-        },
-        {
             "rotation": 343.1,
             "scale": 0.98,
             "type": "supply_cart",
@@ -6258,13 +6083,6 @@
             "z": 228.28
         },
         {
-            "rotation": 341.6,
-            "scale": 0.99,
-            "type": "dead_tree",
-            "x": 311.24,
-            "z": 119.89
-        },
-        {
             "rotation": 304.3,
             "scale": 0.87,
             "type": "ruins",
@@ -6286,13 +6104,6 @@
             "z": 395.55
         },
         {
-            "rotation": 170.4,
-            "scale": 1.03,
-            "type": "dead_tree",
-            "x": 359.02,
-            "z": 110.46000000000001
-        },
-        {
             "rotation": 57,
             "scale": 0.97,
             "type": "ruins",
@@ -6307,25 +6118,11 @@
             "z": 20
         },
         {
-            "rotation": 187.4,
-            "scale": 1.16,
-            "type": "ruins",
-            "x": 317,
-            "z": 27
-        },
-        {
             "rotation": 8.700000000000001,
             "scale": 1.12,
             "type": "ruins",
             "x": 300,
             "z": 17
-        },
-        {
-            "rotation": 9.9,
-            "scale": 0.99,
-            "type": "dead_tree",
-            "x": 216.93,
-            "z": 625.09
         },
         {
             "rotation": 79.3,
@@ -6349,32 +6146,11 @@
             "z": 525.77
         },
         {
-            "rotation": 185.3,
-            "scale": 1.16,
-            "type": "ruins",
-            "x": 21.16,
-            "z": 332.03000000000003
-        },
-        {
-            "rotation": 16.5,
-            "scale": 1.09,
-            "type": "ruins",
-            "x": 36.79,
-            "z": 330.17
-        },
-        {
             "rotation": 233.4,
             "scale": 0.9500000000000001,
             "type": "ruins",
             "x": 16.87,
             "z": 248.93
-        },
-        {
-            "rotation": 40.1,
-            "scale": 0.93,
-            "type": "dead_tree",
-            "x": 473.51,
-            "z": 631.9300000000001
         },
         {
             "rotation": 351.5,
@@ -6391,32 +6167,11 @@
             "z": 293.67
         },
         {
-            "rotation": 202.3,
-            "scale": 1.12,
-            "type": "dead_tree",
-            "x": 496.93,
-            "z": 442.19
-        },
-        {
-            "rotation": 114.10000000000001,
-            "scale": 1.1300000000000001,
-            "type": "dead_tree",
-            "x": 543.84,
-            "z": 525.64
-        },
-        {
             "rotation": 111.3,
             "scale": 0.96,
             "type": "ruins",
             "x": 50.13,
             "z": 302.54
-        },
-        {
-            "rotation": 100.9,
-            "scale": 1.1,
-            "type": "dead_tree",
-            "x": 28.84,
-            "z": 595.15
         },
         {
             "rotation": 344.1,
@@ -6480,13 +6235,6 @@
             "type": "abandoned_home",
             "x": 117.93,
             "z": 224.8
-        },
-        {
-            "rotation": 140.20000000000002,
-            "scale": 1.05,
-            "type": "abandoned_home",
-            "x": 106.35000000000001,
-            "z": 250.48000000000002
         },
         {
             "rotation": 347.1,
@@ -6750,14 +6498,6 @@
             "type": "statue",
             "x": 195,
             "z": 352
-        },
-        {
-            "landmark": "campania_vesuvian_shrine",
-            "rotation": 90,
-            "scale": 1,
-            "type": "ruins",
-            "x": 205,
-            "z": 367
         },
         {
             "landmark": "campania_vesuvian_shrine",
@@ -7167,6 +6907,2388 @@
             "type": "cursed_gold_vein",
             "x": 62,
             "z": 362
+        },
+        {
+            "type": "cypress_tree",
+            "x": 377.44,
+            "z": 247.19,
+            "scale": 1.03,
+            "rotation": 6.05,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 376.27,
+            "z": 260.03,
+            "scale": 0.96,
+            "rotation": 5.224,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 386.86,
+            "z": 247.6,
+            "scale": 1.06,
+            "rotation": 0.966,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 384.63,
+            "z": 261.3,
+            "scale": 0.92,
+            "rotation": 4.068,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 395.08,
+            "z": 249.38,
+            "scale": 1.09,
+            "rotation": 0.008,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 393.58,
+            "z": 262.09,
+            "scale": 0.97,
+            "rotation": 1.996,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 404.01,
+            "z": 249.79,
+            "scale": 1.03,
+            "rotation": 5.704,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 402.57,
+            "z": 262.26,
+            "scale": 1.07,
+            "rotation": 2.751,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 413.62,
+            "z": 250.83,
+            "scale": 0.91,
+            "rotation": 3.357,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 422.17,
+            "z": 251.58,
+            "scale": 1.02,
+            "rotation": 4.493,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 431.74,
+            "z": 253.96,
+            "scale": 0.97,
+            "rotation": 0.465,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 429.35,
+            "z": 264.49,
+            "scale": 0.91,
+            "rotation": 4.081,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 441.02,
+            "z": 256.7,
+            "scale": 1.06,
+            "rotation": 5.909,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 437.01,
+            "z": 269.11,
+            "scale": 1.09,
+            "rotation": 1.21,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 445.3,
+            "z": 272.38,
+            "scale": 0.91,
+            "rotation": 5.64,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 453.43,
+            "z": 275.97,
+            "scale": 0.94,
+            "rotation": 2.646,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 466.18,
+            "z": 266.8,
+            "scale": 1.03,
+            "rotation": 0.25,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 462.2,
+            "z": 279.01,
+            "scale": 1.0,
+            "rotation": 2.051,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 469.03,
+            "z": 283.42,
+            "scale": 0.96,
+            "rotation": 5.476,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 483.38,
+            "z": 273.58,
+            "scale": 0.96,
+            "rotation": 3.439,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 477.9,
+            "z": 285.36,
+            "scale": 1.01,
+            "rotation": 4.317,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 489.37,
+            "z": 275.41,
+            "scale": 1.02,
+            "rotation": 4.044,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 486.81,
+            "z": 288.78,
+            "scale": 1.1,
+            "rotation": 4.94,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 499.57,
+            "z": 279.81,
+            "scale": 1.09,
+            "rotation": 4.741,
+            "dressing": "campania_appian_way"
+        },
+        {
+            "type": "ruins",
+            "x": 262.0,
+            "z": 261.55,
+            "scale": 1.14,
+            "rotation": 1.533,
+            "dressing": "campania_villa_ruin"
+        },
+        {
+            "type": "ruins",
+            "x": 251.18,
+            "z": 252.39,
+            "scale": 0.96,
+            "rotation": 6.441,
+            "dressing": "campania_villa_ruin"
+        },
+        {
+            "type": "statue",
+            "x": 231.82,
+            "z": 258.69,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "campania_villa_ruin"
+        },
+        {
+            "type": "statue",
+            "x": 231.28,
+            "z": 264.32,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "campania_villa_ruin"
+        },
+        {
+            "type": "firecamp",
+            "x": 248.0,
+            "z": 262.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_villa_ruin",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 254.22,
+            "z": 259.98,
+            "scale": 1.0,
+            "rotation": 5.344,
+            "dressing": "campania_villa_ruin"
+        },
+        {
+            "type": "dead_tree",
+            "x": 253.19,
+            "z": 265.9,
+            "scale": 1.0,
+            "rotation": 6.215,
+            "dressing": "campania_villa_ruin"
+        },
+        {
+            "type": "boulder",
+            "x": 292.97,
+            "z": 304.67,
+            "scale": 1.0,
+            "rotation": 1.109,
+            "dressing": "campania_villa_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 297.51,
+            "z": 309.07,
+            "scale": 1.11,
+            "rotation": 5.298,
+            "dressing": "campania_villa_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 291.89,
+            "z": 291.32,
+            "scale": 1.0,
+            "rotation": 2.775,
+            "dressing": "campania_villa_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 263.68,
+            "z": 319.86,
+            "scale": 1.43,
+            "rotation": 3.799,
+            "dressing": "campania_villa_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 264.67,
+            "z": 326.11,
+            "scale": 1.49,
+            "rotation": 4.203,
+            "dressing": "campania_villa_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 267.4,
+            "z": 329.2,
+            "scale": 1.0,
+            "rotation": -2.049,
+            "dressing": "campania_villa_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 306.0,
+            "z": 306.0,
+            "scale": 1.1,
+            "rotation": 0.0,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "firecamp",
+            "x": 310.0,
+            "z": 309.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_olive_terrace",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "olive_tree",
+            "x": 320.87,
+            "z": 306.54,
+            "scale": 0.99,
+            "rotation": 4.042,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 317.55,
+            "z": 313.73,
+            "scale": 1.07,
+            "rotation": 4.649,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 312.54,
+            "z": 317.97,
+            "scale": 1.03,
+            "rotation": 4.941,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 302.57,
+            "z": 320.44,
+            "scale": 0.98,
+            "rotation": 0.193,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 296.66,
+            "z": 315.95,
+            "scale": 0.95,
+            "rotation": 1.184,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 297.85,
+            "z": 300.65,
+            "scale": 1.0,
+            "rotation": 3.583,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 299.57,
+            "z": 291.53,
+            "scale": 0.96,
+            "rotation": 1.93,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 304.99,
+            "z": 291.23,
+            "scale": 1.05,
+            "rotation": 2.317,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 310.36,
+            "z": 292.47,
+            "scale": 0.94,
+            "rotation": 2.778,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 317.72,
+            "z": 300.67,
+            "scale": 0.94,
+            "rotation": 0.931,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "boulder",
+            "x": 308.51,
+            "z": 313.23,
+            "scale": 0.89,
+            "rotation": 1.829,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "boulder",
+            "x": 313.69,
+            "z": 305.57,
+            "scale": 0.74,
+            "rotation": 0.167,
+            "dressing": "campania_olive_terrace"
+        },
+        {
+            "type": "firecamp",
+            "x": 396.0,
+            "z": 212.0,
+            "scale": 1.1,
+            "rotation": 0.0,
+            "dressing": "campania_second_terrace",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "olive_tree",
+            "x": 407.38,
+            "z": 210.37,
+            "scale": 0.96,
+            "rotation": 5.475,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 406.28,
+            "z": 218.43,
+            "scale": 1.04,
+            "rotation": 1.742,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 399.12,
+            "z": 222.99,
+            "scale": 1.03,
+            "rotation": 3.679,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 389.89,
+            "z": 221.6,
+            "scale": 1.07,
+            "rotation": 3.89,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 384.95,
+            "z": 216.34,
+            "scale": 1.1,
+            "rotation": 5.939,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 386.04,
+            "z": 208.4,
+            "scale": 1.1,
+            "rotation": 3.799,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 400.05,
+            "z": 199.73,
+            "scale": 0.98,
+            "rotation": 6.059,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "olive_tree",
+            "x": 404.54,
+            "z": 204.09,
+            "scale": 0.92,
+            "rotation": 3.874,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "boulder",
+            "x": 394.33,
+            "z": 217.15,
+            "scale": 0.83,
+            "rotation": 0.646,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "boulder",
+            "x": 402.41,
+            "z": 213.43,
+            "scale": 0.78,
+            "rotation": 0.273,
+            "dressing": "campania_second_terrace"
+        },
+        {
+            "type": "ruins",
+            "x": 594.78,
+            "z": 53.07,
+            "scale": 0.87,
+            "rotation": 1.912,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 588.86,
+            "z": 61.62,
+            "scale": 1.0,
+            "rotation": 5.692,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 577.81,
+            "z": 61.03,
+            "scale": 0.91,
+            "rotation": 4.045,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 574.82,
+            "z": 52.42,
+            "scale": 1.15,
+            "rotation": 3.115,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 580.89,
+            "z": 42.78,
+            "scale": 1.02,
+            "rotation": 5.737,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 590.12,
+            "z": 42.45,
+            "scale": 0.87,
+            "rotation": 0.052,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 599.93,
+            "z": 61.88,
+            "scale": 0.85,
+            "rotation": 2.598,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 571.48,
+            "z": 58.78,
+            "scale": 1.06,
+            "rotation": 3.154,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 575.96,
+            "z": 39.01,
+            "scale": 0.95,
+            "rotation": 2.159,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 595.69,
+            "z": 37.37,
+            "scale": 1.13,
+            "rotation": 3.646,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 593.77,
+            "z": 67.89,
+            "scale": 1.02,
+            "rotation": 5.255,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 592.19,
+            "z": 49.51,
+            "scale": 0.9,
+            "rotation": 5.16,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 576.93,
+            "z": 46.8,
+            "scale": 0.9,
+            "rotation": 5.677,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 572.79,
+            "z": 47.02,
+            "scale": 1.27,
+            "rotation": 3.137,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 599.24,
+            "z": 52.21,
+            "scale": 0.88,
+            "rotation": 4.96,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 582.58,
+            "z": 36.72,
+            "scale": 1.05,
+            "rotation": 3.394,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 585.0,
+            "z": 52.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_river_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 174.34,
+            "z": 586.72,
+            "scale": 1.02,
+            "rotation": 4.789,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 164.81,
+            "z": 595.97,
+            "scale": 1.11,
+            "rotation": 0.006,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 154.59,
+            "z": 595.42,
+            "scale": 1.12,
+            "rotation": 1.35,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 150.95,
+            "z": 584.69,
+            "scale": 1.15,
+            "rotation": 0.885,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 155.85,
+            "z": 577.17,
+            "scale": 1.12,
+            "rotation": 4.517,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 167.27,
+            "z": 575.48,
+            "scale": 0.99,
+            "rotation": 3.733,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 170.77,
+            "z": 600.03,
+            "scale": 1.03,
+            "rotation": 4.904,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 147.93,
+            "z": 594.34,
+            "scale": 0.89,
+            "rotation": 5.901,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 147.99,
+            "z": 576.89,
+            "scale": 0.85,
+            "rotation": 1.731,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 175.5,
+            "z": 575.34,
+            "scale": 1.05,
+            "rotation": 1.956,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 168.01,
+            "z": 604.47,
+            "scale": 0.88,
+            "rotation": 0.382,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 170.55,
+            "z": 590.37,
+            "scale": 0.9,
+            "rotation": 4.225,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 156.29,
+            "z": 583.28,
+            "scale": 0.9,
+            "rotation": 4.527,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 151.07,
+            "z": 590.74,
+            "scale": 1.19,
+            "rotation": 1.33,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 170.86,
+            "z": 579.23,
+            "scale": 0.84,
+            "rotation": 3.091,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 151.08,
+            "z": 574.61,
+            "scale": 0.99,
+            "rotation": 1.663,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 174.69,
+            "z": 579.76,
+            "scale": 1.15,
+            "rotation": 1.281,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 162.0,
+            "z": 586.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_coast_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 35.85,
+            "z": 276.06,
+            "scale": 0.99,
+            "rotation": 4.178,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 33.91,
+            "z": 286.36,
+            "scale": 1.09,
+            "rotation": 5.351,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 16.89,
+            "z": 282.86,
+            "scale": 0.91,
+            "rotation": 0.257,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 19.31,
+            "z": 272.48,
+            "scale": 1.17,
+            "rotation": 2.119,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 30.97,
+            "z": 267.49,
+            "scale": 0.85,
+            "rotation": 1.57,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 40.18,
+            "z": 291.39,
+            "scale": 1.12,
+            "rotation": 1.866,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 20.2,
+            "z": 291.74,
+            "scale": 0.86,
+            "rotation": 5.538,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 18.71,
+            "z": 264.41,
+            "scale": 0.9,
+            "rotation": 3.916,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 35.6,
+            "z": 262.13,
+            "scale": 0.9,
+            "rotation": 0.303,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "statue",
+            "x": 33.26,
+            "z": 271.76,
+            "scale": 0.9,
+            "rotation": 6.076,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "statue",
+            "x": 16.97,
+            "z": 277.31,
+            "scale": 0.9,
+            "rotation": 1.746,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 34.29,
+            "z": 292.82,
+            "scale": 1.29,
+            "rotation": 2.661,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 41.35,
+            "z": 269.85,
+            "scale": 1.04,
+            "rotation": 0.464,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 24.83,
+            "z": 292.27,
+            "scale": 1.18,
+            "rotation": 5.505,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 28.0,
+            "z": 277.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_old_grave_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 622.65,
+            "z": 390.88,
+            "scale": 0.86,
+            "rotation": 3.632,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 619.33,
+            "z": 399.64,
+            "scale": 1.2,
+            "rotation": 1.595,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 607.6,
+            "z": 403.84,
+            "scale": 1.05,
+            "rotation": 3.325,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 601.53,
+            "z": 394.19,
+            "scale": 1.04,
+            "rotation": 6.024,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 600.13,
+            "z": 386.41,
+            "scale": 1.04,
+            "rotation": 2.002,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 607.89,
+            "z": 382.21,
+            "scale": 1.08,
+            "rotation": 2.633,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "ruins",
+            "x": 617.55,
+            "z": 385.31,
+            "scale": 1.13,
+            "rotation": 3.391,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 626.69,
+            "z": 399.01,
+            "scale": 1.09,
+            "rotation": 5.143,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 603.56,
+            "z": 408.73,
+            "scale": 0.94,
+            "rotation": 1.068,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 598.23,
+            "z": 378.28,
+            "scale": 1.04,
+            "rotation": 0.19,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 620.98,
+            "z": 379.24,
+            "scale": 1.08,
+            "rotation": 5.143,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "dead_tree",
+            "x": 619.42,
+            "z": 407.47,
+            "scale": 1.02,
+            "rotation": 6.268,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "statue",
+            "x": 618.07,
+            "z": 394.34,
+            "scale": 0.9,
+            "rotation": 5.996,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "statue",
+            "x": 604.74,
+            "z": 390.01,
+            "scale": 0.9,
+            "rotation": 4.007,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "statue",
+            "x": 617.23,
+            "z": 392.36,
+            "scale": 0.9,
+            "rotation": 1.113,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 623.43,
+            "z": 383.57,
+            "scale": 1.14,
+            "rotation": 5.171,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 595.34,
+            "z": 390.01,
+            "scale": 1.06,
+            "rotation": 2.063,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 622.9,
+            "z": 405.31,
+            "scale": 1.03,
+            "rotation": 5.223,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 594.58,
+            "z": 392.78,
+            "scale": 0.99,
+            "rotation": 3.377,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 611.0,
+            "z": 392.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_tomb_ring"
+        },
+        {
+            "type": "boulder",
+            "x": 211.02,
+            "z": 172.76,
+            "scale": 1.12,
+            "rotation": 0.764,
+            "dressing": "campania_volturnus_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 198.59,
+            "z": 174.29,
+            "scale": 1.13,
+            "rotation": 0.821,
+            "dressing": "campania_volturnus_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 196.93,
+            "z": 171.41,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_volturnus_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 215.0,
+            "z": 167.29,
+            "scale": 1.0,
+            "rotation": 3.498,
+            "dressing": "campania_volturnus_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 193.1,
+            "z": 167.7,
+            "scale": 1.0,
+            "rotation": -1.361,
+            "dressing": "campania_volturnus_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 212.58,
+            "z": 188.59,
+            "scale": 1.23,
+            "rotation": 6.047,
+            "dressing": "campania_volturnus_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 197.47,
+            "z": 187.06,
+            "scale": 1.24,
+            "rotation": 2.04,
+            "dressing": "campania_volturnus_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 215.5,
+            "z": 192.59,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_volturnus_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 200.29,
+            "z": 196.46,
+            "scale": 1.0,
+            "rotation": 2.288,
+            "dressing": "campania_volturnus_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 431.56,
+            "z": 189.71,
+            "scale": 0.9,
+            "rotation": 6.075,
+            "dressing": "campania_east_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 434.38,
+            "z": 189.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_east_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 387.06,
+            "z": 475.06,
+            "scale": 1.19,
+            "rotation": 5.733,
+            "dressing": "campania_appian_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 373.25,
+            "z": 475.12,
+            "scale": 1.26,
+            "rotation": 6.021,
+            "dressing": "campania_appian_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 370.45,
+            "z": 471.13,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_appian_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 388.93,
+            "z": 468.05,
+            "scale": 1.0,
+            "rotation": 0.285,
+            "dressing": "campania_appian_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 386.76,
+            "z": 490.06,
+            "scale": 1.03,
+            "rotation": 2.433,
+            "dressing": "campania_appian_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 372.8,
+            "z": 490.12,
+            "scale": 1.06,
+            "rotation": 1.807,
+            "dressing": "campania_appian_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 389.54,
+            "z": 494.05,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_appian_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 371.06,
+            "z": 497.13,
+            "scale": 1.0,
+            "rotation": 1.351,
+            "dressing": "campania_appian_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 215.91,
+            "z": 324.03,
+            "scale": 1.23,
+            "rotation": 2.681,
+            "dressing": "campania_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 212.86,
+            "z": 322.51,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 231.68,
+            "z": 319.27,
+            "scale": 1.0,
+            "rotation": 1.967,
+            "dressing": "campania_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 229.94,
+            "z": 339.4,
+            "scale": 0.96,
+            "rotation": 1.209,
+            "dressing": "campania_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 215.58,
+            "z": 338.66,
+            "scale": 1.04,
+            "rotation": 0.803,
+            "dressing": "campania_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 231.91,
+            "z": 343.51,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 210.87,
+            "z": 343.16,
+            "scale": 1.0,
+            "rotation": 3.926,
+            "dressing": "campania_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 351.73,
+            "z": 333.35,
+            "scale": 1.26,
+            "rotation": 3.264,
+            "dressing": "campania_centre_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 338.57,
+            "z": 331.45,
+            "scale": 0.95,
+            "rotation": 3.936,
+            "dressing": "campania_centre_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 335.87,
+            "z": 328.49,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_centre_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 354.51,
+            "z": 326.49,
+            "scale": 1.0,
+            "rotation": 5.88,
+            "dressing": "campania_centre_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 351.82,
+            "z": 345.86,
+            "scale": 0.84,
+            "rotation": 3.49,
+            "dressing": "campania_centre_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 337.43,
+            "z": 345.09,
+            "scale": 0.95,
+            "rotation": 1.615,
+            "dressing": "campania_centre_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 353.75,
+            "z": 349.97,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_centre_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 335.11,
+            "z": 351.97,
+            "scale": 1.0,
+            "rotation": 3.178,
+            "dressing": "campania_centre_bridge"
+        },
+        {
+            "type": "statue",
+            "x": 6.28,
+            "z": 221.04,
+            "scale": 1.0,
+            "rotation": -1.222,
+            "dressing": "campania_west_junction"
+        },
+        {
+            "type": "cypress_tree",
+            "x": 5.51,
+            "z": 227.09,
+            "scale": 1.0,
+            "rotation": 1.082,
+            "dressing": "campania_west_junction"
+        },
+        {
+            "type": "statue",
+            "x": 295.91,
+            "z": 20.44,
+            "scale": 1.0,
+            "rotation": 0.932,
+            "dressing": "campania_north_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 291.46,
+            "z": 20.88,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_north_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "ruins",
+            "x": 301.07,
+            "z": 9.23,
+            "scale": 0.8,
+            "rotation": 1.774,
+            "dressing": "campania_north_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 560.59,
+            "z": 305.02,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_siege_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "plant",
+            "x": 36.52,
+            "z": 188.61,
+            "scale": 1.0,
+            "rotation": 2.334,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 39.0,
+            "z": 191.08,
+            "scale": 1.05,
+            "rotation": 5.931,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 68.28,
+            "z": 173.82,
+            "scale": 1.05,
+            "rotation": 1.332,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 71.0,
+            "z": 170.88,
+            "scale": 1.4,
+            "rotation": 6.042,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 99.96,
+            "z": 188.52,
+            "scale": 0.88,
+            "rotation": 1.448,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 131.83,
+            "z": 175.1,
+            "scale": 1.05,
+            "rotation": 4.355,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 164.83,
+            "z": 190.31,
+            "scale": 0.92,
+            "rotation": 5.144,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 167.0,
+            "z": 192.24,
+            "scale": 1.19,
+            "rotation": 2.289,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 197.46,
+            "z": 176.58,
+            "scale": 1.15,
+            "rotation": 2.681,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 227.66,
+            "z": 186.8,
+            "scale": 1.23,
+            "rotation": 3.967,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 231.0,
+            "z": 189.56,
+            "scale": 1.05,
+            "rotation": 4.328,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 290.76,
+            "z": 188.24,
+            "scale": 0.98,
+            "rotation": 0.045,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 356.56,
+            "z": 189.88,
+            "scale": 1.28,
+            "rotation": 3.44,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 359.0,
+            "z": 191.62,
+            "scale": 1.09,
+            "rotation": 3.895,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 386.64,
+            "z": 171.61,
+            "scale": 1.05,
+            "rotation": 4.555,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 391.0,
+            "z": 171.86,
+            "scale": 1.28,
+            "rotation": 5.494,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 453.14,
+            "z": 174.75,
+            "scale": 1.04,
+            "rotation": 0.827,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 483.82,
+            "z": 190.03,
+            "scale": 0.87,
+            "rotation": 0.515,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 487.0,
+            "z": 190.72,
+            "scale": 1.17,
+            "rotation": 4.582,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 514.91,
+            "z": 174.86,
+            "scale": 1.18,
+            "rotation": 3.764,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 519.0,
+            "z": 172.18,
+            "scale": 1.26,
+            "rotation": 4.621,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 547.47,
+            "z": 191.45,
+            "scale": 0.88,
+            "rotation": 1.508,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "plant",
+            "x": 549.64,
+            "z": 195.22,
+            "scale": 1.18,
+            "rotation": 1.717,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 581.51,
+            "z": 178.07,
+            "scale": 0.99,
+            "rotation": 1.557,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 611.56,
+            "z": 197.37,
+            "scale": 0.9,
+            "rotation": 5.763,
+            "dressing": "campania_volturnus_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 114.6,
+            "z": 455.18,
+            "scale": 1.29,
+            "rotation": 6.05,
+            "dressing": "campania_coast_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 124.44,
+            "z": 435.35,
+            "scale": 1.17,
+            "rotation": 1.778,
+            "dressing": "campania_coast_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 118.73,
+            "z": 432.63,
+            "scale": 1.4,
+            "rotation": 5.612,
+            "dressing": "campania_coast_ramp"
+        },
+        {
+            "type": "firecamp",
+            "x": 113.1,
+            "z": 429.92,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_coast_ramp",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 141.0,
+            "z": 62.12,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 143.81,
+            "z": 62.94,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_1"
+        },
+        {
+            "type": "firecamp",
+            "x": 114.12,
+            "z": 91.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 101.88,
+            "z": 91.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 100.88,
+            "z": 95.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "campania_gate_2"
+        },
+        {
+            "type": "supply_cart",
+            "x": 115.62,
+            "z": 97.0,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "campania_gate_2"
+        },
+        {
+            "type": "firecamp",
+            "x": 507.0,
+            "z": 134.4,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 507.0,
+            "z": 145.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 511.0,
+            "z": 146.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_3"
+        },
+        {
+            "type": "supply_cart",
+            "x": 513.0,
+            "z": 132.9,
+            "scale": 1.0,
+            "rotation": 0.3,
+            "dressing": "campania_gate_3"
+        },
+        {
+            "type": "firecamp",
+            "x": 61.0,
+            "z": 473.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 61.0,
+            "z": 462.7,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 57.0,
+            "z": 461.7,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "campania_gate_4"
+        },
+        {
+            "type": "supply_cart",
+            "x": 55.0,
+            "z": 474.8,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "campania_gate_4"
+        },
+        {
+            "type": "firecamp",
+            "x": 509.0,
+            "z": 284.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 505.0,
+            "z": 283.0,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "campania_gate_5"
+        },
+        {
+            "type": "supply_cart",
+            "x": 501.88,
+            "z": 297.93,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "campania_gate_5"
+        },
+        {
+            "type": "statue",
+            "x": 498.0,
+            "z": 297.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "campania_gate_5"
+        },
+        {
+            "type": "firecamp",
+            "x": 508.11,
+            "z": 342.72,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 509.43,
+            "z": 335.12,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 505.0,
+            "z": 333.0,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "campania_gate_6"
+        },
+        {
+            "type": "statue",
+            "x": 498.0,
+            "z": 333.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "campania_gate_6"
+        },
+        {
+            "type": "firecamp",
+            "x": 352.0,
+            "z": 215.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_7",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 364.0,
+            "z": 215.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_7",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 365.0,
+            "z": 211.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "campania_gate_7"
+        },
+        {
+            "type": "supply_cart",
+            "x": 350.5,
+            "z": 209.0,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "campania_gate_7"
+        },
+        {
+            "type": "statue",
+            "x": 351.0,
+            "z": 204.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_7"
+        },
+        {
+            "type": "statue",
+            "x": 365.0,
+            "z": 204.0,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "campania_gate_7"
+        },
+        {
+            "type": "firecamp",
+            "x": 371.71,
+            "z": 245.13,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_8",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "supply_cart",
+            "x": 381.87,
+            "z": 241.21,
+            "scale": 1.0,
+            "rotation": 0.3,
+            "dressing": "campania_gate_8"
+        },
+        {
+            "type": "statue",
+            "x": 386.87,
+            "z": 241.71,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "campania_gate_8"
+        },
+        {
+            "type": "firecamp",
+            "x": 333.43,
+            "z": 282.12,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_9",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 323.0,
+            "z": 281.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_9",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 322.0,
+            "z": 285.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "campania_gate_9"
+        },
+        {
+            "type": "supply_cart",
+            "x": 334.93,
+            "z": 288.12,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "campania_gate_9"
+        },
+        {
+            "type": "statue",
+            "x": 334.43,
+            "z": 293.12,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "campania_gate_9"
+        },
+        {
+            "type": "statue",
+            "x": 322.0,
+            "z": 292.0,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "campania_gate_9"
+        },
+        {
+            "type": "firecamp",
+            "x": 299.81,
+            "z": 247.62,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_10",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 300.11,
+            "z": 232.92,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_10",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 296.05,
+            "z": 230.8,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "campania_gate_10"
+        },
+        {
+            "type": "supply_cart",
+            "x": 295.0,
+            "z": 249.3,
+            "scale": 1.0,
+            "rotation": 3.442,
+            "dressing": "campania_gate_10"
+        },
+        {
+            "type": "statue",
+            "x": 290.0,
+            "z": 248.8,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "campania_gate_10"
+        },
+        {
+            "type": "statue",
+            "x": 289.13,
+            "z": 238.49,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "campania_gate_10"
+        },
+        {
+            "type": "firecamp",
+            "x": 378.82,
+            "z": 499.72,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_11",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 391.0,
+            "z": 499.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_11",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 392.43,
+            "z": 496.12,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "campania_gate_11"
+        },
+        {
+            "type": "supply_cart",
+            "x": 376.22,
+            "z": 493.89,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "campania_gate_11"
+        },
+        {
+            "type": "firecamp",
+            "x": 379.3,
+            "z": 557.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_12",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 370.95,
+            "z": 557.47,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "campania_gate_12",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 367.7,
+            "z": 561.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "campania_gate_12"
+        },
+        {
+            "type": "supply_cart",
+            "x": 380.8,
+            "z": 563.0,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "campania_gate_12"
+        }
+    ],
+    "dressing": [
+        {
+            "id": "campania_appian_way",
+            "kind": "tree_avenue",
+            "from": [
+                372,
+                256
+            ],
+            "to": [
+                500,
+                292
+            ],
+            "tree": "cypress_tree",
+            "spacing": 9
+        },
+        {
+            "id": "campania_villa_ruin",
+            "kind": "hilltop_ruin",
+            "x": 250,
+            "z": 262,
+            "facing": "east",
+            "radius": 14,
+            "ruins": 8,
+            "dead_trees": 2
+        },
+        {
+            "id": "campania_villa_ramp",
+            "kind": "ramp_mouth",
+            "x": 265,
+            "z": 292,
+            "statue": true
+        },
+        {
+            "id": "campania_olive_terrace",
+            "kind": "sacred_grove",
+            "x": 306,
+            "z": 306,
+            "tree": "olive_tree",
+            "count": 11,
+            "radius": 14,
+            "centre": "statue"
+        },
+        {
+            "id": "campania_second_terrace",
+            "kind": "sacred_grove",
+            "x": 396,
+            "z": 212,
+            "tree": "olive_tree",
+            "count": 9,
+            "radius": 12,
+            "centre": "firecamp",
+            "fire": false
+        },
+        {
+            "id": "campania_river_barrows",
+            "kind": "barrow_field",
+            "x": 585,
+            "z": 52,
+            "radius": 12,
+            "shrine": true,
+            "ruins": 6,
+            "dead_trees": 5,
+            "boulders": 3
+        },
+        {
+            "id": "campania_coast_barrows",
+            "kind": "barrow_field",
+            "x": 162,
+            "z": 586,
+            "radius": 12,
+            "shrine": true,
+            "ruins": 6,
+            "dead_trees": 5,
+            "boulders": 4
+        },
+        {
+            "id": "campania_old_grave_ring",
+            "kind": "barrow_field",
+            "x": 28,
+            "z": 277,
+            "radius": 12,
+            "shrine": true,
+            "ruins": 5,
+            "dead_trees": 4,
+            "boulders": 3
+        },
+        {
+            "id": "campania_tomb_ring",
+            "kind": "barrow_field",
+            "x": 611,
+            "z": 392,
+            "radius": 12,
+            "shrine": true,
+            "ruins": 7,
+            "dead_trees": 5,
+            "statues": 3
+        },
+        {
+            "id": "campania_volturnus_bridge",
+            "kind": "bridgehead",
+            "x": 206,
+            "z": 181
+        },
+        {
+            "id": "campania_east_bridge",
+            "kind": "bridgehead",
+            "x": 424,
+            "z": 181
+        },
+        {
+            "id": "campania_appian_bridge",
+            "kind": "bridgehead",
+            "x": 380,
+            "z": 482
+        },
+        {
+            "id": "campania_south_bridge",
+            "kind": "bridgehead",
+            "x": 223,
+            "z": 332,
+            "cart": false
+        },
+        {
+            "id": "campania_centre_bridge",
+            "kind": "bridgehead",
+            "x": 344,
+            "z": 339,
+            "cart": false
+        },
+        {
+            "id": "campania_west_junction",
+            "kind": "junction",
+            "x": 8,
+            "z": 214,
+            "style": "milestone",
+            "tree": "cypress_tree"
+        },
+        {
+            "id": "campania_north_junction",
+            "kind": "junction",
+            "x": 300,
+            "z": 24,
+            "style": "shrine",
+            "snap": 6
+        },
+        {
+            "id": "campania_siege_junction",
+            "kind": "junction",
+            "x": 566,
+            "z": 300,
+            "style": "camp"
+        },
+        {
+            "id": "campania_volturnus_bank",
+            "kind": "riverbank",
+            "from": [
+                20,
+                182
+            ],
+            "to": [
+                630,
+                195
+            ],
+            "spacing": 32,
+            "kinds": [
+                "plant",
+                "plant",
+                "boulder",
+                "dead_tree",
+                "plant"
+            ]
+        },
+        {
+            "id": "campania_coast_ramp",
+            "kind": "ramp_mouth",
+            "x": 141,
+            "z": 448,
+            "fire": true
+        },
+        {
+            "id": "campania_gate_1",
+            "kind": "gate_approach",
+            "x": 132.0,
+            "z": 56.0
+        },
+        {
+            "id": "campania_gate_2",
+            "kind": "gate_approach",
+            "x": 108.0,
+            "z": 82.0
+        },
+        {
+            "id": "campania_gate_3",
+            "kind": "gate_approach",
+            "x": 498.0,
+            "z": 140.0
+        },
+        {
+            "id": "campania_gate_4",
+            "kind": "gate_approach",
+            "x": 70.0,
+            "z": 468.0
+        },
+        {
+            "id": "campania_gate_5",
+            "kind": "gate_approach",
+            "x": 518.0,
+            "z": 290.0,
+            "statues": true
+        },
+        {
+            "id": "campania_gate_6",
+            "kind": "gate_approach",
+            "x": 518.0,
+            "z": 340.0,
+            "statues": true
+        },
+        {
+            "id": "campania_gate_7",
+            "kind": "gate_approach",
+            "x": 358,
+            "z": 224,
+            "statues": true
+        },
+        {
+            "id": "campania_gate_8",
+            "kind": "gate_approach",
+            "x": 366,
+            "z": 252,
+            "statues": true
+        },
+        {
+            "id": "campania_gate_9",
+            "kind": "gate_approach",
+            "x": 328,
+            "z": 272,
+            "statues": true
+        },
+        {
+            "id": "campania_gate_10",
+            "kind": "gate_approach",
+            "x": 310,
+            "z": 242,
+            "statues": true
+        },
+        {
+            "id": "campania_gate_11",
+            "kind": "gate_approach",
+            "x": 386,
+            "z": 508
+        },
+        {
+            "id": "campania_gate_12",
+            "kind": "gate_approach",
+            "x": 374,
+            "z": 548
         }
     ]
 }

--- a/assets/maps/map_crossing_alps.json
+++ b/assets/maps/map_crossing_alps.json
@@ -91,7 +91,7 @@
     "environment": {
         "day_length_seconds": 2400,
         "fog_density": 0.01,
-        "lighting_profile": "mediterranean_summer",
+        "lighting_profile": "alpine_clear",
         "start_time": 8,
         "time_mode": "locked"
     },
@@ -3189,18 +3189,19 @@
     ],
     "undead_zones": [
         {
-            "anchor_type": "magic_shrine",
+            "anchor_type": "ruins",
             "awaken_on": [
                 "unit_enters_radius"
             ],
             "clear_reward": {
-                "iron": 100,
-                "stone": 140
+                "iron": 110,
+                "stone": 140,
+                "food": 60
             },
-            "id": "pass_shrine",
-            "leash_radius": 29.42,
+            "id": "alps_frozen_dead",
+            "leash_radius": 30.0,
             "owner_id": 99,
-            "radius": 16.81,
+            "radius": 17.0,
             "team_id": 99,
             "waves": [
                 {
@@ -3211,8 +3212,9 @@
                     }
                 }
             ],
-            "x": 466,
-            "z": 83
+            "x": 252,
+            "z": 548,
+            "fog_density": 0.32
         }
     ],
     "victory": {
@@ -3310,20 +3312,6 @@
             "z": 64.85
         },
         {
-            "rotation": 2.5,
-            "scale": 1,
-            "type": "tent",
-            "x": 56.97,
-            "z": 39.07
-        },
-        {
-            "rotation": 1.2,
-            "scale": 1,
-            "type": "supply_cart",
-            "x": 67.14,
-            "z": 75.97
-        },
-        {
             "rotation": 4,
             "scale": 1,
             "type": "weapon_rack",
@@ -3352,13 +3340,6 @@
             "z": 151.27
         },
         {
-            "rotation": 1,
-            "scale": 1,
-            "type": "ruins",
-            "x": 158.69,
-            "z": 306.05
-        },
-        {
             "rotation": 3.4,
             "scale": 0.9,
             "type": "ruins",
@@ -3385,20 +3366,6 @@
             "type": "dead_tree",
             "x": 258.38,
             "z": 360.31
-        },
-        {
-            "rotation": 1.3,
-            "scale": 1.2,
-            "type": "dead_tree",
-            "x": 305.17,
-            "z": 297.37
-        },
-        {
-            "rotation": 3.2,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 325.52,
-            "z": 327.76
         },
         {
             "rotation": 5.4,
@@ -3441,13 +3408,6 @@
             "type": "tent",
             "x": 547.4,
             "z": 529.5
-        },
-        {
-            "rotation": 4.1,
-            "scale": 0.9,
-            "type": "tent",
-            "x": 581.86,
-            "z": 535.91
         },
         {
             "rotation": 2.5,
@@ -3506,13 +3466,6 @@
             "type": "pine_tree",
             "x": 55.09,
             "z": 62.120000000000005
-        },
-        {
-            "rotation": 1.58,
-            "scale": 1.04,
-            "type": "pine_tree",
-            "x": 46.28,
-            "z": 72.71
         },
         {
             "rotation": 4.51,
@@ -3967,13 +3920,6 @@
             "z": 377.32
         },
         {
-            "rotation": 93.2,
-            "scale": 1.17,
-            "type": "tent",
-            "x": 501.53000000000003,
-            "z": 627.3000000000001
-        },
-        {
             "intensity": 0.88,
             "persistent": true,
             "radius": 3.2,
@@ -3990,20 +3936,6 @@
             "type": "firecamp",
             "x": 102.66,
             "z": 99.59
-        },
-        {
-            "rotation": 200.6,
-            "scale": 1.08,
-            "type": "tent",
-            "x": 148.23,
-            "z": 397.02
-        },
-        {
-            "rotation": 243.1,
-            "scale": 1.11,
-            "type": "supply_cart",
-            "x": 594.59,
-            "z": 431.69
         },
         {
             "intensity": 0.97,
@@ -4093,20 +4025,6 @@
             "z": 282.36
         },
         {
-            "rotation": 76.10000000000001,
-            "scale": 1.16,
-            "type": "weapon_rack",
-            "x": 488.34000000000003,
-            "z": 607.23
-        },
-        {
-            "rotation": 64,
-            "scale": 1.08,
-            "type": "tent",
-            "x": 26.34,
-            "z": 125.47
-        },
-        {
             "rotation": 11,
             "scale": 1.1,
             "type": "tent",
@@ -4119,13 +4037,6 @@
             "type": "tent",
             "x": 140.34,
             "z": 375.31
-        },
-        {
-            "rotation": 241.5,
-            "scale": 1.03,
-            "type": "tent",
-            "x": 534.66,
-            "z": 440.07
         },
         {
             "rotation": 118.60000000000001,
@@ -4183,39 +4094,11 @@
             "z": 42.94
         },
         {
-            "rotation": 219.4,
-            "scale": 0.99,
-            "type": "dead_tree",
-            "x": 439.74,
-            "z": 257
-        },
-        {
             "rotation": 307.6,
             "scale": 1.03,
             "type": "ruins",
             "x": 199.41,
             "z": 536.22
-        },
-        {
-            "rotation": 158.1,
-            "scale": 1.16,
-            "type": "dead_tree",
-            "x": 67.59,
-            "z": 432.25
-        },
-        {
-            "rotation": 88.3,
-            "scale": 1.1400000000000001,
-            "type": "dead_tree",
-            "x": 259.28000000000003,
-            "z": 51.17
-        },
-        {
-            "rotation": 281.8,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 390.78000000000003,
-            "z": 18.3
         },
         {
             "rotation": 164.5,
@@ -4251,13 +4134,6 @@
             "type": "ruins",
             "x": 291.98,
             "z": 53.980000000000004
-        },
-        {
-            "rotation": 330.1,
-            "scale": 1.12,
-            "type": "dead_tree",
-            "x": 200.92000000000002,
-            "z": 47.43
         },
         {
             "rotation": 74,
@@ -4344,13 +4220,6 @@
             "z": 99.5
         },
         {
-            "rotation": 279.6,
-            "scale": 1.08,
-            "type": "abandoned_home",
-            "x": 439.1,
-            "z": 81.7
-        },
-        {
             "rotation": 183.6,
             "scale": 1.1,
             "type": "abandoned_home",
@@ -4363,13 +4232,6 @@
             "type": "abandoned_home",
             "x": 505.84000000000003,
             "z": 71.02
-        },
-        {
-            "rotation": 177.8,
-            "scale": 0.96,
-            "type": "abandoned_home",
-            "x": 290.36,
-            "z": 551.0600000000001
         },
         {
             "landmark": "alps_ascent_sanctuary",
@@ -5255,6 +5117,1453 @@
             "type": "cursed_gold_vein",
             "x": 222,
             "z": 292
+        },
+        {
+            "type": "boulder",
+            "x": 95.57,
+            "z": 255.15,
+            "scale": 1.48,
+            "rotation": 5.757,
+            "dressing": "alps_avalanche"
+        },
+        {
+            "type": "boulder",
+            "x": 87.24,
+            "z": 256.44,
+            "scale": 1.09,
+            "rotation": 4.272,
+            "dressing": "alps_avalanche"
+        },
+        {
+            "type": "boulder",
+            "x": 90.51,
+            "z": 252.19,
+            "scale": 0.93,
+            "rotation": 2.278,
+            "dressing": "alps_avalanche"
+        },
+        {
+            "type": "boulder",
+            "x": 86.73,
+            "z": 253.12,
+            "scale": 1.27,
+            "rotation": 3.333,
+            "dressing": "alps_avalanche"
+        },
+        {
+            "type": "boulder",
+            "x": 98.73,
+            "z": 256.16,
+            "scale": 0.83,
+            "rotation": 2.398,
+            "dressing": "alps_avalanche"
+        },
+        {
+            "type": "supply_cart",
+            "x": 87.55,
+            "z": 261.34,
+            "scale": 1.0,
+            "rotation": 1.884,
+            "dressing": "alps_avalanche"
+        },
+        {
+            "type": "statue",
+            "x": 262.0,
+            "z": 396.0,
+            "scale": 1.15,
+            "rotation": 1.571,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "boulder",
+            "x": 266.96,
+            "z": 396.63,
+            "scale": 1.09,
+            "rotation": 2.963,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "boulder",
+            "x": 265.77,
+            "z": 399.28,
+            "scale": 1.0,
+            "rotation": 5.753,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "boulder",
+            "x": 261.28,
+            "z": 400.95,
+            "scale": 1.03,
+            "rotation": 3.145,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "boulder",
+            "x": 258.18,
+            "z": 400.88,
+            "scale": 0.99,
+            "rotation": 6.238,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "boulder",
+            "x": 257.0,
+            "z": 396.16,
+            "scale": 0.73,
+            "rotation": 2.007,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "boulder",
+            "x": 258.29,
+            "z": 392.64,
+            "scale": 0.89,
+            "rotation": 2.665,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "boulder",
+            "x": 261.03,
+            "z": 391.1,
+            "scale": 0.91,
+            "rotation": 1.146,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "boulder",
+            "x": 265.49,
+            "z": 392.42,
+            "scale": 0.94,
+            "rotation": 4.939,
+            "dressing": "alps_summit_cairn"
+        },
+        {
+            "type": "firecamp",
+            "x": 271.0,
+            "z": 397.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_summit_cairn",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 230.32,
+            "z": 374.61,
+            "scale": 0.98,
+            "rotation": 0.574,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "boulder",
+            "x": 232.3,
+            "z": 377.66,
+            "scale": 1.23,
+            "rotation": 0.189,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "boulder",
+            "x": 234.93,
+            "z": 376.93,
+            "scale": 0.82,
+            "rotation": 2.937,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "boulder",
+            "x": 227.94,
+            "z": 375.77,
+            "scale": 0.89,
+            "rotation": 5.946,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "boulder",
+            "x": 246.27,
+            "z": 384.74,
+            "scale": 1.09,
+            "rotation": 2.0,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "boulder",
+            "x": 237.59,
+            "z": 382.29,
+            "scale": 1.48,
+            "rotation": 0.594,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "boulder",
+            "x": 240.84,
+            "z": 380.65,
+            "scale": 1.14,
+            "rotation": 0.82,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "boulder",
+            "x": 238.03,
+            "z": 378.73,
+            "scale": 1.16,
+            "rotation": 0.84,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "dead_tree",
+            "x": 250.03,
+            "z": 379.55,
+            "scale": 0.8,
+            "rotation": 6.031,
+            "dressing": "alps_summit_scree"
+        },
+        {
+            "type": "ruins",
+            "x": 263.71,
+            "z": 549.37,
+            "scale": 0.93,
+            "rotation": 6.242,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "ruins",
+            "x": 257.94,
+            "z": 557.63,
+            "scale": 0.95,
+            "rotation": 3.684,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "ruins",
+            "x": 245.51,
+            "z": 557.71,
+            "scale": 1.14,
+            "rotation": 0.034,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "ruins",
+            "x": 241.58,
+            "z": 550.01,
+            "scale": 0.96,
+            "rotation": 2.011,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "ruins",
+            "x": 245.86,
+            "z": 540.06,
+            "scale": 0.88,
+            "rotation": 5.431,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "ruins",
+            "x": 256.98,
+            "z": 539.66,
+            "scale": 1.13,
+            "rotation": 0.024,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 263.22,
+            "z": 560.62,
+            "scale": 0.99,
+            "rotation": 5.188,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 235.06,
+            "z": 555.23,
+            "scale": 0.9,
+            "rotation": 2.84,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 237.9,
+            "z": 539.12,
+            "scale": 0.98,
+            "rotation": 3.226,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 262.66,
+            "z": 535.48,
+            "scale": 0.86,
+            "rotation": 2.104,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 265.9,
+            "z": 555.34,
+            "scale": 1.13,
+            "rotation": 3.748,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 239.68,
+            "z": 561.34,
+            "scale": 0.98,
+            "rotation": 2.249,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "statue",
+            "x": 260.74,
+            "z": 544.03,
+            "scale": 0.9,
+            "rotation": 3.236,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "statue",
+            "x": 240.74,
+            "z": 545.42,
+            "scale": 0.9,
+            "rotation": 1.893,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "boulder",
+            "x": 255.75,
+            "z": 562.51,
+            "scale": 1.24,
+            "rotation": 2.919,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "boulder",
+            "x": 249.18,
+            "z": 562.41,
+            "scale": 1.04,
+            "rotation": 6.261,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "boulder",
+            "x": 249.87,
+            "z": 534.17,
+            "scale": 1.1,
+            "rotation": 4.188,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "boulder",
+            "x": 259.4,
+            "z": 552.54,
+            "scale": 1.03,
+            "rotation": 4.801,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "boulder",
+            "x": 239.11,
+            "z": 557.27,
+            "scale": 1.19,
+            "rotation": 2.355,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "boulder",
+            "x": 241.64,
+            "z": 537.85,
+            "scale": 1.17,
+            "rotation": 2.02,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 252.0,
+            "z": 548.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_frozen_dead_field"
+        },
+        {
+            "type": "dead_tree",
+            "x": 233.33,
+            "z": 563.64,
+            "scale": 0.95,
+            "rotation": 2.736,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 220.96,
+            "z": 569.71,
+            "scale": 0.86,
+            "rotation": 0.92,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 224.46,
+            "z": 572.48,
+            "scale": 0.92,
+            "rotation": 2.809,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 223.14,
+            "z": 556.75,
+            "scale": 0.87,
+            "rotation": 3.191,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 229.5,
+            "z": 574.64,
+            "scale": 1.04,
+            "rotation": 4.519,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 236.78,
+            "z": 567.07,
+            "scale": 1.02,
+            "rotation": 2.17,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 228.8,
+            "z": 568.02,
+            "scale": 0.99,
+            "rotation": 0.253,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 223.93,
+            "z": 560.91,
+            "scale": 1.04,
+            "rotation": 0.8,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 235.1,
+            "z": 559.21,
+            "scale": 0.62,
+            "rotation": 1.83,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 233.8,
+            "z": 570.04,
+            "scale": 0.89,
+            "rotation": 0.713,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 226.35,
+            "z": 563.54,
+            "scale": 0.79,
+            "rotation": 5.76,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 229.9,
+            "z": 559.57,
+            "scale": 0.73,
+            "rotation": 3.577,
+            "dressing": "alps_frozen_dead_bones"
+        },
+        {
+            "type": "pine_tree",
+            "x": 531.98,
+            "z": 554.07,
+            "scale": 1.08,
+            "rotation": 0.391,
+            "dressing": "alps_descent_avenue"
+        },
+        {
+            "type": "pine_tree",
+            "x": 521.73,
+            "z": 556.25,
+            "scale": 1.01,
+            "rotation": 2.758,
+            "dressing": "alps_descent_avenue"
+        },
+        {
+            "type": "pine_tree",
+            "x": 521.03,
+            "z": 544.35,
+            "scale": 1.0,
+            "rotation": 3.262,
+            "dressing": "alps_descent_avenue"
+        },
+        {
+            "type": "statue",
+            "x": 42.0,
+            "z": 262.0,
+            "scale": 1.1,
+            "rotation": 0.0,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "firecamp",
+            "x": 46.0,
+            "z": 265.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_ascent_grove",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "pine_tree",
+            "x": 52.76,
+            "z": 261.57,
+            "scale": 0.91,
+            "rotation": 4.282,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "pine_tree",
+            "x": 50.7,
+            "z": 270.05,
+            "scale": 1.01,
+            "rotation": 0.247,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "pine_tree",
+            "x": 40.38,
+            "z": 271.85,
+            "scale": 0.94,
+            "rotation": 2.53,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "pine_tree",
+            "x": 33.42,
+            "z": 266.82,
+            "scale": 1.05,
+            "rotation": 0.288,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "pine_tree",
+            "x": 32.85,
+            "z": 257.2,
+            "scale": 1.08,
+            "rotation": 6.046,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "pine_tree",
+            "x": 40.58,
+            "z": 252.28,
+            "scale": 0.98,
+            "rotation": 2.026,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "pine_tree",
+            "x": 49.28,
+            "z": 255.0,
+            "scale": 1.0,
+            "rotation": 4.591,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "boulder",
+            "x": 43.16,
+            "z": 266.15,
+            "scale": 0.79,
+            "rotation": 5.251,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "boulder",
+            "x": 41.26,
+            "z": 264.22,
+            "scale": 0.85,
+            "rotation": 3.171,
+            "dressing": "alps_ascent_grove"
+        },
+        {
+            "type": "boulder",
+            "x": 322.22,
+            "z": 99.43,
+            "scale": 0.81,
+            "rotation": 1.654,
+            "dressing": "alps_north_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 310.46,
+            "z": 92.05,
+            "scale": 1.12,
+            "rotation": 0.752,
+            "dressing": "alps_north_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 310.13,
+            "z": 87.12,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_north_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 327.39,
+            "z": 94.42,
+            "scale": 1.0,
+            "rotation": 3.227,
+            "dressing": "alps_north_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 310.82,
+            "z": 82.79,
+            "scale": 1.0,
+            "rotation": -0.983,
+            "dressing": "alps_north_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 315.36,
+            "z": 110.2,
+            "scale": 1.04,
+            "rotation": 1.731,
+            "dressing": "alps_north_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 303.48,
+            "z": 102.74,
+            "scale": 1.23,
+            "rotation": 0.217,
+            "dressing": "alps_north_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 315.18,
+            "z": 114.81,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_north_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 622.01,
+            "z": 542.87,
+            "scale": 0.91,
+            "rotation": 5.847,
+            "dressing": "alps_descent_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 617.53,
+            "z": 557.45,
+            "scale": 0.94,
+            "rotation": 5.409,
+            "dressing": "alps_descent_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 609.25,
+            "z": 556.29,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_descent_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 616.06,
+            "z": 538.75,
+            "scale": 1.0,
+            "rotation": 3.404,
+            "dressing": "alps_descent_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 633.88,
+            "z": 547.54,
+            "scale": 0.8,
+            "rotation": 1.116,
+            "dressing": "alps_descent_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 638.55,
+            "z": 546.42,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_descent_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 635.03,
+            "z": 564.82,
+            "scale": 1.0,
+            "rotation": 2.209,
+            "dressing": "alps_descent_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 297.89,
+            "z": 521.25,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_switchback_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "supply_cart",
+            "x": 300.12,
+            "z": 532.13,
+            "scale": 1.0,
+            "rotation": 0.888,
+            "dressing": "alps_switchback_junction"
+        },
+        {
+            "type": "statue",
+            "x": 411.88,
+            "z": 546.57,
+            "scale": 1.0,
+            "rotation": 1.731,
+            "dressing": "alps_descent_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 407.26,
+            "z": 543.8,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_descent_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "ruins",
+            "x": 418.28,
+            "z": 544.56,
+            "scale": 0.8,
+            "rotation": 1.254,
+            "dressing": "alps_descent_junction"
+        },
+        {
+            "type": "statue",
+            "x": 115.98,
+            "z": 137.63,
+            "scale": 1.0,
+            "rotation": -1.435,
+            "dressing": "alps_first_pass_junction"
+        },
+        {
+            "type": "pine_tree",
+            "x": 113.58,
+            "z": 144.68,
+            "scale": 1.0,
+            "rotation": 4.548,
+            "dressing": "alps_first_pass_junction"
+        },
+        {
+            "type": "boulder",
+            "x": 156.63,
+            "z": 140.81,
+            "scale": 0.98,
+            "rotation": 3.942,
+            "dressing": "alps_first_pass_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 166.11,
+            "z": 142.97,
+            "scale": 1.23,
+            "rotation": 0.925,
+            "dressing": "alps_first_pass_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 155.01,
+            "z": 134.2,
+            "scale": 1.0,
+            "rotation": 5.886,
+            "dressing": "alps_first_pass_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 151.37,
+            "z": 156.38,
+            "scale": 0.93,
+            "rotation": 2.812,
+            "dressing": "alps_first_pass_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 155.55,
+            "z": 161.12,
+            "scale": 1.27,
+            "rotation": 0.089,
+            "dressing": "alps_first_pass_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 403.19,
+            "z": 411.12,
+            "scale": 0.99,
+            "rotation": 2.06,
+            "dressing": "alps_saddle_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 409.16,
+            "z": 413.21,
+            "scale": 0.93,
+            "rotation": 2.594,
+            "dressing": "alps_saddle_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 401.56,
+            "z": 403.53,
+            "scale": 1.0,
+            "rotation": 2.969,
+            "dressing": "alps_saddle_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 394.01,
+            "z": 422.98,
+            "scale": 0.92,
+            "rotation": 0.396,
+            "dressing": "alps_saddle_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 397.54,
+            "z": 428.24,
+            "scale": 1.1,
+            "rotation": 1.221,
+            "dressing": "alps_saddle_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 401.31,
+            "z": 429.89,
+            "scale": 1.0,
+            "rotation": -2.483,
+            "dressing": "alps_saddle_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 493.17,
+            "z": 565.5,
+            "scale": 1.23,
+            "rotation": 4.711,
+            "dressing": "alps_descent_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 495.31,
+            "z": 571.45,
+            "scale": 1.24,
+            "rotation": 4.41,
+            "dressing": "alps_descent_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 496.79,
+            "z": 558.59,
+            "scale": 1.0,
+            "rotation": 5.575,
+            "dressing": "alps_descent_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 456.18,
+            "z": 566.39,
+            "scale": 1.5,
+            "rotation": 4.839,
+            "dressing": "alps_descent_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 454.33,
+            "z": 572.44,
+            "scale": 1.21,
+            "rotation": 2.775,
+            "dressing": "alps_descent_ramp"
+        },
+        {
+            "type": "firecamp",
+            "x": 453.52,
+            "z": 580.46,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_descent_ramp",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 192.0,
+            "z": 32.76,
+            "scale": 0.87,
+            "rotation": 2.307,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 225.76,
+            "z": 39.96,
+            "scale": 1.02,
+            "rotation": 1.841,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 249.1,
+            "z": 68.7,
+            "scale": 0.95,
+            "rotation": 0.317,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "plant",
+            "x": 284.8,
+            "z": 75.08,
+            "scale": 1.29,
+            "rotation": 2.338,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "plant",
+            "x": 288.92,
+            "z": 75.71,
+            "scale": 1.28,
+            "rotation": 0.124,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 304.63,
+            "z": 105.71,
+            "scale": 1.09,
+            "rotation": 5.079,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 343.42,
+            "z": 112.15,
+            "scale": 1.29,
+            "rotation": 5.687,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 365.42,
+            "z": 141.43,
+            "scale": 1.26,
+            "rotation": 5.387,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "plant",
+            "x": 398.98,
+            "z": 149.96,
+            "scale": 1.15,
+            "rotation": 5.431,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "plant",
+            "x": 403.49,
+            "z": 149.25,
+            "scale": 1.39,
+            "rotation": 3.653,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 421.82,
+            "z": 178.16,
+            "scale": 1.25,
+            "rotation": 2.09,
+            "dressing": "alps_river_bank"
+        },
+        {
+            "type": "firecamp",
+            "x": 116.12,
+            "z": 184.57,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 105.0,
+            "z": 185.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 102.28,
+            "z": 187.47,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "alps_gate_1"
+        },
+        {
+            "type": "supply_cart",
+            "x": 116.5,
+            "z": 191.0,
+            "scale": 1.0,
+            "rotation": 1.871,
+            "dressing": "alps_gate_1"
+        },
+        {
+            "type": "firecamp",
+            "x": 134.28,
+            "z": 158.82,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 135.0,
+            "z": 171.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 139.0,
+            "z": 172.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_2"
+        },
+        {
+            "type": "firecamp",
+            "x": 177.7,
+            "z": 290.59,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 175.87,
+            "z": 287.88,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "alps_gate_3"
+        },
+        {
+            "type": "supply_cart",
+            "x": 163.67,
+            "z": 284.75,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "alps_gate_3"
+        },
+        {
+            "type": "firecamp",
+            "x": 571.28,
+            "z": 535.47,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 583.0,
+            "z": 537.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 584.0,
+            "z": 533.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "alps_gate_4"
+        },
+        {
+            "type": "supply_cart",
+            "x": 571.5,
+            "z": 531.0,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "alps_gate_4"
+        },
+        {
+            "type": "statue",
+            "x": 572.0,
+            "z": 526.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_4"
+        },
+        {
+            "type": "statue",
+            "x": 584.0,
+            "z": 526.0,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "alps_gate_4"
+        },
+        {
+            "type": "firecamp",
+            "x": 535.0,
+            "z": 543.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 529.81,
+            "z": 541.82,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "alps_gate_5"
+        },
+        {
+            "type": "statue",
+            "x": 526.4,
+            "z": 539.59,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "alps_gate_5"
+        },
+        {
+            "type": "firecamp",
+            "x": 86.85,
+            "z": 87.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 97.62,
+            "z": 84.75,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_6",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 97.72,
+            "z": 81.88,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "alps_gate_6"
+        },
+        {
+            "type": "supply_cart",
+            "x": 85.35,
+            "z": 81.0,
+            "scale": 1.0,
+            "rotation": -1.271,
+            "dressing": "alps_gate_6"
+        },
+        {
+            "type": "firecamp",
+            "x": 95.58,
+            "z": 119.47,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_7",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 87.13,
+            "z": 122.12,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "alps_gate_7",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 85.7,
+            "z": 125.0,
+            "scale": 1.0,
+            "rotation": 1.571,
+            "dressing": "alps_gate_7"
+        }
+    ],
+    "dressing": [
+        {
+            "id": "alps_avalanche",
+            "kind": "scree",
+            "x": 96,
+            "z": 262,
+            "rotation": 45,
+            "width": 34,
+            "depth": 16,
+            "boulders": 18,
+            "dead_trees": 4
+        },
+        {
+            "id": "alps_summit_cairn",
+            "kind": "cairn",
+            "x": 262,
+            "z": 396,
+            "facing": "south",
+            "boulders": 8,
+            "radius": 5
+        },
+        {
+            "id": "alps_summit_scree",
+            "kind": "scree",
+            "x": 236,
+            "z": 380,
+            "rotation": 20,
+            "width": 24,
+            "depth": 10,
+            "boulders": 10,
+            "dead_trees": 1,
+            "cart": false
+        },
+        {
+            "id": "alps_frozen_dead_field",
+            "kind": "barrow_field",
+            "x": 252,
+            "z": 548,
+            "radius": 12,
+            "shrine": true,
+            "ruins": 6,
+            "dead_trees": 6,
+            "boulders": 6
+        },
+        {
+            "id": "alps_frozen_dead_bones",
+            "kind": "boneyard",
+            "x": 226,
+            "z": 566,
+            "radius": 11,
+            "statues": 0,
+            "dead_trees": 6
+        },
+        {
+            "id": "alps_descent_avenue",
+            "kind": "tree_avenue",
+            "from": [
+                500,
+                556
+            ],
+            "to": [
+                548,
+                562
+            ],
+            "tree": "pine_tree",
+            "spacing": 10
+        },
+        {
+            "id": "alps_ascent_grove",
+            "kind": "sacred_grove",
+            "x": 42,
+            "z": 262,
+            "tree": "pine_tree",
+            "count": 7,
+            "radius": 10,
+            "centre": "statue"
+        },
+        {
+            "id": "alps_north_bridge",
+            "kind": "bridgehead",
+            "x": 312,
+            "z": 101,
+            "dead_trees": true
+        },
+        {
+            "id": "alps_descent_bridge",
+            "kind": "bridgehead",
+            "x": 625,
+            "z": 551,
+            "cart": false
+        },
+        {
+            "id": "alps_switchback_junction",
+            "kind": "junction",
+            "x": 300,
+            "z": 520,
+            "style": "camp"
+        },
+        {
+            "id": "alps_descent_junction",
+            "kind": "junction",
+            "x": 400,
+            "z": 560,
+            "style": "shrine"
+        },
+        {
+            "id": "alps_first_pass_junction",
+            "kind": "junction",
+            "x": 116,
+            "z": 130,
+            "style": "milestone",
+            "tree": "pine_tree"
+        },
+        {
+            "id": "alps_first_pass_ramp",
+            "kind": "ramp_mouth",
+            "x": 147,
+            "z": 144,
+            "dead_tree": true
+        },
+        {
+            "id": "alps_saddle_ramp",
+            "kind": "ramp_mouth",
+            "x": 388,
+            "z": 410,
+            "statue": true
+        },
+        {
+            "id": "alps_descent_ramp",
+            "kind": "ramp_mouth",
+            "x": 472,
+            "z": 538,
+            "fire": true
+        },
+        {
+            "id": "alps_river_bank",
+            "kind": "riverbank",
+            "from": [
+                180,
+                20
+            ],
+            "to": [
+                450,
+                190
+            ],
+            "spacing": 34,
+            "kinds": [
+                "boulder",
+                "dead_tree",
+                "boulder",
+                "plant"
+            ]
+        },
+        {
+            "id": "alps_gate_1",
+            "kind": "gate_approach",
+            "x": 110.0,
+            "z": 176.0
+        },
+        {
+            "id": "alps_gate_2",
+            "kind": "gate_approach",
+            "x": 126.0,
+            "z": 166.0
+        },
+        {
+            "id": "alps_gate_3",
+            "kind": "gate_approach",
+            "x": 170.0,
+            "z": 302.0
+        },
+        {
+            "id": "alps_gate_4",
+            "kind": "gate_approach",
+            "x": 578.0,
+            "z": 546.0,
+            "statues": true
+        },
+        {
+            "id": "alps_gate_5",
+            "kind": "gate_approach",
+            "x": 544.0,
+            "z": 548.0,
+            "statues": true
+        },
+        {
+            "id": "alps_gate_6",
+            "kind": "gate_approach",
+            "x": 92,
+            "z": 96,
+            "tents": 2
+        },
+        {
+            "id": "alps_gate_7",
+            "kind": "gate_approach",
+            "x": 92,
+            "z": 112,
+            "tents": 2
         }
     ]
 }

--- a/assets/maps/map_crossing_rhone.json
+++ b/assets/maps/map_crossing_rhone.json
@@ -6560,7 +6560,7 @@
                 "food": 80,
                 "gold": 120
             },
-            "id": "crossing_ruins",
+            "id": "rhone_gaul_barrows",
             "leash_radius": 38.13,
             "owner_id": 99,
             "radius": 20.53,
@@ -6575,7 +6575,8 @@
                 }
             ],
             "x": 37.59,
-            "z": 360.56
+            "z": 360.56,
+            "fog_density": 0.3
         }
     ],
     "victory": {
@@ -6834,20 +6835,6 @@
             "z": 312.48
         },
         {
-            "rotation": -13,
-            "scale": 1,
-            "type": "dead_tree",
-            "x": 112.76,
-            "z": 412.06
-        },
-        {
-            "rotation": 18,
-            "scale": 0.9500000000000001,
-            "type": "ruins",
-            "x": 82.69,
-            "z": 264.41
-        },
-        {
             "rotation": 89,
             "scale": 0.8,
             "type": "supply_cart",
@@ -6897,25 +6884,11 @@
             "z": 460.14
         },
         {
-            "rotation": 40,
-            "scale": 0.8,
-            "type": "weapon_rack",
-            "x": 90.21000000000001,
-            "z": 425.8
-        },
-        {
             "rotation": 16,
             "scale": 1.1,
             "type": "dead_tree",
             "x": 55.13,
             "z": 422.37
-        },
-        {
-            "rotation": -16,
-            "scale": 0.7000000000000001,
-            "type": "ruins",
-            "x": 42.6,
-            "z": 288.44
         },
         {
             "rotation": 95,
@@ -6930,13 +6903,6 @@
             "type": "supply_cart",
             "x": 298.19,
             "z": 309.05
-        },
-        {
-            "rotation": 12,
-            "scale": 1,
-            "type": "tent",
-            "x": 370.86,
-            "z": 130.49
         },
         {
             "rotation": -18,
@@ -6973,32 +6939,11 @@
             "z": 175.13
         },
         {
-            "rotation": 20,
-            "scale": 0.85,
-            "type": "ruins",
-            "x": 298.19,
-            "z": 394.89
-        },
-        {
-            "rotation": -25,
-            "scale": 0.85,
-            "type": "dead_tree",
-            "x": 282.09,
-            "z": 450.38
-        },
-        {
             "rotation": 4,
             "scale": 0.9,
             "type": "supply_cart",
             "x": 285.66,
             "z": 257.54
-        },
-        {
-            "rotation": 30,
-            "scale": 0.9,
-            "type": "dead_tree",
-            "x": 388.40000000000003,
-            "z": 216.33
         },
         {
             "rotation": -40,
@@ -7080,15 +7025,6 @@
             "z": 288.44
         },
         {
-            "intensity": 1.1,
-            "persistent": true,
-            "radius": 3,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 378.37,
-            "z": 99.58
-        },
-        {
             "scale": 1,
             "type": "magic_shrine",
             "x": 17.54,
@@ -7160,12 +7096,6 @@
         {
             "scale": 1,
             "type": "dead_tree",
-            "x": 50.12,
-            "z": 217.14
-        },
-        {
-            "scale": 1,
-            "type": "dead_tree",
             "x": 50.120000000000005,
             "z": 75.54
         },
@@ -7186,15 +7116,6 @@
             "type": "dead_tree",
             "x": 180.42000000000002,
             "z": 463.57
-        },
-        {
-            "intensity": 1,
-            "persistent": true,
-            "radius": 3,
-            "scale": 1,
-            "type": "firecamp",
-            "x": 132.81,
-            "z": 422.37
         },
         {
             "intensity": 1,
@@ -8008,6 +7929,1592 @@
             "type": "cursed_gold_vein",
             "x": 122,
             "z": 192
+        },
+        {
+            "type": "supply_cart",
+            "x": 217.13,
+            "z": 267.67,
+            "scale": 1.0,
+            "rotation": 4.536,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "supply_cart",
+            "x": 218.59,
+            "z": 261.68,
+            "scale": 1.0,
+            "rotation": 4.844,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "supply_cart",
+            "x": 218.96,
+            "z": 255.86,
+            "scale": 1.0,
+            "rotation": 4.729,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "supply_cart",
+            "x": 217.63,
+            "z": 249.32,
+            "scale": 1.0,
+            "rotation": 4.827,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "supply_cart",
+            "x": 216.87,
+            "z": 244.39,
+            "scale": 1.0,
+            "rotation": 4.768,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "supply_cart",
+            "x": 218.86,
+            "z": 238.19,
+            "scale": 1.0,
+            "rotation": 4.864,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "supply_cart",
+            "x": 217.6,
+            "z": 232.31,
+            "scale": 1.0,
+            "rotation": 4.526,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "tent",
+            "x": 209.19,
+            "z": 258.55,
+            "scale": 0.97,
+            "rotation": 6.283,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "tent",
+            "x": 208.21,
+            "z": 249.08,
+            "scale": 1.02,
+            "rotation": 6.283,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "tent",
+            "x": 207.13,
+            "z": 241.3,
+            "scale": 0.98,
+            "rotation": 6.283,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "tent",
+            "x": 200.67,
+            "z": 257.35,
+            "scale": 1.03,
+            "rotation": 6.283,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "tent",
+            "x": 200.08,
+            "z": 249.56,
+            "scale": 0.99,
+            "rotation": 6.283,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "tent",
+            "x": 198.96,
+            "z": 241.98,
+            "scale": 0.99,
+            "rotation": 6.283,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "tent",
+            "x": 192.96,
+            "z": 257.2,
+            "scale": 1.0,
+            "rotation": 6.283,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "tent",
+            "x": 191.35,
+            "z": 249.64,
+            "scale": 0.98,
+            "rotation": 6.283,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "firecamp",
+            "x": 206.21,
+            "z": 264.34,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_landing",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 203.8,
+            "z": 245.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_landing",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 203.04,
+            "z": 236.6,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_landing",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 204.71,
+            "z": 228.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_landing",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 214.18,
+            "z": 258.28,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 212.0,
+            "z": 241.0,
+            "scale": 1.0,
+            "rotation": 3.142,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "boulder",
+            "x": 221.99,
+            "z": 232.03,
+            "scale": 1.05,
+            "rotation": 2.647,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "boulder",
+            "x": 220.89,
+            "z": 234.78,
+            "scale": 1.01,
+            "rotation": 4.83,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "boulder",
+            "x": 222.29,
+            "z": 263.01,
+            "scale": 0.99,
+            "rotation": 4.434,
+            "dressing": "rhone_landing"
+        },
+        {
+            "type": "boulder",
+            "x": 231.26,
+            "z": 182.34,
+            "scale": 1.03,
+            "rotation": 3.609,
+            "dressing": "rhone_landing_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 231.24,
+            "z": 196.34,
+            "scale": 0.97,
+            "rotation": 3.301,
+            "dressing": "rhone_landing_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 227.23,
+            "z": 199.02,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_landing_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 224.27,
+            "z": 180.51,
+            "scale": 1.0,
+            "rotation": 4.153,
+            "dressing": "rhone_landing_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 222.23,
+            "z": 200.01,
+            "scale": 1.0,
+            "rotation": -2.987,
+            "dressing": "rhone_landing_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 249.34,
+            "z": 182.94,
+            "scale": 1.17,
+            "rotation": 1.716,
+            "dressing": "rhone_landing_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 250.0,
+            "z": 195.21,
+            "scale": 0.93,
+            "rotation": 4.718,
+            "dressing": "rhone_landing_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 254.47,
+            "z": 180.06,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_landing_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 257.43,
+            "z": 198.57,
+            "scale": 1.0,
+            "rotation": 5.421,
+            "dressing": "rhone_landing_bridge"
+        },
+        {
+            "type": "ruins",
+            "x": 565.42,
+            "z": 158.43,
+            "scale": 1.22,
+            "rotation": 2.324,
+            "dressing": "rhone_oppidum"
+        },
+        {
+            "type": "ruins",
+            "x": 556.35,
+            "z": 160.48,
+            "scale": 1.19,
+            "rotation": 2.998,
+            "dressing": "rhone_oppidum"
+        },
+        {
+            "type": "ruins",
+            "x": 547.56,
+            "z": 158.68,
+            "scale": 1.16,
+            "rotation": 3.988,
+            "dressing": "rhone_oppidum"
+        },
+        {
+            "type": "ruins",
+            "x": 546.04,
+            "z": 150.12,
+            "scale": 1.01,
+            "rotation": 4.702,
+            "dressing": "rhone_oppidum"
+        },
+        {
+            "type": "firecamp",
+            "x": 560.0,
+            "z": 150.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_oppidum",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 552.08,
+            "z": 153.67,
+            "scale": 1.0,
+            "rotation": 3.214,
+            "dressing": "rhone_oppidum"
+        },
+        {
+            "type": "dead_tree",
+            "x": 552.8,
+            "z": 144.15,
+            "scale": 1.0,
+            "rotation": 0.356,
+            "dressing": "rhone_oppidum"
+        },
+        {
+            "type": "boulder",
+            "x": 548.57,
+            "z": 164.51,
+            "scale": 1.02,
+            "rotation": 1.073,
+            "dressing": "rhone_oppidum"
+        },
+        {
+            "type": "boulder",
+            "x": 562.56,
+            "z": 164.87,
+            "scale": 1.03,
+            "rotation": 3.148,
+            "dressing": "rhone_oppidum"
+        },
+        {
+            "type": "statue",
+            "x": 524.47,
+            "z": 177.75,
+            "scale": 1.1,
+            "rotation": 0.0,
+            "dressing": "rhone_druid_grove"
+        },
+        {
+            "type": "firecamp",
+            "x": 529.38,
+            "z": 178.72,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_druid_grove",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "pine_tree",
+            "x": 536.34,
+            "z": 180.03,
+            "scale": 0.94,
+            "rotation": 4.586,
+            "dressing": "rhone_druid_grove"
+        },
+        {
+            "type": "pine_tree",
+            "x": 525.92,
+            "z": 168.48,
+            "scale": 1.07,
+            "rotation": 1.296,
+            "dressing": "rhone_druid_grove"
+        },
+        {
+            "type": "pine_tree",
+            "x": 533.33,
+            "z": 171.12,
+            "scale": 0.97,
+            "rotation": 0.065,
+            "dressing": "rhone_druid_grove"
+        },
+        {
+            "type": "boulder",
+            "x": 518.53,
+            "z": 178.54,
+            "scale": 0.82,
+            "rotation": 0.65,
+            "dressing": "rhone_druid_grove"
+        },
+        {
+            "type": "ruins",
+            "x": 49.89,
+            "z": 357.97,
+            "scale": 1.07,
+            "rotation": 0.273,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 44.36,
+            "z": 368.48,
+            "scale": 0.8,
+            "rotation": 4.716,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 36.78,
+            "z": 370.47,
+            "scale": 0.86,
+            "rotation": 0.917,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 26.32,
+            "z": 366.1,
+            "scale": 0.85,
+            "rotation": 4.208,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 28.4,
+            "z": 354.46,
+            "scale": 0.92,
+            "rotation": 0.697,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 37.07,
+            "z": 350.86,
+            "scale": 0.92,
+            "rotation": 1.437,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "ruins",
+            "x": 44.82,
+            "z": 350.92,
+            "scale": 1.11,
+            "rotation": 4.308,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 51.08,
+            "z": 370.89,
+            "scale": 0.85,
+            "rotation": 4.717,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 24.21,
+            "z": 371.87,
+            "scale": 1.14,
+            "rotation": 5.921,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 29.93,
+            "z": 343.56,
+            "scale": 0.95,
+            "rotation": 1.802,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 50.1,
+            "z": 347.06,
+            "scale": 0.92,
+            "rotation": 2.37,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 46.87,
+            "z": 375.34,
+            "scale": 1.09,
+            "rotation": 0.902,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 45.63,
+            "z": 361.53,
+            "scale": 0.9,
+            "rotation": 5.773,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "statue",
+            "x": 27.96,
+            "z": 362.21,
+            "scale": 0.9,
+            "rotation": 2.097,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 36.28,
+            "z": 345.98,
+            "scale": 1.18,
+            "rotation": 5.455,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 49.18,
+            "z": 364.04,
+            "scale": 1.15,
+            "rotation": 3.558,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 40.9,
+            "z": 372.62,
+            "scale": 1.05,
+            "rotation": 6.156,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "boulder",
+            "x": 29.51,
+            "z": 348.84,
+            "scale": 1.11,
+            "rotation": 1.549,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "magic_shrine",
+            "x": 37.59,
+            "z": 360.56,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_barrows"
+        },
+        {
+            "type": "dead_tree",
+            "x": 66.32,
+            "z": 387.17,
+            "scale": 0.92,
+            "rotation": 2.819,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 66.0,
+            "z": 380.62,
+            "scale": 1.1,
+            "rotation": 4.1,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 67.55,
+            "z": 400.25,
+            "scale": 0.98,
+            "rotation": 1.75,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 76.31,
+            "z": 391.27,
+            "scale": 1.11,
+            "rotation": 0.21,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 71.3,
+            "z": 381.11,
+            "scale": 0.85,
+            "rotation": 5.238,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 72.31,
+            "z": 402.12,
+            "scale": 1.08,
+            "rotation": 4.004,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "dead_tree",
+            "x": 56.21,
+            "z": 392.18,
+            "scale": 1.03,
+            "rotation": 4.969,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 61.11,
+            "z": 397.16,
+            "scale": 0.93,
+            "rotation": 5.219,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 70.58,
+            "z": 394.97,
+            "scale": 0.92,
+            "rotation": 1.328,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "ruins",
+            "x": 60.72,
+            "z": 388.2,
+            "scale": 0.87,
+            "rotation": 2.966,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 74.85,
+            "z": 398.16,
+            "scale": 1.12,
+            "rotation": 4.68,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 77.66,
+            "z": 387.35,
+            "scale": 0.91,
+            "rotation": 2.228,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 55.6,
+            "z": 387.33,
+            "scale": 1.14,
+            "rotation": 1.327,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 80.66,
+            "z": 388.95,
+            "scale": 1.18,
+            "rotation": 5.127,
+            "dressing": "rhone_barrow_bones"
+        },
+        {
+            "type": "boulder",
+            "x": 231.13,
+            "z": 295.06,
+            "scale": 0.94,
+            "rotation": 3.237,
+            "dressing": "rhone_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 230.26,
+            "z": 308.79,
+            "scale": 1.11,
+            "rotation": 2.686,
+            "dressing": "rhone_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 226.11,
+            "z": 310.89,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 224.76,
+            "z": 289.99,
+            "scale": 1.0,
+            "rotation": 5.285,
+            "dressing": "rhone_south_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 221.06,
+            "z": 311.57,
+            "scale": 1.0,
+            "rotation": -2.872,
+            "dressing": "rhone_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 250.34,
+            "z": 295.51,
+            "scale": 0.82,
+            "rotation": 4.153,
+            "dressing": "rhone_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 249.4,
+            "z": 310.34,
+            "scale": 0.86,
+            "rotation": 5.166,
+            "dressing": "rhone_south_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 254.47,
+            "z": 293.66,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_south_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 254.76,
+            "z": 314.02,
+            "scale": 1.0,
+            "rotation": 1.328,
+            "dressing": "rhone_south_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 342.39,
+            "z": 234.61,
+            "scale": 1.1,
+            "rotation": 2.291,
+            "dressing": "rhone_branch_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 328.73,
+            "z": 235.37,
+            "scale": 0.85,
+            "rotation": 3.626,
+            "dressing": "rhone_branch_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 325.76,
+            "z": 231.53,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_branch_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 344.06,
+            "z": 227.5,
+            "scale": 1.0,
+            "rotation": 5.008,
+            "dressing": "rhone_branch_bridge"
+        },
+        {
+            "type": "supply_cart",
+            "x": 324.48,
+            "z": 226.6,
+            "scale": 1.0,
+            "rotation": -1.858,
+            "dressing": "rhone_branch_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 343.33,
+            "z": 247.05,
+            "scale": 1.17,
+            "rotation": 5.785,
+            "dressing": "rhone_branch_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 327.02,
+            "z": 246.34,
+            "scale": 0.91,
+            "rotation": 5.565,
+            "dressing": "rhone_branch_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 345.87,
+            "z": 250.92,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_branch_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 328.0,
+            "z": 256.06,
+            "scale": 1.0,
+            "rotation": 3.789,
+            "dressing": "rhone_branch_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 558.79,
+            "z": 490.15,
+            "scale": 1.29,
+            "rotation": 0.313,
+            "dressing": "rhone_town_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 547.08,
+            "z": 492.98,
+            "scale": 1.0,
+            "rotation": 2.951,
+            "dressing": "rhone_town_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 543.89,
+            "z": 489.64,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_town_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 559.66,
+            "z": 483.97,
+            "scale": 1.0,
+            "rotation": 3.446,
+            "dressing": "rhone_town_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 563.64,
+            "z": 511.62,
+            "scale": 0.95,
+            "rotation": 3.08,
+            "dressing": "rhone_town_bridge"
+        },
+        {
+            "type": "boulder",
+            "x": 552.74,
+            "z": 514.25,
+            "scale": 1.0,
+            "rotation": 1.825,
+            "dressing": "rhone_town_bridge"
+        },
+        {
+            "type": "firecamp",
+            "x": 567.46,
+            "z": 514.81,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_town_bridge",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "dead_tree",
+            "x": 551.19,
+            "z": 520.85,
+            "scale": 1.0,
+            "rotation": 2.514,
+            "dressing": "rhone_town_bridge"
+        },
+        {
+            "type": "statue",
+            "x": 505.56,
+            "z": 237.47,
+            "scale": 1.0,
+            "rotation": 1.806,
+            "dressing": "rhone_east_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 501.88,
+            "z": 236.54,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_east_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "ruins",
+            "x": 511.92,
+            "z": 234.85,
+            "scale": 0.8,
+            "rotation": 3.062,
+            "dressing": "rhone_east_junction"
+        },
+        {
+            "type": "statue",
+            "x": 156.61,
+            "z": 370.8,
+            "scale": 1.0,
+            "rotation": 2.892,
+            "dressing": "rhone_west_junction"
+        },
+        {
+            "type": "firecamp",
+            "x": 599.23,
+            "z": 460.45,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_south_junction",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "supply_cart",
+            "x": 603.9,
+            "z": 463.12,
+            "scale": 1.0,
+            "rotation": 0.14,
+            "dressing": "rhone_south_junction"
+        },
+        {
+            "type": "weapon_rack",
+            "x": 594.99,
+            "z": 461.87,
+            "scale": 1.0,
+            "rotation": 0.14,
+            "dressing": "rhone_south_junction"
+        },
+        {
+            "type": "boulder",
+            "x": 392.5,
+            "z": 104.0,
+            "scale": 1.17,
+            "rotation": 5.877,
+            "dressing": "rhone_fort_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 394.5,
+            "z": 110.0,
+            "scale": 1.35,
+            "rotation": 5.791,
+            "dressing": "rhone_fort_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 394.97,
+            "z": 97.72,
+            "scale": 1.0,
+            "rotation": 0.847,
+            "dressing": "rhone_fort_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 359.5,
+            "z": 104.0,
+            "scale": 0.98,
+            "rotation": 0.64,
+            "dressing": "rhone_fort_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 357.5,
+            "z": 110.0,
+            "scale": 0.9,
+            "rotation": 2.809,
+            "dressing": "rhone_fort_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 358.5,
+            "z": 114.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "rhone_fort_ramp"
+        },
+        {
+            "type": "firecamp",
+            "x": 356.5,
+            "z": 118.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_fort_ramp",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "boulder",
+            "x": 450.18,
+            "z": 176.5,
+            "scale": 1.17,
+            "rotation": 1.763,
+            "dressing": "rhone_oppidum_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 444.18,
+            "z": 178.5,
+            "scale": 1.3,
+            "rotation": 2.48,
+            "dressing": "rhone_oppidum_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 458.18,
+            "z": 180.5,
+            "scale": 1.0,
+            "rotation": 0.04,
+            "dressing": "rhone_oppidum_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 450.18,
+            "z": 147.5,
+            "scale": 1.25,
+            "rotation": 1.153,
+            "dressing": "rhone_oppidum_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 444.18,
+            "z": 145.5,
+            "scale": 1.01,
+            "rotation": 3.24,
+            "dressing": "rhone_oppidum_ramp"
+        },
+        {
+            "type": "statue",
+            "x": 440.18,
+            "z": 146.5,
+            "scale": 1.0,
+            "rotation": -0.0,
+            "dressing": "rhone_oppidum_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 557.5,
+            "z": 233.44,
+            "scale": 0.93,
+            "rotation": 2.502,
+            "dressing": "rhone_oppidum_south_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 558.61,
+            "z": 236.16,
+            "scale": 1.02,
+            "rotation": 2.549,
+            "dressing": "rhone_oppidum_south_ramp"
+        },
+        {
+            "type": "dead_tree",
+            "x": 561.5,
+            "z": 225.44,
+            "scale": 1.0,
+            "rotation": 3.282,
+            "dressing": "rhone_oppidum_south_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 524.5,
+            "z": 233.44,
+            "scale": 0.94,
+            "rotation": 2.185,
+            "dressing": "rhone_oppidum_south_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 521.61,
+            "z": 236.16,
+            "scale": 1.44,
+            "rotation": 2.178,
+            "dressing": "rhone_oppidum_south_ramp"
+        },
+        {
+            "type": "boulder",
+            "x": 227.35,
+            "z": 56.74,
+            "scale": 0.87,
+            "rotation": 1.99,
+            "dressing": "rhone_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 250.76,
+            "z": 83.21,
+            "scale": 1.21,
+            "rotation": 1.458,
+            "dressing": "rhone_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 252.28,
+            "z": 87.45,
+            "scale": 1.18,
+            "rotation": 5.423,
+            "dressing": "rhone_upper_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 229.84,
+            "z": 115.07,
+            "scale": 0.81,
+            "rotation": 5.779,
+            "dressing": "rhone_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 250.16,
+            "z": 144.83,
+            "scale": 1.18,
+            "rotation": 6.131,
+            "dressing": "rhone_upper_bank"
+        },
+        {
+            "type": "plant",
+            "x": 252.75,
+            "z": 147.89,
+            "scale": 1.06,
+            "rotation": 2.678,
+            "dressing": "rhone_upper_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 228.39,
+            "z": 174.82,
+            "scale": 0.82,
+            "rotation": 1.371,
+            "dressing": "rhone_upper_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 227.99,
+            "z": 335.4,
+            "scale": 0.98,
+            "rotation": 4.222,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 245.24,
+            "z": 372.22,
+            "scale": 0.95,
+            "rotation": 1.113,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 244.93,
+            "z": 375.97,
+            "scale": 1.1,
+            "rotation": 5.575,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 221.67,
+            "z": 404.76,
+            "scale": 0.81,
+            "rotation": 5.519,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 241.2,
+            "z": 439.17,
+            "scale": 1.27,
+            "rotation": 0.78,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 243.98,
+            "z": 441.13,
+            "scale": 1.25,
+            "rotation": 2.89,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 222.55,
+            "z": 474.35,
+            "scale": 1.12,
+            "rotation": 1.298,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "boulder",
+            "x": 246.99,
+            "z": 506.31,
+            "scale": 1.26,
+            "rotation": 1.661,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 226.3,
+            "z": 539.7,
+            "scale": 1.17,
+            "rotation": 5.965,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "plant",
+            "x": 225.34,
+            "z": 544.11,
+            "scale": 1.34,
+            "rotation": 0.835,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "dead_tree",
+            "x": 249.82,
+            "z": 573.69,
+            "scale": 0.81,
+            "rotation": 2.362,
+            "dressing": "rhone_lower_bank"
+        },
+        {
+            "type": "firecamp",
+            "x": 379.55,
+            "z": 65.47,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 369.01,
+            "z": 65.47,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_1",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 409.0,
+            "z": 42.73,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 409.0,
+            "z": 53.27,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_2",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 413.43,
+            "z": 55.39,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_2"
+        },
+        {
+            "type": "firecamp",
+            "x": 554.14,
+            "z": 517.25,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 564.27,
+            "z": 515.43,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_3",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 566.39,
+            "z": 511.0,
+            "scale": 1.0,
+            "rotation": -1.571,
+            "dressing": "rhone_gate_3"
+        },
+        {
+            "type": "statue",
+            "x": 567.28,
+            "z": 507.28,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "rhone_gate_3"
+        },
+        {
+            "type": "firecamp",
+            "x": 599.0,
+            "z": 536.7,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 599.0,
+            "z": 547.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_4",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 603.0,
+            "z": 548.3,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_4"
+        },
+        {
+            "type": "firecamp",
+            "x": 64.82,
+            "z": 169.72,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "firecamp",
+            "x": 67.0,
+            "z": 179.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_5",
+            "radius": 3.2,
+            "intensity": 1.15,
+            "persistent": true
+        },
+        {
+            "type": "weapon_rack",
+            "x": 71.0,
+            "z": 180.0,
+            "scale": 1.0,
+            "rotation": 0.0,
+            "dressing": "rhone_gate_5"
+        },
+        {
+            "type": "tent",
+            "x": 75.06,
+            "z": 157.25,
+            "scale": 1.0,
+            "rotation": -3.142,
+            "dressing": "rhone_gate_5"
+        }
+    ],
+    "dressing": [
+        {
+            "id": "rhone_landing",
+            "kind": "raft_camp",
+            "x": 218,
+            "z": 250,
+            "facing": "west",
+            "carts": 7,
+            "tents": 8,
+            "fires": 4
+        },
+        {
+            "id": "rhone_landing_bridge",
+            "kind": "bridgehead",
+            "x": 240,
+            "z": 190
+        },
+        {
+            "id": "rhone_oppidum",
+            "kind": "hilltop_ruin",
+            "x": 558,
+            "z": 150,
+            "facing": "west",
+            "radius": 13,
+            "ruins": 8
+        },
+        {
+            "id": "rhone_druid_grove",
+            "kind": "sacred_grove",
+            "x": 524,
+            "z": 180,
+            "tree": "pine_tree",
+            "count": 9,
+            "radius": 12
+        },
+        {
+            "id": "rhone_barrows",
+            "kind": "barrow_field",
+            "x": 37.59,
+            "z": 360.56,
+            "radius": 12,
+            "shrine": true,
+            "ruins": 7,
+            "dead_trees": 5
+        },
+        {
+            "id": "rhone_barrow_bones",
+            "kind": "boneyard",
+            "x": 66,
+            "z": 392,
+            "radius": 12,
+            "statues": 0
+        },
+        {
+            "id": "rhone_south_bridge",
+            "kind": "bridgehead",
+            "x": 240,
+            "z": 302
+        },
+        {
+            "id": "rhone_branch_bridge",
+            "kind": "bridgehead",
+            "x": 336,
+            "z": 241
+        },
+        {
+            "id": "rhone_town_bridge",
+            "kind": "bridgehead",
+            "x": 556,
+            "z": 502,
+            "cart": false
+        },
+        {
+            "id": "rhone_east_junction",
+            "kind": "junction",
+            "x": 505,
+            "z": 245,
+            "style": "shrine"
+        },
+        {
+            "id": "rhone_west_junction",
+            "kind": "junction",
+            "x": 150,
+            "z": 372,
+            "style": "milestone",
+            "tree": "pine_tree"
+        },
+        {
+            "id": "rhone_south_junction",
+            "kind": "junction",
+            "x": 600,
+            "z": 455,
+            "style": "camp"
+        },
+        {
+            "id": "rhone_fort_ramp",
+            "kind": "ramp_mouth",
+            "x": 376,
+            "z": 88,
+            "statue": true,
+            "fire": true
+        },
+        {
+            "id": "rhone_oppidum_ramp",
+            "kind": "ramp_mouth",
+            "x": 470,
+            "z": 162,
+            "statue": true
+        },
+        {
+            "id": "rhone_oppidum_south_ramp",
+            "kind": "ramp_mouth",
+            "x": 541,
+            "z": 225
+        },
+        {
+            "id": "rhone_upper_bank",
+            "kind": "riverbank",
+            "from": [
+                238,
+                40
+            ],
+            "to": [
+                238,
+                175
+            ],
+            "spacing": 30
+        },
+        {
+            "id": "rhone_lower_bank",
+            "kind": "riverbank",
+            "from": [
+                238,
+                320
+            ],
+            "to": [
+                238,
+                600
+            ],
+            "spacing": 34
+        },
+        {
+            "id": "rhone_gate_1",
+            "kind": "gate_approach",
+            "x": 376.0,
+            "z": 58.0,
+            "statues": true
+        },
+        {
+            "id": "rhone_gate_2",
+            "kind": "gate_approach",
+            "x": 400.0,
+            "z": 48.0,
+            "statues": true
+        },
+        {
+            "id": "rhone_gate_3",
+            "kind": "gate_approach",
+            "x": 560.0,
+            "z": 524.0,
+            "statues": true
+        },
+        {
+            "id": "rhone_gate_4",
+            "kind": "gate_approach",
+            "x": 590.0,
+            "z": 542.0,
+            "statues": true
+        },
+        {
+            "id": "rhone_gate_5",
+            "kind": "gate_approach",
+            "x": 58,
+            "z": 174,
+            "tents": 2
         }
     ]
 }

--- a/assets/shaders/sky_box.frag
+++ b/assets/shaders/sky_box.frag
@@ -37,24 +37,24 @@ const int k_box_edge_octaves = 2;
 const float k_box_edge_weight = 0.22;
 const float k_box_detail_scale = 0.0030;
 const float k_box_detail_drift = 1.7;
-const float k_box_coverage_floor = 0.36;
-const float k_box_coverage_gain = 0.50;
-const float k_box_coverage_softness = 0.09;
+const float k_box_coverage_floor = 0.0;
+const float k_box_coverage_gain = 0.68;
+const float k_box_coverage_softness = 0.12;
 const float k_box_profile_base_soft = 0.15;
 const float k_box_profile_top_soft = 0.62;
 const float k_box_erosion = 0.50;
-const float k_box_density_gain = 2.00;
-const float k_box_extinction = 0.0110;
+const float k_box_density_gain = 1.50;
+const float k_box_extinction = 0.0080;
 const float k_box_light_step = 90.0;
 const float k_box_light_extinction = 0.0045;
-const float k_box_powder = 2.4;
-const float k_box_powder_floor = 0.30;
-const float k_box_sun_gain = 1.50;
-const float k_box_ambient_gain = 0.40;
+const float k_box_powder = 1.8;
+const float k_box_powder_floor = 0.24;
+const float k_box_sun_gain = 0.82;
+const float k_box_ambient_gain = 0.34;
 const float k_box_anisotropy = 0.55;
-const float k_box_phase_weight = 0.45;
+const float k_box_phase_weight = 0.32;
 const float k_box_phase_min = 0.35;
-const float k_box_phase_max = 1.80;
+const float k_box_phase_max = 1.50;
 const float k_box_transmittance_cutoff = 0.02;
 const float k_box_dither_x = 0.06711056;
 const float k_box_dither_y = 0.00583715;
@@ -113,6 +113,11 @@ float sky_box_phase(float cos_angle) {
 }
 
 vec4 sky_box_clouds(vec3 ray, float dither) {
+  float cloud_cover = clamp(environment_cloud_cover(), 0.0, 1.0);
+  if (cloud_cover <= 0.0001) {
+    return vec4(0.0);
+  }
+
   if (ray.y <= k_box_min_upward) {
     return vec4(0.0);
   }
@@ -123,8 +128,8 @@ vec4 sky_box_clouds(vec3 ray, float dither) {
     return vec4(0.0);
   }
 
-  float coverage = clamp(
-      environment_cloud_cover() * k_box_coverage_gain + k_box_coverage_floor, 0.0, 1.0);
+  float coverage =
+      clamp(cloud_cover * k_box_coverage_gain + k_box_coverage_floor, 0.0, 1.0);
   vec3 sun_direction = environment_primary_direction();
   vec3 sun_color = environment_primary_color() * environment_primary_intensity();
   vec3 ambient = sky_cloud_tint(ray);

--- a/game/map/environment_lighting.cpp
+++ b/game/map/environment_lighting.cpp
@@ -332,19 +332,20 @@ auto iberian_high_sun_profile() -> const std::array<LightingKeyframe, 8>& {
 
 auto arena_neutral_profile() -> const std::array<LightingKeyframe, 8>& {
   static const std::array<LightingKeyframe, 8> keyframes = graded_profile({
-      .primary_scale = {0.96F, 0.98F, 1.02F},
+      .primary_scale = {1.02F, 0.96F, 0.88F},
       .primary_intensity_scale = 0.96F,
-      .sky_target = {0.46F, 0.59F, 0.73F},
-      .sky_mix = 0.22F,
-      .bounce_target = {0.26F, 0.24F, 0.20F},
-      .bounce_mix = 0.24F,
-      .fog_target = {0.57F, 0.64F, 0.69F},
-      .fog_mix = 0.24F,
-      .fog_density_add = 0.0010F,
-      .shadow_target = {0.27F, 0.34F, 0.44F},
-      .shadow_mix = 0.24F,
-      .shadow_softness_add = 0.04F,
-      .exposure_scale = 0.98F,
+      .sky_target = {0.24F, 0.38F, 0.58F},
+      .sky_mix = 0.50F,
+      .bounce_target = {0.32F, 0.24F, 0.16F},
+      .bounce_mix = 0.36F,
+      .ambient_scale = 0.99F,
+      .fog_target = {0.50F, 0.52F, 0.52F},
+      .fog_mix = 0.30F,
+      .shadow_target = {0.25F, 0.29F, 0.36F},
+      .shadow_mix = 0.30F,
+      .shadow_strength_scale = 0.98F,
+      .shadow_softness_add = 0.02F,
+      .exposure_scale = 0.95F,
   });
   return keyframes;
 }

--- a/game/map/terrain.h
+++ b/game/map/terrain.h
@@ -511,14 +511,14 @@ inline void apply_ground_type_defaults(BiomeSettings& settings,
 
   case GroundType::SoilRocky:
 
-    settings.grass_primary = QVector3D(0.38F, 0.46F, 0.27F);
-    settings.grass_secondary = QVector3D(0.45F, 0.54F, 0.31F);
-    settings.grass_dry = QVector3D(0.58F, 0.52F, 0.38F);
-    settings.soil_color = QVector3D(0.55F, 0.48F, 0.38F);
-    settings.rock_low = QVector3D(0.52F, 0.50F, 0.46F);
-    settings.rock_high = QVector3D(0.72F, 0.70F, 0.66F);
-    settings.terrain_ambient_boost = 0.96F;
-    settings.terrain_rock_detail_strength = 0.65F;
+    settings.grass_primary = QVector3D(0.31F, 0.34F, 0.22F);
+    settings.grass_secondary = QVector3D(0.38F, 0.40F, 0.24F);
+    settings.grass_dry = QVector3D(0.51F, 0.44F, 0.30F);
+    settings.soil_color = QVector3D(0.44F, 0.34F, 0.24F);
+    settings.rock_low = QVector3D(0.42F, 0.40F, 0.36F);
+    settings.rock_high = QVector3D(0.62F, 0.59F, 0.53F);
+    settings.terrain_ambient_boost = 0.93F;
+    settings.terrain_rock_detail_strength = 0.68F;
 
     settings.patch_density = 2.2F;
     settings.patch_jitter = 0.60F;
@@ -543,11 +543,11 @@ inline void apply_ground_type_defaults(BiomeSettings& settings,
     settings.plant_density = 0.18F;
 
     settings.snow_coverage = 0.0F;
-    settings.moisture_level = 0.35F;
-    settings.crack_intensity = 0.25F;
-    settings.rock_exposure = 0.75F;
-    settings.grass_saturation = 1.00F;
-    settings.soil_roughness = 0.85F;
+    settings.moisture_level = 0.28F;
+    settings.crack_intensity = 0.32F;
+    settings.rock_exposure = 0.82F;
+    settings.grass_saturation = 0.78F;
+    settings.soil_roughness = 0.88F;
     settings.snow_color = QVector3D(0.92F, 0.94F, 0.98F);
     break;
 

--- a/scripts/generate-map-dressing.py
+++ b/scripts/generate-map-dressing.py
@@ -1,0 +1,1471 @@
+#!/usr/bin/env python3
+"""Stamp hand-authored dressing into Standard of Iron map JSON.
+
+Settlements come from ``settlements`` and the four stock landmark kinds from
+``landmarks``. Everything else that makes a battlefield read as one place - the
+raft camp on a river bank, the boulder field under a pass, the cypress avenue
+into a town, the fires either side of a gate, the cairn at a ramp mouth - is
+authored as intent in a map's ``dressing`` array and stamped into ``world_props``
+by this tool. One entry is a handful of lines; the composition, the ground
+check and the nudging are here.
+
+Every prop written carries a ``dressing`` key naming the piece it belongs to. A
+run strips its own previous output before writing, and leaves everything
+without the key alone, so this tool composes with ``generate-map-landmarks.py``
+and with hand-placed scatter in either order.
+
+Pieces
+  Landmarks - one place worth walking to:
+    barrow_field   ring of ruins, fallen statues, dead trees and boulders; the
+                   ground a Sepulcher zone rises from. ``shrine`` adds an
+                   authored magic shrine at the centre for the zone to adopt.
+    hilltop_ruin   a razed citadel: ruins in a rough ring, a statue pair at
+                   the gate, a fire still burning in it.
+    sacred_grove   a ring of trees around a monument. ``tree`` picks the
+                   species (cypress_tree, pine_tree, olive_tree, palm_tree),
+                   ``centre`` the monument (statue, magic_shrine, firecamp).
+    tree_avenue    paired trees along a road between ``from`` and ``to``.
+    oasis          palms, water carts and fires around a well of ruins.
+    scree          a slide of boulders with a wrecked cart in it.
+    boneyard       dead trees, broken ruins and stones - a field the dead own.
+    ford_wreck     a lost crossing: boulders and a cart on both banks.
+    raft_camp      an army's landing: a row of carts on the bank, tents,
+                   fires and racks behind them. ``facing`` is the bank's
+                   outward side.
+    cairn          a statue on a ring of stones.
+    shore_hamlet   a fishing village: homes along a shore, carts drawn up,
+                   reeds and stones at the water. ``facing`` is toward the
+                   water.
+    sheepfold      a shepherd's steading by a pasture.
+  Routes - the small things that say a road is used:
+    bridgehead     both ends of the nearest bridge: stones, a fire, a cart.
+    junction       the nearest road junction: a wayside statue and a fire.
+                   ``style`` is ``milestone`` (statue only), ``shrine``
+                   (statue, ruins, fire) or ``camp`` (fire, cart, rack).
+    gate_approach  outside the nearest gate: fires either side of the road,
+                   racks, a cart; statues too for a town.
+    ramp_mouth     the nearest hill entrance: boulders flanking the ramp.
+    riverbank      stones, reeds and dead trees along a river between
+                   ``from`` and ``to``.
+
+Every piece takes ``id``, ``kind``, ``x``, ``z`` and optionally ``seed``,
+``scale`` and ``rotation`` (degrees). Kinds document their own extras.
+
+Placement is checked the way ``fix-map-prop-overlaps.py`` checks it: bodies
+keep out of water, roads and bridges, off other bodies and off walls, and -
+when ``tools/terrain_probe`` is built - off broken ground and hill ramps. A
+prop with nowhere legal to stand within its slack is dropped and reported,
+never pushed somewhere it does not belong.
+
+The command is dry-run by default. Pass --write to update the map.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import random
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Sequence
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+_surface_field = importlib.import_module("map_surface_field")
+_water_geometry = importlib.import_module("map_water_geometry")
+ProbeUnavailable = _surface_field.ProbeUnavailable
+SurfaceField = _surface_field.SurfaceField
+find_probe = _surface_field.find_probe
+load_surface = _surface_field.load_surface
+is_ring_river = _water_geometry.is_ring_river
+river_points = _water_geometry.river_points
+
+
+def load_audit_module():
+    spec = importlib.util.spec_from_file_location(
+        "soi_prop_audit", SCRIPTS / "fix-map-prop-overlaps.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["soi_prop_audit"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+AUDIT = load_audit_module()
+
+DRESSING_KEY = "dressing"
+
+CANOPY_TYPES = {"pine_tree", "olive_tree", "cypress_tree", "palm_tree"}
+BLOCKING_TYPES = {"statue", "abandoned_home"}
+SOLID_TYPES = {
+    "tent",
+    "supply_cart",
+    "weapon_rack",
+    "ruins",
+    "dead_tree",
+    "boulder",
+    "iron_ore",
+    "magic_shrine",
+    "abandoned_home",
+    "statue",
+    "cursed_gold_vein",
+    "firecamp",
+}
+
+DEFAULT_RIVER_WIDTH = 6.0
+DEFAULT_BRIDGE_WIDTH = 8.0
+DEFAULT_ROAD_WIDTH = 3.0
+
+RIVER_DRAWN_HALF = 0.55
+"""The ribbon is drawn wider than the channel is blocked; keep bodies off it."""
+
+ROAD_VERGE = 1.2
+WALL_KEEP_OUT = 3.0
+SPAWN_KEEP_OUT = 3.0
+STRUCTURE_KEEP_OUT = {
+    "barracks": 8.0,
+    "home": 4.5,
+    "marketplace": 6.0,
+    "temple": 10.0,
+    "farm": 8.5,
+    "defense_tower": 3.0,
+}
+STRUCTURE_KEEP_OUT_DEFAULT = 4.0
+PROP_GAP = 0.6
+CAPTURABLE_TYPES = {"magic_shrine", "cursed_gold_vein"}
+CAPTURABLE_KEEP_OUT = 5.5
+"""A shrine or vein raises a barracks body at runtime; nothing built stands on it."""
+CANOPY_CLEARANCE = 1.0
+GROUND_RELIEF = 0.30
+EDGE_MARGIN = 5.0
+NUDGE_SLACK = 4.5
+
+
+@dataclass
+class Segment:
+    ax: float
+    az: float
+    bx: float
+    bz: float
+    half: float
+
+    def distance(self, x: float, z: float) -> float:
+        dx = self.bx - self.ax
+        dz = self.bz - self.az
+        length_sq = dx * dx + dz * dz
+        if length_sq <= 1e-9:
+            return math.hypot(x - self.ax, z - self.az)
+        t = ((x - self.ax) * dx + (z - self.az) * dz) / length_sq
+        t = max(0.0, min(1.0, t))
+        return math.hypot(x - (self.ax + dx * t), z - (self.az + dz * t))
+
+    def tangent(self) -> tuple[float, float]:
+        dx = self.bx - self.ax
+        dz = self.bz - self.az
+        length = math.hypot(dx, dz)
+        if length <= 1e-9:
+            return (1.0, 0.0)
+        return (dx / length, dz / length)
+
+
+def polyline(entry: dict) -> list[tuple[float, float]]:
+    raw = entry.get("waypoints") or [entry.get("start"), entry.get("end")]
+    return [(float(p[0]), float(p[1])) for p in raw if p]
+
+
+def segments_of(points: Sequence[tuple[float, float]], half: float) -> list[Segment]:
+    return [
+        Segment(a[0], a[1], b[0], b[1], half)
+        for a, b in zip(points, points[1:], strict=False)
+    ]
+
+
+@dataclass
+class Body:
+    x: float
+    z: float
+    radius: float
+    kind: str
+    canopy: float = 0.0
+
+
+@dataclass
+class Site:
+    definition: dict
+    surface: SurfaceField | None
+    width: float
+    height: float
+    roads: list[Segment] = field(default_factory=list)
+    road_lines: list[tuple[list[tuple[float, float]], float]] = field(
+        default_factory=list
+    )
+    water: list[Segment] = field(default_factory=list)
+    river_lines: list[tuple[list[tuple[float, float]], float]] = field(
+        default_factory=list
+    )
+    lakes: list[tuple[float, float, float, float]] = field(default_factory=list)
+    bridges: list[Segment] = field(default_factory=list)
+    walls: list[Segment] = field(default_factory=list)
+    bodies: list[Body] = field(default_factory=list)
+    spawns: list[tuple[float, float]] = field(default_factory=list)
+
+    @staticmethod
+    def build(definition: dict, surface: SurfaceField | None) -> "Site":
+        grid = definition.get("grid") or {}
+        site = Site(
+            definition=definition,
+            surface=surface,
+            width=float(grid.get("width", 0)),
+            height=float(grid.get("height", 0)),
+        )
+        for road in definition.get("roads") or []:
+            points = polyline(road)
+            half = float(road.get("width", DEFAULT_ROAD_WIDTH)) * 0.5
+            site.roads.extend(segments_of(points, half))
+            site.road_lines.append((points, half))
+        for river in definition.get("rivers") or []:
+            width = float(river.get("width", DEFAULT_RIVER_WIDTH))
+            points = [(float(p[0]), float(p[1])) for p in river_points(river)]
+            if is_ring_river(river) and points:
+                points = points + [points[0]]
+            half = width * RIVER_DRAWN_HALF
+            site.water.extend(segments_of(points, half))
+            site.river_lines.append((points, width))
+        for lake in definition.get("lakes") or []:
+            site.lakes.append(
+                (
+                    float(lake["x"]),
+                    float(lake["z"]),
+                    float(lake.get("width", lake.get("radius", 20) * 2)) * 0.5,
+                    float(lake.get("depth", lake.get("radius", 20) * 2)) * 0.5,
+                )
+            )
+        for bridge in definition.get("bridges") or []:
+            half = float(bridge.get("width", DEFAULT_BRIDGE_WIDTH)) * 0.5
+            site.bridges.extend(segments_of(polyline(bridge), half + 1.0))
+        for entry in definition.get("structures") or []:
+            kind = str(entry.get("type", ""))
+            if "start" in entry and "end" in entry:
+                a = entry["start"]
+                b = entry["end"]
+                site.walls.append(
+                    Segment(float(a[0]), float(a[1]), float(b[0]), float(b[1]), 1.0)
+                )
+                continue
+            if "x" not in entry:
+                continue
+            site.bodies.append(
+                Body(
+                    float(entry["x"]),
+                    float(entry["z"]),
+                    STRUCTURE_KEEP_OUT.get(kind, STRUCTURE_KEEP_OUT_DEFAULT),
+                    kind,
+                )
+            )
+        for prop in definition.get("world_props") or []:
+            if prop.get(DRESSING_KEY) is not None:
+                continue
+            site.add_prop_body(prop)
+        for spawn in definition.get("spawns") or []:
+            site.spawns.append((float(spawn["x"]), float(spawn["z"])))
+        return site
+
+    def add_prop_body(self, prop: dict) -> None:
+        kind = str(prop["type"])
+        scale = float(prop.get("scale", 1.0) or 1.0)
+        half_x, half_z = AUDIT.prop_ground_half_extents(kind, scale)
+        canopy = 0.0
+        if kind in CANOPY_TYPES:
+            canopy = AUDIT.WORLD_PROP_RENDER_SCALE.get(kind, 1.0) * scale
+        radius = math.hypot(half_x, half_z)
+        if kind in CAPTURABLE_TYPES:
+            radius = max(radius, CAPTURABLE_KEEP_OUT)
+        self.bodies.append(
+            Body(float(prop["x"]), float(prop["z"]), radius, kind, canopy)
+        )
+
+    def ground_ok(
+        self,
+        x: float,
+        z: float,
+        half_x: float,
+        half_z: float,
+        rotation: float,
+        allow_ramp: bool = False,
+    ) -> bool:
+        if self.surface is None:
+            return True
+        points = self.surface.footprint_samples(x, z, half_x, half_z, rotation, False)
+        if self.surface.relief(points) > GROUND_RELIEF:
+            return False
+        if not allow_ramp and self.surface.entrance_coverage(points) > 0.0:
+            return False
+        return True
+
+    def why(
+        self,
+        kind: str,
+        x: float,
+        z: float,
+        scale: float,
+        rotation: float,
+        allow_ramp: bool = False,
+        road_verge: float = ROAD_VERGE,
+    ) -> str | None:
+        """The first reason a body of ``kind`` cannot stand at (x, z), or None."""
+        if not (
+            EDGE_MARGIN <= x <= self.width - EDGE_MARGIN
+            and EDGE_MARGIN <= z <= self.height - EDGE_MARGIN
+        ):
+            return "map edge"
+        half_x, half_z = AUDIT.prop_ground_half_extents(kind, scale)
+        radius = math.hypot(half_x, half_z)
+        for stream in self.water:
+            if stream.distance(x, z) < stream.half + radius + 0.5:
+                return "water"
+        for lx, lz, hx, hz in self.lakes:
+            if ((x - lx) / (hx + radius + 2.0)) ** 2 + (
+                (z - lz) / (hz + radius + 2.0)
+            ) ** 2 < 1.0:
+                return "lake"
+        for deck in self.bridges:
+            if deck.distance(x, z) < deck.half + radius:
+                return "bridge deck"
+        for road in self.roads:
+            if road.distance(x, z) < road.half + road_verge + radius:
+                return "road"
+        for wall in self.walls:
+            if wall.distance(x, z) < WALL_KEEP_OUT + radius:
+                return "wall"
+        canopy = 0.0
+        if kind in CANOPY_TYPES:
+            canopy = AUDIT.WORLD_PROP_RENDER_SCALE.get(kind, 1.0) * scale
+        for body in self.bodies:
+            gap = math.hypot(x - body.x, z - body.z)
+            if gap < body.radius + radius + PROP_GAP:
+                return f"body ({body.kind})"
+            if (
+                canopy > 0.0
+                and body.kind not in CANOPY_TYPES
+                and gap < canopy + body.radius + CANOPY_CLEARANCE
+            ):
+                return f"canopy over {body.kind}"
+            if (
+                body.canopy > 0.0
+                and kind not in CANOPY_TYPES
+                and gap < body.canopy + radius + CANOPY_CLEARANCE
+            ):
+                return f"under {body.kind} canopy"
+        for sx, sz in self.spawns:
+            if math.hypot(x - sx, z - sz) < SPAWN_KEEP_OUT + radius:
+                return "spawn"
+        if self.surface is not None:
+            points = self.surface.footprint_samples(
+                x, z, half_x, half_z, rotation, False
+            )
+            if self.surface.relief(points) > GROUND_RELIEF:
+                return "broken ground"
+            if not allow_ramp and self.surface.entrance_coverage(points) > 0.0:
+                return "hill ramp"
+        return None
+
+    def legal(
+        self,
+        kind: str,
+        x: float,
+        z: float,
+        scale: float,
+        rotation: float,
+        allow_ramp: bool = False,
+        road_verge: float = ROAD_VERGE,
+    ) -> bool:
+        return self.why(kind, x, z, scale, rotation, allow_ramp, road_verge) is None
+
+    def nearest_road(self, x: float, z: float) -> tuple[Segment | None, float]:
+        best = None
+        best_distance = float("inf")
+        for road in self.roads:
+            distance = road.distance(x, z)
+            if distance < best_distance:
+                best = road
+                best_distance = distance
+        return best, best_distance
+
+    def nearest_river(self, x: float, z: float) -> tuple[Segment | None, float]:
+        best = None
+        best_distance = float("inf")
+        for stream in self.water:
+            distance = stream.distance(x, z)
+            if distance < best_distance:
+                best = stream
+                best_distance = distance
+        return best, best_distance
+
+
+class Placer:
+    """Lays one piece's props down, nudging each until it stands legally."""
+
+    def __init__(self, site: Site, piece_id: str, seed: int):
+        self.site = site
+        self.piece_id = piece_id
+        self.rng = random.Random(seed)
+        self.placed: list[dict] = []
+        self.dropped: list[str] = []
+
+    def jitter(self, amount: float) -> float:
+        return self.rng.uniform(-amount, amount)
+
+    def put(
+        self,
+        kind: str,
+        x: float,
+        z: float,
+        rotation: float | None = None,
+        scale: float = 1.0,
+        slack: float = NUDGE_SLACK,
+        allow_ramp: bool = False,
+        road_verge: float = ROAD_VERGE,
+        extra: dict | None = None,
+    ) -> dict | None:
+        if rotation is None:
+            rotation = self.rng.uniform(0.0, math.tau)
+        candidates = [(x, z)]
+        ring = 1.2
+        while ring <= slack:
+            for step in range(12):
+                angle = math.tau * step / 12.0 + ring
+                candidates.append(
+                    (x + math.cos(angle) * ring, z + math.sin(angle) * ring)
+                )
+            ring += 1.1
+        for cx, cz in candidates:
+            if self.site.legal(kind, cx, cz, scale, rotation, allow_ramp, road_verge):
+                prop = {
+                    "type": kind,
+                    "x": round(cx, 2),
+                    "z": round(cz, 2),
+                    "scale": round(scale, 2),
+                    "rotation": round(rotation, 3),
+                    DRESSING_KEY: self.piece_id,
+                }
+                if kind == "firecamp":
+                    prop["radius"] = 3.2
+                    prop["intensity"] = 1.15
+                    prop["persistent"] = True
+                if extra:
+                    prop.update(extra)
+                self.site.add_prop_body(prop)
+                self.placed.append(prop)
+                return prop
+        reason = self.site.why(kind, x, z, scale, rotation, allow_ramp, road_verge)
+        self.dropped.append(f"{kind} at ({x:.0f}, {z:.0f}): {reason}")
+        return None
+
+
+def rotate(along: float, across: float, heading: float) -> tuple[float, float]:
+    """Local (along, across) into a map offset for a piece heading ``heading`` radians."""
+    cos_h = math.cos(heading)
+    sin_h = math.sin(heading)
+    return (along * cos_h - across * sin_h, along * sin_h + across * cos_h)
+
+
+def heading_of(facing: str | None, rotation_deg: float | None) -> float:
+    if rotation_deg is not None:
+        return math.radians(rotation_deg)
+    return {
+        "east": 0.0,
+        "south": math.pi * 0.5,
+        "west": math.pi,
+        "north": -math.pi * 0.5,
+    }.get(str(facing or "east").lower(), 0.0)
+
+
+Composer = Callable[[Placer, dict, float, float], None]
+
+
+def barrow_field(p: Placer, spec: dict, x: float, z: float) -> None:
+    radius = float(spec.get("radius", 11.0))
+    ruins = int(spec.get("ruins", 6))
+    for i in range(ruins):
+        angle = math.tau * i / ruins + p.jitter(0.25)
+        r = radius * p.rng.uniform(0.8, 1.05)
+        p.put(
+            "ruins",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.8, 1.2),
+        )
+    for i in range(int(spec.get("dead_trees", 4))):
+        angle = math.tau * (i + 0.5) / 4 + p.jitter(0.4)
+        r = radius * p.rng.uniform(1.25, 1.6)
+        p.put(
+            "dead_tree",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.85, 1.15),
+        )
+    for i in range(int(spec.get("statues", 2))):
+        angle = math.tau * i / 2 + p.jitter(0.6)
+        r = radius * 0.8
+        p.put(
+            "statue",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            rotation=p.rng.uniform(0.0, math.tau),
+            scale=0.9,
+        )
+    for _ in range(int(spec.get("boulders", 4))):
+        angle = p.rng.uniform(0.0, math.tau)
+        r = radius * p.rng.uniform(0.9, 1.3)
+        p.put(
+            "boulder",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.8, 1.3),
+        )
+    if spec.get("shrine"):
+        p.put("magic_shrine", x, z, rotation=0.0, slack=6.0)
+
+
+def hilltop_ruin(p: Placer, spec: dict, x: float, z: float) -> None:
+    heading = heading_of(spec.get("facing"), spec.get("rotation"))
+    radius = float(spec.get("radius", 12.0))
+    count = int(spec.get("ruins", 7))
+    for i in range(count):
+        angle = math.tau * i / count + p.jitter(0.2)
+        r = radius * p.rng.uniform(0.85, 1.0)
+        p.put(
+            "ruins",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            rotation=angle + math.pi * 0.5,
+            scale=p.rng.uniform(0.9, 1.25),
+        )
+    for side in (-1.0, 1.0):
+        dx, dz = rotate(-radius - 4.0, side * 4.5, heading)
+        p.put("statue", x + dx, z + dz, rotation=heading + side * math.pi * 0.5)
+    dx, dz = rotate(-2.0, 0.0, heading)
+    p.put("firecamp", x + dx, z + dz, rotation=0.0)
+    for i in range(int(spec.get("dead_trees", 2))):
+        dx, dz = rotate(radius * 0.4, (i - 0.5) * radius * 0.9, heading)
+        p.put("dead_tree", x + dx, z + dz)
+    for _ in range(int(spec.get("boulders", 3))):
+        angle = p.rng.uniform(0.0, math.tau)
+        r = radius * p.rng.uniform(1.15, 1.4)
+        p.put(
+            "boulder",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.8, 1.2),
+        )
+
+
+def sacred_grove(p: Placer, spec: dict, x: float, z: float) -> None:
+    tree = str(spec.get("tree", "cypress_tree"))
+    radius = float(spec.get("radius", 11.0))
+    count = int(spec.get("count", 8))
+    centre = str(spec.get("centre", "statue"))
+    p.put(
+        centre,
+        x,
+        z,
+        rotation=heading_of(spec.get("facing"), spec.get("rotation")),
+        scale=float(spec.get("centre_scale", 1.1)),
+        slack=5.0,
+    )
+    if spec.get("fire", True) and centre != "firecamp":
+        p.put("firecamp", x + 4.0, z + 3.0, rotation=0.0)
+    for i in range(count):
+        angle = math.tau * i / count + p.jitter(0.15)
+        r = radius * p.rng.uniform(0.92, 1.08)
+        p.put(
+            tree,
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.9, 1.1),
+            slack=5.0,
+        )
+    for _ in range(int(spec.get("boulders", 2))):
+        angle = p.rng.uniform(0.0, math.tau)
+        p.put(
+            "boulder",
+            x + math.cos(angle) * radius * 0.55,
+            z + math.sin(angle) * radius * 0.55,
+            scale=p.rng.uniform(0.7, 1.0),
+        )
+
+
+def road_path_between(
+    site: Site, start: tuple[float, float], end: tuple[float, float]
+) -> list[tuple[float, float]]:
+    """The stretch of the one road polyline that passes closest to both points."""
+    best = None
+    best_score = float("inf")
+    for points, half in site.road_lines:
+        segs = segments_of(points, half)
+        if not segs:
+            continue
+        s_dist = min(s.distance(*start) for s in segs)
+        e_dist = min(s.distance(*end) for s in segs)
+        score = s_dist + e_dist
+        if score < best_score:
+            best_score = score
+            best = (points, segs)
+    if best is None:
+        return []
+    points, segs = best
+
+    def param(point: tuple[float, float]) -> float:
+        best_t = 0.0
+        best_d = float("inf")
+        run = 0.0
+        for seg in segs:
+            length = math.hypot(seg.bx - seg.ax, seg.bz - seg.az)
+            if length <= 1e-9:
+                continue
+            t = (
+                (point[0] - seg.ax) * (seg.bx - seg.ax)
+                + (point[1] - seg.az) * (seg.bz - seg.az)
+            ) / (length * length)
+            t = max(0.0, min(1.0, t))
+            d = math.hypot(
+                point[0] - (seg.ax + (seg.bx - seg.ax) * t),
+                point[1] - (seg.az + (seg.bz - seg.az) * t),
+            )
+            if d < best_d:
+                best_d = d
+                best_t = run + t * length
+            run += length
+        return best_t
+
+    t0 = param(start)
+    t1 = param(end)
+    if t1 < t0:
+        t0, t1 = t1, t0
+    out: list[tuple[float, float]] = []
+    run = 0.0
+    for seg in segs:
+        length = math.hypot(seg.bx - seg.ax, seg.bz - seg.az)
+        if length <= 1e-9:
+            continue
+        a = max(t0, run)
+        b = min(t1, run + length)
+        if b > a:
+            for t in (a, b):
+                f = (t - run) / length
+                out.append(
+                    (seg.ax + (seg.bx - seg.ax) * f, seg.az + (seg.bz - seg.az) * f)
+                )
+        run += length
+    return out
+
+
+def walk_path(points: Sequence[tuple[float, float]], spacing: float):
+    """Points every ``spacing`` along a polyline with the local tangent."""
+    if len(points) < 2:
+        return
+    carry = spacing * 0.5
+    for a, b in zip(points, points[1:], strict=False):
+        length = math.hypot(b[0] - a[0], b[1] - a[1])
+        if length <= 1e-9:
+            continue
+        tx = (b[0] - a[0]) / length
+        tz = (b[1] - a[1]) / length
+        d = carry
+        while d <= length:
+            yield (a[0] + tx * d, a[1] + tz * d, tx, tz)
+            d += spacing
+        carry = d - length
+
+
+def tree_avenue(p: Placer, spec: dict, x: float, z: float) -> None:
+    tree = str(spec.get("tree", "cypress_tree"))
+    start = (float(spec["from"][0]), float(spec["from"][1]))
+    end = (float(spec["to"][0]), float(spec["to"][1]))
+    path = road_path_between(p.site, start, end)
+    if not path:
+        p.dropped.append("tree_avenue found no road")
+        return
+    road, _ = p.site.nearest_road(*path[0])
+    half = road.half if road else 1.5
+    offset = float(spec.get("offset", half + 4.0))
+    spacing = float(spec.get("spacing", 9.0))
+    sides = spec.get("sides", "both")
+    for px, pz, tx, tz in walk_path(path, spacing):
+        nx, nz = -tz, tx
+        for side in (-1.0, 1.0):
+            if sides == "left" and side > 0 or sides == "right" and side < 0:
+                continue
+            p.put(
+                tree,
+                px + nx * offset * side + p.jitter(0.6),
+                pz + nz * offset * side + p.jitter(0.6),
+                scale=p.rng.uniform(0.9, 1.1),
+                slack=3.0,
+            )
+
+
+def oasis(p: Placer, spec: dict, x: float, z: float) -> None:
+    radius = float(spec.get("radius", 12.0))
+    p.put("ruins", x, z, rotation=0.0, scale=0.8)
+    for i in range(int(spec.get("palms", 9))):
+        angle = math.tau * i / 9 + p.jitter(0.3)
+        r = radius * p.rng.uniform(0.6, 1.1)
+        p.put(
+            "palm_tree",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.85, 1.15),
+            slack=5.0,
+        )
+    heading = heading_of(spec.get("facing"), spec.get("rotation"))
+    for along, across in ((radius + 4.0, -3.0), (radius + 5.0, 4.0)):
+        dx, dz = rotate(along, across, heading)
+        p.put("supply_cart", x + dx, z + dz, rotation=heading + p.jitter(0.3))
+    dx, dz = rotate(radius + 9.0, 0.0, heading)
+    p.put("firecamp", x + dx, z + dz, rotation=0.0)
+    for i in range(int(spec.get("tents", 2))):
+        dx, dz = rotate(radius + 12.0, (i - 0.5) * 7.0, heading)
+        p.put("tent", x + dx, z + dz, rotation=heading + math.pi)
+    for _ in range(int(spec.get("boulders", 3))):
+        angle = p.rng.uniform(0.0, math.tau)
+        p.put(
+            "boulder",
+            x + math.cos(angle) * radius * 0.5,
+            z + math.sin(angle) * radius * 0.5,
+            scale=p.rng.uniform(0.6, 0.9),
+        )
+
+
+def scree(p: Placer, spec: dict, x: float, z: float) -> None:
+    half_w = float(spec.get("width", 30.0)) * 0.5
+    half_d = float(spec.get("depth", 14.0)) * 0.5
+    heading = heading_of(spec.get("facing"), spec.get("rotation"))
+    for _ in range(int(spec.get("boulders", 14))):
+        along = p.rng.uniform(-half_w, half_w)
+        across = p.rng.uniform(-half_d, half_d) * (1.0 - abs(along) / half_w * 0.5)
+        dx, dz = rotate(along, across, heading)
+        p.put("boulder", x + dx, z + dz, scale=p.rng.uniform(0.9, 2.1), slack=3.0)
+    for i in range(int(spec.get("dead_trees", 3))):
+        dx, dz = rotate(
+            p.rng.uniform(-half_w, half_w),
+            (half_d + 3.0) * (1 if i % 2 else -1),
+            heading,
+        )
+        p.put("dead_tree", x + dx, z + dz, scale=p.rng.uniform(0.8, 1.1))
+    if spec.get("cart", True):
+        dx, dz = rotate(
+            p.rng.uniform(-half_w * 0.5, half_w * 0.5), half_d * 0.6, heading
+        )
+        p.put("supply_cart", x + dx, z + dz, rotation=heading + p.rng.uniform(0.8, 1.4))
+
+
+def boneyard(p: Placer, spec: dict, x: float, z: float) -> None:
+    radius = float(spec.get("radius", 14.0))
+    for _ in range(int(spec.get("dead_trees", 7))):
+        angle = p.rng.uniform(0.0, math.tau)
+        r = radius * math.sqrt(p.rng.uniform(0.1, 1.0))
+        p.put(
+            "dead_tree",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.8, 1.2),
+        )
+    for _ in range(int(spec.get("ruins", 3))):
+        angle = p.rng.uniform(0.0, math.tau)
+        r = radius * p.rng.uniform(0.3, 0.8)
+        p.put(
+            "ruins",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.7, 1.0),
+        )
+    for _ in range(int(spec.get("boulders", 5))):
+        angle = p.rng.uniform(0.0, math.tau)
+        r = radius * p.rng.uniform(0.2, 1.1)
+        p.put(
+            "boulder",
+            x + math.cos(angle) * r,
+            z + math.sin(angle) * r,
+            scale=p.rng.uniform(0.6, 1.2),
+        )
+    for _i in range(int(spec.get("statues", 1))):
+        p.put("statue", x + p.jitter(3.0), z + p.jitter(3.0), scale=0.9)
+
+
+def bank_frame(
+    site: Site, x: float, z: float
+) -> tuple[Segment, float, float, float, float] | None:
+    stream, _ = site.nearest_river(x, z)
+    if stream is None:
+        return None
+    tx, tz = stream.tangent()
+    nx, nz = -tz, tx
+    return stream, tx, tz, nx, nz
+
+
+def ford_wreck(p: Placer, spec: dict, x: float, z: float) -> None:
+    frame = bank_frame(p.site, x, z)
+    if frame is None:
+        p.dropped.append("ford_wreck found no river")
+        return
+    stream, tx, tz, nx, nz = frame
+    offset = stream.half + 3.0
+    for side in (-1.0, 1.0):
+        for i in range(int(spec.get("boulders", 3))):
+            along = (i - 1) * 5.0 + p.jitter(1.5)
+            out = offset + p.rng.uniform(0.0, 2.5)
+            p.put(
+                "boulder",
+                x + tx * along + nx * out * side,
+                z + tz * along + nz * out * side,
+                scale=p.rng.uniform(0.8, 1.4),
+            )
+        for i in range(int(spec.get("plants", 3))):
+            along = (i - 1) * 4.0 + p.jitter(2.0)
+            out = offset - 0.5 + p.rng.uniform(0.0, 1.5)
+            p.put(
+                "plant",
+                x + tx * along + nx * out * side,
+                z + tz * along + nz * out * side,
+                scale=p.rng.uniform(0.9, 1.3),
+                slack=2.0,
+            )
+    out = offset + 5.0
+    p.put("dead_tree", x + tx * 6.0 + nx * out, z + tz * 6.0 + nz * out)
+    for i in range(int(spec.get("carts", 1))):
+        side = -1.0 if i % 2 == 0 else 1.0
+        p.put(
+            "supply_cart",
+            x - tx * (4.0 + i * 5.0) + nx * (offset + 4.0) * side,
+            z - tz * (4.0 + i * 5.0) + nz * (offset + 4.0) * side,
+            rotation=math.atan2(nz, nx) + p.rng.uniform(0.5, 1.2),
+        )
+    if spec.get("ruins", True):
+        p.put(
+            "ruins",
+            x + tx * 12.0 - nx * (offset + 7.0),
+            z + tz * 12.0 - nz * (offset + 7.0),
+            scale=0.8,
+        )
+
+
+def raft_camp(p: Placer, spec: dict, x: float, z: float) -> None:
+    heading = heading_of(spec.get("facing"), spec.get("rotation"))
+    carts = int(spec.get("carts", 5))
+    for i in range(carts):
+        across = (i - (carts - 1) * 0.5) * 6.0 + p.jitter(0.8)
+        dx, dz = rotate(0.0 + p.jitter(1.0), across, heading)
+        p.put(
+            "supply_cart",
+            x + dx,
+            z + dz,
+            rotation=heading + math.pi * 0.5 + p.jitter(0.2),
+        )
+    tents = int(spec.get("tents", 6))
+    for i in range(tents):
+        row = i // 3
+        across = ((i % 3) - 1) * 8.0 + p.jitter(1.0)
+        dx, dz = rotate(9.0 + row * 8.0 + p.jitter(1.0), across, heading)
+        p.put(
+            "tent",
+            x + dx,
+            z + dz,
+            rotation=heading + math.pi,
+            scale=p.rng.uniform(0.95, 1.05),
+        )
+    for i in range(int(spec.get("fires", 3))):
+        dx, dz = rotate(13.0 + p.jitter(2.0), (i - 1) * 11.0, heading)
+        p.put("firecamp", x + dx, z + dz, rotation=0.0)
+    for i in range(int(spec.get("racks", 2))):
+        dx, dz = rotate(6.0, (i - 0.5) * 18.0, heading)
+        p.put("weapon_rack", x + dx, z + dz, rotation=heading)
+    for _ in range(int(spec.get("boulders", 3))):
+        dx, dz = rotate(-3.0 + p.jitter(1.0), p.jitter(carts * 4.0), heading)
+        p.put("boulder", x + dx, z + dz, scale=p.rng.uniform(0.7, 1.1))
+
+
+def shore_hamlet(p: Placer, spec: dict, x: float, z: float) -> None:
+    heading = heading_of(spec.get("facing"), spec.get("rotation"))
+    homes = int(spec.get("homes", 3))
+    for i in range(homes):
+        dx, dz = rotate(p.jitter(2.0), (i - (homes - 1) * 0.5) * 11.0, heading)
+        p.put(
+            "abandoned_home",
+            x + dx,
+            z + dz,
+            rotation=heading + p.jitter(0.25),
+            scale=p.rng.uniform(0.9, 1.05),
+            slack=6.0,
+        )
+    for i in range(int(spec.get("carts", 2))):
+        dx, dz = rotate(8.0 + p.jitter(1.5), (i - 0.5) * 9.0 + p.jitter(1.0), heading)
+        p.put(
+            "supply_cart",
+            x + dx,
+            z + dz,
+            rotation=heading + math.pi * 0.5 + p.jitter(0.4),
+        )
+    dx, dz = rotate(7.0, homes * 5.5 + 3.0, heading)
+    p.put("ruins", x + dx, z + dz, scale=0.85)
+    dx, dz = rotate(-7.0, -homes * 5.5, heading)
+    p.put("dead_tree", x + dx, z + dz)
+    dx, dz = rotate(5.0, 0.0, heading)
+    p.put("firecamp", x + dx, z + dz, rotation=0.0)
+    for _ in range(int(spec.get("plants", 5))):
+        dx, dz = rotate(
+            12.0 + p.rng.uniform(0.0, 3.0),
+            p.rng.uniform(-homes * 6.0, homes * 6.0),
+            heading,
+        )
+        p.put("plant", x + dx, z + dz, scale=p.rng.uniform(0.9, 1.4), slack=2.5)
+    for _ in range(int(spec.get("boulders", 3))):
+        dx, dz = rotate(
+            11.0 + p.rng.uniform(0.0, 4.0),
+            p.rng.uniform(-homes * 6.0, homes * 6.0),
+            heading,
+        )
+        p.put("boulder", x + dx, z + dz, scale=p.rng.uniform(0.6, 1.0), slack=2.5)
+
+
+def cairn(p: Placer, spec: dict, x: float, z: float) -> None:
+    p.put(
+        "statue",
+        x,
+        z,
+        rotation=heading_of(spec.get("facing"), spec.get("rotation")),
+        scale=float(spec.get("scale", 1.15)),
+        slack=6.0,
+    )
+    count = int(spec.get("boulders", 6))
+    radius = float(spec.get("radius", 4.5))
+    for i in range(count):
+        angle = math.tau * i / count + p.jitter(0.2)
+        p.put(
+            "boulder",
+            x + math.cos(angle) * radius,
+            z + math.sin(angle) * radius,
+            scale=p.rng.uniform(1.1, 1.7),
+            slack=3.0,
+        )
+    if spec.get("fire", True):
+        p.put("firecamp", x + radius + 4.0, z + 1.0, rotation=0.0)
+
+
+def sheepfold(p: Placer, spec: dict, x: float, z: float) -> None:
+    heading = heading_of(spec.get("facing"), spec.get("rotation"))
+    p.put("abandoned_home", x, z, rotation=heading, slack=6.0)
+    for i in range(int(spec.get("boulders", 6))):
+        angle = heading + math.pi * 0.5 + math.pi * (i / 5.0) + p.jitter(0.15)
+        p.put(
+            "boulder",
+            x + math.cos(angle) * 8.0,
+            z + math.sin(angle) * 8.0,
+            scale=p.rng.uniform(0.7, 1.0),
+        )
+    dx, dz = rotate(-6.0, 5.0, heading)
+    p.put("dead_tree", x + dx, z + dz)
+    dx, dz = rotate(5.0, -4.0, heading)
+    p.put("supply_cart", x + dx, z + dz, rotation=heading + 0.4)
+
+
+def nearest_bridge(site: Site, x: float, z: float) -> Segment | None:
+    best = None
+    best_distance = float("inf")
+    for deck in site.bridges:
+        d = deck.distance(x, z)
+        if d < best_distance:
+            best_distance = d
+            best = deck
+    return best
+
+
+def bridgehead(p: Placer, spec: dict, x: float, z: float) -> None:
+    deck = nearest_bridge(p.site, x, z)
+    if deck is None:
+        p.dropped.append("bridgehead found no bridge")
+        return
+    tx, tz = deck.tangent()
+    nx, nz = -tz, tx
+    ends = ((deck.ax, deck.az, -1.0), (deck.bx, deck.bz, 1.0))
+    for i, (ex, ez, direction) in enumerate(ends):
+        ax, az = tx * direction, tz * direction
+        for side in (-1.0, 1.0):
+            reach = deck.half + 1.5 + p.rng.uniform(0.0, 1.0)
+            p.put(
+                "boulder",
+                ex + ax * 4.0 + nx * reach * side,
+                ez + az * 4.0 + nz * reach * side,
+                scale=p.rng.uniform(0.8, 1.3),
+                slack=3.0,
+            )
+        fire_side = 1.0 if i == 0 else -1.0
+        reach = deck.half + 4.5
+        p.put(
+            "firecamp",
+            ex + ax * 8.0 + nx * reach * fire_side,
+            ez + az * 8.0 + nz * reach * fire_side,
+            rotation=0.0,
+            slack=3.5,
+        )
+        p.put(
+            "dead_tree" if spec.get("dead_trees", True) else "boulder",
+            ex + ax * 11.0 - nx * (deck.half + 4.0) * fire_side,
+            ez + az * 11.0 - nz * (deck.half + 4.0) * fire_side,
+            slack=3.5,
+        )
+        if spec.get("cart", True) and i == 0:
+            p.put(
+                "supply_cart",
+                ex + ax * 13.0 + nx * (deck.half + 5.5) * fire_side,
+                ez + az * 13.0 + nz * (deck.half + 5.5) * fire_side,
+                rotation=math.atan2(az, ax) + p.jitter(0.3),
+                slack=3.5,
+            )
+
+
+def road_junctions(site: Site) -> list[tuple[float, float]]:
+    """Where one road's end meets another road, or two roads share an endpoint."""
+    points: list[tuple[float, float]] = []
+    for index, (line, _half) in enumerate(site.road_lines):
+        if len(line) < 2:
+            continue
+        for end in (line[0], line[-1]):
+            for other_index, (other, other_half) in enumerate(site.road_lines):
+                if other_index == index:
+                    continue
+                if min(s.distance(*end) for s in segments_of(other, other_half)) <= 4.0:
+                    if all(
+                        math.hypot(end[0] - q[0], end[1] - q[1]) > 6.0 for q in points
+                    ):
+                        points.append(end)
+                    break
+    return points
+
+
+def junction(p: Placer, spec: dict, x: float, z: float) -> None:
+    candidates = road_junctions(p.site)
+    if not candidates:
+        p.dropped.append("junction found no road junction")
+        return
+    jx, jz = min(candidates, key=lambda q: math.hypot(q[0] - x, q[1] - z))
+    if math.hypot(jx - x, jz - z) > float(spec.get("snap", 25.0)):
+        jx, jz = x, z
+    road, _ = p.site.nearest_road(jx, jz)
+    tx, tz = road.tangent() if road else (1.0, 0.0)
+    nx, nz = -tz, tx
+    style = str(spec.get("style", "shrine"))
+    side = 1.0 if spec.get("side", "left") == "left" else -1.0
+    reach = (road.half if road else 1.5) + 4.0
+    sx, sz = jx + nx * reach * side, jz + nz * reach * side
+    if style in ("milestone", "shrine"):
+        p.put(
+            "statue",
+            sx,
+            sz,
+            rotation=math.atan2(-nz * side, -nx * side),
+            scale=1.0,
+            slack=6.0,
+        )
+    if style == "shrine":
+        p.put(
+            "firecamp",
+            sx + tx * 5.0 + nx * 2.0 * side,
+            sz + tz * 5.0 + nz * 2.0 * side,
+            rotation=0.0,
+        )
+        p.put(
+            "ruins",
+            sx - tx * 6.0 + nx * 3.0 * side,
+            sz - tz * 6.0 + nz * 3.0 * side,
+            scale=0.8,
+        )
+    if style == "camp":
+        p.put("firecamp", sx, sz, rotation=0.0, slack=6.0)
+        p.put(
+            "supply_cart",
+            sx + tx * 5.0 + nx * 2.0 * side,
+            sz + tz * 5.0 + nz * 2.0 * side,
+            rotation=math.atan2(tz, tx),
+        )
+        p.put(
+            "weapon_rack",
+            sx - tx * 4.0 + nx * 2.0 * side,
+            sz - tz * 4.0 + nz * 2.0 * side,
+            rotation=math.atan2(tz, tx),
+        )
+    if spec.get("tree"):
+        p.put(str(spec["tree"]), sx + nx * 6.0 * side, sz + nz * 6.0 * side, slack=5.0)
+
+
+def nearest_gate(site: Site, x: float, z: float) -> dict | None:
+    best = None
+    best_distance = float("inf")
+    for entry in site.definition.get("structures") or []:
+        if entry.get("type") != "wall_gate" or "x" not in entry:
+            continue
+        d = math.hypot(float(entry["x"]) - x, float(entry["z"]) - z)
+        if d < best_distance:
+            best_distance = d
+            best = entry
+    return best
+
+
+def gate_approach(p: Placer, spec: dict, x: float, z: float) -> None:
+    gate = nearest_gate(p.site, x, z)
+    if gate is None:
+        p.dropped.append("gate_approach found no gate")
+        return
+    gx, gz = float(gate["x"]), float(gate["z"])
+    settlement_id = gate.get("settlement")
+    centre = None
+    for s in p.site.definition.get("settlements") or []:
+        if s.get("id") == settlement_id:
+            centre = (float(s["x"]), float(s["z"]))
+    if centre is None:
+        centre = min(
+            (
+                (float(s["x"]), float(s["z"]))
+                for s in p.site.definition.get("settlements") or []
+            ),
+            key=lambda c: math.hypot(c[0] - gx, c[1] - gz),
+            default=(x, z),
+        )
+    ox, oz = gx - centre[0], gz - centre[1]
+    if abs(ox) > abs(oz):
+        ox, oz = (1.0 if ox > 0 else -1.0), 0.0
+    else:
+        ox, oz = 0.0, (1.0 if oz > 0 else -1.0)
+    nx, nz = -oz, ox
+    road, _ = p.site.nearest_road(gx + ox * 8.0, gz + oz * 8.0)
+    half = road.half if road else 1.6
+    reach = half + 3.5
+    for side in (-1.0, 1.0):
+        p.put(
+            "firecamp",
+            gx + ox * 9.0 + nx * reach * side,
+            gz + oz * 9.0 + nz * reach * side,
+            rotation=0.0,
+            slack=4.0,
+        )
+    p.put(
+        "weapon_rack",
+        gx + ox * 13.0 + nx * (reach + 1.0),
+        gz + oz * 13.0 + nz * (reach + 1.0),
+        rotation=math.atan2(oz, ox),
+    )
+    p.put(
+        "supply_cart",
+        gx + ox * 15.0 - nx * (reach + 1.5),
+        gz + oz * 15.0 - nz * (reach + 1.5),
+        rotation=math.atan2(oz, ox) + 0.3,
+    )
+    if spec.get("statues", False):
+        for side in (-1.0, 1.0):
+            p.put(
+                "statue",
+                gx + ox * 20.0 + nx * (reach + 1.0) * side,
+                gz + oz * 20.0 + nz * (reach + 1.0) * side,
+                rotation=math.atan2(-nz * side, -nx * side),
+                slack=4.0,
+            )
+    if spec.get("tents", 0):
+        for i in range(int(spec["tents"])):
+            p.put(
+                "tent",
+                gx + ox * (18.0 + 6.0 * (i // 2)) - nx * (reach + 6.0 + 5.0 * (i % 2)),
+                gz + oz * (18.0 + 6.0 * (i // 2)) - nz * (reach + 6.0 + 5.0 * (i % 2)),
+                rotation=math.atan2(-oz, -ox),
+            )
+
+
+def hill_entrances(site: Site) -> list[tuple[float, float, float, float]]:
+    out = []
+    for feature in site.definition.get("terrain") or []:
+        if feature.get("type") != "hill":
+            continue
+        hx, hz = float(feature["x"]), float(feature["z"])
+        for entrance in feature.get("entrances") or []:
+            ex, ez = float(entrance["x"]), float(entrance["z"])
+            out.append((ex, ez, hx, hz))
+    return out
+
+
+def ramp_mouth(p: Placer, spec: dict, x: float, z: float) -> None:
+    """Frame the mouth of the nearest hill ramp where its corridor meets flat ground.
+
+    The engine's ramp corridor runs from the crown out well past the authored
+    entrance and flares as it goes, so the mouth is found on the built surface:
+    walk out along the ramp axis until the entrance mask ends, then out to each
+    side until it ends there too, and stand the stones just beyond that edge."""
+    entrances = hill_entrances(p.site)
+    if not entrances:
+        p.dropped.append("ramp_mouth found no hill entrance")
+        return
+    ex, ez, hx, hz = min(entrances, key=lambda e: math.hypot(e[0] - x, e[1] - z))
+    ax, az = ex - hx, ez - hz
+    length = math.hypot(ax, az) or 1.0
+    ax, az = ax / length, az / length
+    nx, nz = -az, ax
+    surface = p.site.surface
+
+    def on_ramp(px: float, pz: float) -> bool:
+        return surface is not None and surface.is_hill_entrance(px, pz)
+
+    foot = None
+    for along in range(0, 70, 2):
+        if not on_ramp(ex + ax * along, ez + az * along):
+            foot = float(along)
+            break
+    if foot is None:
+        p.dropped.append(
+            f"ramp_mouth at ({ex:.0f}, {ez:.0f}): corridor never reaches flat ground"
+        )
+        return
+    for side in (-1.0, 1.0):
+        along = max(foot - 6.0, 2.0)
+        reach = None
+        for candidate in range(4, 40, 2):
+            if not on_ramp(
+                ex + ax * along + nx * candidate * side,
+                ez + az * along + nz * candidate * side,
+            ):
+                reach = float(candidate) + 2.5
+                break
+        if reach is None:
+            continue
+        for step in range(int(spec.get("pairs", 2))):
+            p.put(
+                "boulder",
+                ex + ax * (along + step * 6.0) + nx * (reach + step * 2.0) * side,
+                ez + az * (along + step * 6.0) + nz * (reach + step * 2.0) * side,
+                scale=p.rng.uniform(0.9, 1.5),
+                slack=5.0,
+            )
+        if side < 0 and spec.get("dead_tree", True):
+            p.put(
+                "dead_tree",
+                ex + ax * (along - 8.0) + nx * (reach + 4.0) * side,
+                ez + az * (along - 8.0) + nz * (reach + 4.0) * side,
+                slack=5.0,
+            )
+        if side > 0 and spec.get("statue", False):
+            p.put(
+                "statue",
+                ex + ax * (foot + 4.0) + nx * (reach + 1.0) * side,
+                ez + az * (foot + 4.0) + nz * (reach + 1.0) * side,
+                rotation=math.atan2(-az, -ax),
+                slack=5.0,
+            )
+        if side > 0 and spec.get("fire", False):
+            p.put(
+                "firecamp",
+                ex + ax * (foot + 8.0) + nx * (reach + 3.0) * side,
+                ez + az * (foot + 8.0) + nz * (reach + 3.0) * side,
+                rotation=0.0,
+                slack=5.0,
+            )
+
+
+def river_path_between(
+    site: Site, start: tuple[float, float], end: tuple[float, float]
+) -> tuple[list[tuple[float, float]], float]:
+    best = None
+    best_score = float("inf")
+    for points, width in site.river_lines:
+        segs = segments_of(points, width * 0.5)
+        if not segs:
+            continue
+        score = min(s.distance(*start) for s in segs) + min(
+            s.distance(*end) for s in segs
+        )
+        if score < best_score:
+            best_score = score
+            best = (points, width)
+    if best is None:
+        return [], 0.0
+    points, width = best
+    fake = Site(site.definition, None, site.width, site.height)
+    fake.road_lines = [(points, width * 0.5)]
+    fake.roads = segments_of(points, width * 0.5)
+    return road_path_between(fake, start, end), width
+
+
+def riverbank(p: Placer, spec: dict, x: float, z: float) -> None:
+    start = (float(spec["from"][0]), float(spec["from"][1]))
+    end = (float(spec["to"][0]), float(spec["to"][1]))
+    path, width = river_path_between(p.site, start, end)
+    if not path:
+        p.dropped.append("riverbank found no river")
+        return
+    spacing = float(spec.get("spacing", 26.0))
+    offset = width * RIVER_DRAWN_HALF + 2.5
+    kinds = spec.get("kinds") or ["boulder", "plant", "dead_tree", "plant", "boulder"]
+    index = 0
+    for px, pz, tx, tz in walk_path(path, spacing):
+        nx, nz = -tz, tx
+        side = 1.0 if index % 2 == 0 else -1.0
+        kind = str(kinds[index % len(kinds)])
+        out = offset + p.rng.uniform(0.0, 3.0)
+        p.put(
+            kind,
+            px + nx * out * side + p.jitter(1.5),
+            pz + nz * out * side + p.jitter(1.5),
+            scale=p.rng.uniform(0.8, 1.3),
+            slack=3.5,
+        )
+        if kind == "plant":
+            p.put(
+                "plant",
+                px + nx * (out + 2.0) * side + tx * 3.0,
+                pz + nz * (out + 2.0) * side + tz * 3.0,
+                scale=p.rng.uniform(0.9, 1.4),
+                slack=2.0,
+            )
+        index += 1
+
+
+COMPOSERS: dict[str, Composer] = {
+    "barrow_field": barrow_field,
+    "hilltop_ruin": hilltop_ruin,
+    "sacred_grove": sacred_grove,
+    "tree_avenue": tree_avenue,
+    "oasis": oasis,
+    "scree": scree,
+    "boneyard": boneyard,
+    "ford_wreck": ford_wreck,
+    "raft_camp": raft_camp,
+    "cairn": cairn,
+    "shore_hamlet": shore_hamlet,
+    "sheepfold": sheepfold,
+    "bridgehead": bridgehead,
+    "junction": junction,
+    "gate_approach": gate_approach,
+    "ramp_mouth": ramp_mouth,
+    "riverbank": riverbank,
+}
+
+
+def strip_generated(entries: Sequence[dict] | None) -> list[dict]:
+    return [entry for entry in entries or [] if entry.get(DRESSING_KEY) is None]
+
+
+def detect_format(source: str, data: dict) -> tuple[int, bool, bool]:
+    found = AUDIT.detect_format(source, data)
+    return found if found is not None else (4, True, True)
+
+
+def run(
+    map_path: Path,
+    write: bool,
+    surface_mode: str,
+    probe: str | None,
+    cache_dir: str | None,
+    verbose: bool,
+) -> int:
+    source = map_path.read_text()
+    definition = json.loads(source)
+    indent, sort_keys, newline = detect_format(source, definition)
+    definition["world_props"] = strip_generated(definition.get("world_props"))
+    pieces = definition.get(DRESSING_KEY) or []
+    surface = None
+    if surface_mode != "off":
+        try:
+            surface = load_surface(
+                map_path, find_probe(probe), Path(cache_dir) if cache_dir else None
+            )
+        except ProbeUnavailable as error:
+            if surface_mode == "require":
+                print(f"{map_path.name}: {error}", file=sys.stderr)
+                return 2
+            print(
+                f"{map_path.name}: warning: {error}; slope and ramp checks skipped",
+                file=sys.stderr,
+            )
+    site = Site.build(definition, surface)
+    placed_total = 0
+    dropped_total = 0
+    seen: set[str] = set()
+    for spec in pieces:
+        piece_id = str(spec.get("id", ""))
+        kind = str(spec.get("kind", ""))
+        if not piece_id or kind not in COMPOSERS:
+            print(
+                f"{map_path.name}: piece {piece_id or '?'} has unknown kind {kind!r}",
+                file=sys.stderr,
+            )
+            return 2
+        if piece_id in seen:
+            print(f"{map_path.name}: duplicate piece id {piece_id}", file=sys.stderr)
+            return 2
+        seen.add(piece_id)
+        seed = int(spec.get("seed", sum(ord(c) for c in piece_id) * 7919))
+        placer = Placer(site, piece_id, seed)
+        anchor = spec.get("from") or [spec.get("x", 0.0), spec.get("z", 0.0)]
+        COMPOSERS[kind](
+            placer,
+            spec,
+            float(spec.get("x", anchor[0])),
+            float(spec.get("z", anchor[1])),
+        )
+        placed_total += len(placer.placed)
+        dropped_total += len(placer.dropped)
+        definition["world_props"].extend(placer.placed)
+        if verbose or placer.dropped:
+            print(
+                f"  {piece_id} ({kind}): {len(placer.placed)} placed, {len(placer.dropped)} dropped"
+            )
+            for line in placer.dropped:
+                print(f"      dropped {line}")
+    print(
+        f"{map_path.name}: {len(pieces)} pieces, {placed_total} props placed, {dropped_total} dropped"
+    )
+    if write:
+        text = json.dumps(definition, indent=indent, sort_keys=sort_keys) + (
+            "\n" if newline else ""
+        )
+        map_path.write_text(text)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("maps", nargs="+", type=Path)
+    parser.add_argument(
+        "--write", action="store_true", help="Update the map files in place."
+    )
+    parser.add_argument(
+        "--surface",
+        choices=("auto", "require", "off"),
+        default="auto",
+        help="Use tools/terrain_probe for slope and ramp checks.",
+    )
+    parser.add_argument("--probe", help="Path to the terrain_probe binary.")
+    parser.add_argument("--surface-cache", help="Directory for probe dumps.")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    status = 0
+    for map_path in args.maps:
+        status = max(
+            status,
+            run(
+                map_path,
+                args.write,
+                args.surface,
+                args.probe,
+                args.surface_cache,
+                args.verbose,
+            ),
+        )
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/core/ground_type_test.cpp
+++ b/tests/core/ground_type_test.cpp
@@ -107,13 +107,13 @@ TEST_F(GroundTypeTest, ApplyGroundTypeDefaultsSoilRocky) {
   apply_ground_type_defaults(settings, GroundType::SoilRocky);
 
   EXPECT_EQ(settings.ground_type, GroundType::SoilRocky);
-  EXPECT_FLOAT_EQ(settings.soil_color.x(), 0.55F);
-  EXPECT_FLOAT_EQ(settings.soil_color.y(), 0.48F);
-  EXPECT_FLOAT_EQ(settings.soil_color.z(), 0.38F);
-  EXPECT_FLOAT_EQ(settings.terrain_rock_detail_strength, 0.65F);
+  EXPECT_FLOAT_EQ(settings.soil_color.x(), 0.44F);
+  EXPECT_FLOAT_EQ(settings.soil_color.y(), 0.34F);
+  EXPECT_FLOAT_EQ(settings.soil_color.z(), 0.24F);
+  EXPECT_FLOAT_EQ(settings.terrain_rock_detail_strength, 0.68F);
 
-  EXPECT_FLOAT_EQ(settings.rock_exposure, 0.75F);
-  EXPECT_FLOAT_EQ(settings.soil_roughness, 0.85F);
+  EXPECT_FLOAT_EQ(settings.rock_exposure, 0.82F);
+  EXPECT_FLOAT_EQ(settings.soil_roughness, 0.88F);
 }
 
 TEST_F(GroundTypeTest, ApplyGroundTypeDefaultsAlpineMix) {

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -399,8 +399,8 @@ private:
   QTimer m_frame_timer;
   QElapsedTimer m_frame_clock;
   TerrainSettings m_terrain_settings;
-  Game::Map::GroundType m_ground_type = Game::Map::GroundType::GrassDry;
-  Game::Map::GroundType m_ground_type_baseline = Game::Map::GroundType::GrassDry;
+  Game::Map::GroundType m_ground_type = Game::Map::GroundType::SoilRocky;
+  Game::Map::GroundType m_ground_type_baseline = Game::Map::GroundType::SoilRocky;
   int m_terrain_seed_baseline = 1337;
   Game::Map::TimeOfDay m_time_of_day = Game::Map::TimeOfDay::Day;
   float m_environment_hour = 13.0F;

--- a/ui/qml/MapPreview.qml
+++ b/ui/qml/MapPreview.qml
@@ -61,8 +61,8 @@ Rectangle {
     }
 
     radius: Theme.radiusSmall
-    color: "#241c14"
-    border.color: "#8f6d43"
+    color: "#b814100d"
+    border.color: "#6b5032"
     border.width: 1
     clip: true
     onMap_pathChanged: refresh_preview()
@@ -72,7 +72,7 @@ Rectangle {
         id: preview_image
 
         anchors.fill: parent
-        anchors.margins: Theme.spacingSmall
+        anchors.margins: 6
         fillMode: Image.PreserveAspectFit
         smooth: true
         cache: false
@@ -149,8 +149,16 @@ Rectangle {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         height: legend_label.implicitHeight + Theme.spacingSmall
-        color: "#cc140f0b"
+        color: "#df100c09"
         visible: preview_image.visible && root.legend_text.length > 0
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            height: 1
+            color: "#785a35"
+        }
 
         Text {
             id: legend_label

--- a/ui/qml/MapSelect.qml
+++ b/ui/qml/MapSelect.qml
@@ -793,6 +793,7 @@ Item {
 
     Item {
         anchors.fill: parent
+        z: -2
 
         Image {
             anchors.fill: parent
@@ -801,7 +802,7 @@ Item {
             asynchronous: true
             smooth: true
             mipmap: true
-            opacity: 0.62
+            opacity: 0.88
         }
 
         Rectangle {
@@ -809,41 +810,52 @@ Item {
             gradient: Gradient {
                 GradientStop {
                     position: 0
-                    color: "#b00b0b0d"
+                    color: "#700b0b0d"
                 }
 
                 GradientStop {
                     position: 0.55
-                    color: "#d0120d09"
+                    color: "#bd120d09"
                 }
 
                 GradientStop {
                     position: 1
-                    color: "#f00a0806"
+                    color: "#e80a0806"
                 }
             }
         }
     }
 
     Rectangle {
+        width: container.width
+        height: container.height
+        anchors.centerIn: parent
+        anchors.horizontalCenterOffset: 9
+        anchors.verticalCenterOffset: 12
+        radius: container.radius + 2
+        color: "#80000000"
+        z: -1
+    }
+
+    Rectangle {
         id: container
 
-        width: Math.min(parent.width * 0.95, 1600)
-        height: Math.min(parent.height * 0.95, 1000)
+        width: Math.min(parent.width * 0.935, 1560)
+        height: Math.min(parent.height * 0.93, 980)
         anchors.centerIn: parent
         radius: Theme.radiusPanel
         gradient: Gradient {
             GradientStop {
                 position: 0
-                color: "#f22a2119"
+                color: "#dc281f18"
             }
 
             GradientStop {
                 position: 1
-                color: "#fa15100c"
+                color: "#ec130e0b"
             }
         }
-        border.color: "#a78048"
+        border.color: "#8b683d"
         border.width: 1
         clip: true
 
@@ -851,9 +863,10 @@ Item {
             anchors.fill: parent
             anchors.margins: 4
             color: "transparent"
-            border.color: "#594024"
+            border.color: "#704d29"
             border.width: 1
             radius: Math.max(2, container.radius - 4)
+            opacity: 0.72
         }
 
         ColumnLayout {
@@ -896,6 +909,34 @@ Item {
                 }
             }
 
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 1
+                gradient: Gradient {
+                    orientation: Gradient.Horizontal
+
+                    GradientStop {
+                        position: 0
+                        color: "#00b88b4c"
+                    }
+
+                    GradientStop {
+                        position: 0.12
+                        color: "#a8b88b4c"
+                    }
+
+                    GradientStop {
+                        position: 0.68
+                        color: "#4fb88b4c"
+                    }
+
+                    GradientStop {
+                        position: 1
+                        color: "#00b88b4c"
+                    }
+                }
+            }
+
             RowLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -910,15 +951,15 @@ Item {
                     gradient: Gradient {
                         GradientStop {
                             position: 0
-                            color: "#e833291f"
+                            color: "#d52b231b"
                         }
 
                         GradientStop {
                             position: 1
-                            color: "#f21d1712"
+                            color: "#e514100d"
                         }
                     }
-                    border.color: "#765a37"
+                    border.color: "#59432d"
                     border.width: 1
 
                     ColumnLayout {
@@ -953,7 +994,7 @@ Item {
 
                             Layout.fillWidth: true
                             Layout.fillHeight: true
-                            color: "#b818130f"
+                            color: "#a8120f0c"
                             radius: Theme.radiusSmall
                             border.color: "#493521"
                             border.width: 1
@@ -1188,15 +1229,15 @@ Item {
                         gradient: Gradient {
                             GradientStop {
                                 position: 0
-                                color: "#e833291f"
+                                color: "#d52b231b"
                             }
 
                             GradientStop {
                                 position: 1
-                                color: "#f21d1712"
+                                color: "#e514100d"
                             }
                         }
-                        border.color: "#765a37"
+                        border.color: "#59432d"
                         border.width: 1
 
                         RowLayout {
@@ -1330,15 +1371,15 @@ Item {
                         gradient: Gradient {
                             GradientStop {
                                 position: 0
-                                color: "#e833291f"
+                                color: "#d52b231b"
                             }
 
                             GradientStop {
                                 position: 1
-                                color: "#f21d1712"
+                                color: "#e514100d"
                             }
                         }
-                        border.color: "#765a37"
+                        border.color: "#59432d"
                         border.width: 1
                         visible: root.has_selection
 
@@ -1407,9 +1448,9 @@ Item {
                                     width: players_list.width - (players_list.ScrollBar.vertical.visible ? Theme.spacingMedium : 0)
                                     height: 68
                                     radius: Theme.radiusSmall
-                                    color: player_card.focused ? "#4a3726" : (model.isHuman ? "#33261a" : "#2c231a")
-                                    border.color: player_card.focused ? Theme.accentBright : (model.isEnabled ? (model.isHuman ? Theme.accent : Theme.thumbBr) : Theme.thumbBr)
-                                    border.width: (player_card.focused || (model.isHuman && model.isEnabled)) ? 2 : 1
+                                    color: player_card.focused ? "#493126" : (model.isHuman ? "#30231a" : "#251d17")
+                                    border.color: player_card.focused ? Theme.accentBright : (model.isEnabled ? "#61482e" : "#463522")
+                                    border.width: player_card.focused ? 2 : 1
                                     opacity: model.isEnabled ? 1 : 0.55
                                     enabled: true
 
@@ -1571,8 +1612,8 @@ Item {
                                 Layout.fillWidth: true
                                 Layout.preferredHeight: dossier_column.implicitHeight + Theme.spacingMedium * 2
                                 radius: Theme.radiusSmall
-                                color: "#241c14"
-                                border.color: "#8f6d43"
+                                color: "#b817120e"
+                                border.color: "#59432d"
                                 border.width: 1
                                 visible: human_commander_name !== ""
 
@@ -1654,7 +1695,7 @@ Item {
             Rectangle {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 1
-                color: Theme.panelBr
+                color: "#684c2d"
             }
 
             RowLayout {


### PR DESCRIPTION
Introduce a reusable map-dressing generator that composes authored landmarks, route details, riverbank scenes, settlement approaches, and other battlefield set pieces into validated world props while preserving hand-placed content.\n\nRefresh the authored Cannae, Ticino, Trasimene, Trebia, Zama, Campania, Alps, and Rhone maps with more coherent terrain dressing, renamed and repositioned undead encounters, environmental atmosphere, and expanded landmark compositions.\n\nTune SoilRocky terrain colors and defaults, align the arena baseline and expectations with the revised ground profile, and adjust sky-cloud and neutral arena lighting for the darker battlefield palette. Polish the map preview and selection surfaces with stronger imagery, framing, contrast, dividers, and selection states so authored maps read clearly in the setup flow.