### PR TITLE
fix: reject disruptive orders while crews haul resources

### DIFF
--- a/app/orders/order_submission.cpp
+++ b/app/orders/order_submission.cpp
@@ -1,14 +1,50 @@
 #include "app/orders/order_submission.h"
 
+#include <algorithm>
 #include <type_traits>
 #include <utility>
 #include <variant>
 
 #include "game/command/command_queue.h"
 #include "game/command/command_validator.h"
+#include "game/core/component.h"
 #include "game/core/world.h"
 
 namespace App::Core {
+
+namespace {
+
+auto payload_units(const Game::Command::Payload& payload)
+    -> const std::vector<Engine::Core::EntityID>* {
+  return std::visit(
+      [](const auto& body) -> const std::vector<Engine::Core::EntityID>* {
+        if constexpr (requires { body.units; }) {
+          return &body.units;
+        } else {
+          return nullptr;
+        }
+      },
+      payload);
+}
+
+auto is_hauling_a_load(const Engine::Core::World& world,
+                       Engine::Core::EntityID unit) -> bool {
+  const auto* carry = world.try_get<Engine::Core::ResourceCarryComponent>(unit);
+  return carry != nullptr && !carry->empty();
+}
+
+auto every_unit_is_hauling(const Engine::Core::World& world,
+                           const Game::Command::Payload& payload) -> bool {
+  const auto* units = payload_units(payload);
+  if (units == nullptr || units->empty()) {
+    return false;
+  }
+  return std::all_of(units->begin(), units->end(), [&world](auto id) {
+    return is_hauling_a_load(world, id);
+  });
+}
+
+} // namespace
 
 auto payload_unit_count(const Game::Command::Payload& payload) -> std::size_t {
   return std::visit(
@@ -36,6 +72,15 @@ auto submit_player_order(Engine::Core::World& world,
   outcome.target = request.target;
   outcome.has_destination = request.has_destination;
   outcome.destination = request.destination;
+
+  if (every_unit_is_hauling(world, request.payload)) {
+    outcome.unit_count = payload_unit_count(request.payload);
+    outcome.status = OrderStatus::Rejected;
+    auto refusal = hauling_load_reason();
+    outcome.failure = refusal.failure;
+    outcome.reason = std::move(refusal.text);
+    return outcome;
+  }
 
   const Game::Command::Command command{.source = Game::Command::Source::LocalPlayer,
                                        .owner_id = owner_id,

--- a/tests/core/order_feedback_test.cpp
+++ b/tests/core/order_feedback_test.cpp
@@ -98,6 +98,55 @@ TEST_F(OrderFeedbackTest, FriendlyTargetIsRejectedAndNothingIsDispatched) {
   EXPECT_EQ(archer->get_component<Engine::Core::AttackTargetComponent>(), nullptr);
 }
 
+TEST_F(OrderFeedbackTest, ACrewHaulingALoadRefusesEveryOrderUntilItIsDroppedOff) {
+  auto* hauler = create_unit(0.0F, 0.0F, 1);
+  auto* carry = hauler->add_component<Engine::Core::ResourceCarryComponent>();
+  carry->amounts.set(Game::Systems::ResourceType::Wood, 10);
+  auto* enemy = create_unit(5.0F, 0.0F, 2);
+
+  OrderRequest attack;
+  attack.kind = OrderKind::Attack;
+  attack.payload = Game::Command::AttackTarget{.units = {hauler->get_id()},
+                                               .target = enemy->get_id()};
+  const auto attack_outcome =
+      App::Core::submit_player_order(world, 1, std::move(attack));
+  EXPECT_TRUE(attack_outcome.rejected());
+  EXPECT_EQ(attack_outcome.failure, App::Core::OrderFailure::UnitBusy);
+  EXPECT_EQ(attack_outcome.unit_count, 1U);
+  EXPECT_FALSE(attack_outcome.reason.isEmpty());
+  EXPECT_EQ(hauler->get_component<Engine::Core::AttackTargetComponent>(), nullptr);
+
+  OrderRequest stop;
+  stop.kind = OrderKind::Stop;
+  stop.payload = Game::Command::Stop{.units = {hauler->get_id()}};
+  const auto stop_outcome = App::Core::submit_player_order(world, 1, std::move(stop));
+  EXPECT_TRUE(stop_outcome.rejected());
+  EXPECT_EQ(stop_outcome.failure, App::Core::OrderFailure::UnitBusy);
+
+  carry->amounts.set(Game::Systems::ResourceType::Wood, 0);
+  OrderRequest after_dropoff;
+  after_dropoff.kind = OrderKind::Attack;
+  after_dropoff.payload = Game::Command::AttackTarget{.units = {hauler->get_id()},
+                                                      .target = enemy->get_id()};
+  EXPECT_TRUE(
+      App::Core::submit_player_order(world, 1, std::move(after_dropoff)).accepted());
+}
+
+TEST_F(OrderFeedbackTest, AMixedCrewWithOneHaulerStillTakesTheOrder) {
+  auto* hauler = create_unit(0.0F, 0.0F, 1);
+  hauler->add_component<Engine::Core::ResourceCarryComponent>()->amounts.set(
+      Game::Systems::ResourceType::Stone, 4);
+  auto* archer = create_unit(1.0F, 0.0F, 1);
+  auto* enemy = create_unit(5.0F, 0.0F, 2);
+
+  OrderRequest request;
+  request.kind = OrderKind::Attack;
+  request.payload = Game::Command::AttackTarget{
+      .units = {hauler->get_id(), archer->get_id()}, .target = enemy->get_id()};
+
+  EXPECT_TRUE(App::Core::submit_player_order(world, 1, std::move(request)).accepted());
+}
+
 TEST_F(OrderFeedbackTest, EmptySubjectListIsRejectedAsNoSubjects) {
   auto* enemy = create_unit(5.0F, 0.0F, 2);
 

--- a/tests/ui/qml/tst_system_voice.qml
+++ b/tests/ui/qml/tst_system_voice.qml
@@ -80,6 +80,23 @@ TestCase {
         compare(testCase.spoken_lines(), 0, "a successful order is not a refusal");
     }
 
+    function test_a_hauling_crew_is_told_at_once_and_loudly() {
+        testCase.reset();
+        voice.announce_busy("Hauling a load - it cannot be interrupted until the load is dropped off.");
+        compare(testCase.spoken_lines(), 1, "a busy crew does not wait for the third refusal");
+        compare(Notifications.current.priority, "urgent", "the refusal outranks the ambient chatter");
+        compare(Notifications.current.channel, "refusal-unit_busy");
+        voice.announce_busy("Hauling a load - it cannot be interrupted until the load is dropped off.");
+        compare(testCase.spoken_lines(), 1, "repeats fold into the same card instead of stacking");
+        compare(Notifications.current.repeats, 2);
+    }
+
+    function test_a_busy_refusal_with_no_words_stays_quiet() {
+        testCase.reset();
+        voice.announce_busy("");
+        compare(testCase.spoken_lines(), 0);
+    }
+
     function test_every_line_it_can_say_is_worth_saying() {
         var kinds = ["no_selection", "unreachable", "insufficient_resources", "manpower_cap", "unit_busy", "out_of_range", "wrong_owner", "invalid_target"];
         for (var i = 0; i < kinds.length; ++i) {

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -58,8 +58,9 @@ ApplicationWindow {
         tip.delay = Design.Metrics.tooltipDelay;
         tip.timeout = 8000;
         tip.padding = Design.Metrics.space8;
-        tip.background = sharedTooltipBackground.createObject(tip);
-        var body = sharedTooltipText.createObject(tip, {
+        var host = (tip.contentItem && tip.contentItem.parent) ? tip.contentItem.parent : sharedTooltipAnchor;
+        tip.background = sharedTooltipBackground.createObject(host);
+        var body = sharedTooltipText.createObject(host, {
                 "text": Qt.binding(function () {
                         return tip.text;
                     }),
@@ -67,6 +68,7 @@ ApplicationWindow {
                         return tip.availableWidth;
                     })
             });
+        body.parent = null;
         tip.contentItem = body;
         tip.implicitWidth = Qt.binding(function () {
                 return Math.min(body.implicitWidth + tip.leftPadding + tip.rightPadding, Design.Metrics.tooltipWidth);

--- a/ui/qml/SystemVoice.qml
+++ b/ui/qml/SystemVoice.qml
@@ -65,6 +65,7 @@ Item {
     function announce_busy(message) {
         if (!message || message.length === 0)
             return;
+        Design.UiSound.warning();
         Design.Notifications.urgent(message, {
                 "channel": "refusal-unit_busy",
                 "icon": Design.Icons.warning


### PR DESCRIPTION
Treat a selected crew as unavailable when every unit in the order payload is carrying a non-empty resource load. Return the existing unit-busy failure classification with the affected unit count and refusal text before any command reaches the game command queue, while allowing mixed selections to proceed normally and permitting orders again once the load is dropped off.\n\nExtend order feedback coverage for attack and stop requests, all-hauler and mixed crews, and recovery after unloading. Make the busy system-voice refusal announce immediately at urgent priority with the warning sound, keep repeated notices consolidated, and ignore empty messages. Correct tooltip object parenting so dynamically created background and content items attach to the tooltip host consistently.