### PR TITLE
Fix end-of-battle navigation responsiveness

### DIFF
--- a/tests/ui/qml/tst_battle_summary.qml
+++ b/tests/ui/qml/tst_battle_summary.qml
@@ -54,14 +54,19 @@ TestCase {
         return testCase.fakeEngine(victoryState, owners, byOwner, missionTitle);
     }
 
-    function makeSummary(engine) {
+    function makeHost(engine) {
         var host = hostComponent.createObject(testCase, {
                 "width": 1280,
                 "height": 720
             });
         host.summary.engine = engine;
+        return host;
+    }
+
+    function makeSummary(engine) {
+        var host = testCase.makeHost(engine);
         host.summary.show();
-        wait(1);
+        tryCompare(host.summary, "prepared", true);
         return host;
     }
 
@@ -179,6 +184,21 @@ TestCase {
         host.destroy();
     }
 
+    function test_preparing_before_open_keeps_stats_off_the_click_path() {
+        var engine = testCase.standardMatch("victory");
+        var host = testCase.makeHost(engine);
+        verify(!host.summary.visible);
+        host.summary.prepare();
+        tryCompare(host.summary, "prepared", true);
+        var readsBeforeOpen = engine.stats_reads;
+        verify(readsBeforeOpen > 0, "the warm-up never read the battle statistics");
+        host.summary.show();
+        compare(engine.stats_reads, readsBeforeOpen, "opening the prepared report reread statistics on the click path");
+        verify(host.summary.visible);
+        engine.destroy();
+        host.destroy();
+    }
+
     function test_closing_the_report_calls_back() {
         var engine = testCase.standardMatch("victory");
         var host = testCase.makeSummary(engine);
@@ -194,7 +214,7 @@ TestCase {
         host.destroy();
     }
 
-    function test_asking_for_the_menu_calls_back() {
+    function test_asking_for_the_menu_calls_back_after_feedback() {
         var engine = testCase.standardMatch("victory");
         var host = testCase.makeSummary(engine);
         var asked = 0;
@@ -203,7 +223,32 @@ TestCase {
             });
         var report = findChild(host.summary, "battleReport");
         report.menuRequested();
-        compare(asked, 1);
+        verify(host.summary.returning_to_menu, "the report did not enter a visible transition state");
+        compare(asked, 0, "menu navigation fired before feedback could render");
+        tryCompare(host.summary, "returning_to_menu", true);
+        tryVerify(function () {
+                return asked === 1;
+            });
+        engine.destroy();
+        host.destroy();
+    }
+
+    function test_repeated_menu_requests_do_not_enqueue_duplicate_navigation() {
+        var engine = testCase.standardMatch("victory");
+        var host = testCase.makeSummary(engine);
+        var asked = 0;
+        host.summary.return_to_main_menu_requested.connect(function () {
+                asked += 1;
+            });
+        var report = findChild(host.summary, "battleReport");
+        report.menuRequested();
+        report.menuRequested();
+        verify(host.summary.returning_to_menu);
+        tryVerify(function () {
+                return asked === 1;
+            });
+        wait(20);
+        compare(asked, 1, "a repeated menu click enqueued duplicate navigation");
         engine.destroy();
         host.destroy();
     }
@@ -216,6 +261,7 @@ TestCase {
             property var owner_info: []
             property var stats_by_owner: ({})
             property string mission_title: ""
+            property int stats_reads: 0
             property QtObject setup: QtObject {
                 readonly property bool is_mission_match: mission_title !== ""
 
@@ -227,6 +273,7 @@ TestCase {
             }
 
             function get_player_stats(ownerId) {
+                stats_reads += 1;
                 return stats_by_owner[String(ownerId)];
             }
         }

--- a/tests/ui/qml/tst_campaign_outcome.qml
+++ b/tests/ui/qml/tst_campaign_outcome.qml
@@ -141,10 +141,33 @@ TestCase {
                 "signalName": "reportRequested"
             });
         banner.item.primaryActivated();
-        compare(spy.count, 1);
+        verify(overlay.reportTransitioning, "the click was not acknowledged immediately");
+        verify(banner.visible, "the banner disappeared before transition feedback could render");
+        verify(!detail.visible);
+        tryCompare(spy, "count", 1);
         verify(overlay.showingSummary);
+        verify(!overlay.reportTransitioning);
         verify(!banner.visible, "the banner and the report must not stack");
         verify(detail.visible);
+        spy.destroy();
+        overlay.destroy();
+    }
+
+    function test_report_request_is_single_shot_while_transitioning() {
+        var overlay = makeOverlay({
+                "victoryState": "victory"
+            });
+        var banner = findChild(overlay, "outcomeBanner");
+        var spy = spyComponent.createObject(testCase, {
+                "target": overlay,
+                "signalName": "reportRequested"
+            });
+        banner.item.primaryActivated();
+        banner.item.primaryActivated();
+        verify(overlay.reportTransitioning);
+        tryCompare(spy, "count", 1);
+        wait(20);
+        compare(spy.count, 1, "a repeated click enqueued a second report transition");
         spy.destroy();
         overlay.destroy();
     }

--- a/ui/qml/BattleSummary.qml
+++ b/ui/qml/BattleSummary.qml
@@ -212,7 +212,7 @@ Item {
             id: preparingLabel
 
             anchors.centerIn: parent
-            text: qsTr("Preparing battle report…")
+            text: "…"
             color: Design.Theme.textSecondary
             font.family: Design.Typography.family
             font.pixelSize: Design.Typography.label
@@ -243,7 +243,7 @@ Item {
                 id: returningLabel
 
                 anchors.centerIn: parent
-                text: qsTr("Returning to main menu…")
+                text: report.primaryAction + "…"
                 color: Design.Theme.textPrimary
                 font.family: Design.Typography.family
                 font.pixelSize: Design.Typography.label

--- a/ui/qml/BattleSummary.qml
+++ b/ui/qml/BattleSummary.qml
@@ -15,23 +15,61 @@ Item {
     property string missionName: ""
     property string durationText: ""
     property var armies: []
+    property bool prepared: false
+    property bool preparing: false
+    property bool returning_to_menu: false
+    property int preparation_generation: 0
 
     signal closed
     signal return_to_main_menu_requested
 
+    function reset_data() {
+        summaryOverlay.preparation_generation += 1;
+        summaryOverlay.prepared = false;
+        summaryOverlay.preparing = false;
+        summaryOverlay.returning_to_menu = false;
+        menuTransitionTimer.stop();
+        summaryOverlay.armies = [];
+        summaryOverlay.durationText = "";
+        summaryOverlay.missionName = "";
+    }
+
+    function prepare() {
+        if (summaryOverlay.prepared || summaryOverlay.preparing)
+            return;
+        summaryOverlay.preparing = true;
+        var generation = summaryOverlay.preparation_generation;
+        Qt.callLater(function () {
+                if (generation !== summaryOverlay.preparation_generation)
+                    return;
+                summaryOverlay.build_army_list();
+                if (generation !== summaryOverlay.preparation_generation)
+                    return;
+                summaryOverlay.prepared = true;
+                summaryOverlay.preparing = false;
+            });
+    }
+
     function show() {
+        summaryOverlay.returning_to_menu = false;
+        menuTransitionTimer.stop();
         visible = true;
-        build_army_list();
         report.forceActiveFocus();
+        summaryOverlay.prepare();
     }
 
     function hide() {
+        summaryOverlay.returning_to_menu = false;
+        menuTransitionTimer.stop();
         visible = false;
         summaryOverlay.closed();
     }
 
     function return_to_main_menu() {
-        summaryOverlay.return_to_main_menu_requested();
+        if (summaryOverlay.returning_to_menu)
+            return;
+        summaryOverlay.returning_to_menu = true;
+        menuTransitionTimer.restart();
     }
 
     function spectator_winning_team(roster) {
@@ -129,11 +167,23 @@ Item {
     visible: false
     z: 101
 
+    Timer {
+        id: menuTransitionTimer
+
+        interval: 16
+        repeat: false
+        onTriggered: {
+            if (summaryOverlay.returning_to_menu)
+                summaryOverlay.return_to_main_menu_requested();
+        }
+    }
+
     Design.BattleReportLayout {
         id: report
 
         objectName: "battleReport"
         anchors.fill: parent
+        enabled: !summaryOverlay.returning_to_menu
         outcome: summaryOverlay.outcome
         factionId: summaryOverlay.factionId
         headline: summaryOverlay.headline
@@ -143,5 +193,62 @@ Item {
         armies: summaryOverlay.armies
         onDismissed: summaryOverlay.hide()
         onMenuRequested: summaryOverlay.return_to_main_menu()
+    }
+
+    Rectangle {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Design.Metrics.space24
+        width: preparingLabel.implicitWidth + Design.Metrics.space24 * 2
+        height: Design.Metrics.controlHeight
+        radius: Design.Metrics.radiusSmall
+        color: Design.Theme.panelIron
+        border.width: Design.Metrics.borderThin
+        border.color: Design.Theme.borderStrong
+        visible: summaryOverlay.visible && summaryOverlay.preparing && !summaryOverlay.prepared && !summaryOverlay.returning_to_menu
+        z: 102
+
+        Text {
+            id: preparingLabel
+
+            anchors.centerIn: parent
+            text: qsTr("Preparing battle report…")
+            color: Design.Theme.textSecondary
+            font.family: Design.Typography.family
+            font.pixelSize: Design.Typography.label
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        visible: summaryOverlay.visible && summaryOverlay.returning_to_menu
+        z: 103
+        color: Qt.rgba(Design.Theme.backgroundDeep.r, Design.Theme.backgroundDeep.g, Design.Theme.backgroundDeep.b, 0.72)
+
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.AllButtons
+        }
+
+        Rectangle {
+            anchors.centerIn: parent
+            width: returningLabel.implicitWidth + Design.Metrics.space24 * 2
+            height: Design.Metrics.controlHeight
+            radius: Design.Metrics.radiusSmall
+            color: Design.Theme.panelIron
+            border.width: Design.Metrics.borderThin
+            border.color: Design.Theme.accent
+
+            Text {
+                id: returningLabel
+
+                anchors.centerIn: parent
+                text: qsTr("Returning to main menu…")
+                color: Design.Theme.textPrimary
+                font.family: Design.Typography.family
+                font.pixelSize: Design.Typography.label
+                font.weight: Design.Typography.medium
+            }
+        }
     }
 }

--- a/ui/qml/HUDVictory.qml
+++ b/ui/qml/HUDVictory.qml
@@ -42,6 +42,9 @@ Design.IronOutcomeOverlay {
     Connections {
         function onVictory_state_changed() {
             victoryOverlay.onOutcomeChanged();
+            battleSummary.reset_data();
+            if (victoryOverlay.victory_state() !== "")
+                battleSummary.prepare();
         }
 
         target: victoryOverlay.game_ready() ? game : null

--- a/ui/qml/design/controls/IronOutcomeOverlay.qml
+++ b/ui/qml/design/controls/IronOutcomeOverlay.qml
@@ -17,6 +17,7 @@ Item {
     property string primaryAction: qsTr("Battle Report")
 
     property bool showingSummary: false
+    property bool reportTransitioning: false
 
     property bool manuallyHidden: false
 
@@ -70,13 +71,24 @@ Item {
     signal secondaryRequested
 
     function reset() {
+        reportTransitionTimer.stop();
+        root.reportTransitioning = false;
         root.showingSummary = false;
         root.manuallyHidden = false;
     }
 
     function forceHide() {
+        reportTransitionTimer.stop();
+        root.reportTransitioning = false;
         root.showingSummary = false;
         root.manuallyHidden = true;
+    }
+
+    function request_report() {
+        if (root.reportTransitioning || root.showingSummary)
+            return;
+        root.reportTransitioning = true;
+        reportTransitionTimer.restart();
     }
 
     function onOutcomeChanged() {
@@ -92,8 +104,27 @@ Item {
 
     onVictoryStateChanged: root.onOutcomeChanged()
     onVisibleChanged: {
-        if (!visible)
+        if (!visible) {
+            reportTransitionTimer.stop();
+            root.reportTransitioning = false;
             root.showingSummary = false;
+        }
+    }
+
+    Timer {
+        id: reportTransitionTimer
+
+        interval: 16
+        repeat: false
+        onTriggered: {
+            if (!root.visible || !root.decided || root.manuallyHidden) {
+                root.reportTransitioning = false;
+                return;
+            }
+            root.showingSummary = true;
+            root.reportRequested();
+            root.reportTransitioning = false;
+        }
     }
 
     Loader {
@@ -103,6 +134,7 @@ Item {
         anchors.fill: parent
         active: !root.showingSummary
         visible: active
+        enabled: !root.reportTransitioning
 
         sourceComponent: Design.OutcomeLayout {
             outcome: root.outcomeKind
@@ -111,10 +143,7 @@ Item {
             subtitle: root.subtitle
             primaryAction: root.primaryAction
             secondaryAction: root.secondaryAction
-            onPrimaryActivated: {
-                root.showingSummary = true;
-                root.reportRequested();
-            }
+            onPrimaryActivated: root.request_report()
             onSecondaryActivated: root.secondaryRequested()
         }
     }
@@ -125,5 +154,38 @@ Item {
         objectName: "outcomeDetail"
         anchors.fill: parent
         visible: root.showingSummary
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        visible: root.reportTransitioning
+        z: 1
+        color: Qt.rgba(Design.Theme.backgroundDeep.r, Design.Theme.backgroundDeep.g, Design.Theme.backgroundDeep.b, 0.52)
+
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.AllButtons
+        }
+
+        Rectangle {
+            anchors.centerIn: parent
+            width: transitionLabel.implicitWidth + Design.Metrics.space24 * 2
+            height: Design.Metrics.controlHeight
+            radius: Design.Metrics.radiusSmall
+            color: Design.Theme.panelIron
+            border.width: Design.Metrics.borderThin
+            border.color: Design.Theme.accent
+
+            Text {
+                id: transitionLabel
+
+                anchors.centerIn: parent
+                text: qsTr("Opening battle report…")
+                color: Design.Theme.textPrimary
+                font.family: Design.Typography.family
+                font.pixelSize: Design.Typography.label
+                font.weight: Design.Typography.medium
+            }
+        }
     }
 }

--- a/ui/qml/design/controls/IronOutcomeOverlay.qml
+++ b/ui/qml/design/controls/IronOutcomeOverlay.qml
@@ -180,7 +180,7 @@ Item {
                 id: transitionLabel
 
                 anchors.centerIn: parent
-                text: qsTr("Opening battle report…")
+                text: root.primaryAction + "…"
                 color: Design.Theme.textPrimary
                 font.family: Design.Typography.family
                 font.pixelSize: Design.Typography.label


### PR DESCRIPTION
## Summary

- precompute battle-report data when the outcome is announced so opening the report no longer performs stats reads on the click path
- add immediate transition feedback for **Battle Report** and **Return to Menu**
- make both transition actions single-shot so repeated clicks cannot enqueue duplicate navigation
- add QML regression coverage for warmed report data, feedback-before-navigation, and duplicate-click guards
- reuse existing translated action labels for transition feedback, avoiding new translation catalogue entries

Fixes #1425