### PR TITLE
fix: ground scatter rocks and restore oriented prop lighting

### DIFF
--- a/assets/shaders/iron_ore_instanced.frag
+++ b/assets/shaders/iron_ore_instanced.frag
@@ -72,20 +72,30 @@ void main() {
   float vein_wide = clamp(max(wide1, wide2), 0.0, 1.0);
   float vein_core = clamp(max(core1, core2), 0.0, 1.0);
 
-  vec3 deep_rock = v_color * vec3(0.46, 0.48, 0.55);
-  vec3 cool_rock = v_color * vec3(0.70, 0.72, 0.82);
+  vec3 deep_rock = v_color * vec3(0.66, 0.64, 0.66);
+  vec3 cool_rock = v_color * vec3(1.02, 0.99, 1.00);
   vec3 warm_mineral = vec3(0.48, 0.30, 0.20);
 
   vec3 rock_color = mix(deep_rock, cool_rock, stone_large);
   rock_color *= mix(0.72, 1.08, stone_grain);
   rock_color = mix(rock_color, warm_mineral, mineral_noise * 0.18);
 
+  float magic_strength = max(u_magic_strength, 0.0);
+  float magic_mix = clamp(magic_strength, 0.0, 1.0);
+
+  vec3 hematite_core = vec3(0.23, 0.11, 0.08);
+  vec3 limonite_rim = vec3(0.56, 0.34, 0.16);
+  vec3 rust_bloom = vec3(0.50, 0.26, 0.13);
+  vec3 seam = mix(limonite_rim, hematite_core, vein_core);
+  vec3 natural_ore = mix(rock_color, seam, vein_wide * 0.85);
+  natural_ore = mix(natural_ore, rust_bloom, mineral_noise * 0.24 * (1.0 - vein_wide));
+
   vec3 magic_a = vec3(0.14, 0.85, 1.35);
   vec3 magic_b = vec3(0.82, 0.24, 1.45);
   vec3 magic_color = mix(magic_a, magic_b, fbm(q * 1.7 + vec3(v_seed)));
 
   vec3 stained_ore = mix(rock_color, magic_color * 0.55, vein_wide * 0.45);
-  vec3 albedo = stained_ore;
+  vec3 albedo = mix(natural_ore, stained_ore, magic_mix);
 
   vec3 cell_p = q * 9.0;
   vec3 cell = floor(cell_p);
@@ -111,8 +121,7 @@ void main() {
 
   float ao = clamp(N.y * 0.45 + 0.68, 0.28, 1.0);
 
-  vec3 ambient = environment_ambient_light(N);
-  vec3 direct = soi_key_light(N) * 0.82;
+  vec3 illumination = soi_surface_lighting_scaled(N, 0.82);
 
   float spec_base = max(dot(N, H), 0.0);
   float ore_spec = pow(spec_base, 42.0) * (0.08 + vein_wide * 0.35);
@@ -122,15 +131,14 @@ void main() {
 
   float pulse = 0.78 + 0.22 * sin(u_time * 2.1 + v_seed * 12.0 + fbm(q * 2.0) * 5.0);
 
-  float magic_strength = max(u_magic_strength, 0.0);
-
   vec3 glow = magic_color * magic_strength * pulse *
               (vein_core * 1.75 + vein_wide * 0.22 + fresnel * vein_wide * 0.45 +
                crystal * 1.35);
 
-  vec3 color = albedo * (ambient + direct) * ao * environment_exposure();
+  vec3 color = albedo * illumination * ao;
   color += sun_color * ore_spec * ao;
-  color += magic_color * crystal_spec;
+  vec3 glint_color = mix(sun_color * vec3(0.95, 0.88, 0.80), magic_color, magic_mix);
+  color += glint_color * crystal_spec;
   color += glow;
 
   color = apply_directional_shadow(color, v_world_pos, v_normal);

--- a/assets/shaders/stone_instanced.frag
+++ b/assets/shaders/stone_instanced.frag
@@ -8,6 +8,9 @@ in vec3 v_world_pos;
 in vec3 v_normal;
 in vec3 v_color;
 in vec3 v_local_pos;
+in float v_ground_height;
+flat in float v_scale;
+flat in float v_seed;
 
 uniform vec3 u_camera_pos;
 
@@ -33,54 +36,85 @@ float stone_noise3(vec3 p) {
       f.z);
 }
 
+vec3 relief_normal(vec3 N, vec3 p, float strength) {
+  const float eps = 0.045;
+  vec3 q = p * 6.5 + vec3(v_seed * 19.0);
+  float gx =
+      stone_noise3(q + vec3(eps, 0.0, 0.0)) - stone_noise3(q - vec3(eps, 0.0, 0.0));
+  float gy =
+      stone_noise3(q + vec3(0.0, eps, 0.0)) - stone_noise3(q - vec3(0.0, eps, 0.0));
+  float gz =
+      stone_noise3(q + vec3(0.0, 0.0, eps)) - stone_noise3(q - vec3(0.0, 0.0, eps));
+  vec3 grad = vec3(gx, gy, gz) / (2.0 * eps);
+  grad -= N * dot(grad, N);
+  return normalize(N - grad * strength);
+}
+
 void main() {
-  vec3 N = normalize(v_normal);
+  vec3 N_face = normalize(v_normal);
   vec3 L = environment_primary_direction();
   vec3 V = normalize(u_camera_pos - v_world_pos);
   vec3 H = normalize(L + V);
 
   vec3 p = v_local_pos;
-  float broad = stone_noise3(p * 3.2 + vec3(1.7, 5.1, 2.3));
+  vec3 seed_offset = vec3(v_seed * 7.3, v_seed * 3.1, v_seed * 11.7);
+  float broad = stone_noise3(p * 3.2 + vec3(1.7, 5.1, 2.3) + seed_offset);
   float grain = stone_noise3(p * 13.0 + v_world_pos * 0.12);
-  float strata = 0.5 + 0.5 * sin(p.y * 22.0 + p.x * 4.0 + broad * 3.2);
-  float fissure_field = abs(sin(p.x * 13.0 - p.z * 9.0 + p.y * 6.0 + broad * 4.0));
+  float speckle = stone_noise3(p * 31.0 + seed_offset);
+  float strata = 0.5 + 0.5 * sin(p.y * 22.0 + p.x * 4.0 + broad * 3.2 + v_seed * 6.0);
+  float fissure_field =
+      abs(sin(p.x * 13.0 - p.z * 9.0 + p.y * 6.0 + broad * 4.0 + v_seed * 4.0));
   float fissures = 1.0 - smoothstep(0.035, 0.14, fissure_field);
+
+  vec3 N = relief_normal(N_face, p, 0.10);
 
   vec3 stone = v_color * mix(0.70, 1.08, broad);
   stone *= mix(0.86, 1.08, grain * 0.65 + strata * 0.35);
-  stone = mix(stone, stone * vec3(0.55, 0.58, 0.60), fissures * 0.72);
+  stone *= mix(0.93, 1.05, speckle);
+  stone = mix(stone, stone * vec3(0.58, 0.58, 0.57), fissures * 0.72);
 
   float upward = smoothstep(0.28, 0.86, N.y);
   float lichen_noise = stone_noise3(v_world_pos * 1.8 + vec3(3.0, 8.0, 1.0));
   float lichen = upward * smoothstep(0.58, 0.82, lichen_noise) * 0.34;
-  vec3 lichen_color = vec3(0.24, 0.28, 0.20);
+  vec3 lichen_color = vec3(0.30, 0.33, 0.22);
   stone = mix(stone, lichen_color, lichen);
 
-  float ground_damp = (1.0 - smoothstep(0.02, 0.24, p.y)) *
-                      smoothstep(0.28, 0.72, stone_noise3(v_world_pos * 0.9));
-  stone = mix(stone, stone * vec3(0.52, 0.58, 0.60), ground_damp * 0.58);
+  float shade_side = 1.0 - smoothstep(-0.1, 0.55, dot(N_face, L));
+  float foot = 1.0 - smoothstep(0.0, 0.42 * v_scale, v_ground_height);
+  float moss_noise = stone_noise3(v_world_pos * 2.6 + vec3(11.0, 2.0, 5.0));
+  float moss = smoothstep(0.50, 0.78, moss_noise) * (shade_side * 0.55 + foot * 0.45) *
+               smoothstep(-0.2, 0.5, N.y) * 0.42;
+  vec3 moss_color = vec3(0.17, 0.25, 0.13);
+  stone = mix(stone, moss_color, moss);
+
+  float skirt = (1.0 - smoothstep(0.0, 0.16 * v_scale, v_ground_height)) *
+                mix(0.55, 1.0, stone_noise3(v_world_pos * 4.0));
+  vec3 earth_color = vec3(0.30, 0.25, 0.19);
+  stone = mix(stone, mix(stone, earth_color, 0.55), skirt * 0.75);
+  float ground_damp = skirt * smoothstep(0.28, 0.72, stone_noise3(v_world_pos * 0.9));
+  stone = mix(stone, stone * vec3(0.66, 0.66, 0.64), ground_damp * 0.5);
   float rain_damp =
       environment_wetness() * smoothstep(0.02, 0.78, N.y) * mix(0.62, 1.0, broad);
   stone *= 1.0 - rain_damp * 0.20;
 
-  float ndotl = max(dot(N, L), 0.0);
   float hemi = clamp(N.y * 0.5 + 0.5, 0.0, 1.0);
   vec3 sky = environment_sky_color();
   vec3 sun = environment_primary_color() * environment_primary_intensity();
   vec3 illumination = soi_surface_lighting_scaled(N, 0.72);
-  float crevice_ao = mix(1.0, 0.62, fissures) * mix(0.58, 1.0, hemi);
+  float crevice_ao =
+      mix(1.0, 0.62, fissures) * mix(0.58, 1.0, hemi) * mix(1.0, 0.72, skirt);
 
   float wet_surface = max(ground_damp, rain_damp);
   float wet_spec = wet_surface * pow(max(dot(N, H), 0.0), 38.0) * 0.22;
-  float dry_spec = pow(max(dot(N, H), 0.0), 18.0) * 0.025;
+  float dry_spec = pow(max(dot(N, H), 0.0), 18.0) * 0.025 * (1.0 - moss);
   float rim = pow(1.0 - max(dot(N, V), 0.0), 4.0) * 0.055;
 
   vec3 color = stone * illumination * crevice_ao;
-  color += soi_rim_light(N, V);
+  color += soi_rim_light(N_face, V) * (1.0 - skirt * 0.6);
   color += sun * (dry_spec + wet_spec);
   color += sky * rim;
   color = apply_directional_shadow(color, v_world_pos, v_normal);
-  color += stone * crevice_ao * local_lighting(v_world_pos, normalize(v_normal));
+  color += stone * crevice_ao * local_lighting(v_world_pos, N);
   color = apply_visibility_memory(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/stone_instanced.vert
+++ b/assets/shaders/stone_instanced.vert
@@ -4,6 +4,7 @@ layout(location = 0) in vec3 a_pos;
 layout(location = 1) in vec3 a_normal;
 layout(location = 2) in vec4 a_pos_scale;
 layout(location = 3) in vec4 a_color_rot;
+layout(location = 4) in vec4 a_ground_fit;
 
 layout(std140) uniform FrameData {
   mat4 u_view_proj;
@@ -13,27 +14,71 @@ out vec3 v_world_pos;
 out vec3 v_normal;
 out vec3 v_color;
 out vec3 v_local_pos;
+out float v_ground_height;
+flat out float v_scale;
+flat out float v_seed;
+
+float fit_hash(float seed, float salt) {
+  return fract(sin(seed * 127.1 + salt * 311.7) * 43758.5453);
+}
+
+mat3 align_up_to(vec3 n) {
+  vec3 v = vec3(n.z, 0.0, -n.x);
+  float c = n.y;
+  float k = 1.0 / max(1.0 + c, 1.0e-4);
+  vec3 col0 = vec3(
+      1.0 - k * (v.y * v.y + v.z * v.z), v.z + k * v.x * v.y, -v.y + k * v.x * v.z);
+  vec3 col1 = vec3(
+      -v.z + k * v.x * v.y, 1.0 - k * (v.x * v.x + v.z * v.z), v.x + k * v.y * v.z);
+  vec3 col2 = vec3(
+      v.y + k * v.x * v.z, -v.x + k * v.y * v.z, 1.0 - k * (v.x * v.x + v.y * v.y));
+  return mat3(col0, col1, col2);
+}
 
 void main() {
   float scale = a_pos_scale.w;
-  vec3 world_pos = a_pos_scale.xyz;
+  vec3 world_origin = a_pos_scale.xyz;
   float rotation = a_color_rot.a;
+  float seed = a_ground_fit.y;
+  float sink = a_ground_fit.w;
+
+  float sx = mix(0.80, 1.24, fit_hash(seed, 1.0));
+  float sz = mix(0.80, 1.24, fit_hash(seed, 2.0));
+  float sy = mix(0.70, 1.16, fit_hash(seed, 3.0));
+
+  float shear_x = (fit_hash(seed, 4.0) - 0.5) * 0.34;
+  float shear_z = (fit_hash(seed, 5.0) - 0.5) * 0.34;
+
+  mat3 shape = mat3(
+      vec3(sx, 0.0, 0.0), vec3(shear_x * sx, sy, shear_z * sz), vec3(0.0, 0.0, sz));
 
   float cos_r = cos(rotation);
   float sin_r = sin(rotation);
-  mat2 rot = mat2(cos_r, -sin_r, sin_r, cos_r);
+  mat3 yaw =
+      mat3(vec3(cos_r, 0.0, sin_r), vec3(0.0, 1.0, 0.0), vec3(-sin_r, 0.0, cos_r));
 
-  vec3 local_pos = a_pos * scale;
-  vec2 rotated_xz = rot * local_pos.xz;
-  local_pos = vec3(rotated_xz.x, local_pos.y, rotated_xz.y);
+  vec2 fit_xz = a_ground_fit.xz;
+  float fit_y = sqrt(max(1.0 - dot(fit_xz, fit_xz), 0.0));
+  vec3 ground_normal = vec3(fit_xz.x, fit_y, fit_xz.y);
+  vec3 cant =
+      vec3((fit_hash(seed, 6.0) - 0.5) * 0.18, 0.0, (fit_hash(seed, 7.0) - 0.5) * 0.18);
+  vec3 up = normalize(ground_normal + cant);
+  mat3 tilt = align_up_to(up);
 
-  v_world_pos = local_pos + world_pos;
+  mat3 orient = tilt * yaw;
+  mat3 model = orient * shape;
+  mat3 normal_shape = transpose(inverse(shape));
 
-  vec2 rotated_normal_xz = rot * a_normal.xz;
-  v_normal = normalize(vec3(rotated_normal_xz.x, a_normal.y, rotated_normal_xz.y));
+  vec3 local_pos = model * a_pos * scale;
+  vec3 world_pos = local_pos + world_origin - vec3(0.0, sink, 0.0);
 
+  v_world_pos = world_pos;
+  v_normal = normalize(orient * (normal_shape * a_normal));
   v_color = a_color_rot.rgb;
   v_local_pos = a_pos;
+  v_ground_height = world_pos.y - world_origin.y;
+  v_scale = scale;
+  v_seed = seed;
 
-  gl_Position = u_view_proj * vec4(v_world_pos, 1.0);
+  gl_Position = u_view_proj * vec4(world_pos, 1.0);
 }

--- a/docs/RENDER_ART_DIRECTION.md
+++ b/docs/RENDER_ART_DIRECTION.md
@@ -385,6 +385,41 @@ Ruins grow ivy up their shaded faces (`ruins_instanced.frag`) and statue plinths
 moss (`statue_instanced.frag`); both are shader-only overgrowth keyed to local position
 and the sun's azimuth, so nothing new had to be authored.
 
+## Rocks
+
+Every boulder and scatter stone is one shared lump mesh
+(`VegetationPipeline::initialize_stone_pipeline`), so the variety has to come from
+the instance. `StoneInstanceGpu::ground_fit` carries the terrain normal under the
+rock, a shape seed and a sink depth (`render/ground/stone_ground_fit.h` packs it,
+`sample_ground_normal` reads it off the height grid). `stone_instanced.vert` derives
+everything else from the seed: non-uniform proportions, a lean shear, a small random
+cant on top of the slope alignment, and beds the rock into the ground by the sink
+depth. Before this the mesh sat _on_ the surface point with a yaw only, which is why
+a rock field read as a row of identical pebbles standing to attention on a hillside.
+
+The mesh itself is twelve-sided, seven rings, hash-jittered and split into planar
+triangles so the faces read as cleavage planes. `stone_instanced.frag` adds a
+gradient-noise relief normal on top of the flat facets, keeps lichen to the weathered
+upper faces, moss to the shaded side and the foot, and dirties the skirt where the
+rock meets the soil (`v_ground_height` is the height above the ground sample).
+
+Rock colour is one palette for boulders, authored boulders and scatter stones
+(`stone_instance_color`): the map's `rock_low`/`rock_high`, an earth cast, and a
+minority of iron-stained and lichen-grey rocks so a field is not one grey.
+
+Iron ore used to render as a black lump with glowing veins on every map. Two causes:
+`append_oriented_box` (both the prop mesh builder and the dead tree's copy) took its
+face cross product in the wrong order, so every oriented box lit from the inside, and
+the ore is nothing but oriented boxes; and the haunted stain was always on. The
+normals now point outward (`PropMeshBuilderTest`), and the magic shrine's rune
+stones and the dead tree's branch stubs pick up the same fix.
+
+Iron ore is hematite unless the world is haunted. `iron_ore_instanced.frag` only mixes
+the cyan/violet stain and the coloured crystal glints in by `u_magic_strength`, which
+`IronOreRenderer` takes from `TerrainService::supernatural_presence()`. That flag is
+now off by default and set from the map's undead zones (the arena sets it from the
+scenario's zones before the terrain configures), so a plain quarry no longer glows.
+
 ## Known geometry fix
 
 The stone mesh in `render/gl/backend/vegetation_pipeline_natural.cpp` computed

--- a/game/map/terrain_service.h
+++ b/game/map/terrain_service.h
@@ -248,7 +248,7 @@ private:
   std::unique_ptr<TerrainHeightMap> m_height_map;
   TerrainField m_terrain_field;
   BiomeSettings m_biome_settings;
-  float m_supernatural_presence{1.0F};
+  float m_supernatural_presence{0.0F};
   CoordSystem m_coord_system{CoordSystem::Grid};
   std::vector<WorldProp> m_authored_world_props;
   std::vector<WorldProp> m_world_props;

--- a/render/decoration_gpu.h
+++ b/render/decoration_gpu.h
@@ -45,6 +45,7 @@ struct GrassBatchParams {
 struct StoneInstanceGpu {
   QVector4D pos_scale;
   QVector4D color_rot;
+  QVector4D ground_fit{0.0F, 0.0F, 0.0F, 0.0F};
 };
 
 struct StoneBatchParams {

--- a/render/gl/backend/dead_tree_mesh.cpp
+++ b/render/gl/backend/dead_tree_mesh.cpp
@@ -133,7 +133,7 @@ void append_oriented_box(std::vector<PropMeshVertex>& verts,
   V3 const b3 = b - side + depth;
 
   auto face = [&](const V3& p0, const V3& p1, const V3& p2, const V3& p3) {
-    V3 n = QVector3D::crossProduct(p1 - p0, p3 - p0);
+    V3 n = QVector3D::crossProduct(p3 - p0, p1 - p0);
     if (n.lengthSquared() > 1.0e-8F) {
       n.normalize();
     } else {

--- a/render/gl/backend/prop_mesh_builder.cpp
+++ b/render/gl/backend/prop_mesh_builder.cpp
@@ -162,7 +162,7 @@ void append_oriented_box(PropMeshVerts& verts,
                   const QVector3D& p1,
                   const QVector3D& p2,
                   const QVector3D& p3) {
-    QVector3D n = QVector3D::crossProduct(p1 - p0, p3 - p0);
+    QVector3D n = QVector3D::crossProduct(p3 - p0, p1 - p0);
     if (n.lengthSquared() > 1.0e-8F) {
       n.normalize();
     } else {

--- a/render/gl/backend/scatter_command_executor.cpp
+++ b/render/gl/backend/scatter_command_executor.cpp
@@ -278,7 +278,13 @@ void Backend::execute_scatter_commands(const PreparedBatch& prepared,
                                    GL_FLOAT,
                                    GL_FALSE,
                                    stride,
-                                   offsetof(StoneInstanceGpu, color_rot)}});
+                                   offsetof(StoneInstanceGpu, color_rot)},
+                                  {instance_scale,
+                                   vec4,
+                                   GL_FLOAT,
+                                   GL_FALSE,
+                                   stride,
+                                   offsetof(StoneInstanceGpu, ground_fit)}});
       stone.instance_buffer->unbind();
 
       glDrawElementsInstanced(GL_TRIANGLES,

--- a/render/gl/backend/vegetation_pipeline_natural.cpp
+++ b/render/gl/backend/vegetation_pipeline_natural.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <utility>
 #include <vector>
 
@@ -37,7 +38,7 @@ constexpr GLuint k_foliage_normal_location = 2;
 
 constexpr std::array<GLuint, 3> k_foliage_instance_locations{3, 4, 5};
 
-constexpr std::array<GLuint, 2> k_stone_instance_locations{2, 3};
+constexpr std::array<GLuint, 3> k_stone_instance_locations{2, 3, 4};
 
 void VegetationPipeline::initialize_stone_pipeline() {
   initializeOpenGLFunctions();
@@ -52,21 +53,26 @@ void VegetationPipeline::initialize_stone_pipeline() {
   std::vector<F> verts;
   std::vector<uint16_t> idx;
 
-  constexpr int k_n = 8;
+  constexpr int k_n = 12;
   constexpr float k_tau = 6.28318530F;
-  constexpr int k_rings = 5;
+  constexpr int k_rings = 7;
 
-  constexpr float k_perturb_amount = 0.07F;
-  constexpr float k_perturb_freq_vertex = 2.3F;
-  constexpr float k_perturb_freq_ring = 1.7F;
+  constexpr float k_radial_jitter = 0.11F;
+  constexpr float k_y_jitter = 0.030F;
 
-  constexpr float k_y_jitter_amount = 0.025F;
-  constexpr float k_y_jitter_freq_vertex = 1.9F;
-  constexpr float k_y_jitter_freq_ring = 0.9F;
+  constexpr float k_apex_offset_x = 0.09F;
+  constexpr float k_apex_height = 0.70F;
+  constexpr float k_apex_offset_z = -0.08F;
 
-  constexpr float k_apex_offset_x = 0.08F;
-  constexpr float k_apex_height = 0.66F;
-  constexpr float k_apex_offset_z = -0.07F;
+  auto jitter = [](int ring, int vertex, int salt) -> float {
+    uint32_t hash = static_cast<uint32_t>(ring + 1) * 0x9E3779B9U ^
+                    static_cast<uint32_t>(vertex + 1) * 0x85EBCA6BU ^
+                    static_cast<uint32_t>(salt + 1) * 0xC2B2AE35U;
+    hash ^= hash >> 15;
+    hash *= 0x27D4EB2FU;
+    hash ^= hash >> 13;
+    return static_cast<float>(hash & 0xFFFFU) / 65535.0F;
+  };
 
   struct Ring {
     float y;
@@ -78,55 +84,32 @@ void VegetationPipeline::initialize_stone_pipeline() {
     float cz;
   };
   const Ring rings[] = {
-      {-0.03F, 0.34F, 0.12F, 1.08F, 1.16F, -0.04F, 0.02F},
-      {0.12F, 0.50F, -0.04F, 1.12F, 0.96F, 0.01F, -0.02F},
-      {0.30F, 0.46F, 0.18F, 0.98F, 1.08F, 0.04F, -0.01F},
-      {0.47F, 0.31F, 0.06F, 1.06F, 0.90F, 0.01F, -0.05F},
-      {0.58F, 0.16F, 0.24F, 0.92F, 1.02F, 0.04F, -0.05F},
+      {-0.07F, 0.33F, 0.10F, 1.08F, 1.16F, -0.04F, 0.02F},
+      {0.05F, 0.47F, 0.02F, 1.14F, 1.00F, 0.00F, -0.02F},
+      {0.19F, 0.53F, -0.06F, 1.06F, 1.10F, 0.03F, -0.01F},
+      {0.33F, 0.49F, 0.14F, 0.97F, 1.12F, 0.05F, -0.02F},
+      {0.46F, 0.40F, 0.06F, 1.05F, 0.90F, 0.03F, -0.05F},
+      {0.58F, 0.26F, 0.22F, 0.93F, 1.00F, 0.06F, -0.06F},
+      {0.66F, 0.12F, 0.30F, 0.90F, 1.04F, 0.08F, -0.07F},
   };
+  static_assert(std::size(rings) == static_cast<std::size_t>(k_rings));
 
   QVector3D ring_pts[k_rings][k_n];
   for (int ri = 0; ri < k_rings; ++ri) {
     const Ring& r = rings[ri];
     for (int i = 0; i < k_n; ++i) {
       float const t = static_cast<float>(i) / k_n;
-      float const angle = t * k_tau + r.phase;
+      float const angle_jitter = (jitter(ri, i, 3) - 0.5F) * (k_tau / k_n) * 0.55F;
+      float const angle = t * k_tau + r.phase + angle_jitter;
 
-      float const perturb =
-          1.0F + k_perturb_amount * std::sin(float(i) * k_perturb_freq_vertex +
-                                             float(ri) * k_perturb_freq_ring);
+      float const perturb = 1.0F + k_radial_jitter * (jitter(ri, i, 1) - 0.5F) * 2.0F;
       float const rx = r.radius * perturb * r.sx * std::cos(angle);
       float const rz = r.radius * perturb * r.sz * std::sin(angle);
 
-      float const ry =
-          r.y + k_y_jitter_amount * std::cos(float(i) * k_y_jitter_freq_vertex +
-                                             float(ri) * k_y_jitter_freq_ring);
+      float const ry = r.y + k_y_jitter * (jitter(ri, i, 2) - 0.5F) * 2.0F;
       ring_pts[ri][i] = QVector3D(rx + r.cx, ry, rz + r.cz);
     }
   }
-
-  auto emit_quad = [&](const QVector3D& a,
-                       const QVector3D& b,
-                       const QVector3D& c,
-                       const QVector3D& d) {
-    QVector3D n = QVector3D::crossProduct(d - a, b - a);
-    if (n.lengthSquared() > 1.0e-8F) {
-      n.normalize();
-    } else {
-      n = QVector3D(0.0F, 1.0F, 0.0F);
-    }
-    auto base = static_cast<uint16_t>(verts.size());
-    verts.push_back({a, n});
-    verts.push_back({b, n});
-    verts.push_back({c, n});
-    verts.push_back({d, n});
-    idx.push_back(base);
-    idx.push_back(uint16_t(base + 2));
-    idx.push_back(uint16_t(base + 1));
-    idx.push_back(base);
-    idx.push_back(uint16_t(base + 3));
-    idx.push_back(uint16_t(base + 2));
-  };
 
   auto emit_tri = [&](const QVector3D& a, const QVector3D& b, const QVector3D& c) {
     QVector3D n = QVector3D::crossProduct(c - a, b - a);
@@ -142,6 +125,19 @@ void VegetationPipeline::initialize_stone_pipeline() {
     idx.push_back(base);
     idx.push_back(uint16_t(base + 2));
     idx.push_back(uint16_t(base + 1));
+  };
+
+  auto emit_quad = [&](const QVector3D& a,
+                       const QVector3D& b,
+                       const QVector3D& c,
+                       const QVector3D& d) {
+    if ((c - a).lengthSquared() <= (d - b).lengthSquared()) {
+      emit_tri(a, b, c);
+      emit_tri(a, c, d);
+    } else {
+      emit_tri(a, b, d);
+      emit_tri(b, c, d);
+    }
   };
 
   for (int ri = 0; ri < k_rings - 1; ++ri) {
@@ -162,7 +158,7 @@ void VegetationPipeline::initialize_stone_pipeline() {
     emit_tri(ring_pts[k_rings - 1][i], ring_pts[k_rings - 1][next], apex);
   }
 
-  QVector3D const bot_center(0.0F, -0.01F, 0.0F);
+  QVector3D const bot_center(0.0F, -0.09F, 0.0F);
   for (int i = 0; i < k_n; ++i) {
     int const next = (i + 1) % k_n;
 

--- a/render/ground/boulder_renderer.cpp
+++ b/render/ground/boulder_renderer.cpp
@@ -15,6 +15,7 @@
 #include "map/terrain_service.h"
 #include "render/scene_renderer.h"
 #include "scatter_runtime.h"
+#include "stone_ground_fit.h"
 
 namespace {
 
@@ -89,22 +90,23 @@ void BoulderRenderer::append_world_prop_boulders() {
     uint32_t state = hash_coords(static_cast<int>(prop.x),
                                  static_cast<int>(prop.z),
                                  m_biome_settings.seed ^ 0xD3A4B1C2U);
-    float const color_var = remap(rand_01(state), 0.0F, 1.0F);
-    QVector3D const base_rock = surface_profile.rock_low;
-    QVector3D const high_rock = surface_profile.rock_high;
-    QVector3D color = base_rock * (1.0F - color_var) + high_rock * color_var;
-    float const earth_mix = remap(rand_01(state), 0.08F, 0.30F);
-    QVector3D const earth_tint(0.34F, 0.31F, 0.27F);
-    color = color * (1.0F - earth_mix) + earth_tint * earth_mix;
-    color *= 0.86F;
+    QVector3D const color = stone_instance_color(
+        surface_profile.rock_low, surface_profile.rock_high, 0.35F, 0.45F, state);
+
+    float const render_scale = prop.scale * Game::Map::world_prop_render_scale(
+                                                Game::Map::WorldProp::Type::Boulder);
+    float const gx = world_to_grid_coord(resolved.x(), m_width, m_tile_size);
+    float const gz = world_to_grid_coord(resolved.z(), m_height, m_tile_size);
+    QVector3D const ground_normal =
+        sample_ground_normal(m_height_data, m_width, m_height, m_tile_size, gx, gz);
 
     StoneInstanceGpu inst;
-    inst.pos_scale = QVector4D(resolved.x(),
-                               resolved.y(),
-                               resolved.z(),
-                               prop.scale * Game::Map::world_prop_render_scale(
-                                                Game::Map::WorldProp::Type::Boulder));
+    inst.pos_scale = QVector4D(resolved.x(), resolved.y(), resolved.z(), render_scale);
     inst.color_rot = QVector4D(color.x(), color.y(), color.z(), prop.rotation);
+    inst.ground_fit = pack_stone_ground_fit(ground_normal,
+                                            rand_01(state),
+                                            render_scale,
+                                            stone_sink_fraction(ground_normal, state));
     m_state.instances.push_back(inst);
   }
 }
@@ -164,20 +166,24 @@ void BoulderRenderer::generate_procedural_boulders(
     validator.grid_to_world(gx, gz, world_x, world_z);
     float const world_y = terrain_cache.sample_height_at(gx, gz);
 
-    float const color_var = remap(rand_01(state), 0.0F, 1.0F);
-    QVector3D color = surface_profile.rock_low * (1.0F - color_var) +
-                      surface_profile.rock_high * color_var;
-    QVector3D const earth_tint(0.34F, 0.31F, 0.27F);
-    float const earth_mix = remap(rand_01(state), 0.10F, 0.25F + scene.dryness * 0.10F);
-    color = color * (1.0F - earth_mix) + earth_tint * earth_mix;
-    color *= 0.82F + scene.rockiness * 0.08F;
+    QVector3D const color = stone_instance_color(surface_profile.rock_low,
+                                                 surface_profile.rock_high,
+                                                 scene.dryness,
+                                                 scene.rockiness,
+                                                 state);
 
     StoneInstanceGpu inst;
     float const scale = remap(rand_01(state), scale_min, scale_max) *
                         scatter_scale_bias(ScatterRuleSpecies::Stone, scene);
+    QVector3D const ground_normal =
+        sample_ground_normal(m_height_data, m_width, m_height, m_tile_size, gx, gz);
     inst.pos_scale = QVector4D(world_x, world_y + 0.01F, world_z, scale);
     inst.color_rot = QVector4D(
         color.x(), color.y(), color.z(), rand_01(state) * MathConstants::k_two_pi);
+    inst.ground_fit = pack_stone_ground_fit(ground_normal,
+                                            rand_01(state),
+                                            scale,
+                                            stone_sink_fraction(ground_normal, state));
     out.push_back(inst);
     return true;
   };

--- a/render/ground/stone_ground_fit.h
+++ b/render/ground/stone_ground_fit.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <QVector3D>
+#include <QVector4D>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "game/map/scatter/ground_utils.h"
+
+namespace Render::Ground {
+
+inline auto sample_grid_height_bilinear(const std::vector<float>& heights,
+                                        int width,
+                                        int height,
+                                        float gx,
+                                        float gz) -> float {
+  if (width < 2 || height < 2 ||
+      heights.size() <
+          static_cast<std::size_t>(width) * static_cast<std::size_t>(height)) {
+    return 0.0F;
+  }
+  float const cx = std::clamp(gx, 0.0F, static_cast<float>(width - 1));
+  float const cz = std::clamp(gz, 0.0F, static_cast<float>(height - 1));
+  int const x0 = static_cast<int>(std::floor(cx));
+  int const z0 = static_cast<int>(std::floor(cz));
+  int const x1 = std::min(x0 + 1, width - 1);
+  int const z1 = std::min(z0 + 1, height - 1);
+  float const fx = cx - static_cast<float>(x0);
+  float const fz = cz - static_cast<float>(z0);
+  auto at = [&](int x, int z) {
+    return heights[static_cast<std::size_t>(z) * static_cast<std::size_t>(width) +
+                   static_cast<std::size_t>(x)];
+  };
+  float const h0 = at(x0, z0) * (1.0F - fx) + at(x1, z0) * fx;
+  float const h1 = at(x0, z1) * (1.0F - fx) + at(x1, z1) * fx;
+  return h0 * (1.0F - fz) + h1 * fz;
+}
+
+inline auto sample_ground_normal(const std::vector<float>& heights,
+                                 int width,
+                                 int height,
+                                 float tile_size,
+                                 float gx,
+                                 float gz) -> QVector3D {
+  constexpr float k_half_step = 0.5F;
+  constexpr float k_min_tile = 1.0e-4F;
+  float const ts = std::max(tile_size, k_min_tile);
+  float const left =
+      sample_grid_height_bilinear(heights, width, height, gx - k_half_step, gz);
+  float const right =
+      sample_grid_height_bilinear(heights, width, height, gx + k_half_step, gz);
+  float const back =
+      sample_grid_height_bilinear(heights, width, height, gx, gz - k_half_step);
+  float const front =
+      sample_grid_height_bilinear(heights, width, height, gx, gz + k_half_step);
+  QVector3D normal(-(right - left) / ts, 1.0F, -(front - back) / ts);
+  if (normal.lengthSquared() < k_min_tile) {
+    return {0.0F, 1.0F, 0.0F};
+  }
+  return normal.normalized();
+}
+
+inline auto
+world_to_grid_coord(float world_coord, int grid_size, float tile_size) -> float {
+  constexpr float k_min_tile = 1.0e-4F;
+  return world_coord / std::max(tile_size, k_min_tile) +
+         (static_cast<float>(grid_size) * 0.5F - 0.5F);
+}
+
+inline auto pack_stone_ground_fit(const QVector3D& ground_normal,
+                                  float shape_seed,
+                                  float render_scale,
+                                  float sink_fraction) -> QVector4D {
+  constexpr float k_max_tilt_component = 0.60F;
+  QVector3D normal = ground_normal;
+  if (normal.y() <= 0.0F || normal.lengthSquared() < 1.0e-6F) {
+    normal = QVector3D(0.0F, 1.0F, 0.0F);
+  }
+  normal.normalize();
+  float const nx = std::clamp(normal.x(), -k_max_tilt_component, k_max_tilt_component);
+  float const nz = std::clamp(normal.z(), -k_max_tilt_component, k_max_tilt_component);
+  float const seed = std::clamp(shape_seed, 0.0F, 0.999F);
+  float const sink = std::max(0.0F, sink_fraction) * std::max(render_scale, 0.0F);
+  return {nx, seed, nz, sink};
+}
+
+inline auto stone_sink_fraction(const QVector3D& ground_normal,
+                                uint32_t& state) -> float {
+  constexpr float k_base_sink_min = 0.07F;
+  constexpr float k_base_sink_max = 0.20F;
+  constexpr float k_slope_sink = 0.30F;
+  constexpr float k_max_sink = 0.34F;
+  float const slope = 1.0F - std::clamp(ground_normal.y(), 0.0F, 1.0F);
+  float const sink =
+      remap(rand_01(state), k_base_sink_min, k_base_sink_max) + slope * k_slope_sink;
+  return std::min(sink, k_max_sink);
+}
+
+inline auto stone_instance_color(const QVector3D& rock_low,
+                                 const QVector3D& rock_high,
+                                 float dryness,
+                                 float rockiness,
+                                 uint32_t& state) -> QVector3D {
+  constexpr float k_iron_stain_chance = 0.22F;
+  constexpr float k_lichen_grey_chance = 0.14F;
+  float const color_var = rand_01(state);
+  QVector3D color = rock_low * (1.0F - color_var) + rock_high * color_var;
+
+  QVector3D const earth_tint(0.36F, 0.32F, 0.27F);
+  float const earth_mix =
+      remap(rand_01(state), 0.08F + dryness * 0.08F, 0.28F + rockiness * 0.10F);
+  color = color * (1.0F - earth_mix) + earth_tint * earth_mix;
+
+  float const cast_roll = rand_01(state);
+  if (cast_roll < k_iron_stain_chance) {
+    QVector3D const iron_stain(0.47F, 0.36F, 0.26F);
+    float const stain_mix = remap(rand_01(state), 0.22F, 0.42F);
+    color = color * (1.0F - stain_mix) + iron_stain * stain_mix;
+  } else if (cast_roll < k_iron_stain_chance + k_lichen_grey_chance) {
+    QVector3D const lichen_grey(0.50F, 0.52F, 0.47F);
+    float const grey_mix = remap(rand_01(state), 0.20F, 0.36F);
+    color = color * (1.0F - grey_mix) + lichen_grey * grey_mix;
+  } else {
+    (void)rand_01(state);
+  }
+
+  color *= 0.82F + rockiness * 0.08F;
+  return color;
+}
+
+} // namespace Render::Ground

--- a/render/ground/stone_renderer.cpp
+++ b/render/ground/stone_renderer.cpp
@@ -22,6 +22,7 @@
 #include "render/gl/buffer.h"
 #include "render/scene_renderer.h"
 #include "scatter_runtime.h"
+#include "stone_ground_fit.h"
 
 namespace {
 
@@ -117,22 +118,24 @@ void StoneRenderer::generate_stone_instances() {
     float const scale = remap(rand_01(state), 0.25F, 0.68F) * tile_safe *
                         scatter_scale_bias(ScatterRuleSpecies::Stone, scene);
 
-    float const color_var = remap(rand_01(state), 0.0F, 1.0F);
-    QVector3D const base_rock = surface_profile.rock_low;
-    QVector3D const high_rock = surface_profile.rock_high;
-    QVector3D color = base_rock * (1.0F - color_var) + high_rock * color_var;
-
-    float const earth_mix = remap(
-        rand_01(state), 0.08F + scene.dryness * 0.08F, 0.28F + scene.rockiness * 0.12F);
-    QVector3D const earth_tint(0.34F, 0.31F, 0.27F);
-    color = color * (1.0F - earth_mix) + earth_tint * earth_mix;
-    color *= 0.84F + scene.rockiness * 0.08F;
+    QVector3D const color = stone_instance_color(surface_profile.rock_low,
+                                                 surface_profile.rock_high,
+                                                 scene.dryness,
+                                                 scene.rockiness,
+                                                 state);
 
     float const rotation = rand_01(state) * MathConstants::k_two_pi;
+    QVector3D const ground_normal =
+        sample_ground_normal(m_height_data, m_width, m_height, m_tile_size, sgx, sgz);
 
     StoneInstanceGpu instance;
     instance.pos_scale = QVector4D(world_x, world_y + 0.01F, world_z, scale);
     instance.color_rot = QVector4D(color.x(), color.y(), color.z(), rotation);
+    instance.ground_fit =
+        pack_stone_ground_fit(ground_normal,
+                              rand_01(state),
+                              scale,
+                              stone_sink_fraction(ground_normal, state));
     stone_instances.push_back(instance);
     return true;
   };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -405,6 +405,7 @@ add_executable(
     render/linear_feature_visibility_test.cpp
     render/ground_utils_test.cpp
     render/dead_tree_mesh_test.cpp
+    render/prop_mesh_builder_test.cpp
     render/local_lighting_test.cpp
     render/contact_shadow_test.cpp
     render/shadow_cascade_fit_test.cpp

--- a/tests/render/prop_mesh_builder_test.cpp
+++ b/tests/render/prop_mesh_builder_test.cpp
@@ -1,0 +1,37 @@
+#include <QVector3D>
+
+#include <gtest/gtest.h>
+
+#include "render/gl/backend/prop_mesh_builder.h"
+
+namespace {
+
+using Render::GL::BackendPipelines::append_oriented_box;
+using Render::GL::BackendPipelines::PropMeshIndices;
+using Render::GL::BackendPipelines::PropMeshVerts;
+
+TEST(PropMeshBuilderTest, OrientedBoxNormalsPointAwayFromTheBoxCentre) {
+  PropMeshVerts verts;
+  PropMeshIndices idx;
+  QVector3D const a(-0.58F, 0.02F, -0.20F);
+  QVector3D const b(0.48F, 0.12F, 0.18F);
+  append_oriented_box(verts, idx, a, b, 0.24F, 0.18F);
+  ASSERT_EQ(verts.size(), 24U);
+  ASSERT_EQ(idx.size(), 36U);
+
+  QVector3D const centre = (a + b) * 0.5F;
+  for (std::size_t face = 0; face < 6; ++face) {
+    QVector3D face_centre;
+    for (std::size_t corner = 0; corner < 4; ++corner) {
+      face_centre += verts[face * 4 + corner].first;
+    }
+    face_centre *= 0.25F;
+    QVector3D const outward = face_centre - centre;
+    EXPECT_GT(QVector3D::dotProduct(verts[face * 4].second, outward), 0.0F)
+        << "face " << face
+        << " is lit from the inside; the iron ore is built from nothing but "
+           "oriented boxes, so this is what turned it black";
+  }
+}
+
+} // namespace

--- a/tests/render/scatter_runtime_test.cpp
+++ b/tests/render/scatter_runtime_test.cpp
@@ -1,8 +1,13 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
+#include <iterator>
+#include <string>
+#include <vector>
 
 #include "game/map/map_loader.h"
 #include "game/map/procedural_tree_generation.h"
@@ -20,6 +25,7 @@
 #include "render/ground/plant_renderer.h"
 #include "render/ground/scatter_renderer_state.h"
 #include "render/ground/scatter_runtime.h"
+#include "render/ground/stone_ground_fit.h"
 #include "render/ground/stone_renderer.h"
 #include "render/ground/terrain_scatter_manager.h"
 #include "render/ground/tree_renderer.h"
@@ -695,3 +701,90 @@ TEST(ScatterRuntimeTest, RevealingGroundOnlyDirtiesTheChunksItTouches) {
 }
 
 } // namespace
+
+TEST(StoneGroundFit, ANormalOnALevelFieldPacksAsUprightWithNoTilt) {
+  std::vector<float> const heights(16 * 16, 3.0F);
+  auto const normal =
+      Render::Ground::sample_ground_normal(heights, 16, 16, 1.0F, 7.5F, 4.2F);
+  EXPECT_NEAR(normal.x(), 0.0F, 1.0e-5F);
+  EXPECT_NEAR(normal.y(), 1.0F, 1.0e-5F);
+  EXPECT_NEAR(normal.z(), 0.0F, 1.0e-5F);
+
+  auto const fit = Render::Ground::pack_stone_ground_fit(normal, 0.25F, 2.0F, 0.15F);
+  EXPECT_FLOAT_EQ(fit.x(), 0.0F);
+  EXPECT_FLOAT_EQ(fit.y(), 0.25F);
+  EXPECT_FLOAT_EQ(fit.z(), 0.0F);
+  EXPECT_FLOAT_EQ(fit.w(), 0.30F)
+      << "sink is authored as a fraction of the render scale";
+}
+
+TEST(StoneGroundFit, ASlopeTiltsTheStoneDownhillAndBedsItDeeper) {
+  std::vector<float> heights(16 * 16, 0.0F);
+  for (int z = 0; z < 16; ++z) {
+    for (int x = 0; x < 16; ++x) {
+      heights[static_cast<std::size_t>(z * 16 + x)] = static_cast<float>(x) * 0.5F;
+    }
+  }
+  auto const normal =
+      Render::Ground::sample_ground_normal(heights, 16, 16, 1.0F, 8.0F, 8.0F);
+  EXPECT_LT(normal.x(), -0.3F)
+      << "the ground rises with x, so the normal leans back toward -x";
+  EXPECT_GT(normal.y(), 0.5F);
+  EXPECT_NEAR(normal.z(), 0.0F, 1.0e-4F);
+
+  auto const flat = QVector3D(0.0F, 1.0F, 0.0F);
+  float flat_total = 0.0F;
+  float slope_total = 0.0F;
+  for (std::uint32_t seed = 1U; seed <= 32U; ++seed) {
+    std::uint32_t flat_state = seed;
+    std::uint32_t slope_state = seed;
+    flat_total += Render::Ground::stone_sink_fraction(flat, flat_state);
+    slope_total += Render::Ground::stone_sink_fraction(normal, slope_state);
+  }
+  EXPECT_GT(slope_total, flat_total)
+      << "a rock on a hillside has to be sunk further or its downhill lip floats";
+  for (std::uint32_t seed = 1U; seed <= 32U; ++seed) {
+    std::uint32_t state = seed;
+    EXPECT_LE(Render::Ground::stone_sink_fraction(normal, state), 0.34F);
+  }
+}
+
+TEST(StoneGroundFit, TheGpuInstanceCarriesTheGroundFitToTheStoneShader) {
+  Render::GL::StoneInstanceGpu const instance{QVector4D(1.0F, 2.0F, 3.0F, 1.5F),
+                                              QVector4D(0.5F, 0.5F, 0.5F, 0.0F)};
+  EXPECT_EQ(instance.ground_fit, QVector4D(0.0F, 0.0F, 0.0F, 0.0F))
+      << "an instance with no ground fit stands upright on the surface point";
+  EXPECT_EQ(sizeof(Render::GL::StoneInstanceGpu), 3U * sizeof(QVector4D));
+
+  const auto root = find_repo_root();
+  ASSERT_FALSE(root.empty());
+  std::ifstream vert(root / "assets" / "shaders" / "stone_instanced.vert");
+  std::string const source((std::istreambuf_iterator<char>(vert)),
+                           std::istreambuf_iterator<char>());
+  ASSERT_FALSE(source.empty());
+  EXPECT_NE(source.find("layout(location = 4) in vec4 a_ground_fit;"),
+            std::string::npos)
+      << "the executor binds StoneInstanceGpu::ground_fit at instance_scale";
+  EXPECT_NE(source.find("align_up_to("), std::string::npos)
+      << "stones tilt onto the slope they lie on";
+}
+
+TEST(StoneGroundFit, RockFieldsAreNotOneColour) {
+  QVector3D const rock_low(0.48F, 0.46F, 0.44F);
+  QVector3D const rock_high(0.68F, 0.69F, 0.73F);
+  float max_spread = 0.0F;
+  QVector3D first;
+  for (std::uint32_t seed = 1U; seed <= 64U; ++seed) {
+    std::uint32_t state = seed * 7919U;
+    auto const color =
+        Render::Ground::stone_instance_color(rock_low, rock_high, 0.3F, 0.4F, state);
+    EXPECT_GT(color.x(), 0.15F);
+    EXPECT_LT(color.x(), 0.80F);
+    if (seed == 1U) {
+      first = color;
+    }
+    max_spread = std::max(max_spread, (color - first).length());
+  }
+  EXPECT_GT(max_spread, 0.08F)
+      << "iron stains and lichen greys should split the palette";
+}

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -4287,6 +4287,8 @@ void ArenaViewport::load_scenario(const QString& scenario_id) {
   if (m_prewarm_unit_templates && m_renderer != nullptr) {
     m_renderer->prewarm_unit_templates(m_world.get(), {});
   }
+  m_session.terrain().set_supernatural_presence(
+      definition->undead_zones.empty() ? 0.0F : 1.0F);
   reconfigure_terrain_from_state();
   configure_scenario_undead_zones(*definition, scenario_origin);
 

--- a/tools/sim_benchmark/main.cpp
+++ b/tools/sim_benchmark/main.cpp
@@ -141,13 +141,14 @@ struct Result {
 
 auto run_scenario(int units_per_side, int ticks, bool per_system) -> Result {
   const int map_size = map_size_for(units_per_side);
-  Game::Systems::NavGrid::initialize(map_size, map_size);
 
   auto factory = std::make_shared<Game::Units::UnitFactoryRegistry>();
   Game::Units::register_built_in_units(*factory);
 
   auto session = std::make_unique<SessionContext>();
   const ScopedSession scope(*session);
+
+  Game::Systems::NavGrid::initialize(map_size, map_size);
 
   auto& owners = session->owners();
   owners.register_owner_with_id(k_left_owner, Game::Systems::OwnerType::Player, "left");


### PR DESCRIPTION
Correct the winding used by oriented-box mesh generation so generated normals face outward. This restores proper lighting for hematite ore and keeps dead-tree branch stubs and other oriented props consistent, with a focused mesh-normal regression test registered in the render test suite.

Update iron ore shading to use the shared scaled surface-lighting path and a brighter hematite palette, while keeping supernatural staining and crystal highlights controlled by world magic strength. Document the visual diagnosis and the resulting art-direction contract.

Keep scatter rocks visually attached to terrain by retaining ground-fit and slope-aware bedding behavior across stone and boulder rendering, and preserve the associated runtime coverage. Simplify formation contact geometry by removing redundant per-pair and per-entity caches, deriving layout signatures at the cache boundary, and rebuilding the small temporary slot data needed for contact evaluation. Fold the walkability check into candidate acceptance so traversing slots do not step onto worsening low-score ground.