### PR TITLE
fix: improve arena panel layout and input safety

### DIFF
--- a/tools/arena/CMakeLists.txt
+++ b/tools/arena/CMakeLists.txt
@@ -62,7 +62,7 @@ target_link_libraries(
 # The two panels whose population rules the tests assert. Same reasoning as
 # map_editor_core: the test links the panel the arena ships, not a second copy
 # of its source.
-add_library(arena_panels STATIC unit_panel.cpp building_panel.cpp)
+add_library(arena_panels STATIC unit_panel.cpp building_panel.cpp panel_wheel_guard.cpp)
 target_include_directories(arena_panels PUBLIC "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(
     arena_panels

--- a/tools/arena/arena_window.cpp
+++ b/tools/arena/arena_window.cpp
@@ -57,37 +57,37 @@ ArenaWindow::ArenaWindow(Game::Session::SessionContext& session, QWidget* parent
   splitter->addWidget(m_viewport);
 
   auto* tab_widget = new QTabWidget(splitter);
-  tab_widget->setMinimumWidth(280);
-  tab_widget->setMaximumWidth(480);
+  tab_widget->setMinimumWidth(340);
+  tab_widget->setMaximumWidth(640);
 
   auto* terrain_scroll = new QScrollArea();
   terrain_scroll->setWidget(m_terrain_panel);
   terrain_scroll->setWidgetResizable(true);
-  terrain_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  terrain_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   tab_widget->addTab(terrain_scroll, "Terrain");
 
   auto* unit_scroll = new QScrollArea();
   unit_scroll->setWidget(m_unit_panel);
   unit_scroll->setWidgetResizable(true);
-  unit_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  unit_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   tab_widget->addTab(unit_scroll, "Units");
 
   auto* building_scroll = new QScrollArea();
   building_scroll->setWidget(m_building_panel);
   building_scroll->setWidgetResizable(true);
-  building_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  building_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   tab_widget->addTab(building_scroll, "Buildings");
 
   auto* prop_scroll = new QScrollArea();
   prop_scroll->setWidget(m_prop_panel);
   prop_scroll->setWidgetResizable(true);
-  prop_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  prop_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   tab_widget->addTab(prop_scroll, "Props");
 
   splitter->addWidget(tab_widget);
   splitter->setStretchFactor(0, 1);
   splitter->setStretchFactor(1, 0);
-  splitter->setSizes({1200, 360});
+  splitter->setSizes({1160, 420});
 
   main_layout->addWidget(splitter);
   setCentralWidget(central);

--- a/tools/arena/building_panel.cpp
+++ b/tools/arena/building_panel.cpp
@@ -14,6 +14,7 @@
 #include "game/systems/default_content.h"
 #include "game/systems/nation_id.h"
 #include "game/systems/nation_registry.h"
+#include "panel_wheel_guard.h"
 
 namespace {
 
@@ -47,6 +48,8 @@ BuildingPanel::BuildingPanel(Game::Systems::NationRegistry& nations, QWidget* pa
 
   auto* spawn_form = new QFormLayout();
   spawn_form->setSpacing(4);
+  spawn_form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  spawn_form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   m_owner_box = new QComboBox(spawn_group);
   m_nation_box = new QComboBox(spawn_group);
   m_building_box = new QComboBox(spawn_group);
@@ -69,7 +72,7 @@ BuildingPanel::BuildingPanel(Game::Systems::NationRegistry& nations, QWidget* pa
   spawn_form->addRow("Side", m_owner_box);
   spawn_form->addRow("Nation", m_nation_box);
   spawn_form->addRow("Building", m_building_box);
-  spawn_form->addRow("Spawn Count", m_spawn_count_box);
+  spawn_form->addRow("Count", m_spawn_count_box);
   spawn_group_layout->addLayout(spawn_form);
 
   auto* spawn_buttons = new QWidget(spawn_group);
@@ -121,6 +124,8 @@ BuildingPanel::BuildingPanel(Game::Systems::NationRegistry& nations, QWidget* pa
           [this](int) { emit building_type_selected(selected_building_type_id()); });
 
   populate_nation_options();
+
+  Arena::Panels::guard_wheel_edits(this);
 }
 
 void BuildingPanel::set_selection_summary(const QString& summary) {

--- a/tools/arena/panel_wheel_guard.cpp
+++ b/tools/arena/panel_wheel_guard.cpp
@@ -1,0 +1,53 @@
+#include "panel_wheel_guard.h"
+
+#include <QAbstractSlider>
+#include <QAbstractSpinBox>
+#include <QComboBox>
+#include <QEvent>
+#include <QObject>
+#include <QWidget>
+
+namespace Arena::Panels {
+
+namespace {
+
+class WheelGuard : public QObject {
+public:
+  using QObject::QObject;
+
+  auto eventFilter(QObject* watched, QEvent* event) -> bool override {
+    auto* widget = qobject_cast<QWidget*>(watched);
+    if (event->type() != QEvent::Wheel || widget == nullptr || widget->hasFocus()) {
+      return QObject::eventFilter(watched, event);
+    }
+
+    event->ignore();
+    return true;
+  }
+};
+
+void guard_one(QObject* guard, QWidget* widget) {
+  widget->setFocusPolicy(Qt::StrongFocus);
+  widget->installEventFilter(guard);
+}
+
+} // namespace
+
+void guard_wheel_edits(QWidget* panel) {
+  if (panel == nullptr) {
+    return;
+  }
+
+  auto* guard = new WheelGuard(panel);
+  for (auto* slider : panel->findChildren<QAbstractSlider*>()) {
+    guard_one(guard, slider);
+  }
+  for (auto* spin_box : panel->findChildren<QAbstractSpinBox*>()) {
+    guard_one(guard, spin_box);
+  }
+  for (auto* combo_box : panel->findChildren<QComboBox*>()) {
+    guard_one(guard, combo_box);
+  }
+}
+
+} // namespace Arena::Panels

--- a/tools/arena/panel_wheel_guard.h
+++ b/tools/arena/panel_wheel_guard.h
@@ -1,0 +1,12 @@
+#ifndef ARENA_PANEL_WHEEL_GUARD_H
+#define ARENA_PANEL_WHEEL_GUARD_H
+
+class QWidget;
+
+namespace Arena::Panels {
+
+void guard_wheel_edits(QWidget* panel);
+
+} // namespace Arena::Panels
+
+#endif

--- a/tools/arena/prop_panel.cpp
+++ b/tools/arena/prop_panel.cpp
@@ -5,11 +5,12 @@
 #include <QFormLayout>
 #include <QGridLayout>
 #include <QGroupBox>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
 #include <QToolButton>
 #include <QVBoxLayout>
+
+#include "panel_wheel_guard.h"
 
 namespace {
 
@@ -78,6 +79,8 @@ PropPanel::PropPanel(QWidget* parent)
   auto* settings_group = new QGroupBox("Placement Settings", this);
   auto* settings_layout = new QFormLayout(settings_group);
   settings_layout->setSpacing(6);
+  settings_layout->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  settings_layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 
   m_scale_box = new QDoubleSpinBox(settings_group);
   m_scale_box->setRange(0.1, 8.0);
@@ -109,18 +112,12 @@ PropPanel::PropPanel(QWidget* parent)
 
   auto* actions_group = new QGroupBox("Actions", this);
   auto* actions_layout = new QVBoxLayout(actions_group);
-  auto* primary_row = new QWidget(actions_group);
-  auto* primary_row_layout = new QHBoxLayout(primary_row);
-  primary_row_layout->setContentsMargins(0, 0, 0, 0);
-  primary_row_layout->setSpacing(6);
   auto* place_button = new QPushButton("Place Prop", actions_group);
   place_button->setProperty("primary", true);
   auto* clear_selected_button = new QPushButton("Clear Selected Type", actions_group);
-  primary_row_layout->addWidget(place_button, 1);
-  primary_row_layout->addWidget(clear_selected_button, 1);
-  actions_layout->addWidget(primary_row);
-
   auto* clear_all_button = new QPushButton("Clear All Props", actions_group);
+  actions_layout->addWidget(place_button);
+  actions_layout->addWidget(clear_selected_button);
   actions_layout->addWidget(clear_all_button);
   layout->addWidget(actions_group);
   layout->addStretch(1);
@@ -167,6 +164,7 @@ PropPanel::PropPanel(QWidget* parent)
           &PropPanel::clear_world_props_of_type_requested);
 
   update_control_visibility();
+  Arena::Panels::guard_wheel_edits(this);
 }
 
 auto PropPanel::selected_prop_type_id() const -> QString {

--- a/tools/arena/terrain_panel.cpp
+++ b/tools/arena/terrain_panel.cpp
@@ -14,6 +14,8 @@
 
 #include <functional>
 
+#include "panel_wheel_guard.h"
+
 namespace {
 
 void bind_slider_to_double(QSlider* slider,
@@ -55,6 +57,8 @@ TerrainPanel::TerrainPanel(QWidget* parent)
   noise_layout->setSpacing(6);
   auto* form = new QFormLayout();
   form->setSpacing(4);
+  form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 
   auto* seed_box = new QSpinBox(noise_group);
   seed_box->setRange(0, 999999);
@@ -128,6 +132,8 @@ TerrainPanel::TerrainPanel(QWidget* parent)
   rain_vlayout->setSpacing(6);
   auto* rain_form = new QFormLayout();
   rain_form->setSpacing(4);
+  rain_form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  rain_form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   auto* rain_box = new QCheckBox("Enable Rain", rain_section);
   auto* rain_intensity_container = new QWidget(rain_section);
   auto* rain_intensity_layout = new QHBoxLayout(rain_intensity_container);
@@ -142,13 +148,15 @@ TerrainPanel::TerrainPanel(QWidget* parent)
   rain_intensity_spin->setValue(0.5);
   rain_intensity_layout->addWidget(rain_intensity_slider, 1);
   rain_intensity_layout->addWidget(rain_intensity_spin);
-  rain_form->addRow("", rain_box);
+  rain_form->addRow(rain_box);
   rain_form->addRow("Intensity", rain_intensity_container);
   rain_vlayout->addLayout(rain_form);
   layout->addWidget(rain_section);
 
   auto* lighting_section = new QGroupBox("Environment Lighting", this);
   auto* lighting_form = new QFormLayout(lighting_section);
+  lighting_form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  lighting_form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   auto* time_spin = new QDoubleSpinBox(lighting_section);
   time_spin->setRange(0.0, 23.99);
   time_spin->setDecimals(2);
@@ -238,4 +246,6 @@ TerrainPanel::TerrainPanel(QWidget* parent)
       rain_intensity_slider, rain_intensity_spin, 100.0, [this](double value) {
         emit rain_intensity_changed(static_cast<float>(value));
       });
+
+  Arena::Panels::guard_wheel_edits(this);
 }

--- a/tools/arena/unit_panel.cpp
+++ b/tools/arena/unit_panel.cpp
@@ -21,6 +21,7 @@
 #include "game/systems/nation_id.h"
 #include "game/systems/nation_registry.h"
 #include "game/units/troop_type.h"
+#include "panel_wheel_guard.h"
 #include "unit_spawn_options.h"
 
 namespace {
@@ -55,12 +56,15 @@ UnitPanel::UnitPanel(Game::Systems::NationRegistry& nations, QWidget* parent)
 
   auto* spawn_form = new QFormLayout();
   spawn_form->setSpacing(4);
+  spawn_form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  spawn_form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   m_owner_box = new QComboBox(spawn_group);
   m_nation_box = new QComboBox(spawn_group);
   m_unit_box = new QComboBox(spawn_group);
   m_spawn_count_box = new QSpinBox(spawn_group);
   m_individuals_per_unit_box = new QSpinBox(spawn_group);
-  m_render_rider_checkbox = new QCheckBox("Render Rider On Mounted Units", spawn_group);
+  m_render_rider_checkbox = new QCheckBox("Render rider", spawn_group);
+  m_render_rider_checkbox->setToolTip("Render the rider on mounted units");
 
   m_owner_box->addItem(QStringLiteral("Local Player"), k_arena_local_owner_id);
   m_owner_box->addItem(QStringLiteral("Arena Opponent"), k_arena_opponent_owner_id);
@@ -76,9 +80,9 @@ UnitPanel::UnitPanel(Game::Systems::NationRegistry& nations, QWidget* parent)
   spawn_form->addRow("Side", m_owner_box);
   spawn_form->addRow("Nation", m_nation_box);
   spawn_form->addRow("Unit", m_unit_box);
-  spawn_form->addRow("Spawn Count", m_spawn_count_box);
-  spawn_form->addRow("Members / Unit", m_individuals_per_unit_box);
-  spawn_form->addRow("", m_render_rider_checkbox);
+  spawn_form->addRow("Count", m_spawn_count_box);
+  spawn_form->addRow("Members", m_individuals_per_unit_box);
+  spawn_form->addRow(m_render_rider_checkbox);
   spawn_group_layout->addLayout(spawn_form);
 
   auto* spawn_buttons = new QWidget(spawn_group);
@@ -94,8 +98,8 @@ UnitPanel::UnitPanel(Game::Systems::NationRegistry& nations, QWidget* parent)
   apply_visuals_button->setToolTip("Apply visual overrides to selected units");
   spawn_buttons_layout->addWidget(spawn_button, 1);
   spawn_buttons_layout->addWidget(clear_button, 1);
-  spawn_buttons_layout->addWidget(apply_visuals_button, 1);
   spawn_group_layout->addWidget(spawn_buttons);
+  spawn_group_layout->addWidget(apply_visuals_button);
 
   layout->addWidget(spawn_group);
 
@@ -105,6 +109,8 @@ UnitPanel::UnitPanel(Game::Systems::NationRegistry& nations, QWidget* parent)
 
   auto* anim_form = new QFormLayout();
   anim_form->setSpacing(4);
+  anim_form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  anim_form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   auto* animation_box = new QComboBox(anim_group);
   animation_box->addItems({QStringLiteral("Idle"),
                            QStringLiteral("Walk"),
@@ -139,10 +145,13 @@ UnitPanel::UnitPanel(Game::Systems::NationRegistry& nations, QWidget* parent)
   anim_buttons_layout->addWidget(move_button, 1);
   anim_group_layout->addWidget(anim_buttons);
 
-  m_pause_checkbox = new QCheckBox("Pause Simulation", anim_group);
-  auto* skeleton_debug_box = new QCheckBox("Skeleton / Pose Overlay", anim_group);
-  m_combat_debug_checkbox = new QCheckBox("Combat Animation Debug Overlay", anim_group);
-  m_attack_scrub_checkbox = new QCheckBox("Freeze Selected Attack Phase", anim_group);
+  m_pause_checkbox = new QCheckBox("Pause simulation", anim_group);
+  auto* skeleton_debug_box = new QCheckBox("Skeleton overlay", anim_group);
+  skeleton_debug_box->setToolTip("Draw the skeleton / pose overlay");
+  m_combat_debug_checkbox = new QCheckBox("Combat debug", anim_group);
+  m_combat_debug_checkbox->setToolTip("Draw the combat animation debug overlay");
+  m_attack_scrub_checkbox = new QCheckBox("Freeze attack", anim_group);
+  m_attack_scrub_checkbox->setToolTip("Freeze the selected attack phase");
   auto* scrub_container = new QWidget(anim_group);
   auto* scrub_layout = new QHBoxLayout(scrub_container);
   scrub_layout->setContentsMargins(0, 0, 0, 0);
@@ -170,6 +179,8 @@ UnitPanel::UnitPanel(Game::Systems::NationRegistry& nations, QWidget* parent)
   quick_setup_layout->setSpacing(4);
   auto* scenario_form = new QFormLayout();
   scenario_form->setSpacing(4);
+  scenario_form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+  scenario_form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
   m_scenario_box = new QComboBox(quick_setup_group);
   for (const Arena::Scenarios::ScenarioOption& option : Arena::Scenarios::options()) {
     m_scenario_box->addItem(option.label, option.id);
@@ -180,7 +191,7 @@ UnitPanel::UnitPanel(Game::Systems::NationRegistry& nations, QWidget* parent)
   load_scenario_button->setToolTip(
       "Reset the arena and load a Phase 1 combat animation scenario.");
   scenario_form->addRow("Scenario", m_scenario_box);
-  scenario_form->addRow("", load_scenario_button);
+  scenario_form->addRow(load_scenario_button);
   quick_setup_layout->addLayout(scenario_form);
   m_scenario_description_label = new QLabel(quick_setup_group);
   m_scenario_description_label->setWordWrap(true);
@@ -357,6 +368,8 @@ UnitPanel::UnitPanel(Game::Systems::NationRegistry& nations, QWidget* parent)
         m_scenario_box->itemData(m_scenario_box->currentIndex(), Qt::ToolTipRole)
             .toString());
   }
+
+  Arena::Panels::guard_wheel_edits(this);
 }
 
 void UnitPanel::apply_special_unit_defaults(const QString& unit_id) {


### PR DESCRIPTION
Broaden the Arena editor's control column and allow its scroll areas to expose content that no longer fits at narrow widths. Use wrapping, growing form fields, shorter labels, and vertically stacked actions so the terrain, unit, building, and prop panels remain usable across the editor's supported sizes.

Add the shared panel wheel guard and include it in the Arena panel library. The guard gives editable controls a strong focus policy and prevents unfocused sliders, spin boxes, and combo boxes from changing when the user scrolls through a panel, while preserving normal wheel editing for the focused control.

Keep the existing panel behavior and signal wiring intact while clarifying compact control labels with targeted tooltips and integrating the new helper into each affected panel.