### PR TITLE
fix: stabilize arena movement and creature animation continuity

### DIFF
--- a/docs/ARENA_MOVEMENT_REVIEW.md
+++ b/docs/ARENA_MOVEMENT_REVIEW.md
@@ -1,0 +1,115 @@
+# Arena movement and animation review — 2026-09-05
+
+Reviewed the production Arena renderer at 30 simulation/render samples per second,
+using fixed cameras, seed 1337, captured PNG sequences, and per-frame JSONL traces.
+Artifacts are under `artifacts/movement-review/` (not committed). These observations
+cover animation and movement; no meshes or combat damage values were changed.
+
+## Coverage
+
+| Cases                                                                | Arena scenarios                                                                                                              |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Infantry start, walk, stop, reverse; walking and running alone       | `infantry_locomotion_matrix`, `rpg_locomotion`                                                                               |
+| Mounted ranks start, ride, stop, reverse; charge and melee           | `mounted_locomotion_matrix`, `mounted_knight_action_transition`, `shield_wall_cavalry_impact`                                |
+| Elephant travel, stop, reverse, group movement and contact           | `elephant_locomotion_matrix`, `elephant_trample`                                                                             |
+| Crowds, crossing traffic and obstacles                               | `crossing_formations`, `path_building_alley`, `nav_ruin_melee`                                                               |
+| Infantry approach, attack, recovery and chase/disengagement          | `swordsman_action_transition`, `attack_to_chase`, `spear_walk_contact`                                                       |
+| Sheep graze, wander and flee; wolves prowl and attack; birds scatter | `wildlife_grazing_herd`, `wildlife_herd_flees_troops`, `wildlife_wolf_pack`, `wildlife_wolf_ambush`, `wildlife_bird_scatter` |
+
+The commander trace includes Walk and Run. The cavalry impact trace includes Walk,
+Run, RidingCharge, and AttackSword. Elephants use their authored walking gait;
+the review does not imply an elephant gallop was tested. Wildlife includes sheep,
+wolves, and birds, the species available in these scenarios.
+
+The low-poly infantry, riders, horses, elephants, sheep, wolves, and birds retain
+their existing silhouettes and proportions. Captures did not motivate a mesh
+change in this pass. The more noticeable problems were temporal: crowded mounted
+reversals, abrupt gait changes, and overlapping/unevenly participating melee ranks.
+Close-up horse and wolf sequences are also saved under `closeup/`; wolves remain
+partly obscured by infantry and combat effects at contact.
+
+## Findings and improvement pass
+
+- Crowded contact resolution applied the entire overlap immediately, once per
+  neighbor. It now shares a per-body correction budget of 2 m/s across all contacts,
+  capped at 0.15 m for a long frame. Holding and melee-locked bodies remain anchored.
+- Formation orientation followed the movement target even when the route's current
+  desired direction differed. It now uses the route follower's desired direction,
+  retaining the existing turn-rate and sideways-translation limits.
+- Retargeting an unfinished horse gait blend discarded the intermediate gait.
+  The next blend now starts from the previous blended gait and retains locomotion
+  playback when a stop interrupts a start.
+- Horse and elephant stride cursors were invalidated during idle. They now stay
+  parked through a stop instead of restarting at an unrelated wall-clock phase.
+- Sheep/wolf foot phases integrated filtered speed, lagging acceleration and
+  continuing to step after stopping. Phases now consume measured travel once;
+  speed filtering and hysteresis still select the gait. Long frames use their
+  actual elapsed time when estimating speed.
+- A wolf's filtered run speed could hide the beginning of a stationary bite.
+  Once measured travel stops for a bite or flinch, the contact clip can begin
+  immediately through the existing animation crossfade.
+- Supporting formation members could inherit the strike carrier's authored phase
+  and clip. Those overrides now remain with the carrier during formation melee,
+  letting other soldiers use their own attack, recovery, and guard presentation.
+
+The original infantry, mounted, and crossing traces contained no moving-idle samples
+(root speed above 0.2 m/s with an Idle animation). Mounted rank reversals still
+showed fast catch-up motion, peaking near 7.7 m/s. This pass does not claim to remove
+all horse overlap or per-soldier foot-skating; the mounted diagnostic foot positions
+describe the rider, not the horse's planted hooves.
+
+## Reproduction
+
+```bash
+cmake --build build --target arena_app render_tests combat_balance_tests simulation_tests app_tests -j 8
+build/bin/arena_app --batch --scenario mounted_locomotion_matrix \
+  --fps 30 --seed 1337 --capture-interval 0.5 \
+  --animation-diagnostics --profile --watchdog-multiplier 20 \
+  --artifact-dir artifacts/movement-review/verified
+```
+
+Use the scenario IDs in the coverage table to reproduce the other cases.
+`before/` holds the original release executable's captures; `after/` holds the
+first rebuilt locomotion checks. The current Arena also requires GPU timings for
+its frame-budget expectation, so final acceptance runs use `--profile` and are
+stored separately in `verified/`. A screenshot or a scenario PASS alone does not
+prove planted-foot accuracy or smooth transitions between every pair of frames.
+
+## Validation
+
+The build completed successfully. All 274 targeted tests passed:
+
+| Test selection                                                                         | Passed |
+| -------------------------------------------------------------------------------------- | -----: |
+| Render, gait, wildlife clip selection, soldier turns, combat presentation              |    109 |
+| Local avoidance/contact, wildlife fights, routes, melee engagement, movement ownership |     39 |
+| Movement motor, formation movement/cohesion, melee exchanges                           |     39 |
+| Wildlife simulation, birds, movement presentation                                      |     42 |
+| Command service, including route-facing regression                                     |     45 |
+
+Nine new regressions cover interrupted horse starts, elephant stride continuity,
+wildlife distance tracking, long-frame speed, bite entry, formation clip ownership,
+dense contact budgets, locked-fighter separation, and route-facing. This is a
+targeted validation pass, not a claim that the entire repository test suite ran.
+
+Before the changes, 16 of the 18 reviewed scenarios passed their scenario checks.
+`path_building_alley` missed its destination after taking a long detour.
+`spear_walk_contact` reported missing combat indicators, soldiers without attack
+animations, and a terminal-pose stall. The clean-capture option suppresses overlays,
+so the indicator errors must be distinguished from movement/animation findings.
+
+Final acceptance passed 16 of 18 scenarios, with the same two scenario failures
+as the baseline. These runs use visible overlays. The alley still misses its destination;
+the dense spear fight still reports 32 living-soldier participation findings,
+two missing indicators, and one group-level `soldiers_never_fought` finding.
+Some non-attacking members have guard/support roles, so these findings need a
+role-aware follow-up rather than forcing every soldier to swing. A terminal-pose
+stall appeared in the baseline and an earlier rebuilt capture, but did not recur
+in the final isolated spear run; it is not claimed fixed.
+
+Concurrent capture runs produced frame-budget warnings. The alley, spear, and
+bird-scatter scenarios were rerun without other Arena processes; their timing
+warnings cleared without changing performance thresholds or scenario expectations.
+The final cavalry-impact run also passed. No final scenario reports a frame-budget
+failure. Captured images are wall-clock snapshots, whereas the trace advances in
+fixed simulation steps; screenshot indices are not exact simulation timestamps.

--- a/game/systems/body_contact_system.cpp
+++ b/game/systems/body_contact_system.cpp
@@ -23,6 +23,7 @@ struct ContactBody {
   float radius{0.0F};
   BodyProfile profile;
   bool movable{false};
+  float separation_remaining{0.0F};
   Engine::Core::EntityID melee_intent{0};
 };
 
@@ -70,6 +71,13 @@ auto profile_for(const Engine::Core::Entity& entity) -> BodyProfile {
 }
 
 auto try_push(ContactBody& body, float dx, float dz) -> bool {
+  float const distance = std::hypot(dx, dz);
+  float const step = std::min(distance, body.separation_remaining);
+  if (step <= 1.0e-6F || distance <= 1.0e-6F) {
+    return true;
+  }
+  dx *= step / distance;
+  dz *= step / distance;
   QVector3D const destination(
       body.transform->position.x + dx, 0.0F, body.transform->position.z + dz);
   if (!Walkability::can_stand(destination, body.profile)) {
@@ -77,6 +85,7 @@ auto try_push(ContactBody& body, float dx, float dz) -> bool {
   }
   body.transform->position.x = destination.x();
   body.transform->position.z = destination.z();
+  body.separation_remaining -= step;
   return true;
 }
 
@@ -122,6 +131,8 @@ void BodyContactSystem::run(Engine::Core::SystemContext& context) {
     body.radius = CommandService::get_unit_radii(world, entry.id).core;
     body.profile = profile_for(*entity);
     body.movable = body_is_movable(*entity, body.facts);
+    body.separation_remaining =
+        std::min(k_separation_speed * delta_time, k_max_separation_step);
     body.melee_intent = melee_intent_of(*entity);
     widest_radius = std::max(widest_radius, body.radius);
   }

--- a/game/systems/body_contact_system.h
+++ b/game/systems/body_contact_system.h
@@ -29,6 +29,9 @@ public:
   static constexpr float k_stale_position_margin = 0.5F;
   static constexpr float k_stale_position_speed_allowance = 12.0F;
 
+  static constexpr float k_separation_speed = 2.0F;
+  static constexpr float k_max_separation_step = 0.15F;
+
 private:
   BodyContactDiagnostics m_diagnostics;
 };

--- a/game/systems/movement_system.cpp
+++ b/game/systems/movement_system.cpp
@@ -85,6 +85,15 @@ auto heading_reference(const Engine::Core::Entity& entity,
   bool const formation =
       unit != nullptr && FormationCombat::has_formation_slots(entity);
   if (formation && movement.get_has_target()) {
+
+    auto const* facts = entity.get_component<Engine::Core::MovementFactsComponent>();
+    if (facts != nullptr && facts->desired.valid) {
+      float const dx = facts->desired.velocity_x;
+      float const dz = facts->desired.velocity_z;
+      if (dx * dx + dz * dz > 1.0e-5F) {
+        return {true, std::atan2(dx, dz) * 180.0F / std::numbers::pi_v<float>};
+      }
+    }
     float const intent_x = movement.get_target_x() - transform.position.x;
     float const intent_z = movement.get_target_y() - transform.position.z;
     if (intent_x * intent_x + intent_z * intent_z >

--- a/render/creature/animation_state_components.h
+++ b/render/creature/animation_state_components.h
@@ -40,6 +40,9 @@ struct HorseAnimationStateComponent {
   float gait_transition_progress{1.0F};
   float transition_start_time{0.0F};
   float idle_bob_intensity{1.0F};
+  Render::GL::HorseGait transition_source{};
+  bool transition_source_valid{false};
+  bool transition_has_motion{false};
   float locomotion_phase{0.0F};
   float locomotion_phase_time{0.0F};
   bool locomotion_phase_valid{false};

--- a/render/elephant/elephant_motion.cpp
+++ b/render/elephant/elephant_motion.cpp
@@ -204,7 +204,8 @@ auto evaluate_elephant_motion(
     state.locomotion_phase_valid = true;
     motion_time = state.locomotion_phase * cycle_time;
   } else {
-    state.locomotion_phase_valid = false;
+
+    state.locomotion_phase_time = anim.time;
   }
   Quadruped::MotionSample const quadruped_motion = Quadruped::evaluate_cycle_motion(
       to_quadruped_dimensions(d),

--- a/render/entity/wildlife/wildlife_draw_state.cpp
+++ b/render/entity/wildlife/wildlife_draw_state.cpp
@@ -18,6 +18,7 @@ struct GaitCursor {
   float stamp{0.0F};
   float speed{0.0F};
   float elapsed{0.0F};
+  float pending_distance{0.0F};
   float ambient{0.0F};
   float action{0.0F};
   float graze_hold{0.0F};
@@ -170,19 +171,32 @@ auto gait_speed(const DrawState& state) -> float {
     cursor.distance = state.distance;
     cursor.stamp = state.time;
     cursor.speed = 0.0F;
+    cursor.pending_distance = 0.0F;
   }
 
-  cursor.elapsed = std::clamp(state.time - cursor.stamp, 0.0F, k_gait_max_step_seconds);
+  float const elapsed = std::max(state.time - cursor.stamp, 0.0F);
+
+  if (!restarted && elapsed <= 1.0e-5F) {
+    cursor.elapsed = 0.0F;
+    return cursor.speed;
+  }
+  cursor.elapsed = std::min(elapsed, k_gait_max_step_seconds);
   cursor.stamp = state.time;
 
   float const stepped = std::max(0.0F, state.distance - cursor.distance);
   cursor.distance = state.distance;
+  cursor.pending_distance += stepped;
 
-  if (cursor.elapsed > 1.0e-5F) {
-    float const measured = stepped / cursor.elapsed;
+  if (elapsed > 1.0e-5F) {
+    float const measured = stepped / elapsed;
     float const blend = std::clamp(
         cursor.elapsed / (k_gait_speed_smoothing + cursor.elapsed), 0.0F, 1.0F);
     cursor.speed += (measured - cursor.speed) * blend;
+    if (stepped <= 1.0e-6F &&
+        (state.bite_progress >= 0.0F || state.flinch_progress >= 0.0F)) {
+
+      cursor.speed = 0.0F;
+    }
   }
   cursor.sampled = true;
   return cursor.speed;
@@ -259,7 +273,10 @@ auto gait_phase(const DrawState& state, float advance) -> float {
   GaitCursor& cursor = entry->second;
 
   if (advance > 1.0e-4F) {
-    cursor.cycles += (cursor.speed * cursor.elapsed) / advance;
+
+    cursor.cycles += cursor.pending_distance / advance;
+    cursor.cycles -= std::floor(cursor.cycles);
+    cursor.pending_distance = 0.0F;
   }
   return cursor.cycles - std::floor(cursor.cycles);
 }

--- a/render/horse/horse_motion.cpp
+++ b/render/horse/horse_motion.cpp
@@ -288,15 +288,22 @@ auto to_render_gait_type(Animation::HorseGaitType gait) noexcept -> GaitType {
 auto resolve_persistent_gait(
     const Render::Creature::HorseAnimationStateComponent& state,
     const HorseProfile& profile) -> HorseGait {
-  HorseGait const current = gait_for_type(state.current_gait, profile.gait);
-  if (state.gait_transition_progress < 1.0F &&
-      state.current_gait != state.target_gait) {
+  HorseGait const current = state.transition_source_valid
+                                ? state.transition_source
+                                : gait_for_type(state.current_gait, profile.gait);
+  if (state.gait_transition_progress < 1.0F) {
     HorseGait const target = gait_for_type(state.target_gait, profile.gait);
     float const t = state.gait_transition_progress;
     float const eased = t * t * (3.0F - 2.0F * t);
     return blend_gaits(current, target, eased);
   }
-  return current;
+  return gait_for_type(state.current_gait, profile.gait);
+}
+
+auto gait_has_motion(const Render::Creature::HorseAnimationStateComponent& state)
+    -> bool {
+  return state.current_gait != GaitType::IDLE || state.target_gait != GaitType::IDLE ||
+         (state.gait_transition_progress < 1.0F && state.transition_has_motion);
 }
 
 void evaluate_phase_and_bob(Render::Creature::HorseAnimationStateComponent& state,
@@ -307,8 +314,7 @@ void evaluate_phase_and_bob(Render::Creature::HorseAnimationStateComponent& stat
                             float rider_intensity,
                             float& out_phase,
                             float& out_bob) {
-  bool const is_moving =
-      state.current_gait != GaitType::IDLE || state.target_gait != GaitType::IDLE;
+  bool const is_moving = gait_has_motion(state);
   float const phase_offset = resolved.phase_offset;
 
   if (is_moving) {
@@ -367,7 +373,8 @@ void evaluate_phase_and_bob(Render::Creature::HorseAnimationStateComponent& stat
     out_phase = quadruped_motion.phase;
     out_bob = (breathing + weight_shift) * profile.dims.idle_bob_amplitude * 0.8F *
               state.idle_bob_intensity;
-    state.locomotion_phase_valid = false;
+
+    state.locomotion_phase_time = anim.time;
   }
 }
 
@@ -405,6 +412,19 @@ auto evaluate_horse_motion(const HorseProfile& profile,
       .speed = speed,
       .anchor = to_animation_gait_type(state.target_gait),
   });
+  if (desired_gait != to_animation_gait_type(state.target_gait)) {
+
+    HorseGait const source = resolve_persistent_gait(state, profile);
+    state.transition_has_motion =
+        gait_has_motion(state) || desired_gait != Animation::HorseGaitType::Idle;
+    state.current_gait =
+        to_render_gait_type(Animation::horse_playback_gait_for_transition(
+            to_animation_gait_type(state.current_gait),
+            to_animation_gait_type(state.target_gait),
+            gait_has_motion(state)));
+    state.transition_source = source;
+    state.transition_source_valid = true;
+  }
   auto const transition = Animation::resolve_horse_gait_transition({
       .current = to_animation_gait_type(state.current_gait),
       .target = to_animation_gait_type(state.target_gait),
@@ -427,8 +447,7 @@ auto evaluate_horse_motion(const HorseProfile& profile,
   resolved.phase_offset =
       Quadruped::wrap_phase(resolved.phase_offset + individuality.gait_phase_offset);
 
-  sample.is_moving =
-      state.current_gait != GaitType::IDLE || state.target_gait != GaitType::IDLE;
+  sample.is_moving = gait_has_motion(state);
   if (sample.is_moving) {
 
     constexpr float k_horse_stride_to_local = 0.56F;

--- a/render/humanoid/runtime/instance_prepare.cpp
+++ b/render/humanoid/runtime/instance_prepare.cpp
@@ -835,6 +835,14 @@ void append_prepared_soldier(const HumanoidUnitSnapshot& s,
   Render::Entity::FormationInstance const& layout =
       soldier_layouts[static_cast<std::size_t>(idx)];
   AnimationInputs soldier_render_anim = soldier_anim;
+  bool const follows_authoritative_strike =
+      !has_shared_formation_layout ||
+      formation_presentation->soldiers[static_cast<std::size_t>(idx)].damage_carrier;
+  if (!follows_authoritative_strike && formation_presentation->melee_ordered) {
+
+    soldier_render_anim.has_authored_action_phase = false;
+    soldier_render_anim.has_authored_action_clip = false;
+  }
   if (creature_presentation != nullptr &&
       !creature_presentation->allow_full_body_hit_reaction &&
       soldier_render_anim.is_hit_reacting) {
@@ -1261,8 +1269,6 @@ void append_prepared_soldier(const HumanoidUnitSnapshot& s,
   raw_combat.is_dying = soldier_render_anim.is_dying;
   raw_combat.is_dead = soldier_render_anim.is_dead;
   raw_combat.locomotion = soldier_render_anim.movement_state;
-  bool const follows_authoritative_strike =
-      soldier_directive == nullptr || soldier_directive->damage_carrier;
   raw_combat.combat_phase = follows_authoritative_strike
                                 ? soldier_render_anim.combat_phase
                                 : Render::GL::CombatAnimPhase::Idle;

--- a/tests/render/creature/elephant_prepare_test.cpp
+++ b/tests/render/creature/elephant_prepare_test.cpp
@@ -411,6 +411,21 @@ TEST(ElephantPrepare, LocomotionClockSurvivesARenderClockRebaseWithoutLegJump) {
   EXPECT_NEAR(after.phase, before.phase, 0.0001F);
 }
 
+TEST(ElephantPrepare, AnIdlePausePreservesThePlantedStridePhase) {
+  auto const profile = make_test_elephant_profile();
+  Render::Creature::ElephantAnimationStateComponent state{};
+  Render::GL::AnimationInputs anim{};
+  anim.time = 0.37F;
+  anim.movement_state = Render::Creature::MovementAnimationState::Walk;
+  auto const walking = Render::GL::evaluate_elephant_motion(profile, anim, &state);
+  anim.movement_state = Render::Creature::MovementAnimationState::Idle;
+  anim.time = 4.0F;
+  (void)Render::GL::evaluate_elephant_motion(profile, anim, &state);
+  anim.movement_state = Render::Creature::MovementAnimationState::Walk;
+  auto const resumed = Render::GL::evaluate_elephant_motion(profile, anim, &state);
+  EXPECT_NEAR(resumed.phase, walking.phase, 1.0e-5F);
+}
+
 TEST(ElephantPrepare, SharedWalkRunClassifierControlsPreparedPlaybackState) {
   Render::GL::ElephantRendererBase const renderer;
   Render::GL::ElephantProfile profile = make_test_elephant_profile();

--- a/tests/render/creature/horse_prepare_test.cpp
+++ b/tests/render/creature/horse_prepare_test.cpp
@@ -543,6 +543,37 @@ TEST(HorsePrepare, MountOwnsItsLocomotionClockInsteadOfFollowingRiderLegPhase) {
   EXPECT_LT(advance, 0.03F);
 }
 
+TEST(HorsePrepare, AnInterruptedStartBlendsBackFromTheVisibleGait) {
+  auto const profile = Render::GL::make_horse_profile(
+      17U, QVector3D(0.4F, 0.3F, 0.2F), QVector3D(0.6F, 0.1F, 0.1F));
+  Render::Creature::HorseAnimationStateComponent state{};
+  Render::GL::HumanoidAnimationContext rider{};
+  rider.gait.state = Render::GL::HumanoidMotionState::Walk;
+  rider.gait.speed = 1.8F;
+  Render::GL::AnimationInputs anim{};
+  anim.movement_state = Render::Creature::MovementAnimationState::Walk;
+  (void)Render::GL::evaluate_horse_motion(profile, anim, rider, &state);
+  anim.time = 0.15F;
+  (void)Render::GL::evaluate_horse_motion(profile, anim, rider, &state);
+  float const expected_lift =
+      Render::GL::blend_gaits(
+          Render::GL::gait_for_type(Render::GL::GaitType::IDLE, profile.gait),
+          Render::GL::gait_for_type(Render::GL::GaitType::WALK, profile.gait),
+          0.5F)
+          .stride_lift;
+  rider.gait.state = Render::GL::HumanoidMotionState::Idle;
+  rider.gait.speed = 0.0F;
+  anim.movement_state = Render::Creature::MovementAnimationState::Idle;
+  auto const stopping = Render::GL::evaluate_horse_motion(profile, anim, rider, &state);
+  EXPECT_TRUE(stopping.is_moving);
+  EXPECT_EQ(stopping.playback_gait_type, Render::GL::GaitType::WALK);
+  EXPECT_NEAR(state.transition_source.stride_lift, expected_lift, 1.0e-5F);
+  EXPECT_GT(stopping.gait.stride_lift, 0.02F);
+  anim.time = 0.5F;
+  EXPECT_FALSE(
+      Render::GL::evaluate_horse_motion(profile, anim, rider, &state).is_moving);
+}
+
 TEST(HorsePrepare, HorseGaitsMapToSharedWalkRunAnimationStates) {
   using Render::Creature::MovementAnimationState;
 

--- a/tests/render/creature/humanoid_prepare_test.cpp
+++ b/tests/render/creature/humanoid_prepare_test.cpp
@@ -1749,6 +1749,59 @@ TEST(HumanoidPrepare, ActiveBuilderWorkOverridesSharedTravellingRowsWithCircle) 
   }
 }
 
+TEST(HumanoidPrepare, FormationGuardDoesNotInheritTheStrikeCarriersAuthoredClip) {
+  Render::GL::HumanoidRendererBase const owner;
+  Render::GL::DrawContext ctx{};
+  ctx.world_view = Render::WorldView::of(Game::Session::SessionContext::active());
+  ctx.allow_template_cache = false;
+  Engine::Core::StandaloneEntity scratch(4343);
+  auto& entity = scratch.entity();
+  auto* unit = entity.add_component<Engine::Core::UnitComponent>(100, 100, 1.0F, 2.0F);
+  unit->spawn_type = Game::Units::SpawnType::Spearman;
+  unit->render_individuals_per_unit_override = 2;
+  entity.add_component<Engine::Core::TransformComponent>();
+  auto* shared = entity.add_component<Engine::Core::FormationPresentationComponent>();
+  shared->rows = 1;
+  shared->cols = 2;
+  shared->melee_ordered = true;
+  shared->target_alive = true;
+  shared->target_id = 99;
+  for (std::uint16_t index = 0; index < 2; ++index) {
+    Engine::Core::FormationSoldierPresentation soldier;
+    soldier.slot_index = index;
+    soldier.col = index;
+    soldier.local_x = static_cast<float>(index);
+    soldier.alive = true;
+    soldier.opponent_id = 99;
+    soldier.damage_carrier = index == 1;
+    soldier.combat_role = index == 0
+                              ? Engine::Core::FormationSoldierCombatRole::Guard
+                              : Engine::Core::FormationSoldierCombatRole::LeadStrike;
+    soldier.action = index == 0 ? Engine::Core::FormationSoldierAction::MeleeGuard
+                                : Engine::Core::FormationSoldierAction::MeleeEngaged;
+    shared->soldiers.push_back(soldier);
+  }
+  ctx.entity = &entity;
+  Render::GL::AnimationInputs anim{};
+  anim.time = 2.0F;
+  anim.is_melee = true;
+  anim.is_attacking = true;
+  anim.is_in_melee_lock = true;
+  anim.attack_family = Engine::Core::CombatAttackFamily::Spear;
+  anim.has_authored_action_phase = true;
+  anim.authored_action_phase = 0.82F;
+  anim.has_authored_action_clip = true;
+  anim.authored_action_clip = Animation::k_humanoid_attack_spear_a_clip;
+  Render::Humanoid::HumanoidPreparation prep;
+  Render::Humanoid::prepare_humanoid_instances(
+      owner, ctx, anim, test_runtime(0U), prep);
+  auto const requests = prep.bodies.requests();
+  ASSERT_EQ(requests.size(), 2U);
+  EXPECT_NE(requests[0].clip_id, anim.authored_action_clip);
+  EXPECT_EQ(requests[1].clip_id, anim.authored_action_clip);
+  EXPECT_NEAR(requests[1].phase, anim.authored_action_phase, 1.0e-4F);
+}
+
 TEST(HumanoidPrepare, BuilderConstructionPlaybackUsesWorkClip) {
   using Render::Creature::AnimationStateId;
   using Render::Creature::Pipeline::humanoid_bpat_playback_for_anim;

--- a/tests/render/wildlife_clip_selection_test.cpp
+++ b/tests/render/wildlife_clip_selection_test.cpp
@@ -56,4 +56,50 @@ TEST(WildlifeClipSelection, AGrazingSheepStillHoldsItsGrazePose) {
   EXPECT_EQ(resolve_sheep_clip(state, GaitTier::Stand, true), AnimationStateId::Hold);
 }
 
+TEST(WildlifeLocomotion, FeetTrackDistanceDuringAccelerationAndStop) {
+  using namespace Render::GL::Wildlife;
+  DrawState state;
+  state.seed = 0xA17001U;
+  (void)gait_speed(state);
+  float const first = gait_phase(state, 1.0F);
+  state.time = 0.1F;
+  state.distance = 0.2F;
+  (void)gait_speed(state);
+  float const moved = gait_phase(state, 1.0F);
+  float const expected = first + 0.2F < 1.0F ? first + 0.2F : first - 0.8F;
+  EXPECT_NEAR(moved, expected, 1.0e-5F);
+
+  EXPECT_FLOAT_EQ(gait_phase(state, 1.0F), moved);
+  state.time = 0.2F;
+  EXPECT_GT(gait_speed(state), 0.0F);
+  EXPECT_FLOAT_EQ(gait_phase(state, 1.0F), moved);
+}
+
+TEST(WildlifeLocomotion, LongFrameDoesNotInventRunningSpeed) {
+  using namespace Render::GL::Wildlife;
+  DrawState state;
+  state.seed = 0xA17002U;
+  (void)gait_speed(state);
+  state.time = 1.0F;
+  state.distance = 1.0F;
+  EXPECT_LE(gait_speed(state), 1.0F);
+}
+
+TEST(WildlifeLocomotion, AStoppedWolfShowsItsBiteWindupImmediately) {
+  using namespace Render::GL::Wildlife;
+  DrawState state;
+  state.seed = 0xA17003U;
+  (void)gait_speed(state);
+  state.time = 0.1F;
+  state.distance = 0.4F;
+  EXPECT_GT(gait_speed(state), 0.5F);
+  (void)gait_phase(state, 1.0F);
+  state.time = 0.2F;
+  state.bite_progress = 0.01F;
+  float const speed = gait_speed(state);
+  auto const tier = resolve_gait_tier(state, speed / 4.6F, 0.02F, 0.55F);
+  EXPECT_EQ(tier, GaitTier::Stand);
+  EXPECT_EQ(resolve_wolf_clip(state, tier), AnimationStateId::AttackMelee);
+}
+
 } // namespace

--- a/tests/systems/battle_movement_refactor_test.cpp
+++ b/tests/systems/battle_movement_refactor_test.cpp
@@ -170,6 +170,53 @@ TEST_F(LocalAvoidanceTest, ContactPassDoesNotShoveAHoldingBody) {
             0.0F);
 }
 
+TEST_F(LocalAvoidanceTest, DenseContactsShareOneBoundedCorrectionPerBody) {
+  std::vector<Entity*> units;
+  for (int i = 0; i < 16; ++i) {
+    auto* entity = world->create_entity();
+    entity->add_component<TransformComponent>(5.0F, 0.0F, 5.0F);
+    entity->add_component<UnitComponent>(100, 100, 2.0F, 12.0F)->owner_id = 1;
+    entity->add_component<MovementComponent>();
+    entity->add_component<MovementFactsComponent>()->desired.valid = true;
+    units.push_back(entity);
+  }
+  BodyContactSystem contact;
+  float const dt = 1.0F / 60.0F;
+  contact.update(world.get(), dt);
+  for (auto const* entity : units) {
+    auto const& pos = entity->get_component<TransformComponent>()->position;
+    EXPECT_LE(std::hypot(pos.x - 5.0F, pos.z - 5.0F),
+              BodyContactSystem::k_separation_speed * dt + 1.0e-5F);
+  }
+  EXPECT_GT(contact.diagnostics().pairs_resolved, 0U);
+}
+
+TEST_F(LocalAvoidanceTest, ContactCorrectionSettlesWithoutMovingALockedFighter) {
+  auto* fighter = world->create_entity();
+  auto* fixed = fighter->add_component<TransformComponent>(5.0F, 0.0F, 5.0F);
+  fighter->add_component<UnitComponent>(100, 100, 2.0F, 12.0F);
+  fighter->add_component<MovementComponent>();
+  fighter->add_component<MovementFactsComponent>()->desired.valid = true;
+  fighter->add_component<AttackComponent>()->in_melee_lock = true;
+  auto* walker = world->create_entity();
+  auto* moved = walker->add_component<TransformComponent>(5.05F, 0.0F, 5.0F);
+  walker->add_component<UnitComponent>(100, 100, 2.0F, 12.0F);
+  walker->add_component<MovementComponent>();
+  walker->add_component<MovementFactsComponent>()->desired.valid = true;
+  BodyContactSystem contact;
+  for (int frame = 0; frame < 180; ++frame) {
+    float const previous_x = moved->position.x;
+    contact.update(world.get(), 1.0F / 60.0F);
+    EXPECT_GE(moved->position.x, previous_x);
+    EXPECT_FLOAT_EQ(fixed->position.x, 5.0F);
+    EXPECT_FLOAT_EQ(fixed->position.z, 5.0F);
+  }
+  float const settled_x = moved->position.x;
+  contact.update(world.get(), 1.0F / 60.0F);
+  EXPECT_FLOAT_EQ(moved->position.x, settled_x);
+  EXPECT_GT(settled_x, 5.1F);
+}
+
 TEST_F(LocalAvoidanceTest, StationaryUnitsNotDisplaced) {
 
   auto* stationary = world->create_entity();

--- a/tests/systems/command_service_test.cpp
+++ b/tests/systems/command_service_test.cpp
@@ -362,6 +362,28 @@ TEST_F(CommandServiceTest, SharpWaypointTurnLimitsSidewaysTranslation) {
   EXPECT_GT(std::hypot(movement->get_vx(), movement->get_vz()), 0.0F);
 }
 
+TEST_F(CommandServiceTest, FormationFacesItsRouteAroundAnObstacleInsteadOfTheGoal) {
+  Engine::Core::World world;
+  auto* entity = create_unit(world, 0.0F, 0.0F, Game::Units::SpawnType::Spearman);
+  entity->get_component<Engine::Core::UnitComponent>()
+      ->render_individuals_per_unit_override = 8;
+  ASSERT_TRUE(Game::Systems::FormationCombat::has_formation_slots(*entity));
+  auto* movement = entity->get_component<Engine::Core::MovementComponent>();
+  auto* transform = entity->get_component<Engine::Core::TransformComponent>();
+  MovementTestAccess::set_has_target(*movement, true);
+  MovementTestAccess::set_target_x(*movement, 0.0F);
+  MovementTestAccess::set_target_y(*movement, -10.0F);
+
+  auto* facts = entity->add_component<Engine::Core::MovementFactsComponent>();
+  facts->desired.valid = true;
+  facts->desired.velocity_x = 2.0F;
+  facts->desired.velocity_z = 0.0F;
+  Game::Systems::MovementSystem motor;
+  motor.update(&world, 1.0F / 60.0F);
+  EXPECT_GT(transform->rotation.y, 0.0F);
+  EXPECT_LT(transform->rotation.y, 90.0F);
+}
+
 TEST_F(CommandServiceTest, MoveOptionsControlFormationModePersistence) {
   Engine::Core::World world;
   auto* unit = create_unit(world, 0.0F, 0.0F, Game::Units::SpawnType::Archer);


### PR DESCRIPTION
Bound per-body contact separation so dense units receive a shared correction budget while melee-locked bodies remain anchored. Orient formations from the route follower's desired direction so obstacle navigation does not make ranks face the distant goal.

Preserve the visible horse gait when an interrupted transition is retargeted, keep horse and elephant locomotion clocks parked through idle pauses, and advance wildlife foot phases from measured travel distance rather than filtered speed. Allow stopped wolves to enter bite presentation immediately and keep authored action phases and clips with the formation soldier carrying the strike.

Add regression coverage for contact budgets, locked-fighter separation, route-facing, interrupted horse starts, elephant stride continuity, wildlife distance tracking and long-frame speed handling, bite entry, and formation clip ownership. Include the Arena movement and animation review with its coverage, findings, reproduction notes, and acceptance observations.