### PR TITLE
feat: add castable AI duel promo pipeline

### DIFF
--- a/docs/PROMO_CAPTURE.md
+++ b/docs/PROMO_CAPTURE.md
@@ -128,6 +128,66 @@ recording even though it was on screen in the arena window:
 A flame card records neither: it is a full-frame effect pass with no world
 behind it.
 
+## Casting a whole match
+
+A cast AI-versus-AI match is a different job from a formation reel: the shots
+have to follow a fight whose timing nobody knows in advance, the town building
+takes minutes that nobody will watch in real time, and a match that ends in a
+stalemate is not worth rendering at all. Four spec features carry that, and
+`tools/arena/promos/ai_war_of_towns_cast.json` uses all of them.
+
+**The dry run.** `"require_decision": true` makes the recorder play every
+scenario the spec names through once before capture, with rendering suppressed
+-- a thirty-minute match takes a minute or two -- and refuse to record when the
+battle reaches no decision. `--promo-precheck` forces the dry run for any spec,
+`--promo-precheck-only` stops after it. Either way the recorder writes
+`timeline.json` beside the clips: when the first wave committed (overall and per
+side), when the armies first met, when the first building fell (overall and per
+side), and when the match was decided, plus each side's closing census.
+
+**Event-driven starts.** A shot may name a match event instead of a second:
+
+```json
+{
+    "name": "first_blood",
+    "duration": 5.0,
+    "start_on": { "event": "first_contact", "offset": -1.0 }
+}
+```
+
+`event` is one of `first_wave`, `first_contact`, `first_building_lost` and
+`decision`; `side` narrows the first two per-side events to one label; `offset`
+may be negative. The recorder resolves every `start_on` from the dry run's
+timeline before planning its passes, so the rest of the pipeline sees ordinary
+`start` values. A shot whose event never happened fails the run by name.
+
+**Time-lapse.** `"time_lapse": 25` shows twenty-five simulation seconds in one
+screen second; it is `slow_motion` written the friendly way round for values
+below one, and a shot may not set both. The arena sub-steps the simulation so no
+system ever sees a tick longer than a thirtieth of a second, and the audio bed
+keeps to real time under a time-lapse rather than compressing minutes of battle
+into a roar. Camera rate limits are judged in screen seconds, so a pan that is
+calm on the clock but whips across a time-lapse is refused.
+
+**The casting strip.** `"casting_overlay": true` (spec-wide, or per shot) paints
+the broadcast strip along the top of every frame: each side's name under its
+colour, army and soldier count, town size, treasury, doctrine and state, a match
+clock, and a strength bar split between the sides by living soldiers. It is the
+same data the closing report card prints, drawn from the scenario runner's live
+census (`ArenaScenarioRunner::live_battle_sides`) and the session economy, in the
+card's typography.
+
+**The world edge.** The first full-match render framed the whole arena from
+130 m, and the corners of every frame showed the boundary mountains and the fog
+box behind them. `view_ground_footprint` in `promo_spec.h` projects a pose's four
+frame corners onto the ground; a frame "shows the world edge" when a corner
+looks over the horizon or lands beyond the scenario's flattened floor
+(`arena_floor_half_extent`, 58 m on the duel maps) plus a small margin.
+Point-focus shots are checked from their keys before capture
+(`world_edge_violations`); every recorded frame is checked at capture time and
+the count lands in `shots.json` as `edge_frames`. `"forbid_world_edge": true`
+turns that warning into a failed run.
+
 ## Transitions
 
 `promo-edit.py` joins the clips. Each shot's `transition` describes the cut

--- a/game/systems/ai_system/ai_attack_wave.cpp
+++ b/game/systems/ai_system/ai_attack_wave.cpp
@@ -383,6 +383,14 @@ void update_attack_wave(const AISnapshot& snapshot, AIContext& context) {
   wave.committed_at = snapshot.game_time;
 }
 
+auto wave_objective(const AISnapshot& snapshot,
+                    const AIContext& context) -> const ContactSnapshot* {
+  if (!context.wave.committed || context.wave.target_id == 0) {
+    return nullptr;
+  }
+  return find_contact(snapshot, context.wave.target_id);
+}
+
 auto wave_force_units(const AISnapshot& snapshot,
                       const AIContext& context) -> std::vector<const EntitySnapshot*> {
   std::vector<const EntitySnapshot*> result;

--- a/game/systems/ai_system/ai_attack_wave.h
+++ b/game/systems/ai_system/ai_attack_wave.h
@@ -14,6 +14,9 @@ wave_force_units(const AISnapshot& snapshot,
 
 [[nodiscard]] auto wave_size_for(const AIContext& context) -> int;
 
+[[nodiscard]] auto wave_objective(const AISnapshot& snapshot,
+                                  const AIContext& context) -> const ContactSnapshot*;
+
 [[nodiscard]] auto garrison_target_for(const AIContext& context,
                                        int combat_unit_count,
                                        int keep_free = 1) -> int;

--- a/game/systems/ai_system/ai_behavior.h
+++ b/game/systems/ai_system/ai_behavior.h
@@ -22,6 +22,12 @@ public:
   [[nodiscard]] virtual auto get_priority() const -> BehaviorPriority = 0;
 
   [[nodiscard]] virtual auto can_run_concurrently() const -> bool { return false; }
+
+  [[nodiscard]] virtual auto
+  yields_to_exclusive(const AIContext& context) const -> bool {
+    (void)context;
+    return !can_run_concurrently();
+  }
 };
 
 } // namespace Game::Systems::AI

--- a/game/systems/ai_system/ai_executor.cpp
+++ b/game/systems/ai_system/ai_executor.cpp
@@ -17,7 +17,7 @@ void AIExecutor::run(const AISnapshot& snapshot,
   bool exclusive_behavior_executed = false;
 
   registry.for_each([&](AIBehavior& behavior) {
-    if (exclusive_behavior_executed && !behavior.can_run_concurrently()) {
+    if (exclusive_behavior_executed && behavior.yields_to_exclusive(context)) {
       return;
     }
 

--- a/game/systems/ai_system/behaviors/attack_behavior.cpp
+++ b/game/systems/ai_system/behaviors/attack_behavior.cpp
@@ -2,6 +2,7 @@
 
 #include <QVector3D>
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <utility>
@@ -79,6 +80,10 @@ auto select_strategic_objective(const AISnapshot& snapshot,
   return best_objective;
 }
 } // namespace
+
+auto AttackBehavior::yields_to_exclusive(const AIContext& context) const -> bool {
+  return !(context.wave.committed && !context.wave.members.empty());
+}
 
 void AttackBehavior::execute(const AISnapshot& snapshot,
                              AIContext& context,
@@ -274,6 +279,27 @@ void AttackBehavior::execute(const AISnapshot& snapshot,
         }
       }
 
+      if (target == nullptr) {
+        target = wave_objective(snapshot, context);
+      }
+      if (target == nullptr) {
+        for (const auto& enemy : snapshot.visible_enemies) {
+          if (!enemy.is_building || enemy.health <= 0) {
+            continue;
+          }
+          float const dist_sq = distance_squared(enemy.pos_x,
+                                                 enemy.pos_y,
+                                                 enemy.pos_z,
+                                                 group_center_x,
+                                                 group_center_y,
+                                                 group_center_z);
+          if (dist_sq < closest_dist_sq) {
+            closest_dist_sq = dist_sq;
+            target = &enemy;
+          }
+        }
+      }
+
       if ((target != nullptr) && !ready_units.empty()) {
 
         float attack_pos_x = target->pos_x;
@@ -346,8 +372,14 @@ void AttackBehavior::execute(const AISnapshot& snapshot,
       ready_units, nearby_enemies, context.state == AIState::Attacking ? 0.7F : 0.9F);
 
   bool const being_attacked = context.damaged_units_count > 0;
+  bool const only_buildings_in_reach =
+      std::none_of(nearby_enemies.begin(),
+                   nearby_enemies.end(),
+                   [](const ContactSnapshot* enemy) { return !enemy->is_building; });
+  bool const wave_at_the_walls = context.wave.committed && only_buildings_in_reach;
 
-  if (!assessment.should_engage && !context.barracks_under_threat && !being_attacked) {
+  if (!assessment.should_engage && !context.barracks_under_threat && !being_attacked &&
+      !wave_at_the_walls) {
 
     m_last_target = 0;
     m_target_lock_duration = 0.0F;
@@ -381,6 +413,33 @@ void AttackBehavior::execute(const AISnapshot& snapshot,
       objective != nullptr && assessment.force_ratio >= k_siege_superiority_ratio) {
 
     target_info.target_id = objective->id;
+  }
+
+  if (target_info.target_id == 0 &&
+      (context.wave.committed || context.state == AIState::Attacking)) {
+    const ContactSnapshot* building = nullptr;
+    float best_score = std::numeric_limits<float>::max();
+    for (const auto* enemy : nearby_enemies) {
+      if (!enemy->is_building || enemy->health <= 0) {
+        continue;
+      }
+      float score = distance_squared(enemy->pos_x,
+                                     enemy->pos_y,
+                                     enemy->pos_z,
+                                     group_center_x,
+                                     group_center_y,
+                                     group_center_z);
+      if (enemy->spawn_type == Game::Units::SpawnType::DefenseTower) {
+        score *= 0.25F;
+      }
+      if (score < best_score) {
+        best_score = score;
+        building = enemy;
+      }
+    }
+    if (building != nullptr) {
+      target_info.target_id = building->id;
+    }
   }
 
   if (target_info.target_id == 0) {

--- a/game/systems/ai_system/behaviors/attack_behavior.h
+++ b/game/systems/ai_system/behaviors/attack_behavior.h
@@ -20,6 +20,9 @@ public:
 
   [[nodiscard]] auto can_run_concurrently() const -> bool override { return false; }
 
+  [[nodiscard]] auto
+  yields_to_exclusive(const AIContext& context) const -> bool override;
+
 private:
   float m_attack_timer = 0.0F;
   Engine::Core::EntityID m_last_target = 0;

--- a/game/systems/ai_system/behaviors/builder_behavior.cpp
+++ b/game/systems/ai_system/behaviors/builder_behavior.cpp
@@ -9,6 +9,7 @@
 #include <initializer_list>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -384,6 +385,14 @@ auto locked_settlement_facing(const AIContext& context,
     return {context.settlement_facing_x, context.settlement_facing_z};
   }
   return settlement_facing(context, snapshot);
+}
+
+auto is_fortification(const char* building_type) -> bool {
+  if (building_type == nullptr) {
+    return false;
+  }
+  const std::string_view type(building_type);
+  return type == BUILDING_TYPE_WALL_SEGMENT || type == BUILDING_TYPE_WALL_GATE;
 }
 
 auto slot_clearance(const char* building_type,
@@ -1415,8 +1424,11 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
     wish(BUILDING_TYPE_MARKETPLACE);
   }
   constexpr int k_roofs_before_the_castle = 4;
+  const bool plan_step_is_a_fortification =
+      has_plan_step && is_fortification(planned.building);
   if (targets.raise_homes_first && standing.homes < MAX_HOMES &&
-      !(has_plan_step && standing.homes >= k_roofs_before_the_castle)) {
+      (!has_plan_step || standing.homes < k_roofs_before_the_castle ||
+       plan_step_is_a_fortification)) {
 
     wish(BUILDING_TYPE_HOME);
   }

--- a/game/systems/ai_system/behaviors/defend_behavior.cpp
+++ b/game/systems/ai_system/behaviors/defend_behavior.cpp
@@ -109,6 +109,11 @@ void DefendBehavior::execute(const AISnapshot& snapshot,
       continue;
     }
 
+    if (!context.strategy_config.full_recall_on_base_threat &&
+        marches_with_the_wave(entity.id, context)) {
+      continue;
+    }
+
     if (is_entity_engaged(entity, snapshot.visible_enemies)) {
       engaged_defenders.push_back(&entity);
     } else {

--- a/render/entity/building_archetype_desc.cpp
+++ b/render/entity/building_archetype_desc.cpp
@@ -164,6 +164,21 @@ void BuildingArchetypeDesc::add_palette_box(const QVector3D& center,
   m_parts.push_back(std::move(part));
 }
 
+void BuildingArchetypeDesc::add_palette_rotated_box(const QVector3D& center,
+                                                    const QVector3D& scale,
+                                                    const QVector3D& euler_deg,
+                                                    std::uint8_t palette_slot,
+                                                    BuildingStateMask states) {
+  BuildingPartDesc part;
+  part.kind = BuildingPartKind::PaletteRotatedBox;
+  part.point_a = center;
+  part.point_b = scale;
+  part.euler_deg = euler_deg;
+  part.palette_slot = palette_slot;
+  part.states = states;
+  m_parts.push_back(std::move(part));
+}
+
 void BuildingArchetypeDesc::add_rotated_box(const QVector3D& center,
                                             const QVector3D& scale,
                                             const QVector3D& euler_deg,

--- a/render/entity/building_archetype_desc.h
+++ b/render/entity/building_archetype_desc.h
@@ -65,6 +65,12 @@ public:
                        std::uint8_t palette_slot,
                        BuildingStateMask states = BuildingStateMask::All);
 
+  void add_palette_rotated_box(const QVector3D& center,
+                               const QVector3D& scale,
+                               const QVector3D& euler_deg,
+                               std::uint8_t palette_slot,
+                               BuildingStateMask states = BuildingStateMask::All);
+
   void add_rotated_box(const QVector3D& center,
                        const QVector3D& scale,
                        const QVector3D& euler_deg,

--- a/render/entity/home_renderer_common.h
+++ b/render/entity/home_renderer_common.h
@@ -13,7 +13,10 @@
 namespace Render::GL {
 
 using HomeArchetypeResolver = const RenderArchetype& (*)(BuildingState);
-using HomePaletteSlotsResolver = std::array<QVector3D, 1> (*)(const QVector3D&);
+
+inline constexpr std::size_t k_home_palette_slots = 2;
+using HomePaletteSlotsResolver =
+    std::array<QVector3D, k_home_palette_slots> (*)(const QVector3D&);
 
 struct HomeRendererConfig {
   std::string_view nation_slug;

--- a/render/entity/marketplace_renderer_common.cpp
+++ b/render/entity/marketplace_renderer_common.cpp
@@ -1,5 +1,7 @@
 #include "marketplace_renderer_common.h"
 
+#include "../entity_appearance.h"
+
 namespace Render::GL {
 
 void register_marketplace_renderer_variant(EntityRendererRegistry& registry,
@@ -9,8 +11,17 @@ void register_marketplace_renderer_variant(EntityRendererRegistry& registry,
       config.nation_slug,
       "marketplace",
       [config](const DrawContext& ctx, ISubmitter& out) {
+        if (ctx.entity == nullptr) {
+          return;
+        }
         const BuildingState state = resolve_building_state(ctx);
-        submit_building_instance(out, ctx, config.archetype(state));
+        if (config.palette_slots != nullptr) {
+          const QVector3D team = Render::entity_color(*ctx.entity);
+          const auto palette_slots = config.palette_slots(team);
+          submit_building_instance(out, ctx, config.archetype(state), palette_slots);
+        } else {
+          submit_building_instance(out, ctx, config.archetype(state));
+        }
         draw_building_selection_overlay(out, ctx, config.selection);
       });
 }

--- a/render/entity/marketplace_renderer_common.h
+++ b/render/entity/marketplace_renderer_common.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QVector3D>
+
+#include <array>
 #include <string_view>
 
 #include "building_render_common.h"
@@ -10,10 +13,13 @@
 namespace Render::GL {
 
 using MarketplaceArchetypeResolver = const RenderArchetype& (*)(BuildingState);
+using MarketplacePaletteSlotsResolver = std::array<QVector3D, 1> (*)(const QVector3D&);
 
 struct MarketplaceRendererConfig {
   std::string_view nation_slug;
   MarketplaceArchetypeResolver archetype;
+
+  MarketplacePaletteSlotsResolver palette_slots;
   BuildingSelectionStyle selection;
 };
 

--- a/render/entity/nations/carthage/home_renderer.cpp
+++ b/render/entity/nations/carthage/home_renderer.cpp
@@ -22,6 +22,9 @@ namespace {
 using Render::Geom::clamp_vec_01;
 
 constexpr std::uint8_t k_home_team_slot = 0;
+constexpr std::uint8_t k_home_roof_slot = 1;
+
+constexpr float k_roof_owner_blend = 0.42F;
 
 struct CarthagePalette {
   QVector3D stone_light{0.88F, 0.79F, 0.63F};
@@ -47,8 +50,12 @@ inline auto make_palette(const QVector3D& team) -> CarthagePalette {
   return p;
 }
 
-auto home_palette_slots(const QVector3D& team) -> std::array<QVector3D, 1> {
-  return {make_palette(team).team};
+auto home_palette_slots(const QVector3D& team)
+    -> std::array<QVector3D, k_home_palette_slots> {
+  const auto palette = make_palette(team);
+  const QVector3D roof = clamp_vec_01(palette.tile_red * (1.0F - k_roof_owner_blend) +
+                                      palette.team * k_roof_owner_blend);
+  return {palette.team, roof};
 }
 
 auto build_home_archetype(BuildingState state) -> RenderArchetype {
@@ -120,10 +127,10 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
   }
 
   float const roof_y = wall_height * height_multiplier + 0.24F;
-  desc.add_box(QVector3D(0.0F, roof_y, 0.0F),
-               QVector3D(1.02F, 0.05F, 1.02F),
-               c.tile_red,
-               k_building_state_mask_intact);
+  desc.add_palette_box(QVector3D(0.0F, roof_y, 0.0F),
+                       QVector3D(1.02F, 0.05F, 1.02F),
+                       k_home_roof_slot,
+                       k_building_state_mask_intact);
   add_tile_rows_z(
       [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
         desc.add_box(center, size, color, k_building_state_mask_intact);

--- a/render/entity/nations/carthage/marketplace_renderer.cpp
+++ b/render/entity/nations/carthage/marketplace_renderer.cpp
@@ -3,6 +3,8 @@
 #include <QMatrix4x4>
 #include <QVector3D>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 
 #include "game/core/component.h"
@@ -50,7 +52,13 @@ struct CarthageMarketPalette {
   QVector3D ember{0.76F, 0.19F, 0.025F};
 };
 
-constexpr std::uint8_t k_marketplace_team_slot = 1;
+constexpr std::uint8_t k_marketplace_team_slot = 0;
+
+auto marketplace_palette_slots(const QVector3D& team) -> std::array<QVector3D, 1> {
+  return {QVector3D(std::clamp(team.x(), 0.0F, 1.0F),
+                    std::clamp(team.y(), 0.0F, 1.0F),
+                    std::clamp(team.z(), 0.0F, 1.0F))};
+}
 
 void add_punic_amphora(BuildingArchetypeDesc& desc,
                        const QVector3D& base,
@@ -440,6 +448,7 @@ void register_marketplace_renderer(EntityRendererRegistry& registry) {
       registry,
       MarketplaceRendererConfig{.nation_slug = "carthage",
                                 .archetype = &marketplace_archetype,
+                                .palette_slots = &marketplace_palette_slots,
                                 .selection = BuildingSelectionStyle{1.7F, 1.7F}});
 }
 

--- a/render/entity/nations/roman/home_renderer.cpp
+++ b/render/entity/nations/roman/home_renderer.cpp
@@ -22,6 +22,9 @@ namespace {
 using Render::Geom::clamp_vec_01;
 
 constexpr std::uint8_t k_home_team_slot = 0;
+constexpr std::uint8_t k_home_roof_slot = 1;
+
+constexpr float k_roof_owner_blend = 0.42F;
 
 struct RomanPalette {
   QVector3D limestone{0.96F, 0.94F, 0.88F};
@@ -47,8 +50,12 @@ inline auto make_palette(const QVector3D& team) -> RomanPalette {
   return p;
 }
 
-auto home_palette_slots(const QVector3D& team) -> std::array<QVector3D, 1> {
-  return {make_palette(team).team};
+auto home_palette_slots(const QVector3D& team)
+    -> std::array<QVector3D, k_home_palette_slots> {
+  const auto palette = make_palette(team);
+  const QVector3D roof = clamp_vec_01(palette.terracotta * (1.0F - k_roof_owner_blend) +
+                                      palette.team * k_roof_owner_blend);
+  return {palette.team, roof};
 }
 
 auto build_home_archetype(BuildingState state) -> RenderArchetype {
@@ -231,8 +238,23 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
   };
   float const eave_y = cornice_y + 0.02F;
   float const roof_rise = 0.55F * height_multiplier;
-  add_gable_roof_z(
-      add_rot, 0.0F, 0.0F, eave_y, 0.98F, 0.98F, roof_rise, 0.05F, c.terracotta, 0.07F);
+  auto add_roof_slab = [&](const QVector3D& center,
+                           const QVector3D& scale,
+                           const QVector3D& euler,
+                           const QVector3D&) {
+    desc.add_palette_rotated_box(
+        center, scale, euler, k_home_roof_slot, k_building_state_mask_intact);
+  };
+  add_gable_roof_z(add_roof_slab,
+                   0.0F,
+                   0.0F,
+                   eave_y,
+                   0.98F,
+                   0.98F,
+                   roof_rise,
+                   0.05F,
+                   c.terracotta,
+                   0.07F);
 
   desc.add_box(QVector3D(0.0F, eave_y + roof_rise + 0.01F, 0.0F),
                QVector3D(0.05F, 0.03F, 1.04F),

--- a/render/entity/nations/roman/marketplace_renderer.cpp
+++ b/render/entity/nations/roman/marketplace_renderer.cpp
@@ -3,6 +3,8 @@
 #include <QMatrix4x4>
 #include <QVector3D>
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 
 #include "game/core/component.h"
@@ -48,7 +50,13 @@ struct RomanMarketPalette {
   QVector3D gold{0.72F, 0.53F, 0.20F};
 };
 
-constexpr std::uint8_t k_marketplace_team_slot = 1;
+constexpr std::uint8_t k_marketplace_team_slot = 0;
+
+auto marketplace_palette_slots(const QVector3D& team) -> std::array<QVector3D, 1> {
+  return {QVector3D(std::clamp(team.x(), 0.0F, 1.0F),
+                    std::clamp(team.y(), 0.0F, 1.0F),
+                    std::clamp(team.z(), 0.0F, 1.0F))};
+}
 
 void add_amphora(BuildingArchetypeDesc& desc,
                  const QVector3D& base,
@@ -443,6 +451,7 @@ void register_marketplace_renderer(EntityRendererRegistry& registry) {
       registry,
       MarketplaceRendererConfig{.nation_slug = "roman",
                                 .archetype = &marketplace_archetype,
+                                .palette_slots = &marketplace_palette_slots,
                                 .selection = BuildingSelectionStyle{1.8F, 1.8F}});
 }
 

--- a/scripts/beat-align.py
+++ b/scripts/beat-align.py
@@ -31,6 +31,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+
+def shot_slow_motion(shot: dict) -> float:
+    """`time_lapse` is `slow_motion` written for values below one."""
+    if "time_lapse" in shot and "slow_motion" not in shot:
+        return 1.0 / max(1.0, float(shot["time_lapse"]))
+    return float(shot.get("slow_motion", 1.0))
+
+
 SAMPLE_RATE = 8000
 HOP = 128
 MIN_BPM, MAX_BPM = 70.0, 190.0
@@ -162,7 +170,7 @@ def quantise(spec: dict, grid: dict, min_beats: int, punch_every: int) -> list[s
     for shot in spec.get("shots", []):
         if shot.get("flame_card"):
             continue
-        slow = float(shot.get("slow_motion", 1.0))
+        slow = shot_slow_motion(shot)
         clip = float(shot["duration"]) * slow
 
         freeze = float(shot.get("freeze", 0.0) or 0.0)
@@ -231,9 +239,7 @@ def main() -> int:
     notes = quantise(spec, grid, args.min_beats, args.punch_every)
     args.spec.write_text(json.dumps(spec, indent=2) + "\n")
 
-    total = sum(
-        shot["duration"] * shot.get("slow_motion", 1.0) for shot in spec["shots"]
-    )
+    total = sum(shot["duration"] * shot_slow_motion(shot) for shot in spec["shots"])
     source = "detected" if grid.get("detected") else "from the track's grid sidecar"
     print(
         f"beat-align: {grid['bpm']} BPM {source}; "

--- a/scripts/place-promo-cues.py
+++ b/scripts/place-promo-cues.py
@@ -27,6 +27,14 @@ Two things it refuses to do quietly:
 import json
 import sys
 
+
+def shot_slow_motion(shot: dict) -> float:
+    """`time_lapse` is `slow_motion` written for values below one."""
+    if "time_lapse" in shot and "slow_motion" not in shot:
+        return 1.0 / max(1.0, float(shot["time_lapse"]))
+    return float(shot.get("slow_motion", 1.0))
+
+
 trace, spec_path = sys.argv[1], sys.argv[2]
 prev = {}
 alive = None
@@ -60,7 +68,7 @@ DEF = spec.get("transition", {"type": "dissolve", "duration": 0.4})
 shots = []
 t = 0.0
 for i, s in enumerate(spec["shots"]):
-    slow = s.get("slow_motion", 1.0)
+    slow = shot_slow_motion(s)
     if i > 0:
         tr = s.get("transition", DEF)
         t -= 0.0 if tr["type"] == "cut" else float(tr["duration"])

--- a/scripts/place-rally-cues.py
+++ b/scripts/place-rally-cues.py
@@ -17,6 +17,14 @@ re-run this after any retime.
 import json
 import sys
 
+
+def shot_slow_motion(shot: dict) -> float:
+    """`time_lapse` is `slow_motion` written for values below one."""
+    if "time_lapse" in shot and "slow_motion" not in shot:
+        return 1.0 / max(1.0, float(shot["time_lapse"]))
+    return float(shot.get("slow_motion", 1.0))
+
+
 trace_path, spec_path = sys.argv[1], sys.argv[2]
 
 alive = {}
@@ -47,7 +55,7 @@ DEFAULT = spec.get("transition", {"type": "cut", "duration": 0.0})
 shots = []
 finished = 0.0
 for index, shot in enumerate(spec["shots"]):
-    slow = shot.get("slow_motion", 1.0)
+    slow = shot_slow_motion(shot)
     if index > 0:
         join = shot.get("transition", DEFAULT)
         if join.get("type") != "cut":

--- a/scripts/place-trailer-cues.py
+++ b/scripts/place-trailer-cues.py
@@ -31,6 +31,14 @@ import json
 import sys
 from pathlib import Path
 
+
+def shot_slow_motion(shot: dict) -> float:
+    """`time_lapse` is `slow_motion` written for values below one."""
+    if "time_lapse" in shot and "slow_motion" not in shot:
+        return 1.0 / max(1.0, float(shot["time_lapse"]))
+    return float(shot.get("slow_motion", 1.0))
+
+
 ROOT = Path(__file__).resolve().parent.parent
 SPEC = (
     Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT / "tools/arena/promos/trailer.json"
@@ -109,7 +117,7 @@ def timeline(spec: dict) -> dict[str, float]:
             overlap = float(join.get("duration", 0.35))
         start = max(0.0, end - overlap)
         starts[shot["name"]] = start
-        end = start + float(shot["duration"]) * float(shot.get("slow_motion", 1.0))
+        end = start + float(shot["duration"]) * shot_slow_motion(shot)
     starts["__total__"] = end
     return starts
 

--- a/scripts/promo-edit.py
+++ b/scripts/promo-edit.py
@@ -284,6 +284,14 @@ def shorter_arc(from_degrees: float, to_degrees: float) -> float:
     return delta - 360.0 if delta > 180.0 else delta
 
 
+def shot_slow_motion(shot: dict) -> float:
+    """Simulation seconds per screen second is 1 / this; `time_lapse` is the
+    same knob written the friendly way round for values below one."""
+    if "time_lapse" in shot and "slow_motion" not in shot:
+        return 1.0 / max(1.0, float(shot["time_lapse"]))
+    return float(shot.get("slow_motion", 1.0))
+
+
 def camera_offences(spec: dict) -> list[str]:
     """Author-time camera limits, mirrored from `Arena::Promo::motion_violations`."""
     offences: list[str] = []
@@ -292,7 +300,8 @@ def camera_offences(spec: dict) -> list[str]:
         if shot.get("flame_card"):
             continue
         name = shot.get("name", "?")
-        clip = float(shot.get("duration", 0.0)) * float(shot.get("slow_motion", 1.0))
+        slow_motion = shot_slow_motion(shot)
+        clip = float(shot.get("duration", 0.0)) * slow_motion
         clips.append(clip)
         if clip + 1e-3 < MOTION_LIMITS["min_clip"]:
             offences.append(
@@ -315,8 +324,11 @@ def camera_offences(spec: dict) -> list[str]:
                 )
                 break
         for before, after in zip(keys, keys[1:], strict=False):
+
             span = max(
-                0.001, float(after.get("time", 0.0)) - float(before.get("time", 0.0))
+                0.001,
+                (float(after.get("time", 0.0)) - float(before.get("time", 0.0)))
+                * slow_motion,
             )
             for axis, limit, delta in (
                 (

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -636,6 +636,7 @@ add_executable(
     tools/arena_unit_spawn_options_test.cpp
     tools/arena_terrain_alignment_test.cpp
     tools/arena_promo_spec_test.cpp
+    tools/arena_casting_overlay_test.cpp
     tools/arena_matchup_short_test.cpp
     tools/arena_video_encoder_test.cpp
     tools/settlement_layout_test.cpp
@@ -656,6 +657,7 @@ target_link_libraries(
         arena_scenario_harness
         arena_panels
         arena_feedback
+        arena_casting_overlay
 )
 soi_register_test_binary(arena_tests)
 if(TARGET bake_creature_assets)

--- a/tests/headless/ai_duel_match_test.cpp
+++ b/tests/headless/ai_duel_match_test.cpp
@@ -27,6 +27,7 @@
 #include "game/systems/nation_registry.h"
 #include "game/systems/nav_grid.h"
 #include "game/systems/owner_registry.h"
+#include "game/systems/pathfinding.h"
 #include "game/systems/player_resource_registry.h"
 #include "game/systems/runtime_system_registry.h"
 #include "game/systems/structure_placement_service.h"
@@ -48,6 +49,64 @@ constexpr int k_south = 3;
 constexpr int k_north_grid = 26;
 constexpr int k_south_grid = k_map_size - 26;
 constexpr int k_opening_builders = 4;
+
+struct DuelSetup {
+  bool river_and_bridge = false;
+  int gold = 500;
+};
+
+constexpr float k_river_crossing_margin = 8.0F;
+
+auto is_across_the_river(int owner, float x, float z) -> bool {
+  const float along = x + z;
+  return owner == k_north ? along > k_river_crossing_margin
+                          : along < -k_river_crossing_margin;
+}
+
+void add_river_and_bridge(Game::Map::MapDefinition& map) {
+  using Game::Map::HillShape;
+  using Game::Map::TerrainType;
+  const auto reach = [](float x, float z) {
+    return QVector3D{x, 0.0F, z};
+  };
+  map.rivers.push_back(
+      Game::Map::RiverSegment{reach(-60.10F, 67.18F), reach(-31.47F, 27.93F), 12.0F});
+  map.rivers.push_back(
+      Game::Map::RiverSegment{reach(-31.47F, 27.93F), reach(-9.90F, 9.90F), 11.0F});
+  map.rivers.push_back(
+      Game::Map::RiverSegment{reach(-9.90F, 9.90F), reach(9.90F, -9.90F), 10.0F});
+  map.rivers.push_back(
+      Game::Map::RiverSegment{reach(9.90F, -9.90F), reach(27.93F, -31.47F), 11.0F});
+  map.rivers.push_back(
+      Game::Map::RiverSegment{reach(27.93F, -31.47F), reach(67.18F, -60.10F), 12.0F});
+  map.bridges.push_back(
+      Game::Map::Bridge{{-5.7F, 0.0F, -5.7F}, {5.7F, 0.0F, 5.7F}, 10.0F, 0.5F});
+
+  const auto hill = [&map](float x,
+                           float z,
+                           float radius,
+                           float height,
+                           HillShape shape,
+                           float thickness,
+                           float rotation) {
+    Game::Map::TerrainFeature feature;
+    feature.type = TerrainType::Hill;
+    feature.center_x = x;
+    feature.center_z = z;
+    feature.radius = radius;
+    feature.height = height;
+    feature.shape = shape;
+    feature.thickness = thickness;
+    feature.rotation_deg = rotation;
+    map.terrain.push_back(feature);
+  };
+  hill(1.41F, -28.28F, 12.0F, 3.6F, HillShape::Corridor, 5.0F, -45.0F);
+  hill(-1.41F, 28.28F, 12.0F, 3.6F, HillShape::Corridor, 5.0F, -45.0F);
+  hill(-43.84F, 2.83F, 11.0F, 4.0F, HillShape::Blob, 7.0F, 0.0F);
+  hill(43.84F, -2.83F, 11.0F, 4.0F, HillShape::Blob, 7.0F, 0.0F);
+  hill(-38.89F, -6.36F, 11.0F, 3.6F, HillShape::Elbow, 5.5F, 135.0F);
+  hill(38.89F, 6.36F, 11.0F, 3.6F, HillShape::Arc, 5.0F, -45.0F);
+}
 
 struct SideReport {
   int buildings = 0;
@@ -77,6 +136,13 @@ struct SideHistory {
   int harvested = 0;
   float commander_lost_at = -1.0F;
   float commander_last_distance_from_home = 0.0F;
+
+  int most_across_the_river = 0;
+  float crossed_the_river_at = -1.0F;
+
+  int buildings_lost = 0;
+
+  float eliminated_at = -1.0F;
 };
 
 class AiDuelMatchTest : public ::testing::Test {
@@ -109,7 +175,8 @@ protected:
   auto make_duel(Game::Units::SpawnType north_commander,
                  Game::Systems::NationID north_nation,
                  Game::Units::SpawnType south_commander,
-                 Game::Systems::NationID south_nation) -> SessionContext& {
+                 Game::Systems::NationID south_nation,
+                 const DuelSetup& setup = {}) -> SessionContext& {
     m_session = std::make_unique<SessionContext>();
     auto& session = *m_session;
     session.world().set_presentation_enabled(false);
@@ -131,6 +198,9 @@ protected:
     map_definition.grid.tile_size = 1.0F;
     scatter_resources(map_definition, k_north_grid, k_north_grid);
     scatter_resources(map_definition, k_south_grid, k_south_grid);
+    if (setup.river_and_bridge) {
+      add_river_and_bridge(map_definition);
+    }
     session.terrain().initialize(map_definition);
 
     Game::Systems::register_runtime_systems(session.world());
@@ -138,7 +208,7 @@ protected:
     for (const int owner : {k_north, k_south}) {
       auto& economy = session.economy();
       economy.ensure_owner(owner);
-      economy.set(owner, Game::Systems::ResourceType::Gold, 500);
+      economy.set(owner, Game::Systems::ResourceType::Gold, setup.gold);
       economy.set(owner, Game::Systems::ResourceType::Food, 200);
       economy.set(owner, Game::Systems::ResourceType::Wood, 250);
       economy.set(owner, Game::Systems::ResourceType::Stone, 120);
@@ -356,6 +426,23 @@ protected:
     return 0.0F;
   }
 
+  static auto fighters_across_the_river(SessionContext& session, int owner) -> int {
+    int across = 0;
+    for (auto [id, unit, transform] :
+         session.world().view<UnitComponent, Engine::Core::TransformComponent>()) {
+      if (unit.owner_id != owner || unit.health <= 0 ||
+          Game::Units::is_building_spawn(unit.spawn_type) ||
+          unit.spawn_type == Game::Units::SpawnType::Builder ||
+          unit.spawn_type == Game::Units::SpawnType::Civilian) {
+        continue;
+      }
+      if (is_across_the_river(owner, transform.position.x, transform.position.z)) {
+        ++across;
+      }
+    }
+    return across;
+  }
+
   static void
   observe(SessionContext& session, int owner, float minute, SideHistory& history) {
     const auto report = survey(session, owner);
@@ -364,6 +451,18 @@ protected:
     if (report.commander_alive) {
       history.commander_last_distance_from_home =
           commander_distance_from_home(session, owner);
+    }
+
+    const int across = fighters_across_the_river(session, owner);
+    history.most_across_the_river = std::max(history.most_across_the_river, across);
+    if (across > 0 && history.crossed_the_river_at < 0.0F) {
+      history.crossed_the_river_at = minute;
+    }
+    history.buildings_lost =
+        std::max(history.buildings_lost, history.most_buildings - report.buildings);
+    if (history.most_buildings > 0 && report.buildings == 0 && report.fighters == 0 &&
+        !report.commander_alive && history.eliminated_at < 0.0F) {
+      history.eliminated_at = minute;
     }
 
     history.most_buildings = std::max(history.most_buildings, report.buildings);
@@ -397,6 +496,105 @@ protected:
     for (const auto& side : sides) {
       const auto report = survey(session, side.first);
       const auto* plan = ai != nullptr ? ai->plan_for(side.first) : nullptr;
+      if (qEnvironmentVariableIsSet("SOI_DUEL_WAVE") && plan != nullptr) {
+        std::printf("    %s wave committed %d target %llu at %.1f,%.1f members %zu\n",
+                    side.second,
+                    plan->wave.committed ? 1 : 0,
+                    static_cast<unsigned long long>(plan->wave.target_id),
+                    plan->wave.target_x,
+                    plan->wave.target_z,
+                    plan->wave.members.size());
+        for (auto [id, unit, transform, movement] :
+             session.world()
+                 .view<UnitComponent,
+                       Engine::Core::TransformComponent,
+                       Engine::Core::MovementComponent>()) {
+          if (unit.owner_id != side.first || unit.health <= 0 ||
+              Game::Units::is_building_spawn(unit.spawn_type) ||
+              unit.spawn_type == Game::Units::SpawnType::Builder ||
+              unit.spawn_type == Game::Units::SpawnType::Civilian) {
+            continue;
+          }
+          const bool in_wave =
+              std::find(plan->wave.members.begin(), plan->wave.members.end(), id) !=
+              plan->wave.members.end();
+
+          auto reach = [&](float gx, float gz) -> std::string {
+            auto* pathfinder = Game::Systems::NavGrid::get_pathfinder();
+            if (pathfinder == nullptr) {
+              return "?";
+            }
+            const auto from = Game::Systems::NavGrid::world_to_grid(
+                transform.position.x, transform.position.z);
+            const auto to = Game::Systems::NavGrid::world_to_grid(gx, gz);
+            const auto path = pathfinder->find_path(from, to);
+            const bool complete = !path.empty() && path.back() == to;
+            return std::to_string(path.size()) + (complete ? "" : "!");
+          };
+          const std::string to_objective =
+              in_wave ? reach(plan->wave.target_x, plan->wave.target_z) : "-";
+          const std::string to_bridge = in_wave ? reach(0.0F, 0.0F) : "-";
+          std::printf("      %s%s %llu at %.1f,%.1f hp %d -> goal %.1f,%.1f target %d "
+                      "path %zu/%zu | reach objective %s bridge %s\n",
+                      in_wave ? "W " : "  ",
+                      Game::Units::spawn_typeToString(unit.spawn_type).c_str(),
+                      static_cast<unsigned long long>(id),
+                      transform.position.x,
+                      transform.position.z,
+                      unit.health,
+                      movement.get_goal_x(),
+                      movement.get_goal_y(),
+                      movement.get_has_target() ? 1 : 0,
+                      movement.get_path_index(),
+                      movement.get_path().size(),
+                      to_objective.c_str(),
+                      to_bridge.c_str());
+        }
+      }
+      if (qEnvironmentVariableIsSet("SOI_DUEL_CIVILIANS")) {
+        for (auto [id, unit, transform, movement] :
+             session.world()
+                 .view<UnitComponent,
+                       Engine::Core::TransformComponent,
+                       Engine::Core::MovementComponent>()) {
+          if (unit.owner_id != side.first || unit.health <= 0 ||
+              unit.spawn_type != Game::Units::SpawnType::Civilian) {
+            continue;
+          }
+          const auto here = Game::Systems::NavGrid::world_to_grid(transform.position.x,
+                                                                  transform.position.z);
+          std::printf("    civilian %llu at %.1f,%.1f (walk %d) -> goal %.1f,%.1f "
+                      "target %d path %zu/%zu\n",
+                      static_cast<unsigned long long>(id),
+                      transform.position.x,
+                      transform.position.z,
+                      Game::Systems::NavGrid::is_grid_walkable(here) ? 1 : 0,
+                      movement.get_goal_x(),
+                      movement.get_goal_y(),
+                      movement.get_has_target() ? 1 : 0,
+                      movement.get_path_index(),
+                      movement.get_path().size());
+        }
+        for (auto [id, unit, transform, prod] :
+             session.world()
+                 .view<UnitComponent,
+                       Engine::Core::TransformComponent,
+                       Engine::Core::ProductionComponent>()) {
+          if (unit.owner_id != side.first ||
+              unit.spawn_type != Game::Units::SpawnType::Barracks) {
+            continue;
+          }
+          std::printf("    barracks %llu at %.1f,%.1f manpower %d/%d (max_units %d) "
+                      "queue %zu\n",
+                      static_cast<unsigned long long>(id),
+                      transform.position.x,
+                      transform.position.z,
+                      prod.manpower_available,
+                      prod.manpower_limit(),
+                      prod.max_units,
+                      prod.production_queue.size());
+        }
+      }
       if (qEnvironmentVariableIsSet("SOI_DUEL_BUILDERS")) {
         for (auto [id, unit, transform, movement] :
              session.world()
@@ -464,7 +662,7 @@ protected:
           "  %-10s bar %d home %d farm %d tow %d wall %d mkt %d | work %d/%d "
           "fight %d (foot %d bow %d horse %d engine %d) | "
           "food %d wood %d stone %d iron %d gold %d manpower %d | "
-          "left %d homesfirst %d | wave %s(%d) %s\n",
+          "left %d homesfirst %d | pop %d/%d | wave %s(%d) %s | across %d\n",
           side.second,
           report.barracks,
           report.homes,
@@ -487,13 +685,16 @@ protected:
           barracks_manpower(session, side.first),
           plan != nullptr ? plan->home_civilians_remaining : -1,
           plan != nullptr && plan->macro_targets.raise_homes_first ? 1 : 0,
+          plan != nullptr ? plan->population_used : -1,
+          plan != nullptr ? plan->population_cap : -1,
           (plan != nullptr && plan->wave.committed) ? "yes" : "no",
           plan != nullptr ? static_cast<int>(plan->wave.members.size()) : 0,
           plan != nullptr
               ? Game::Systems::AI::AIStrategyFactory::state_to_string(plan->state)
                     .toUtf8()
                     .constData()
-              : "?");
+              : "?",
+          fighters_across_the_river(session, side.first));
     }
   }
 
@@ -508,8 +709,9 @@ protected:
             Game::Units::SpawnType south_commander,
             Game::Systems::NationID south_nation,
             const char* south_name,
-            int minutes) -> DuelOutcome {
-    make_duel(north_commander, north_nation, south_commander, south_nation);
+            int minutes,
+            const DuelSetup& setup = {}) -> DuelOutcome {
+    make_duel(north_commander, north_nation, south_commander, south_nation, setup);
     auto& session = *m_session;
     DuelOutcome outcome;
     for (int minute = 1; minute <= minutes; ++minute) {
@@ -689,4 +891,56 @@ TEST_F(AiDuelMatchTest, HannibalAndHasdrubalBothPlayTheirDoctrine) {
   expect_a_commander_played_the_match(outcome.north, "Hannibal");
   expect_a_commander_played_the_match(outcome.south, "Hasdrubal");
   expect_one_of_them_fought_a_war(outcome.north, outcome.south);
+}
+
+TEST_F(AiDuelMatchTest, HannibalMirrorGetsItsArmyAcrossTheRiver) {
+  DuelSetup setup;
+  setup.river_and_bridge = true;
+  setup.gold = 3000;
+  const auto outcome = play(Game::Units::SpawnType::CarthageSwordCommander,
+                            Game::Systems::NationID::Carthage,
+                            "hannibal_n",
+                            Game::Units::SpawnType::CarthageSwordCommander,
+                            Game::Systems::NationID::Carthage,
+                            "hannibal_s",
+                            30,
+                            setup);
+
+  constexpr float k_full_match_minutes = 15.0F;
+  const auto expect_if_it_lived = [&](const SideHistory& side, const char* name) {
+    if (side.eliminated_at < 0.0F || side.eliminated_at >= k_full_match_minutes) {
+      expect_a_commander_played_the_match(side, name);
+    }
+  };
+  expect_if_it_lived(outcome.north, "Hannibal (north)");
+  expect_if_it_lived(outcome.south, "Hannibal (south)");
+  expect_one_of_them_fought_a_war(outcome.north, outcome.south);
+
+  EXPECT_FALSE(outcome.north.eliminated_at >= 0.0F &&
+               outcome.south.eliminated_at >= 0.0F)
+      << "both towns were wiped out";
+
+  const float first_crossing = [&] {
+    float best = -1.0F;
+    for (const float at :
+         {outcome.north.crossed_the_river_at, outcome.south.crossed_the_river_at}) {
+      if (at >= 0.0F && (best < 0.0F || at < best)) {
+        best = at;
+      }
+    }
+    return best;
+  }();
+  EXPECT_GE(first_crossing, 0.0F)
+      << "neither army ever crossed the river in 30 minutes; the aggressive "
+         "doctrine parked at the bridge";
+  if (first_crossing >= 0.0F) {
+    EXPECT_LE(first_crossing, 15.0F)
+        << "the first crossing took " << first_crossing
+        << " minutes; a decisive doctrine with 3000 gold should be over the "
+           "bridge well inside the first half";
+  }
+  EXPECT_GE(std::max(outcome.north.most_across_the_river,
+                     outcome.south.most_across_the_river),
+            3)
+      << "no side ever had more than a straggler across the river";
 }

--- a/tests/systems/ai_system_test.cpp
+++ b/tests/systems/ai_system_test.cpp
@@ -1496,6 +1496,60 @@ TEST_F(AISystemTest, AttackBehaviorPicksSoldierOverCloserBuilding) {
   EXPECT_TRUE(commands.front().should_chase);
 }
 
+TEST_F(AISystemTest,
+       AttackBehaviorMarchesTheWaveOnItsObjectiveWhenOnlyBuildingsAreInView) {
+  Game::Systems::AI::AttackBehavior behavior;
+
+  Game::Systems::AI::AISnapshot snapshot;
+  snapshot.friendly_units = {
+      make_unit(1, 0.0F, 0.0F),
+      make_unit(2, 2.0F, 1.0F),
+      make_unit(3, 1.0F, 3.0F),
+  };
+
+  auto tower = make_enemy_building(101, -24.0F, -14.0F);
+  tower.spawn_type = Game::Units::SpawnType::DefenseTower;
+  snapshot.visible_enemies = {tower};
+
+  snapshot.strategic_objectives = {make_enemy_building(7, -37.5F, -37.5F)};
+
+  Game::Systems::AI::AIContext context;
+  context.player_id = 3;
+  context.state = Game::Systems::AI::AIState::Attacking;
+  context.total_units = 3;
+  context.strategy_config = Game::Systems::AI::AIStrategyFactory::create_config(
+      Game::Systems::AI::AIStrategy::Aggressive);
+  context.wave.committed = true;
+  context.wave.members = {1, 2, 3};
+  context.wave.target_id = 7;
+  context.wave.target_x = -37.5F;
+  context.wave.target_z = -37.5F;
+
+  std::vector<Game::Systems::AI::AICommand> commands;
+  behavior.execute(snapshot, context, 1.6F, commands);
+
+  ASSERT_EQ(commands.size(), 1U)
+      << "a committed wave with its objective out of sight must still be ordered "
+         "to march";
+  const auto& order = commands.front();
+  EXPECT_EQ(order.type, Game::Systems::AI::AICommandType::MoveUnits);
+  ASSERT_EQ(order.move_target_x.size(), 3U);
+  float average_x = 0.0F;
+  float average_z = 0.0F;
+  for (std::size_t index = 0; index < order.move_target_x.size(); ++index) {
+    average_x += order.move_target_x[index];
+    average_z += order.move_target_z[index];
+  }
+  average_x /= 3.0F;
+  average_z /= 3.0F;
+
+  const float from_here = std::hypot(-37.5F - 1.0F, -37.5F - 1.3F);
+  const float from_there = std::hypot(-37.5F - average_x, -37.5F - average_z);
+  EXPECT_LT(from_there, from_here * 0.25F)
+      << "the wave was ordered to " << average_x << "," << average_z
+      << ", which is no closer to its objective at -37.5,-37.5";
+}
+
 TEST_F(AISystemTest, AssaultBehaviorPicksSoldierOverCloserBuilding) {
   Game::Systems::AI::AssaultBehavior behavior;
 

--- a/tests/tools/arena_casting_overlay_test.cpp
+++ b/tests/tools/arena_casting_overlay_test.cpp
@@ -1,0 +1,98 @@
+#include <QColor>
+#include <QImage>
+
+#include <gtest/gtest.h>
+
+#include "tools/arena/arena_casting.h"
+#include "tools/arena/promo_casting_overlay.h"
+
+namespace {
+
+auto side(const char* label, int owner, const QVector3D& color, int units, int soldiers)
+    -> Arena::ArenaCastingSide {
+  Arena::ArenaCastingSide result;
+  result.census.label = QString::fromLatin1(label);
+  result.census.owner_id = owner;
+  result.census.living_units = units;
+  result.census.living_soldiers = soldiers;
+  result.census.living_buildings = 9;
+  result.census.strategy = QStringLiteral("aggressive");
+  result.census.posture = QStringLiteral("field");
+  result.census.ai_state = QStringLiteral("attacking");
+  result.color = color;
+  result.gold = 1200;
+  result.food = 340;
+  result.wood = 210;
+  return result;
+}
+
+auto dominant_hue_matches(const QImage& frame,
+                          int x,
+                          int y,
+                          const QColor& expected) -> bool {
+  const QColor actual = frame.pixelColor(x, y);
+  return std::abs(actual.red() - expected.red()) < 40 &&
+         std::abs(actual.green() - expected.green()) < 40 &&
+         std::abs(actual.blue() - expected.blue()) < 40;
+}
+
+auto count_bright_pixels(const QImage& frame, int y0, int y1) -> int {
+  int bright = 0;
+  for (int y = y0; y < y1; ++y) {
+    for (int x = 0; x < frame.width(); ++x) {
+      if (frame.pixelColor(x, y).lightness() > 180) {
+        ++bright;
+      }
+    }
+  }
+  return bright;
+}
+
+} // namespace
+
+TEST(ArenaCastingOverlayTest, PaintsEachSidesColourBarAndTheStrengthBarInProportion) {
+  QImage frame(1920, 1080, QImage::Format_ARGB32);
+  frame.fill(QColor(90, 130, 70));
+
+  Arena::ArenaCastingSnapshot snapshot;
+  snapshot.valid = true;
+  snapshot.elapsed_seconds = 754.0F;
+  snapshot.sides = {side("scipio", 2, QVector3D(1.0F, 0.3F, 0.3F), 12, 96),
+                    side("hannibal", 3, QVector3D(0.2F, 0.8F, 0.4F), 4, 32)};
+
+  Arena::Promo::paint_casting_overlay(frame, snapshot);
+
+  const int strip = Arena::Promo::casting_overlay_height(frame.height());
+  EXPECT_GT(strip, 60) << "the strip is a readable band on a 1080-high frame";
+
+  EXPECT_TRUE(dominant_hue_matches(frame, 300, 1, QColor(255, 77, 77)));
+  EXPECT_TRUE(dominant_hue_matches(frame, 1620, 1, QColor(51, 204, 102)));
+
+  EXPECT_GT(count_bright_pixels(frame, 0, strip), 2000);
+  EXPECT_TRUE(dominant_hue_matches(frame, 960, 700, QColor(90, 130, 70)));
+
+  int bar_y = -1;
+  for (int y = strip / 2; y < strip + strip / 2 && bar_y < 0; ++y) {
+    if (dominant_hue_matches(frame, 960 - 80, y, QColor(255, 77, 77)) &&
+        dominant_hue_matches(frame, 960 + 130, y, QColor(51, 204, 102))) {
+      bar_y = y;
+    }
+  }
+  EXPECT_GE(bar_y, 0) << "no row of the strip carries a red-then-green strength bar";
+}
+
+TEST(ArenaCastingOverlayTest, LeavesTheFrameAloneWithoutTwoSides) {
+  QImage frame(640, 360, QImage::Format_ARGB32);
+  frame.fill(QColor(10, 20, 30));
+  const QImage before = frame;
+
+  Arena::ArenaCastingSnapshot snapshot;
+  snapshot.valid = true;
+  snapshot.sides = {side("alone", 2, QVector3D(1.0F, 0.0F, 0.0F), 3, 20)};
+  Arena::Promo::paint_casting_overlay(frame, snapshot);
+  EXPECT_EQ(frame, before);
+
+  Arena::ArenaCastingSnapshot invalid;
+  Arena::Promo::paint_casting_overlay(frame, invalid);
+  EXPECT_EQ(frame, before);
+}

--- a/tests/tools/arena_promo_spec_test.cpp
+++ b/tests/tools/arena_promo_spec_test.cpp
@@ -240,3 +240,190 @@ TEST(ArenaPromoSpecTest, AReelCanTurnTheGameplayUiOnWholeOrPerShot) {
   EXPECT_FALSE(spec->shots[1].gameplay_ui)
       << "a shot may still opt out of the gameplay UI";
 }
+
+TEST(ArenaPromoSpecTest, TimeLapseIsSlowMotionWrittenTheFriendlyWayRound) {
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  const QString path = write_spec(dir, R"({
+    "id": "probe",
+    "shots": [
+      { "name": "towns", "scenario": "arena", "duration": 600.0, "time_lapse": 20,
+        "focus": { "mode": "point", "point": [0, 0, 0] },
+        "camera": [ { "time": 0.0, "distance": 60, "pitch": 55 },
+                    { "time": 600.0, "distance": 62, "pitch": 55 } ] }
+    ]
+  })");
+
+  QString error;
+  const auto spec = Arena::Promo::load(path, &error);
+  ASSERT_TRUE(spec.has_value()) << error.toStdString();
+  ASSERT_EQ(spec->shots.size(), 1U);
+  EXPECT_NEAR(spec->shots[0].slow_motion, 0.05F, 1e-5F)
+      << "time_lapse 20 is slow_motion 1/20";
+  EXPECT_TRUE(Arena::Promo::motion_violations(*spec).empty())
+      << "a ten-minute shot shown in thirty seconds is a legal clip";
+}
+
+TEST(ArenaPromoSpecTest, TimeLapseAndSlowMotionTogetherAreRefused) {
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  const QString path = write_spec(dir, R"({
+    "id": "probe",
+    "shots": [
+      { "name": "both", "scenario": "arena", "duration": 4.0, "time_lapse": 4,
+        "slow_motion": 2.0,
+        "focus": { "mode": "all" },
+        "camera": [ { "time": 0.0 }, { "time": 4.0 } ] }
+    ]
+  })");
+
+  QString error;
+  EXPECT_FALSE(Arena::Promo::load(path, &error).has_value());
+  EXPECT_TRUE(error.contains(QStringLiteral("same knob"))) << error.toStdString();
+}
+
+TEST(ArenaPromoSpecTest, CameraRatesAreJudgedInScreenSeconds) {
+
+  auto lapse = shot("lapse", "arena", 0.0F, 30.0F);
+  lapse.slow_motion = 0.05F;
+  lapse.keys = {key(0.0F, 0.0F), key(30.0F, 90.0F)};
+  EXPECT_TRUE(
+      mentions(Arena::Promo::motion_violations(spec_of({lapse})), "swings yaw"));
+
+  auto slow = shot("slow", "arena", 0.0F, 30.0F);
+  slow.slow_motion = 2.0F;
+  slow.keys = {key(0.0F, 0.0F), key(30.0F, 90.0F)};
+  EXPECT_FALSE(
+      mentions(Arena::Promo::motion_violations(spec_of({slow})), "swings yaw"));
+}
+
+TEST(ArenaPromoSpecTest, AShotMayStartOnAMatchEvent) {
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  const QString path = write_spec(dir, R"({
+    "id": "probe",
+    "casting_overlay": true,
+    "require_decision": true,
+    "forbid_world_edge": true,
+    "shots": [
+      { "name": "march", "scenario": "arena", "duration": 8.0,
+        "start_on": { "event": "first_wave", "side": "scipio", "offset": -3.0 },
+        "focus": { "mode": "all" },
+        "camera": [ { "time": 0.0 }, { "time": 8.0 } ] },
+      { "name": "clash", "scenario": "arena", "duration": 6.0,
+        "start_on": { "event": "first_contact" },
+        "casting_overlay": false,
+        "focus": { "mode": "all" },
+        "camera": [ { "time": 0.0 }, { "time": 6.0 } ] }
+    ]
+  })");
+
+  QString error;
+  const auto spec = Arena::Promo::load(path, &error);
+  ASSERT_TRUE(spec.has_value()) << error.toStdString();
+  ASSERT_EQ(spec->shots.size(), 2U);
+  ASSERT_TRUE(spec->shots[0].start_on.has_value());
+  EXPECT_EQ(spec->shots[0].start_on->event, QStringLiteral("first_wave"));
+  EXPECT_EQ(spec->shots[0].start_on->side, QStringLiteral("scipio"));
+  EXPECT_FLOAT_EQ(spec->shots[0].start_on->offset_seconds, -3.0F);
+  ASSERT_TRUE(spec->shots[1].start_on.has_value());
+  EXPECT_TRUE(spec->shots[1].start_on->side.isEmpty());
+  EXPECT_TRUE(Arena::Promo::uses_start_events(*spec));
+  EXPECT_TRUE(spec->require_decision);
+  EXPECT_TRUE(spec->forbid_world_edge);
+  EXPECT_TRUE(spec->shots[0].casting_overlay)
+      << "the spec-level casting overlay is the default for every shot";
+  EXPECT_FALSE(spec->shots[1].casting_overlay) << "a shot may still opt out";
+}
+
+TEST(ArenaPromoSpecTest, AnUnknownStartEventOrAStartOnBothWaysIsRefused) {
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  QString error;
+  EXPECT_FALSE(Arena::Promo::load(write_spec(dir, R"({
+    "id": "probe",
+    "shots": [
+      { "name": "x", "scenario": "arena", "duration": 4.0,
+        "start_on": { "event": "the_big_moment" },
+        "focus": { "mode": "all" }, "camera": [ { "time": 0.0 }, { "time": 4.0 } ] }
+    ]
+  })"),
+                                  &error)
+                   .has_value());
+  EXPECT_TRUE(error.contains(QStringLiteral("unknown start_on event")))
+      << error.toStdString();
+
+  EXPECT_FALSE(Arena::Promo::load(write_spec(dir, R"({
+    "id": "probe",
+    "shots": [
+      { "name": "x", "scenario": "arena", "start": 5.0, "duration": 4.0,
+        "start_on": { "event": "decision" },
+        "focus": { "mode": "all" }, "camera": [ { "time": 0.0 }, { "time": 4.0 } ] }
+    ]
+  })"),
+                                  &error)
+                   .has_value());
+  EXPECT_TRUE(error.contains(QStringLiteral("both start and start_on")))
+      << error.toStdString();
+}
+
+TEST(ArenaPromoSpecTest, TheGroundFootprintKnowsWhenTheViewLeavesTheArenaFloor) {
+  using Arena::Promo::Pose;
+  Pose overhead;
+  overhead.distance = 60.0F;
+  overhead.pitch = 60.0F;
+  overhead.yaw = 315.0F;
+  overhead.fov = 40.0F;
+  const auto tight = Arena::Promo::view_ground_footprint(overhead, {}, 16.0F / 9.0F);
+  EXPECT_FALSE(tight.horizon_visible);
+  EXPECT_LT(tight.max_abs_extent, 58.0F)
+      << "a steep sixty-metre view of the centre stays on a 58 m floor";
+  EXPECT_FALSE(Arena::Promo::frames_world_edge(tight, 58.0F));
+
+  Pose wide = overhead;
+  wide.distance = 130.0F;
+  wide.pitch = 47.0F;
+  const auto loose = Arena::Promo::view_ground_footprint(wide, {}, 16.0F / 9.0F);
+  EXPECT_TRUE(Arena::Promo::frames_world_edge(loose, 58.0F))
+      << "reaches " << loose.max_abs_extent;
+
+  Pose flat = overhead;
+  flat.pitch = 15.0F;
+  const auto horizon = Arena::Promo::view_ground_footprint(flat, {}, 16.0F / 9.0F);
+  EXPECT_TRUE(horizon.horizon_visible)
+      << "a fifteen-degree pitch with a forty-degree lens looks over the horizon";
+}
+
+TEST(ArenaPromoSpecTest, WorldEdgeViolationsNamePointFocusShotsThatFrameTheRim) {
+  auto rim = shot("rim", "arena", 0.0F, 10.0F);
+  rim.focus.mode = Arena::Promo::FocusMode::Point;
+  CameraKey far_key;
+  far_key.time = 0.0F;
+  far_key.distance = 130.0F;
+  far_key.pitch = 47.0F;
+  far_key.yaw = 315.0F;
+  far_key.fov = 40.0F;
+  rim.keys = {far_key};
+
+  auto tight = shot("tight", "arena", 0.0F, 10.0F);
+  tight.focus.mode = Arena::Promo::FocusMode::Point;
+  CameraKey near_key = far_key;
+  near_key.distance = 50.0F;
+  near_key.pitch = 60.0F;
+  tight.keys = {near_key};
+
+  auto dynamic = shot("dynamic", "arena", 0.0F, 10.0F);
+  dynamic.focus.mode = Arena::Promo::FocusMode::AllUnits;
+  dynamic.keys = {far_key};
+
+  const auto breaches =
+      Arena::Promo::world_edge_violations(spec_of({rim, tight, dynamic}), 58.0F);
+  EXPECT_TRUE(mentions(breaches, "rim:"));
+  EXPECT_FALSE(mentions(breaches, "tight:"));
+  EXPECT_FALSE(mentions(breaches, "dynamic:"))
+      << "a dynamic focus cannot be judged before the match plays";
+}

--- a/tools/arena/CMakeLists.txt
+++ b/tools/arena/CMakeLists.txt
@@ -37,6 +37,19 @@ target_link_libraries(
 # the same reason the panels do: arena_tests asserts on the ticks the arena
 # actually paints, not on a second compiled copy of them.
 add_library(arena_feedback STATIC arena_feedback.cpp)
+
+# The casting strip painted over cast-match promo frames. Its own library so
+# arena_tests can paint it onto an image and look at the pixels the arena
+# ships, and because it needs the arena typography but no GL.
+add_library(arena_casting_overlay STATIC promo_casting_overlay.cpp arena_typography.cpp)
+target_include_directories(
+    arena_casting_overlay
+    PUBLIC "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+target_link_libraries(
+    arena_casting_overlay
+    PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui arena_scenario_harness ui_shell
+)
 target_include_directories(
     arena_feedback
     PUBLIC "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -76,6 +89,8 @@ set(ARENA_APP_SOURCES
     promo_runner.cpp
     arena_audio_recorder.cpp
 )
+# arena_typography.cpp moved into arena_casting_overlay, which arena_app links.
+list(REMOVE_ITEM ARENA_APP_SOURCES arena_typography.cpp)
 
 if(QT_VERSION_MAJOR EQUAL 6)
     qt6_add_executable(arena_app ${ARENA_APP_SOURCES})
@@ -105,6 +120,7 @@ target_link_libraries(
         arena_scenario_harness
         arena_panels
         arena_feedback
+        arena_casting_overlay
 )
 
 set_target_properties(

--- a/tools/arena/arena_ai_duel_scenarios.cpp
+++ b/tools/arena/arena_ai_duel_scenarios.cpp
@@ -102,7 +102,7 @@ void add_battlefield(ArenaScenarioDefinition& scenario) {
   };
 
   scenario.rivers.push_back(
-      Game::Map::RiverSegment{reach(-60.10F, 67.18F), reach(-31.47F, 27.93F), 12.0F});
+      Game::Map::RiverSegment{reach(-68.70F, 79.00F), reach(-31.47F, 27.93F), 12.0F});
   scenario.rivers.push_back(
       Game::Map::RiverSegment{reach(-31.47F, 27.93F), reach(-9.90F, 9.90F), 11.0F});
   scenario.rivers.push_back(
@@ -110,7 +110,7 @@ void add_battlefield(ArenaScenarioDefinition& scenario) {
   scenario.rivers.push_back(
       Game::Map::RiverSegment{reach(9.90F, -9.90F), reach(27.93F, -31.47F), 11.0F});
   scenario.rivers.push_back(
-      Game::Map::RiverSegment{reach(27.93F, -31.47F), reach(67.18F, -60.10F), 12.0F});
+      Game::Map::RiverSegment{reach(27.93F, -31.47F), reach(68.70F, -79.00F), 12.0F});
 
   constexpr float k_bridge_reach = 5.7F;
 
@@ -120,6 +120,21 @@ void add_battlefield(ArenaScenarioDefinition& scenario) {
                                                {k_bridge_reach, 0.0F, k_bridge_reach},
                                                k_bridge_deck_width,
                                                0.5F});
+
+  constexpr float k_flank_reach = 7.0F;
+  constexpr float k_flank_deck_width = 9.0F;
+  const QVector3D flank_centre(-40.0F, 0.0F, 39.6F);
+  const QVector3D flank_axis(0.808F, 0.0F, 0.589F);
+  scenario.bridges.push_back(
+      Game::Map::Bridge{flank_centre - flank_axis * k_flank_reach,
+                        flank_centre + flank_axis * k_flank_reach,
+                        k_flank_deck_width,
+                        0.5F});
+  scenario.bridges.push_back(
+      Game::Map::Bridge{-(flank_centre - flank_axis * k_flank_reach),
+                        -(flank_centre + flank_axis * k_flank_reach),
+                        k_flank_deck_width,
+                        0.5F});
 
   const auto hill = [](float x,
                        float z,
@@ -264,9 +279,9 @@ void add_side(ArenaScenarioDefinition& scenario, const DuelSide& side) {
   scenario.resource_patches.push_back(
       patch("boulder", 8, {-14.0F, 0.0F, 37.74F}, {-1.8F, 0.0F, 0.0F}, 1.05F));
   scenario.resource_patches.push_back(
-      patch("iron_ore", 6, {24.0F, 0.0F, 29.74F}, {1.6F, 0.0F, 0.0F}, 1.0F));
+      patch("iron_ore", 4, {24.0F, 0.0F, 29.74F}, {1.6F, 0.0F, 0.0F}, 1.0F));
   scenario.resource_patches.push_back(
-      patch("iron_ore", 5, {34.0F, 0.0F, 13.74F}, {1.2F, 0.0F, 0.0F}, 1.0F));
+      patch("iron_ore", 3, {34.0F, 0.0F, 13.74F}, {1.2F, 0.0F, 0.0F}, 1.0F));
 }
 
 auto war_of_towns_wildlife() -> Game::Wildlife::WildlifeSettings {
@@ -308,7 +323,8 @@ auto duel_definition(const char* id,
   scenario.collect_animation_diagnostics = false;
 
   scenario.suppress_terrain_scatter = false;
-  scenario.terrain_grid_extent = 128;
+
+  scenario.terrain_grid_extent = 160;
 
   scenario.ai_starting_resources = {
       .gold = 2000, .food = 200, .wood = 250, .stone = 120, .iron = 80};

--- a/tools/arena/arena_casting.h
+++ b/tools/arena/arena_casting.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QVector3D>
+
+#include <vector>
+
+#include "arena_scenario.h"
+
+namespace Arena {
+
+struct ArenaCastingSide {
+  ArenaBattleSideResult census;
+  QVector3D color{0.5F, 0.5F, 0.5F};
+  int gold{0};
+  int food{0};
+  int wood{0};
+  int stone{0};
+  int iron{0};
+};
+
+struct ArenaCastingSnapshot {
+  bool valid{false};
+  float elapsed_seconds{0.0F};
+  bool decided{false};
+  std::vector<ArenaCastingSide> sides;
+};
+
+} // namespace Arena

--- a/tools/arena/arena_scenario.cpp
+++ b/tools/arena/arena_scenario.cpp
@@ -844,6 +844,9 @@ struct ArenaScenarioRunner::Impl {
     float eliminated_at{-1.0F};
     bool had_presence{false};
     QSet<Engine::Core::EntityID> seen_units;
+    QString ai_state;
+    bool wave_committed{false};
+    int wave_size{0};
   };
 
   struct UndeadZoneObservation {
@@ -2233,6 +2236,9 @@ struct ArenaScenarioRunner::Impl {
         if (doctrine.valid) {
           side.strategy = doctrine.strategy;
           side.posture = doctrine.posture;
+          side.ai_state = doctrine.state;
+          side.wave_committed = doctrine.wave_committed;
+          side.wave_size = doctrine.wave_size;
           float const step = std::max(0.0F, elapsed - side.seconds_observed);
           side.seconds_observed = elapsed;
           if (doctrine.state == QStringLiteral("attacking")) {
@@ -2307,6 +2313,62 @@ struct ArenaScenarioRunner::Impl {
     return false;
   }
 
+  [[nodiscard]] static auto
+  side_result(const BattleSideState& side) -> ArenaBattleSideResult {
+    ArenaBattleSideResult result;
+    result.owner_id = side.owner_id;
+    result.label = side.label;
+    result.living_units = side.living_units;
+    result.living_soldiers = side.living_soldiers;
+    result.living_buildings = side.living_buildings;
+    result.peak_units = side.peak_units;
+    result.peak_soldiers = std::max(side.peak_soldiers, side.initial_soldiers);
+    result.units_produced =
+        std::max(0, static_cast<int>(side.seen_units.size()) - side.initial_units);
+    result.peak_advance = side.peak_advance;
+    result.final_advance = side.final_advance;
+    result.eliminated_at = side.eliminated_at;
+    result.strategy = side.strategy;
+    result.posture = side.posture;
+    result.ai_state = side.ai_state;
+    result.wave_committed = side.wave_committed;
+    result.wave_size = side.wave_size;
+    result.buildings_constructed =
+        std::max(0,
+                 static_cast<int>(side.seen_buildings.size()) -
+                     static_cast<int>(side.initial_buildings.size()));
+    result.peak_buildings = side.peak_buildings;
+    result.peak_home_units = side.peak_home_units;
+    result.peak_forward_units = side.peak_forward_units;
+    result.mean_home_share =
+        side.home_share_samples > 0
+            ? static_cast<float>(side.home_share_sum /
+                                 static_cast<double>(side.home_share_samples))
+            : 0.0F;
+    {
+      QStringList census;
+      auto keys = side.building_census.keys();
+      std::sort(keys.begin(), keys.end());
+      for (auto const& key : keys) {
+        census.push_back(
+            QStringLiteral("%1x%2").arg(key).arg(side.building_census.value(key)));
+      }
+      result.building_census = census.join(QStringLiteral(","));
+    }
+    result.seconds_attacking = side.seconds_attacking;
+    result.seconds_observed = side.seconds_observed;
+    return result;
+  }
+
+  [[nodiscard]] auto live_sides() const -> std::vector<ArenaBattleSideResult> {
+    std::vector<ArenaBattleSideResult> sides;
+    sides.reserve(battle_sides.size());
+    for (auto const& side : battle_sides) {
+      sides.push_back(side_result(side));
+    }
+    return sides;
+  }
+
   void publish_battle_outcome() {
     if (battle_sides.empty()) {
       return;
@@ -2316,46 +2378,7 @@ struct ArenaScenarioRunner::Impl {
     report.battle.decided_at_seconds = battle_decided_at;
     report.battle.sides.clear();
     for (auto const& side : battle_sides) {
-      ArenaBattleSideResult result;
-      result.owner_id = side.owner_id;
-      result.label = side.label;
-      result.living_units = side.living_units;
-      result.living_soldiers = side.living_soldiers;
-      result.living_buildings = side.living_buildings;
-      result.peak_units = side.peak_units;
-      result.peak_soldiers = std::max(side.peak_soldiers, side.initial_soldiers);
-      result.units_produced =
-          std::max(0, static_cast<int>(side.seen_units.size()) - side.initial_units);
-      result.peak_advance = side.peak_advance;
-      result.final_advance = side.final_advance;
-      result.eliminated_at = side.eliminated_at;
-      result.strategy = side.strategy;
-      result.posture = side.posture;
-      result.buildings_constructed =
-          std::max(0,
-                   static_cast<int>(side.seen_buildings.size()) -
-                       static_cast<int>(side.initial_buildings.size()));
-      result.peak_buildings = side.peak_buildings;
-      result.peak_home_units = side.peak_home_units;
-      result.peak_forward_units = side.peak_forward_units;
-      result.mean_home_share =
-          side.home_share_samples > 0
-              ? static_cast<float>(side.home_share_sum /
-                                   static_cast<double>(side.home_share_samples))
-              : 0.0F;
-      {
-        QStringList census;
-        auto keys = side.building_census.keys();
-        std::sort(keys.begin(), keys.end());
-        for (auto const& key : keys) {
-          census.push_back(
-              QStringLiteral("%1x%2").arg(key).arg(side.building_census.value(key)));
-        }
-        result.building_census = census.join(QStringLiteral(","));
-      }
-      result.seconds_attacking = side.seconds_attacking;
-      result.seconds_observed = side.seconds_observed;
-      report.battle.sides.push_back(std::move(result));
+      report.battle.sides.push_back(side_result(side));
       if (battle_decided && side.eliminated_at < 0.0F) {
         report.battle.victor_owner_id = side.owner_id;
         report.battle.victor_label = side.label;
@@ -6213,6 +6236,15 @@ auto ArenaScenarioRunner::finished() const noexcept -> bool {
 
 auto ArenaScenarioRunner::report() const noexcept -> const ArenaScenarioReport& {
   return m_impl->report;
+}
+
+auto ArenaScenarioRunner::live_battle_sides() const
+    -> std::vector<ArenaBattleSideResult> {
+  return m_impl->live_sides();
+}
+
+auto ArenaScenarioRunner::battle_decided() const noexcept -> bool {
+  return m_impl->battle_decided;
 }
 
 auto ArenaScenarioRunner::group_entities(const QString& group) const

--- a/tools/arena/arena_scenario.h
+++ b/tools/arena/arena_scenario.h
@@ -482,6 +482,10 @@ struct ArenaBattleSideResult {
   int peak_forward_units{0};
 
   float mean_home_share{0.0F};
+
+  QString ai_state;
+  bool wave_committed{false};
+  int wave_size{0};
 };
 
 struct ArenaBattleOutcome {
@@ -572,6 +576,9 @@ struct ArenaAIDoctrineSample {
   QString posture;
 
   QString state;
+
+  bool wave_committed{false};
+  int wave_size{0};
 };
 
 struct ArenaScenarioHost {
@@ -661,6 +668,10 @@ public:
   [[nodiscard]] auto elapsed_seconds() const noexcept -> float;
   [[nodiscard]] auto finished() const noexcept -> bool;
   [[nodiscard]] auto report() const noexcept -> const ArenaScenarioReport&;
+
+  [[nodiscard]] auto live_battle_sides() const -> std::vector<ArenaBattleSideResult>;
+  [[nodiscard]] auto battle_decided() const noexcept -> bool;
+
   [[nodiscard]] auto group_entities(const QString& group) const
       -> const std::vector<Engine::Core::EntityID>&;
   [[nodiscard]] auto all_entities() const -> std::vector<Engine::Core::EntityID>;

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -38,6 +38,7 @@
 #include "app/orders/movement_utils.h"
 #include "app/session/renderer_bootstrap.h"
 #include "app/session/world_bootstrap.h"
+#include "arena_casting.h"
 #include "arena_scenario.h"
 #include "arena_scenarios.h"
 #include "game/core/component.h"
@@ -80,6 +81,7 @@
 #include "game/units/troop_config.h"
 #include "game/units/troop_type.h"
 #include "game/units/unit.h"
+#include "game/visuals/team_colors.h"
 #include "game/wildlife/bird_flock.h"
 #include "game/wildlife/wildlife_system.h"
 #include "render/camera_visibility.h"
@@ -501,6 +503,10 @@ void ArenaViewport::resizeGL(int width, int height) {
   }
 }
 
+namespace {
+constexpr float k_max_simulation_substep = 1.0F / 30.0F;
+} // namespace
+
 void ArenaViewport::paintGL() {
   if (!m_gl_initialized || m_renderer == nullptr || m_camera == nullptr ||
       m_world == nullptr) {
@@ -554,7 +560,14 @@ void ArenaViewport::paintGL() {
 
   if (!m_paused) {
     update_rpg_scenario_controller(simulation_dt);
-    m_world->update(simulation_dt);
+
+    int const substeps = std::max(
+        1,
+        static_cast<int>(std::ceil(simulation_dt / k_max_simulation_substep - 1e-4F)));
+    float const substep = simulation_dt / static_cast<float>(substeps);
+    for (int step = 0; step < substeps; ++step) {
+      m_world->update(substep);
+    }
   }
   m_feedback.advance(simulation_dt);
 
@@ -2895,6 +2908,29 @@ auto ArenaViewport::ai_activity_summary() const -> QString {
       .arg(sides);
 }
 
+auto ArenaViewport::casting_snapshot() const -> Arena::ArenaCastingSnapshot {
+  Arena::ArenaCastingSnapshot snapshot;
+  if (m_scenario_runner == nullptr) {
+    return snapshot;
+  }
+  snapshot.valid = true;
+  snapshot.elapsed_seconds = m_scenario_runner->elapsed_seconds();
+  snapshot.decided = m_scenario_runner->battle_decided();
+  const auto& economy = m_session.economy();
+  for (const auto& side : m_scenario_runner->live_battle_sides()) {
+    Arena::ArenaCastingSide cast;
+    cast.census = side;
+    cast.color = Game::Visuals::team_colorForOwner(side.owner_id);
+    cast.gold = economy.get(side.owner_id, Game::Systems::ResourceType::Gold);
+    cast.food = economy.get(side.owner_id, Game::Systems::ResourceType::Food);
+    cast.wood = economy.get(side.owner_id, Game::Systems::ResourceType::Wood);
+    cast.stone = economy.get(side.owner_id, Game::Systems::ResourceType::Stone);
+    cast.iron = economy.get(side.owner_id, Game::Systems::ResourceType::Iron);
+    snapshot.sides.push_back(std::move(cast));
+  }
+  return snapshot;
+}
+
 void ArenaViewport::set_batch_render_suppressed(bool suppressed) {
   m_batch_render_suppressed = suppressed;
 }
@@ -4103,6 +4139,10 @@ void ArenaViewport::load_scenario(const QString& scenario_id) {
     sample.posture =
         Game::Systems::AI::AIStrategyFactory::posture_to_string(state.posture);
     sample.state = Game::Systems::AI::AIStrategyFactory::state_to_string(state.state);
+    if (const auto* plan = ai_system->plan_for(owner_id); plan != nullptr) {
+      sample.wave_committed = plan->wave.committed;
+      sample.wave_size = static_cast<int>(plan->wave.members.size());
+    }
     return sample;
   };
 

--- a/tools/arena/arena_viewport.h
+++ b/tools/arena/arena_viewport.h
@@ -15,6 +15,7 @@
 #include <optional>
 #include <vector>
 
+#include "arena_casting.h"
 #include "arena_feedback.h"
 #include "arena_scenario.h"
 #include "game/core/component.h"
@@ -214,6 +215,8 @@ public:
   void set_capture_active(bool active);
   void set_batch_render_suppressed(bool suppressed);
   [[nodiscard]] auto ai_activity_summary() const -> QString;
+
+  [[nodiscard]] auto casting_snapshot() const -> Arena::ArenaCastingSnapshot;
   [[nodiscard]] auto world() const -> Engine::Core::World* { return m_world.get(); }
   [[nodiscard]] auto session() -> Game::Session::SessionContext& { return m_session; }
   void set_frame_hook(std::function<void(float)> hook);

--- a/tools/arena/main.cpp
+++ b/tools/arena/main.cpp
@@ -415,6 +415,14 @@ auto main(int argc, char** argv) -> int {
       QStringLiteral("Directory for recorded promo clips, posters, and manifest."),
       QStringLiteral("directory"),
       QStringLiteral("artifacts/promo"));
+  QCommandLineOption const promo_precheck_option(
+      QStringList{QStringLiteral("promo-precheck")},
+      QStringLiteral("Play every scenario the promo spec names through once without "
+                     "rendering first, and write its match timeline."));
+  QCommandLineOption const promo_precheck_only_option(
+      QStringList{QStringLiteral("promo-precheck-only")},
+      QStringLiteral("Only the dry run: write the match timeline and verdict, record "
+                     "nothing."));
   parser.addOptions({batch_option,
                      all_option,
                      scenario_option,
@@ -442,6 +450,8 @@ auto main(int argc, char** argv) -> int {
                      fog_of_war_option,
                      promo_spec_option,
                      promo_out_option,
+                     promo_precheck_option,
+                     promo_precheck_only_option,
                      matchup_option,
                      matchup_seconds_option,
                      matchup_report_option,
@@ -580,6 +590,8 @@ auto main(int argc, char** argv) -> int {
     Arena::Promo::RunOptions promo_options;
     promo_options.output_directory =
         QDir(QDir::cleanPath(parser.value(promo_out_option))).filePath(spec->id);
+    promo_options.force_precheck = parser.isSet(promo_precheck_option);
+    promo_options.precheck_only = parser.isSet(promo_precheck_only_option);
     const int promo_status =
         Arena::Promo::run(*window.viewport(), *spec, promo_options, &promo_error);
     if (promo_status == 2 && !promo_error.isEmpty()) {

--- a/tools/arena/promo_casting_overlay.cpp
+++ b/tools/arena/promo_casting_overlay.cpp
@@ -1,0 +1,186 @@
+#include "promo_casting_overlay.h"
+
+#include <QColor>
+#include <QFont>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+#include <QString>
+
+#include <algorithm>
+#include <cmath>
+
+#include "arena_typography.h"
+
+namespace Arena::Promo {
+namespace {
+
+constexpr double k_strip_height_fraction = 0.082;
+
+auto to_color(const QVector3D& rgb, int alpha = 255) -> QColor {
+  const auto channel = [](float value) {
+    return std::clamp(static_cast<int>(std::lround(value * 255.0F)), 0, 255);
+  };
+  return QColor(channel(rgb.x()), channel(rgb.y()), channel(rgb.z()), alpha);
+}
+
+auto display_name(QString label) -> QString {
+  return label.replace(QLatin1Char('_'), QLatin1Char(' ')).toUpper();
+}
+
+auto clock_text(float seconds) -> QString {
+  const int total = std::max(0, static_cast<int>(std::lround(seconds)));
+  return QStringLiteral("%1:%2")
+      .arg(total / 60)
+      .arg(total % 60, 2, 10, QLatin1Char('0'));
+}
+
+auto strip_font(double ui, double pixels, bool bold = false) -> QFont {
+  QFont font = Arena::Typography::small_label(1.0);
+  font.setPixelSize(std::max(6, static_cast<int>(std::lround(pixels * ui))));
+  font.setBold(bold);
+  return font;
+}
+
+auto state_word(const ArenaBattleSideResult& census) -> QString {
+  if (census.eliminated_at >= 0.0F) {
+    return QStringLiteral("DESTROYED");
+  }
+  if (census.wave_committed && census.wave_size > 0) {
+    return QStringLiteral("WAVE OF %1 MARCHING").arg(census.wave_size);
+  }
+  return census.ai_state.toUpper();
+}
+
+} // namespace
+
+auto casting_overlay_height(int frame_height) -> int {
+  return std::max(
+      24, static_cast<int>(std::lround(frame_height * k_strip_height_fraction)));
+}
+
+void paint_casting_overlay(QImage& frame, const ArenaCastingSnapshot& snapshot) {
+  if (frame.isNull() || !snapshot.valid || snapshot.sides.size() < 2U) {
+    return;
+  }
+  if (frame.format() != QImage::Format_ARGB32 &&
+      frame.format() != QImage::Format_RGB32) {
+    frame = frame.convertToFormat(QImage::Format_ARGB32);
+  }
+
+  const double width = frame.width();
+  const double height = frame.height();
+  const double ui = std::clamp(height / 1080.0, 0.4, 2.4);
+  const double strip = casting_overlay_height(frame.height());
+
+  const QColor ink(238, 232, 218);
+  const QColor faded(190, 182, 164);
+  const QColor gold(214, 186, 116);
+
+  QPainter painter(&frame);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  painter.setRenderHint(QPainter::TextAntialiasing, true);
+
+  QLinearGradient shade(0.0, 0.0, 0.0, strip * 1.35);
+  shade.setColorAt(0.0, QColor(10, 9, 8, 228));
+  shade.setColorAt(0.78, QColor(10, 9, 8, 210));
+  shade.setColorAt(1.0, QColor(10, 9, 8, 0));
+  painter.fillRect(QRectF(0.0, 0.0, width, strip * 1.35), shade);
+
+  const auto& left = snapshot.sides[0];
+  const auto& right = snapshot.sides[1];
+  const QColor left_color = to_color(left.color);
+  const QColor right_color = to_color(right.color);
+
+  const double bar_height = std::max(2.0, 5.0 * ui);
+  painter.fillRect(QRectF(0.0, 0.0, width * 0.5, bar_height), left_color);
+  painter.fillRect(QRectF(width * 0.5, 0.0, width * 0.5, bar_height), right_color);
+
+  const double margin = 22.0 * ui;
+  const double name_pixels = 26.0;
+  const double figure_pixels = 16.0;
+  const double name_y = bar_height + 6.0 * ui;
+  const double figures_y = name_y + name_pixels * ui * 1.15;
+  const double centre_width = std::min(width * 0.26, 340.0 * ui);
+  const double side_width = (width - centre_width) * 0.5 - margin;
+
+  const auto paint_side =
+      [&](const ArenaCastingSide& side, const QColor& color, bool on_left) {
+        const double x0 = on_left ? margin : width - margin - side_width;
+        const Qt::Alignment align = on_left ? Qt::AlignLeft : Qt::AlignRight;
+        const QRectF name_rect(x0, name_y, side_width, name_pixels * ui * 1.2);
+        painter.setFont(strip_font(ui, name_pixels, true));
+        painter.setPen(color);
+        painter.drawText(
+            name_rect, align | Qt::AlignVCenter, display_name(side.census.label));
+
+        const QString figures =
+            QStringLiteral("ARMY %1 · %2 MEN    TOWN %3    GOLD %4  FOOD %5  WOOD %6")
+                .arg(side.census.living_units)
+                .arg(side.census.living_soldiers)
+                .arg(side.census.living_buildings)
+                .arg(side.gold)
+                .arg(side.food)
+                .arg(side.wood);
+        const QRectF figures_rect(x0, figures_y, side_width, figure_pixels * ui * 1.3);
+        painter.setFont(strip_font(ui, figure_pixels));
+        painter.setPen(ink);
+        painter.drawText(figures_rect, align | Qt::AlignVCenter, figures);
+
+        const QString doctrine = QStringLiteral("%1 · %2   %3")
+                                     .arg(side.census.strategy.toUpper(),
+                                          side.census.posture.toUpper(),
+                                          state_word(side.census));
+        const QRectF doctrine_rect(x0,
+                                   figures_y + figure_pixels * ui * 1.25,
+                                   side_width,
+                                   figure_pixels * ui * 1.2);
+        painter.setFont(strip_font(ui, figure_pixels * 0.82));
+        painter.setPen(faded);
+        painter.drawText(doctrine_rect, align | Qt::AlignVCenter, doctrine);
+      };
+  paint_side(left, left_color, true);
+  paint_side(right, right_color, false);
+
+  const QRectF clock_rect((width - centre_width) * 0.5,
+                          name_y - 2.0 * ui,
+                          centre_width,
+                          name_pixels * ui * 1.3);
+  painter.setFont(strip_font(ui, name_pixels * 1.15, true));
+  painter.setPen(snapshot.decided ? gold : ink);
+  painter.drawText(clock_rect, Qt::AlignCenter, clock_text(snapshot.elapsed_seconds));
+
+  const double bar_width = centre_width * 0.86;
+  const double bar_x = (width - bar_width) * 0.5;
+  const double bar_y = figures_y + 4.0 * ui;
+  const double bar_h = std::max(3.0, 8.0 * ui);
+  const int left_men = std::max(0, left.census.living_soldiers);
+  const int right_men = std::max(0, right.census.living_soldiers);
+  const int total_men = left_men + right_men;
+  const double left_share =
+      total_men > 0 ? static_cast<double>(left_men) / static_cast<double>(total_men)
+                    : 0.5;
+  painter.setPen(Qt::NoPen);
+  painter.setBrush(QColor(40, 38, 34, 220));
+  painter.drawRoundedRect(
+      QRectF(bar_x, bar_y, bar_width, bar_h), bar_h * 0.5, bar_h * 0.5);
+  QPainterPath clip;
+  clip.addRoundedRect(QRectF(bar_x, bar_y, bar_width, bar_h), bar_h * 0.5, bar_h * 0.5);
+  painter.save();
+  painter.setClipPath(clip);
+  painter.fillRect(QRectF(bar_x, bar_y, bar_width * left_share, bar_h), left_color);
+  painter.fillRect(
+      QRectF(
+          bar_x + bar_width * left_share, bar_y, bar_width * (1.0 - left_share), bar_h),
+      right_color);
+  painter.restore();
+
+  painter.setFont(strip_font(ui, figure_pixels * 0.8));
+  painter.setPen(faded);
+  painter.drawText(
+      QRectF(bar_x, bar_y + bar_h + 2.0 * ui, bar_width, figure_pixels * ui * 1.2),
+      Qt::AlignCenter,
+      QStringLiteral("%1 · SOLDIERS IN THE FIELD · %2").arg(left_men).arg(right_men));
+}
+
+} // namespace Arena::Promo

--- a/tools/arena/promo_casting_overlay.h
+++ b/tools/arena/promo_casting_overlay.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QImage>
+
+#include "arena_casting.h"
+
+namespace Arena::Promo {
+
+void paint_casting_overlay(QImage& frame, const ArenaCastingSnapshot& snapshot);
+
+[[nodiscard]] auto casting_overlay_height(int frame_height) -> int;
+
+} // namespace Arena::Promo

--- a/tools/arena/promo_runner.cpp
+++ b/tools/arena/promo_runner.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <map>
 #include <memory>
 #include <numbers>
 #include <optional>
@@ -24,11 +25,13 @@
 #include <vector>
 
 #include "arena_audio_recorder.h"
+#include "arena_casting.h"
 #include "arena_scenario.h"
 #include "arena_typography.h"
 #include "arena_viewport.h"
 #include "game/session/session_context.h"
 #include "game/visuals/team_colors.h"
+#include "promo_casting_overlay.h"
 #include "render/humanoid/runtime/runtime_stats.h"
 #include "video_encoder.h"
 
@@ -576,7 +579,39 @@ struct ShotResult {
   int frames{0};
   float scene_duration{0.0F};
   float clip_duration{0.0F};
+
+  int edge_frames{0};
+  float worst_edge_extent{0.0F};
 };
+
+struct MatchTimeline {
+  QString scenario;
+  int seed{0};
+  float elapsed_seconds{0.0F};
+  bool tracked{false};
+  bool decided{false};
+  QString victor;
+  float decided_at{-1.0F};
+  std::vector<std::pair<QString, float>> events;
+  std::vector<Arena::ArenaBattleSideResult> sides;
+
+  [[nodiscard]] auto event_time(const QString& key) const -> std::optional<float> {
+    for (const auto& [name, at] : events) {
+      if (name == key) {
+        return at;
+      }
+    }
+    return std::nullopt;
+  }
+
+  void note(const QString& key, float at) {
+    if (!event_time(key).has_value()) {
+      events.emplace_back(key, at);
+    }
+  }
+};
+
+constexpr float k_contact_radius = 14.0F;
 
 class Recorder {
 public:
@@ -586,6 +621,11 @@ public:
       , m_options(std::move(options))
       , m_passes(plan_passes(spec))
       , m_results(spec.shots.size()) {}
+
+  [[nodiscard]] auto wants_precheck() const -> bool {
+    return m_options.force_precheck || m_options.precheck_only ||
+           m_spec.require_decision || uses_start_events(m_spec);
+  }
 
   auto start(QString* error) -> bool {
     if (!VideoEncoder::ffmpeg_available()) {
@@ -608,7 +648,18 @@ public:
                                       m_spec.height * m_spec.supersample);
     m_viewport.set_capture_sink([this](const QImage& frame) { on_frame(frame); });
     m_viewport.set_frame_hook([this](float scenario_time) { on_tick(scenario_time); });
-    QTimer::singleShot(250, [this]() { begin_next_pass(); });
+    if (wants_precheck()) {
+      for (const Shot& shot : m_spec.shots) {
+        const auto key = std::make_pair(shot.scenario, shot.seed);
+        if (std::find(m_precheck_targets.begin(), m_precheck_targets.end(), key) ==
+            m_precheck_targets.end()) {
+          m_precheck_targets.push_back(key);
+        }
+      }
+      QTimer::singleShot(250, [this]() { begin_next_precheck(); });
+    } else {
+      QTimer::singleShot(250, [this]() { begin_next_pass(); });
+    }
     return true;
   }
 
@@ -619,6 +670,268 @@ private:
 
   [[nodiscard]] auto current_shot_index() const -> std::size_t {
     return m_passes[m_pass_index].shots[m_slot_index];
+  }
+
+  void begin_next_precheck() {
+    if (m_precheck_index >= m_precheck_targets.size()) {
+      finish_precheck();
+      return;
+    }
+    const auto& [scenario_id, seed] = m_precheck_targets[m_precheck_index];
+    const auto* definition = Arena::Scenarios::find_definition(scenario_id);
+    if (definition == nullptr) {
+      qCritical().noquote()
+          << QStringLiteral("Promo spec names unknown scenario '%1'").arg(scenario_id);
+      m_failed = true;
+      ++m_precheck_index;
+      QTimer::singleShot(0, [this]() { begin_next_precheck(); });
+      return;
+    }
+
+    m_timelines.push_back(MatchTimeline{});
+    m_timelines.back().scenario = scenario_id;
+    m_timelines.back().seed = seed;
+    m_precheck_peak_buildings.clear();
+    m_precheck_active = true;
+    m_precheck_frames = 0;
+    m_viewport.set_terrain_seed(seed);
+    m_viewport.set_batch_fixed_step(idle_step());
+    m_viewport.set_capture_active(false);
+    m_viewport.clear_cinematic_view();
+    m_viewport.set_scenario_duration_override(definition->duration_seconds);
+    m_viewport.load_scenario(scenario_id);
+    m_viewport.set_batch_render_suppressed(true);
+
+    qInfo().noquote() << QStringLiteral("Promo dry run %1/%2: %3 (seed %4), up to %5 s "
+                                        "of match")
+                             .arg(m_precheck_index + 1U)
+                             .arg(m_precheck_targets.size())
+                             .arg(scenario_id)
+                             .arg(seed)
+                             .arg(
+                                 QString::number(definition->duration_seconds, 'f', 0));
+
+    const std::size_t guarded = m_precheck_index;
+    const int watchdog_ms = std::max(k_pass_watchdog_ms,
+                                     static_cast<int>(definition->duration_seconds *
+                                                      1000.0F * k_pass_watchdog_scale));
+    QTimer::singleShot(watchdog_ms, [this, guarded]() {
+      if (m_precheck_active && m_precheck_index == guarded) {
+        qCritical().noquote() << QStringLiteral("Promo dry run of '%1' exceeded its "
+                                                "watchdog")
+                                     .arg(m_precheck_targets[guarded].first);
+        m_failed = true;
+        end_precheck();
+      }
+    });
+  }
+
+  void tick_precheck(float scenario_time) {
+    ++m_precheck_frames;
+    if (m_precheck_frames <= k_pass_warmup_frames) {
+      return;
+    }
+    MatchTimeline& timeline = m_timelines.back();
+    const auto snapshot = m_viewport.casting_snapshot();
+    if (snapshot.valid) {
+      for (const auto& side : snapshot.sides) {
+        const auto& census = side.census;
+        if (census.wave_committed && census.wave_size > 0) {
+          timeline.note(QLatin1String(k_event_first_wave), scenario_time);
+          timeline.note(QStringLiteral("%1:%2").arg(QLatin1String(k_event_first_wave),
+                                                    census.label),
+                        scenario_time);
+        }
+        int& peak = m_precheck_peak_buildings[census.owner_id];
+        if (census.living_buildings < peak) {
+          timeline.note(QLatin1String(k_event_first_building_lost), scenario_time);
+          timeline.note(QStringLiteral("%1:%2").arg(
+                            QLatin1String(k_event_first_building_lost), census.label),
+                        scenario_time);
+        }
+        peak = std::max(peak, census.living_buildings);
+      }
+    }
+    if (m_viewport.scenario_battle_center(0, k_contact_radius).has_value()) {
+      timeline.note(QLatin1String(k_event_first_contact), scenario_time);
+    }
+    if (m_viewport.active_scenario_finished()) {
+      end_precheck();
+    }
+  }
+
+  void end_precheck() {
+    if (!m_precheck_active) {
+      return;
+    }
+    m_precheck_active = false;
+    MatchTimeline& timeline = m_timelines.back();
+    if (const auto* report = m_viewport.active_scenario_report(); report != nullptr) {
+      timeline.elapsed_seconds = report->elapsed_seconds;
+      timeline.tracked = report->battle.tracked;
+      timeline.decided = report->battle.decided;
+      timeline.victor = report->battle.victor_label;
+      timeline.decided_at = report->battle.decided_at_seconds;
+      timeline.sides = report->battle.sides;
+      if (timeline.decided) {
+        timeline.note(QLatin1String(k_event_decision), timeline.decided_at);
+      }
+    }
+    std::stable_sort(
+        timeline.events.begin(),
+        timeline.events.end(),
+        [](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
+
+    qInfo().noquote() << QStringLiteral("  %1 after %2 s: %3")
+                             .arg(timeline.scenario)
+                             .arg(QString::number(timeline.elapsed_seconds, 'f', 1))
+                             .arg(timeline.decided
+                                      ? QStringLiteral("%1 wins at %2 s")
+                                            .arg(side_display_name(timeline.victor))
+                                            .arg(QString::number(
+                                                timeline.decided_at, 'f', 1))
+                                      : QStringLiteral("no decision"));
+    for (const auto& [name, at] : timeline.events) {
+      qInfo().noquote() << QStringLiteral("    %1 s  %2")
+                               .arg(QString::number(at, 'f', 1), 7)
+                               .arg(name);
+    }
+    for (const auto& side : timeline.sides) {
+      qInfo().noquote() << QStringLiteral("    %1: %2 units raised, peak army %3, %4 "
+                                          "buildings raised, %5 s on the attack%6")
+                               .arg(side_display_name(side.label))
+                               .arg(side.units_produced)
+                               .arg(side.peak_units)
+                               .arg(side.buildings_constructed)
+                               .arg(QString::number(side.seconds_attacking, 'f', 0))
+                               .arg(side.eliminated_at >= 0.0F
+                                        ? QStringLiteral(", fell at %1 s")
+                                              .arg(QString::number(
+                                                  side.eliminated_at, 'f', 0))
+                                        : QString{});
+    }
+
+    m_viewport.set_batch_render_suppressed(false);
+    ++m_precheck_index;
+    QTimer::singleShot(0, [this]() { begin_next_precheck(); });
+  }
+
+  [[nodiscard]] auto timeline_for(const QString& scenario,
+                                  int seed) const -> const MatchTimeline* {
+    for (const MatchTimeline& timeline : m_timelines) {
+      if (timeline.scenario == scenario && timeline.seed == seed) {
+        return &timeline;
+      }
+    }
+    return nullptr;
+  }
+
+  [[nodiscard]] auto resolve_from_timelines() -> bool {
+    bool ok = true;
+    for (Shot& shot : m_spec.shots) {
+      if (!shot.start_on.has_value()) {
+        continue;
+      }
+      const MatchTimeline* timeline = timeline_for(shot.scenario, shot.seed);
+      const QString key =
+          shot.start_on->side.isEmpty()
+              ? shot.start_on->event
+              : QStringLiteral("%1:%2").arg(shot.start_on->event, shot.start_on->side);
+      const auto at = timeline != nullptr ? timeline->event_time(key) : std::nullopt;
+      if (!at.has_value()) {
+        qCritical().noquote()
+            << QStringLiteral("Promo shot '%1' starts on '%2', which never happened in "
+                              "the dry run of %3")
+                   .arg(shot.name, key, shot.scenario);
+        ok = false;
+        continue;
+      }
+      shot.start_seconds = std::max(0.0F, *at + shot.start_on->offset_seconds);
+      qInfo().noquote() << QStringLiteral("  shot %1 starts at %2 s (%3 %4 s)")
+                               .arg(shot.name)
+                               .arg(QString::number(shot.start_seconds, 'f', 1))
+                               .arg(key)
+                               .arg(QString::number(
+                                   shot.start_on->offset_seconds, 'f', 1));
+    }
+    if (m_spec.require_decision) {
+      for (const MatchTimeline& timeline : m_timelines) {
+        if (timeline.tracked && !timeline.decided) {
+          qCritical().noquote()
+              << QStringLiteral("Promo spec requires a decision, but %1 (seed %2) ran "
+                                "%3 s without one; not recording a stalemate")
+                     .arg(timeline.scenario)
+                     .arg(timeline.seed)
+                     .arg(QString::number(timeline.elapsed_seconds, 'f', 0));
+          ok = false;
+        }
+      }
+    }
+    return ok;
+  }
+
+  void write_timelines() const {
+    QJsonArray matches;
+    for (const MatchTimeline& timeline : m_timelines) {
+      QJsonArray events;
+      for (const auto& [name, at] : timeline.events) {
+        events.append(QJsonObject{{QStringLiteral("event"), name},
+                                  {QStringLiteral("at"), static_cast<double>(at)}});
+      }
+      QJsonArray sides;
+      for (const auto& side : timeline.sides) {
+        sides.append(QJsonObject{
+            {QStringLiteral("label"), side.label},
+            {QStringLiteral("owner_id"), side.owner_id},
+            {QStringLiteral("units_produced"), side.units_produced},
+            {QStringLiteral("peak_units"), side.peak_units},
+            {QStringLiteral("peak_soldiers"), side.peak_soldiers},
+            {QStringLiteral("buildings_constructed"), side.buildings_constructed},
+            {QStringLiteral("peak_buildings"), side.peak_buildings},
+            {QStringLiteral("living_units"), side.living_units},
+            {QStringLiteral("living_buildings"), side.living_buildings},
+            {QStringLiteral("seconds_attacking"),
+             static_cast<double>(side.seconds_attacking)},
+            {QStringLiteral("eliminated_at"), static_cast<double>(side.eliminated_at)},
+            {QStringLiteral("strategy"), side.strategy},
+            {QStringLiteral("posture"), side.posture}});
+      }
+      matches.append(QJsonObject{
+          {QStringLiteral("scenario"), timeline.scenario},
+          {QStringLiteral("seed"), timeline.seed},
+          {QStringLiteral("elapsed_seconds"),
+           static_cast<double>(timeline.elapsed_seconds)},
+          {QStringLiteral("decided"), timeline.decided},
+          {QStringLiteral("victor"), timeline.victor},
+          {QStringLiteral("decided_at"), static_cast<double>(timeline.decided_at)},
+          {QStringLiteral("events"), events},
+          {QStringLiteral("sides"), sides}});
+    }
+    QFile file(
+        QDir(m_options.output_directory).filePath(QStringLiteral("timeline.json")));
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+      file.write(QJsonDocument(QJsonObject{{QStringLiteral("id"), m_spec.id},
+                                           {QStringLiteral("matches"), matches}})
+                     .toJson(QJsonDocument::Indented));
+    }
+  }
+
+  void finish_precheck() {
+    write_timelines();
+    if (!resolve_from_timelines()) {
+      m_failed = true;
+      finish_run();
+      return;
+    }
+    if (m_options.precheck_only) {
+      qInfo().noquote() << QStringLiteral("Promo dry run complete; timeline in %1")
+                               .arg(QDir(m_options.output_directory).absolutePath());
+      finish_run();
+      return;
+    }
+    m_passes = plan_passes(m_spec);
+    m_pass_index = 0;
+    begin_next_pass();
   }
 
   void begin_next_pass() {
@@ -734,6 +1047,13 @@ private:
     m_card_frames_target = 0;
     m_card_image.reset();
     m_last_frame.reset();
+    m_edge_frames = 0;
+    m_worst_edge_extent = 0.0F;
+    m_floor_half_extent = 0.0F;
+    if (const auto* definition = Arena::Scenarios::find_definition(shot.scenario);
+        definition != nullptr) {
+      m_floor_half_extent = definition->arena_floor_half_extent;
+    }
     m_viewport.set_batch_fixed_step(idle_step());
     m_viewport.set_flame_card(shot.flame_card, shot.flame_speed, shot.flame_intensity);
     m_viewport.set_capture_gameplay_ui(shot.gameplay_ui && !shot.flame_card,
@@ -772,6 +1092,10 @@ private:
                    .arg(describe(m_viewport.scenario_army_center(3, 24.0F)));
       }
     }
+    if (m_precheck_active) {
+      tick_precheck(scenario_time);
+      return;
+    }
     if (!m_shot_active) {
       return;
     }
@@ -783,6 +1107,7 @@ private:
     const float shot_time = std::max(0.0F, scenario_time - shot.start_seconds);
 
     QVector3D target;
+    std::optional<GroundFootprint> footprint;
     if (shot.gameplay_camera || shot.flame_card) {
 
       m_viewport.clear_cinematic_view();
@@ -795,6 +1120,12 @@ private:
       }
       m_viewport.set_cinematic_view(
           target, pose.distance, pose.pitch, pose.yaw, pose.fov, pose.roll);
+      footprint =
+          view_ground_footprint(pose,
+                                focus + shot.focus.offset,
+                                static_cast<float>(m_spec.width) /
+                                    static_cast<float>(std::max(1, m_spec.height)),
+                                0.0F);
     }
 
     const bool in_window =
@@ -818,7 +1149,19 @@ private:
     const bool recording = in_window && m_frames_written < m_target_frames;
     m_viewport.set_capture_active(recording);
     if (m_audio != nullptr) {
-      m_audio->advance(m_shot_armed ? m_step_seconds : idle_step(), recording);
+
+      const bool time_lapse = shot.slow_motion < 1.0F;
+      const float audio_step =
+          (m_shot_armed && !time_lapse) ? m_step_seconds : idle_step();
+      m_audio->advance(audio_step, recording);
+    }
+    if (recording && footprint.has_value() && m_floor_half_extent > 0.0F &&
+        frames_world_edge(*footprint, m_floor_half_extent)) {
+      ++m_edge_frames;
+      m_worst_edge_extent = std::max(m_worst_edge_extent, footprint->max_abs_extent);
+      if (footprint->horizon_visible) {
+        m_worst_edge_extent = std::max(m_worst_edge_extent, 1e6F);
+      }
     }
 
     if (recording && !m_logged_framing) {
@@ -993,6 +1336,9 @@ private:
       }
       m_viewport.paint_capture_gameplay_ui(output);
     }
+    if (current_shot().casting_overlay && !current_shot().flame_card) {
+      paint_casting_overlay(output, m_viewport.casting_snapshot());
+    }
 
     QString error;
     if (!m_encoder->write_frame(output, &error)) {
@@ -1104,6 +1450,29 @@ private:
     result.scene_duration = static_cast<float>(m_frames_written) * m_step_seconds;
     result.clip_duration =
         static_cast<float>(m_frames_written) / static_cast<float>(m_spec.fps);
+    result.edge_frames = m_edge_frames;
+    result.worst_edge_extent = m_worst_edge_extent;
+    if (m_edge_frames > 0) {
+      const QString what =
+          m_worst_edge_extent >= 1e6F
+              ? QStringLiteral("sees over the horizon")
+              : QStringLiteral("reaches %1 m from the centre, past the %2 m floor")
+                    .arg(QString::number(m_worst_edge_extent, 'f', 1))
+                    .arg(QString::number(m_floor_half_extent, 'f', 1));
+      const QString message =
+          QStringLiteral("Promo shot '%1' shows the world edge in %2 of %3 frames: the "
+                         "view %4")
+              .arg(shot.name)
+              .arg(m_edge_frames)
+              .arg(m_frames_written)
+              .arg(what);
+      if (m_spec.forbid_world_edge) {
+        qCritical().noquote() << message;
+        m_failed = true;
+      } else {
+        qWarning().noquote() << message;
+      }
+    }
     if (m_options.write_posters && m_last_frame.has_value()) {
       result.poster_path =
           QDir(m_options.output_directory)
@@ -1168,7 +1537,8 @@ private:
                                         : QFileInfo(result.poster_path).fileName()},
           {QStringLiteral("frames"), result.frames},
           {QStringLiteral("scene_seconds"), result.scene_duration},
-          {QStringLiteral("clip_seconds"), result.clip_duration}});
+          {QStringLiteral("clip_seconds"), result.clip_duration},
+          {QStringLiteral("edge_frames"), result.edge_frames}});
     }
     const QJsonObject manifest{{QStringLiteral("id"), m_spec.id},
                                {QStringLiteral("title"), m_spec.title},
@@ -1183,9 +1553,18 @@ private:
   }
 
   ArenaViewport& m_viewport;
-  const Spec& m_spec;
+  Spec m_spec;
   RunOptions m_options;
   std::vector<CapturePass> m_passes;
+  std::vector<std::pair<QString, int>> m_precheck_targets;
+  std::vector<MatchTimeline> m_timelines;
+  std::map<int, int> m_precheck_peak_buildings;
+  std::size_t m_precheck_index{0};
+  int m_precheck_frames{0};
+  bool m_precheck_active{false};
+  int m_edge_frames{0};
+  float m_worst_edge_extent{0.0F};
+  float m_floor_half_extent{0.0F};
   std::unique_ptr<VideoEncoder> m_encoder;
   std::vector<ShotResult> m_results;
   std::optional<QImage> m_last_frame;

--- a/tools/arena/promo_runner.h
+++ b/tools/arena/promo_runner.h
@@ -12,6 +12,10 @@ struct RunOptions {
   QString output_directory;
 
   bool write_posters{true};
+
+  bool force_precheck{false};
+
+  bool precheck_only{false};
 };
 
 [[nodiscard]] auto run(ArenaViewport& viewport,

--- a/tools/arena/promo_spec.cpp
+++ b/tools/arena/promo_spec.cpp
@@ -6,6 +6,7 @@
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <QStringList>
+#include <QtMath>
 
 #include <algorithm>
 #include <cmath>
@@ -13,6 +14,10 @@
 
 namespace Arena::Promo {
 namespace {
+
+constexpr float k_min_slow_motion = 1.0F / 60.0F;
+
+constexpr float k_world_edge_margin = 4.0F;
 
 auto parse_vector(const QJsonValue& value, const QVector3D& fallback) -> QVector3D {
   if (!value.isArray()) {
@@ -287,6 +292,12 @@ auto load(const QString& path, QString* error) -> std::optional<Spec> {
   spec.gameplay_ui = root.value(QStringLiteral("gameplay_ui")).toBool(spec.gameplay_ui);
   spec.gameplay_ui_all_owners = root.value(QStringLiteral("gameplay_ui_all_owners"))
                                     .toBool(spec.gameplay_ui_all_owners);
+  spec.casting_overlay =
+      root.value(QStringLiteral("casting_overlay")).toBool(spec.casting_overlay);
+  spec.require_decision =
+      root.value(QStringLiteral("require_decision")).toBool(spec.require_decision);
+  spec.forbid_world_edge =
+      root.value(QStringLiteral("forbid_world_edge")).toBool(spec.forbid_world_edge);
 
   if (spec.id.trimmed().isEmpty()) {
     if (error != nullptr) {
@@ -330,6 +341,7 @@ auto load(const QString& path, QString* error) -> std::optional<Spec> {
     Shot shot;
     shot.gameplay_ui = spec.gameplay_ui;
     shot.gameplay_ui_all_owners = spec.gameplay_ui_all_owners;
+    shot.casting_overlay = spec.casting_overlay;
     shot.name = shot_object.value(QStringLiteral("name")).toString();
     shot.scenario = shot_object.value(QStringLiteral("scenario")).toString().trimmed();
     shot.seed = shot_object.value(QStringLiteral("seed")).toInt(shot.seed);
@@ -339,6 +351,59 @@ auto load(const QString& path, QString* error) -> std::optional<Spec> {
         shot_object.value(QStringLiteral("duration")).toDouble(shot.duration_seconds));
     shot.slow_motion = static_cast<float>(
         shot_object.value(QStringLiteral("slow_motion")).toDouble(shot.slow_motion));
+    if (const QJsonValue time_lapse = shot_object.value(QStringLiteral("time_lapse"));
+        time_lapse.isDouble()) {
+      if (shot_object.contains(QStringLiteral("slow_motion"))) {
+        if (error != nullptr) {
+          *error = QStringLiteral("shot '%1' sets both slow_motion and time_lapse; "
+                                  "they are the same knob")
+                       .arg(shot.name);
+        }
+        return std::nullopt;
+      }
+      const float factor = static_cast<float>(time_lapse.toDouble(1.0));
+      if (factor < 1.0F) {
+        if (error != nullptr) {
+          *error = QStringLiteral("shot '%1': time_lapse must be at least 1 (use "
+                                  "slow_motion to slow a shot down)")
+                       .arg(shot.name);
+        }
+        return std::nullopt;
+      }
+      shot.slow_motion = 1.0F / factor;
+    }
+    shot.casting_overlay = shot_object.value(QStringLiteral("casting_overlay"))
+                               .toBool(shot.casting_overlay);
+    if (const QJsonValue start_on = shot_object.value(QStringLiteral("start_on"));
+        start_on.isObject()) {
+      const QJsonObject trigger = start_on.toObject();
+      StartOn resolved;
+      resolved.event = trigger.value(QStringLiteral("event")).toString().trimmed();
+      resolved.side = trigger.value(QStringLiteral("side")).toString().trimmed();
+      resolved.offset_seconds =
+          static_cast<float>(trigger.value(QStringLiteral("offset")).toDouble(0.0));
+      if (!known_start_event(resolved.event)) {
+        if (error != nullptr) {
+          *error = QStringLiteral("shot '%1': unknown start_on event '%2' (one of "
+                                  "%3, %4, %5, %6)")
+                       .arg(shot.name,
+                            resolved.event,
+                            QLatin1String(k_event_first_wave),
+                            QLatin1String(k_event_first_contact),
+                            QLatin1String(k_event_first_building_lost),
+                            QLatin1String(k_event_decision));
+        }
+        return std::nullopt;
+      }
+      if (shot_object.contains(QStringLiteral("start"))) {
+        if (error != nullptr) {
+          *error =
+              QStringLiteral("shot '%1' sets both start and start_on").arg(shot.name);
+        }
+        return std::nullopt;
+      }
+      shot.start_on = resolved;
+    }
     shot.shake = static_cast<float>(
         shot_object.value(QStringLiteral("shake")).toDouble(shot.shake));
     shot.gameplay_camera = shot_object.value(QStringLiteral("gameplay_camera"))
@@ -379,7 +444,7 @@ auto load(const QString& path, QString* error) -> std::optional<Spec> {
       }
       return std::nullopt;
     }
-    shot.slow_motion = std::clamp(shot.slow_motion, 0.05F, 8.0F);
+    shot.slow_motion = std::clamp(shot.slow_motion, k_min_slow_motion, 8.0F);
 
     if (shot.gameplay_camera || shot.flame_card) {
 
@@ -504,7 +569,8 @@ auto motion_violations(const Spec& spec,
     for (std::size_t index = 1; index < shot.keys.size(); ++index) {
       const CameraKey& from = shot.keys[index - 1];
       const CameraKey& to = shot.keys[index];
-      float const span = std::max(0.001F, to.time - from.time);
+
+      float const span = std::max(0.001F, (to.time - from.time) * shot.slow_motion);
 
       auto rate = [&](const QString& what, float delta, float limit) {
         float const measured = std::abs(delta) / span;
@@ -539,6 +605,116 @@ auto motion_violations(const Spec& spec,
     }
   }
 
+  return breaches;
+}
+
+} // namespace Arena::Promo
+
+namespace Arena::Promo {
+
+auto known_start_event(const QString& event) -> bool {
+  return event == QLatin1String(k_event_first_wave) ||
+         event == QLatin1String(k_event_first_contact) ||
+         event == QLatin1String(k_event_first_building_lost) ||
+         event == QLatin1String(k_event_decision);
+}
+
+auto uses_start_events(const Spec& spec) -> bool {
+  return std::any_of(spec.shots.begin(), spec.shots.end(), [](const Shot& shot) {
+    return shot.start_on.has_value();
+  });
+}
+
+auto view_ground_footprint(const Pose& pose,
+                           const QVector3D& focus,
+                           float aspect,
+                           float ground_y) -> GroundFootprint {
+
+  const float pitch = qDegreesToRadians(pose.pitch);
+  const float yaw = qDegreesToRadians(pose.yaw);
+  const float horizontal = pose.distance * std::cos(pitch);
+  const QVector3D target = focus + QVector3D(0.0F, pose.height, 0.0F);
+  const QVector3D position = target + QVector3D(std::sin(yaw) * horizontal,
+                                                pose.distance * std::sin(pitch),
+                                                std::cos(yaw) * horizontal);
+  const QVector3D forward = (target - position).normalized();
+  QVector3D right = QVector3D::crossProduct(forward, QVector3D(0.0F, 1.0F, 0.0F));
+  if (right.lengthSquared() < 1e-6F) {
+    right = QVector3D(1.0F, 0.0F, 0.0F);
+  }
+  right.normalize();
+  const QVector3D up = QVector3D::crossProduct(right, forward).normalized();
+
+  const float tan_vertical = std::tan(qDegreesToRadians(pose.fov) * 0.5F);
+  const float tan_horizontal = tan_vertical * std::max(0.01F, aspect);
+
+  GroundFootprint footprint;
+  for (const float sx : {-1.0F, 1.0F}) {
+    for (const float sy : {-1.0F, 1.0F}) {
+      const QVector3D ray =
+          forward + (right * (sx * tan_horizontal)) + (up * (sy * tan_vertical));
+      if (ray.y() >= -1e-4F) {
+        footprint.horizon_visible = true;
+        continue;
+      }
+      const float t = (ground_y - position.y()) / ray.y();
+      if (t <= 0.0F) {
+        footprint.horizon_visible = true;
+        continue;
+      }
+      const QVector3D hit = position + (ray * t);
+      footprint.max_abs_extent = std::max(
+          footprint.max_abs_extent, std::max(std::abs(hit.x()), std::abs(hit.z())));
+    }
+  }
+  return footprint;
+}
+
+auto frames_world_edge(const GroundFootprint& footprint,
+                       float floor_half_extent) -> bool {
+  return footprint.horizon_visible ||
+         footprint.max_abs_extent > floor_half_extent + k_world_edge_margin;
+}
+
+auto world_edge_violations(const Spec& spec,
+                           float floor_half_extent) -> std::vector<QString> {
+  std::vector<QString> breaches;
+  const float aspect =
+      static_cast<float>(spec.width) / static_cast<float>(std::max(1, spec.height));
+  for (const Shot& shot : spec.shots) {
+    if (shot.flame_card || shot.gameplay_camera ||
+        shot.focus.mode != FocusMode::Point || shot.keys.empty()) {
+      continue;
+    }
+    std::vector<float> sample_times;
+    for (const CameraKey& key : shot.keys) {
+      sample_times.push_back(key.time);
+    }
+    sample_times.push_back(shot.duration_seconds);
+    for (const float time : sample_times) {
+      const Pose pose = evaluate(shot.keys, time);
+      const GroundFootprint footprint = view_ground_footprint(
+          pose, shot.focus.point + shot.focus.offset, aspect, 0.0F);
+      if (!frames_world_edge(footprint, floor_half_extent)) {
+        continue;
+      }
+      breaches.push_back(
+          footprint.horizon_visible
+              ? QStringLiteral("%1: at %2 s the camera sees over the horizon (pitch "
+                               "%3 with fov %4)")
+                    .arg(shot.name)
+                    .arg(time, 0, 'f', 1)
+                    .arg(pose.pitch, 0, 'f', 1)
+                    .arg(pose.fov, 0, 'f', 1)
+              : QStringLiteral("%1: at %2 s the frame reaches %3 m from the centre, "
+                               "past the %4 m arena floor")
+                    .arg(shot.name)
+                    .arg(time, 0, 'f', 1)
+                    .arg(footprint.max_abs_extent, 0, 'f', 1)
+                    .arg(floor_half_extent, 0, 'f', 1));
+      break;
+    }
+  }
   return breaches;
 }
 

--- a/tools/arena/promo_spec.h
+++ b/tools/arena/promo_spec.h
@@ -56,15 +56,32 @@ struct CameraKey {
   Ease ease{Ease::Smooth};
 };
 
+struct StartOn {
+  QString event;
+  QString side;
+  float offset_seconds{0.0F};
+};
+
+inline constexpr const char* k_event_first_wave = "first_wave";
+inline constexpr const char* k_event_first_contact = "first_contact";
+inline constexpr const char* k_event_first_building_lost = "first_building_lost";
+inline constexpr const char* k_event_decision = "decision";
+
+[[nodiscard]] auto known_start_event(const QString& event) -> bool;
+
 struct Shot {
   QString name;
   QString scenario;
   int seed{1337};
 
   float start_seconds{0.0F};
+  std::optional<StartOn> start_on;
   float duration_seconds{3.0F};
+
   float slow_motion{1.0F};
   float shake{0.0F};
+
+  bool casting_overlay{false};
 
   bool gameplay_camera{false};
 
@@ -111,9 +128,35 @@ struct Spec {
   float report_sound_volume{0.45F};
   bool gameplay_ui{false};
   bool gameplay_ui_all_owners{false};
+  bool casting_overlay{false};
+
+  bool require_decision{false};
+
+  bool forbid_world_edge{false};
+
   ReportCardStyle report_card_style{ReportCardStyle::Reel};
   std::vector<Shot> shots;
 };
+
+struct GroundFootprint {
+  bool horizon_visible{false};
+  float max_abs_extent{0.0F};
+};
+
+struct Pose;
+
+[[nodiscard]] auto view_ground_footprint(const Pose& pose,
+                                         const QVector3D& focus,
+                                         float aspect,
+                                         float ground_y = 0.0F) -> GroundFootprint;
+
+[[nodiscard]] auto frames_world_edge(const GroundFootprint& footprint,
+                                     float floor_half_extent) -> bool;
+
+[[nodiscard]] auto world_edge_violations(const Spec& spec, float floor_half_extent)
+    -> std::vector<QString>;
+
+[[nodiscard]] auto uses_start_events(const Spec& spec) -> bool;
 
 struct Pose {
   QVector3D target;

--- a/tools/arena/promos/ai_war_of_towns_cast.json
+++ b/tools/arena/promos/ai_war_of_towns_cast.json
@@ -1,0 +1,413 @@
+{
+  "id": "ai_war_of_towns_cast",
+  "title": "SCIPIO  VS  HANNIBAL",
+  "subtitle": "AI VS AI  ·  STANDARD OF IRON",
+  "_comment": [
+    "A cast match, not a surveillance tape. The recorder plays the match through",
+    "once without rendering (require_decision), refuses to record a stalemate,",
+    "and resolves every start_on from that dry run, so the cut follows the",
+    "fight wherever it happens. Time-lapse shots carry the town building;",
+    "the wave and the clashes are shot at full speed and half speed from",
+    "inside the arena floor, with the casting strip on for the whole cut.",
+    "Point-focus keys are checked against the 58 m floor before capture, and",
+    "any frame that still reaches the rim fails the run (forbid_world_edge)."
+  ],
+  "width": 1920,
+  "height": 1080,
+  "fps": 30,
+  "supersample": 1,
+  "audio": true,
+  "casting_overlay": true,
+  "require_decision": true,
+  "forbid_world_edge": true,
+  "music_track": "music.combat.dust_of_trasimene",
+  "report_sound_decided": "music.stinger.victory_fanfare",
+  "report_sound_undecided": "music.stinger.defeat_quiet_field",
+  "music_volume": 0.16,
+  "end_card_seconds": 4.5,
+  "end_card_lines": [
+    "GITHUB.COM/DJEADA/STANDARD-OF-IRON",
+    "EVERY ORDER IN THIS MATCH CAME FROM THE GAME AI"
+  ],
+  "transition": { "type": "dissolve", "duration": 0.4 },
+  "grade": {
+    "contrast": 1.08,
+    "saturation": 1.1,
+    "brightness": 0.02,
+    "gamma": 1.04,
+    "grain": 2,
+    "vignette": 0.1,
+    "sharpen": 0.5
+  },
+  "shots": [
+    {
+      "name": "field",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 1.0,
+      "duration": 6.0,
+      "casting_overlay": false,
+      "focus": { "mode": "point", "point": [0.0, 0.0, 0.0], "smoothing": 0.0 },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 62,
+          "pitch": 58,
+          "yaw": 315,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 6.0,
+          "distance": 58,
+          "pitch": 56,
+          "yaw": 321,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "ONE RIVER  ·  THREE CROSSINGS  ·  TWO COMPUTER COMMANDERS"
+    },
+    {
+      "name": "rome_intro",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 8.0,
+      "duration": 5.0,
+      "focus": {
+        "mode": "group",
+        "group": "scipio_commander",
+        "smoothing": 0.4
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 22,
+          "pitch": 24,
+          "yaw": 28,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 5.0,
+          "distance": 20,
+          "pitch": 22,
+          "yaw": 40,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "NORTH BANK — SCIPIO OF THE ROMAN REPUBLIC"
+    },
+    {
+      "name": "carthage_intro",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 14.0,
+      "duration": 5.0,
+      "focus": {
+        "mode": "group",
+        "group": "hannibal_commander",
+        "smoothing": 0.4
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 22,
+          "pitch": 24,
+          "yaw": 208,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 5.0,
+          "distance": 20,
+          "pitch": 22,
+          "yaw": 220,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "SOUTH BANK — HANNIBAL OF CARTHAGE"
+    },
+    {
+      "name": "rome_builds",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 20.0,
+      "duration": 300.0,
+      "time_lapse": 25,
+      "focus": {
+        "mode": "point",
+        "point": [-38.0, 0.0, -38.0],
+        "smoothing": 0.0
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 46,
+          "pitch": 52,
+          "yaw": 40,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 300.0,
+          "distance": 44,
+          "pitch": 50,
+          "yaw": 52,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "FIVE MINUTES IN TWELVE SECONDS — THE LEGION RAISES A TOWN"
+    },
+    {
+      "name": "carthage_builds",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start": 20.0,
+      "duration": 300.0,
+      "time_lapse": 25,
+      "focus": {
+        "mode": "point",
+        "point": [38.0, 0.0, 38.0],
+        "smoothing": 0.0
+      },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 46,
+          "pitch": 52,
+          "yaw": 220,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 300.0,
+          "distance": 44,
+          "pitch": 50,
+          "yaw": 232,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "HANNIBAL BUILDS WIDER"
+    },
+    {
+      "name": "muster",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start_on": { "event": "first_wave", "offset": -4.0 },
+      "duration": 7.0,
+      "focus": { "mode": "all", "smoothing": 0.5 },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 58,
+          "pitch": 54,
+          "yaw": 300,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 7.0,
+          "distance": 54,
+          "pitch": 52,
+          "yaw": 312,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE FIRST WAVE MUSTERS"
+    },
+    {
+      "name": "march",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start_on": { "event": "first_contact", "offset": -18.0 },
+      "duration": 9.0,
+      "focus": { "mode": "battle", "engagement_radius": 40, "smoothing": 0.8 },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 34,
+          "pitch": 30,
+          "yaw": 250,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 9.0,
+          "distance": 30,
+          "pitch": 28,
+          "yaw": 262,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "ACROSS THE RIVER"
+    },
+    {
+      "name": "first_blood",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start_on": { "event": "first_contact", "offset": -1.0 },
+      "duration": 5.0,
+      "slow_motion": 1.6,
+      "focus": { "mode": "battle", "engagement_radius": 16, "smoothing": 0.35 },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 15,
+          "pitch": 18,
+          "yaw": 80,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 5.0,
+          "distance": 13,
+          "pitch": 16,
+          "yaw": 92,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "FIRST BLOOD"
+    },
+    {
+      "name": "the_fight",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start_on": { "event": "first_contact", "offset": 6.0 },
+      "duration": 10.0,
+      "focus": { "mode": "battle", "engagement_radius": 24, "smoothing": 0.5 },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 24,
+          "pitch": 26,
+          "yaw": 60,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 10.0,
+          "distance": 22,
+          "pitch": 24,
+          "yaw": 80,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ]
+    },
+    {
+      "name": "the_town_burns",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start_on": { "event": "first_building_lost", "offset": -3.0 },
+      "duration": 9.0,
+      "focus": { "mode": "battle", "engagement_radius": 30, "smoothing": 0.6 },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 28,
+          "pitch": 30,
+          "yaw": 20,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 9.0,
+          "distance": 26,
+          "pitch": 28,
+          "yaw": 38,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE FIRST HOUSE FALLS"
+    },
+    {
+      "name": "the_long_war",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start_on": { "event": "first_building_lost", "offset": 8.0 },
+      "duration": 360.0,
+      "time_lapse": 30,
+      "focus": { "mode": "point", "point": [0.0, 0.0, 0.0], "smoothing": 0.0 },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 62,
+          "pitch": 58,
+          "yaw": 315,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        },
+        {
+          "time": 360.0,
+          "distance": 60,
+          "pitch": 57,
+          "yaw": 325,
+          "fov": 40,
+          "height": 0,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "SIX MINUTES IN TWELVE SECONDS"
+    },
+    {
+      "name": "the_end",
+      "scenario": "ai_war_of_towns",
+      "seed": 1337,
+      "start_on": { "event": "decision", "offset": -14.0 },
+      "duration": 16.0,
+      "report_card": 6.0,
+      "focus": { "mode": "battle", "engagement_radius": 34, "smoothing": 0.7 },
+      "camera": [
+        {
+          "time": 0.0,
+          "distance": 30,
+          "pitch": 32,
+          "yaw": 200,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        },
+        {
+          "time": 16.0,
+          "distance": 40,
+          "pitch": 40,
+          "yaw": 224,
+          "fov": 40,
+          "height": 1.2,
+          "ease": "smooth"
+        }
+      ],
+      "caption": "THE DECISION"
+    }
+  ]
+}


### PR DESCRIPTION
Extend arena duel simulation and promo capture so a full AI-versus-AI match can be recorded as a deterministic broadcast package. Preserve committed attack waves through exclusive behavior execution, keep wave units focused on strategic and building objectives, allow fortification plans to proceed, and prevent defenders from abandoning a marching wave unless a full recall is configured. Add palette-driven roof, gate, and marketplace rendering variants for faction-owned buildings.\n\nAdd promo specification and runner support for decision preflight, match event start markers, side-specific event offsets, long-form time-lapse capture with bounded simulation substeps and real-time audio, live battle census and economy snapshots, casting overlays, camera/world-edge validation, and capture metadata. Include the Rome-versus-Carthage cast specification, overlay renderer, scenario wiring, registration changes, and updated capture documentation.\n\nExpand arena, AI, and promo-spec coverage for wave continuity, building targeting, casting data, event resolution, time-lapse behavior, overlay registration, and world-edge checks; update the supporting cue-placement and editing scripts to match the expanded capture workflow.