### PR TITLE
Rework Rome and Carthage building silhouettes and shared materials

### DIFF
--- a/render/entity/nations/carthage/barracks_renderer.cpp
+++ b/render/entity/nations/carthage/barracks_renderer.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cmath>
 
+#include "building_palette.h"
 #include "game/core/component.h"
 #include "game/visuals/team_colors.h"
 #include "math/math_utils.h"
@@ -38,20 +39,20 @@ constexpr auto k_mask_normal = BuildingStateMask::Normal;
 constexpr float k_pi = 3.14159265F;
 
 struct CarthagePalette {
-  QVector3D sandstone{0.82F, 0.70F, 0.52F};
-  QVector3D sandstone_light{0.92F, 0.84F, 0.68F};
-  QVector3D sandstone_dark{0.55F, 0.44F, 0.31F};
-  QVector3D stone_dark{0.38F, 0.32F, 0.24F};
-  QVector3D plaster{0.90F, 0.83F, 0.68F};
-  QVector3D plaster_shade{0.80F, 0.73F, 0.58F};
-  QVector3D brick_dark{0.40F, 0.18F, 0.11F};
-  QVector3D indigo{0.21F, 0.25F, 0.45F};
-  QVector3D oxblood{0.47F, 0.10F, 0.08F};
-  QVector3D saffron{0.76F, 0.36F, 0.035F};
-  QVector3D wood{0.46F, 0.30F, 0.16F};
-  QVector3D wood_dark{0.23F, 0.16F, 0.09F};
+  QVector3D sandstone = BuildingPalette::k_sandstone;
+  QVector3D sandstone_light = BuildingPalette::k_sandstone_light;
+  QVector3D sandstone_dark = BuildingPalette::k_sandstone_dark;
+  QVector3D stone_dark = BuildingPalette::k_sandstone_dark;
+  QVector3D plaster = BuildingPalette::k_plaster;
+  QVector3D plaster_shade = BuildingPalette::k_plaster_shade;
+  QVector3D brick_dark = BuildingPalette::k_brick_dark;
+  QVector3D indigo = BuildingPalette::k_indigo;
+  QVector3D oxblood = BuildingPalette::k_oxblood;
+  QVector3D saffron = BuildingPalette::k_saffron;
+  QVector3D wood = BuildingPalette::k_wood;
+  QVector3D wood_dark = BuildingPalette::k_wood_dark;
   QVector3D iron{0.24F, 0.23F, 0.21F};
-  QVector3D bronze{0.72F, 0.43F, 0.12F};
+  QVector3D bronze = BuildingPalette::k_bronze;
   QVector3D ember{0.68F, 0.22F, 0.045F};
   QVector3D flame{0.95F, 0.55F, 0.12F};
   QVector3D shadow{0.10F, 0.08F, 0.06F};

--- a/render/entity/nations/carthage/barracks_renderer.cpp
+++ b/render/entity/nations/carthage/barracks_renderer.cpp
@@ -548,14 +548,6 @@ void add_donjon(BuildingArchetypeDesc& desc,
       c.bronze,
       c.brick_dark,
       k_mask_intact);
-
-  add_punic_horned_crown(desc,
-                         QVector3D(0.0F, top + 0.03F, cz),
-                         0.92F,
-                         c.iron,
-                         c.bronze,
-                         c.ember,
-                         k_mask_normal);
 }
 
 void add_gatehouse(BuildingArchetypeDesc& desc,

--- a/render/entity/nations/carthage/building_palette.h
+++ b/render/entity/nations/carthage/building_palette.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QVector3D>
+
+namespace Render::GL::Carthage::BuildingPalette {
+
+// Shared architectural materials keep civilian and military buildings cohesive.
+// Player colors belong on banners and trim, never on the roof materials.
+inline constexpr QVector3D k_sandstone{0.82F, 0.70F, 0.52F};
+inline constexpr QVector3D k_sandstone_light{0.92F, 0.84F, 0.68F};
+inline constexpr QVector3D k_sandstone_dark{0.55F, 0.44F, 0.31F};
+inline constexpr QVector3D k_sandstone_shade{0.70F, 0.59F, 0.44F};
+inline constexpr QVector3D k_plaster{0.90F, 0.83F, 0.68F};
+inline constexpr QVector3D k_plaster_shade{0.80F, 0.73F, 0.58F};
+inline constexpr QVector3D k_brick{0.71F, 0.43F, 0.27F};
+inline constexpr QVector3D k_brick_dark{0.40F, 0.18F, 0.11F};
+inline constexpr QVector3D k_tile_red{0.57F, 0.21F, 0.12F};
+inline constexpr QVector3D k_tile_dark{0.43F, 0.18F, 0.11F};
+inline constexpr QVector3D k_wood{0.46F, 0.30F, 0.16F};
+inline constexpr QVector3D k_wood_dark{0.23F, 0.16F, 0.09F};
+inline constexpr QVector3D k_wood_light{0.60F, 0.42F, 0.21F};
+inline constexpr QVector3D k_bronze{0.72F, 0.43F, 0.12F};
+inline constexpr QVector3D k_indigo{0.21F, 0.25F, 0.45F};
+inline constexpr QVector3D k_oxblood{0.47F, 0.10F, 0.08F};
+inline constexpr QVector3D k_saffron{0.76F, 0.36F, 0.035F};
+
+} // namespace Render::GL::Carthage::BuildingPalette

--- a/render/entity/nations/carthage/defense_tower_renderer.cpp
+++ b/render/entity/nations/carthage/defense_tower_renderer.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <numbers>
 
+#include "building_palette.h"
 #include "game/core/component.h"
 #include "math/math_utils.h"
 #include "render/entity/barracks_flag_renderer.h"
@@ -26,16 +27,16 @@ namespace {
 using Render::Geom::clamp_vec_01;
 
 struct TowerPalette {
-  QVector3D stone_light{0.88F, 0.79F, 0.63F};
-  QVector3D stone_dark{0.38F, 0.32F, 0.24F};
-  QVector3D stone_base{0.74F, 0.64F, 0.48F};
-  QVector3D brick{0.71F, 0.43F, 0.27F};
-  QVector3D brick_dark{0.40F, 0.18F, 0.11F};
-  QVector3D tile_red{0.57F, 0.21F, 0.12F};
-  QVector3D wood{0.46F, 0.30F, 0.16F};
-  QVector3D wood_dark{0.23F, 0.16F, 0.09F};
+  QVector3D stone_light = BuildingPalette::k_sandstone_light;
+  QVector3D stone_dark = BuildingPalette::k_sandstone_dark;
+  QVector3D stone_base = BuildingPalette::k_sandstone;
+  QVector3D brick = BuildingPalette::k_brick;
+  QVector3D brick_dark = BuildingPalette::k_brick_dark;
+  QVector3D tile_red = BuildingPalette::k_tile_red;
+  QVector3D wood = BuildingPalette::k_wood;
+  QVector3D wood_dark = BuildingPalette::k_wood_dark;
   QVector3D iron{0.24F, 0.23F, 0.21F};
-  QVector3D bronze{0.72F, 0.43F, 0.12F};
+  QVector3D bronze = BuildingPalette::k_bronze;
   QVector3D ember{0.68F, 0.22F, 0.045F};
   QVector3D team{0.8F, 0.9F, 1.0F};
   QVector3D team_trim{0.48F, 0.54F, 0.60F};

--- a/render/entity/nations/carthage/defense_tower_renderer.cpp
+++ b/render/entity/nations/carthage/defense_tower_renderer.cpp
@@ -60,7 +60,6 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
   const float core_top = 0.5F + core_half_y * 2.0F;
   const float upper_drum_y = destroyed ? 0.0F : (damaged ? 1.86F : 2.16F);
   const float deck_y = destroyed ? 0.0F : (damaged ? 2.20F : 2.52F);
-  const float roof_y = destroyed ? 0.0F : (damaged ? 2.50F : 2.94F);
 
   desc.add_box(
       QVector3D(0.0F, 0.04F, 0.0F), QVector3D(1.24F, 0.04F, 1.24F), c.stone_dark);
@@ -230,23 +229,18 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
       }
     }
 
-    const float canopy_y = roof_y + (damaged ? 0.22F : 0.30F);
-    const float post_half = parapet_half - 0.12F;
-    for (const float px : {-post_half, post_half}) {
-      for (const float pz : {-post_half, post_half}) {
-        desc.add_box(QVector3D(px, (merlon_y + canopy_y) * 0.5F, pz),
-                     QVector3D(0.055F, (canopy_y - merlon_y) * 0.5F, 0.055F),
-                     c.wood_dark,
-                     BuildingStateMask::All);
-      }
+    // Leave an open military terrace, framed by the same sandstone cornice
+    // as the barracks. The parapet already supplies its stepped silhouette.
+    for (const float side : {-1.0F, 1.0F}) {
+      desc.add_box(QVector3D(0.0F, deck_y - 0.02F, side * parapet_half),
+                   QVector3D(parapet_half + 0.08F, 0.055F, 0.065F),
+                   c.stone_light,
+                   k_building_state_mask_intact);
+      desc.add_box(QVector3D(side * parapet_half, deck_y - 0.02F, 0.0F),
+                   QVector3D(0.065F, 0.055F, parapet_half + 0.08F),
+                   c.stone_light,
+                   k_building_state_mask_intact);
     }
-    desc.add_box(QVector3D(0.0F, canopy_y, 0.0F),
-                 QVector3D(damaged ? 0.70F : 0.80F, 0.03F, damaged ? 0.70F : 0.80F),
-                 c.tile_red);
-    desc.add_box(QVector3D(0.0F, canopy_y + 0.05F, 0.0F),
-                 QVector3D(damaged ? 0.48F : 0.56F, 0.03F, damaged ? 0.48F : 0.56F),
-                 c.tile_red,
-                 BuildingStateMask::All);
   }
 
   if (damaged) {
@@ -275,12 +269,6 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
         damaged ? 0.58F : 0.72F,
         c.brick,
         c.stone_dark);
-    add_punic_horned_crown(desc,
-                           QVector3D(0.0F, roof_y + 0.05F, 0.0F),
-                           damaged ? 0.54F : 0.78F,
-                           c.iron,
-                           c.bronze,
-                           c.ember);
   }
 
   add_broken_rim(desc,

--- a/render/entity/nations/carthage/farm_renderer.cpp
+++ b/render/entity/nations/carthage/farm_renderer.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <string>
 
+#include "building_palette.h"
 #include "render/entity/building_archetype_desc.h"
 #include "render/entity/building_decay.h"
 #include "render/entity/building_ornaments.h"
@@ -18,19 +19,19 @@ namespace Render::GL::Carthage {
 namespace {
 
 struct CarthageFarmPalette {
-  QVector3D sandstone{0.78F, 0.68F, 0.51F};
-  QVector3D sandstone_shade{0.63F, 0.53F, 0.39F};
-  QVector3D sandstone_dark{0.37F, 0.31F, 0.23F};
-  QVector3D mudbrick{0.63F, 0.43F, 0.28F};
-  QVector3D mudbrick_dark{0.44F, 0.28F, 0.18F};
-  QVector3D lime_wash{0.85F, 0.81F, 0.72F};
+  QVector3D sandstone = BuildingPalette::k_sandstone;
+  QVector3D sandstone_shade = BuildingPalette::k_sandstone_shade;
+  QVector3D sandstone_dark = BuildingPalette::k_sandstone_dark;
+  QVector3D mudbrick = BuildingPalette::k_brick;
+  QVector3D mudbrick_dark = BuildingPalette::k_brick_dark;
+  QVector3D lime_wash = BuildingPalette::k_plaster;
   QVector3D basalt{0.24F, 0.23F, 0.22F};
-  QVector3D palm_wood{0.42F, 0.29F, 0.17F};
-  QVector3D palm_dark{0.24F, 0.16F, 0.09F};
+  QVector3D palm_wood = BuildingPalette::k_wood;
+  QVector3D palm_dark = BuildingPalette::k_wood_dark;
   QVector3D thatch{0.70F, 0.56F, 0.30F};
   QVector3D thatch_dark{0.50F, 0.39F, 0.21F};
-  QVector3D indigo{0.18F, 0.21F, 0.36F};
-  QVector3D oxblood{0.39F, 0.11F, 0.09F};
+  QVector3D indigo = BuildingPalette::k_indigo;
+  QVector3D oxblood = BuildingPalette::k_oxblood;
   QVector3D clay{0.63F, 0.40F, 0.24F};
   QVector3D clay_band{0.32F, 0.15F, 0.10F};
   QVector3D sack{0.72F, 0.62F, 0.44F};

--- a/render/entity/nations/carthage/farm_renderer.cpp
+++ b/render/entity/nations/carthage/farm_renderer.cpp
@@ -19,6 +19,7 @@ namespace Render::GL::Carthage {
 namespace {
 
 struct CarthageFarmPalette {
+  QVector3D sandstone_light = BuildingPalette::k_sandstone_light;
   QVector3D sandstone = BuildingPalette::k_sandstone;
   QVector3D sandstone_shade = BuildingPalette::k_sandstone_shade;
   QVector3D sandstone_dark = BuildingPalette::k_sandstone_dark;
@@ -139,18 +140,18 @@ void add_storehouse(BuildingArchetypeDesc& desc, const CarthageFarmPalette& c) {
   }
   desc.add_box(centre + QVector3D(0.0F, roof_y + 0.045F, 0.0F),
                QVector3D(k_half_x + 0.03F, 0.014F, k_half_z + 0.03F),
-               c.thatch,
+               c.lime_wash,
                k_building_state_mask_intact);
-  for (float const sx : {-1.0F, 1.0F}) {
-    desc.add_box(centre + QVector3D(sx * (k_half_x + 0.015F), roof_y + 0.075F, 0.0F),
-                 QVector3D(0.015F, 0.03F, k_half_z + 0.03F),
-                 c.mudbrick,
+  for (const float side : {-1.0F, 1.0F}) {
+    desc.add_box(centre + QVector3D(side * (k_half_x + 0.015F), roof_y + 0.085F, 0.0F),
+                 QVector3D(0.022F, 0.035F, k_half_z + 0.04F),
+                 c.sandstone_light,
+                 k_building_state_mask_intact);
+    desc.add_box(centre + QVector3D(0.0F, roof_y + 0.085F, side * (k_half_z + 0.015F)),
+                 QVector3D(k_half_x + 0.04F, 0.035F, 0.022F),
+                 c.sandstone_light,
                  k_building_state_mask_intact);
   }
-  desc.add_box(centre + QVector3D(0.0F, roof_y + 0.075F, k_half_z + 0.015F),
-               QVector3D(k_half_x + 0.03F, 0.03F, 0.015F),
-               c.mudbrick,
-               k_building_state_mask_intact);
 
   desc.add_cylinder(centre + QVector3D(-k_half_x - 0.10F, 0.09F, 0.06F),
                     centre + QVector3D(-k_half_x + 0.03F, roof_y + 0.09F, 0.06F),

--- a/render/entity/nations/carthage/home_renderer.cpp
+++ b/render/entity/nations/carthage/home_renderer.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 
+#include "building_palette.h"
 #include "game/core/component.h"
 #include "math/math_utils.h"
 #include "render/entity/building_archetype_desc.h"
@@ -24,19 +25,17 @@ using Render::Geom::clamp_vec_01;
 constexpr std::uint8_t k_home_team_slot = 0;
 constexpr std::uint8_t k_home_roof_slot = 1;
 
-constexpr float k_roof_owner_blend = 0.42F;
-
 struct CarthagePalette {
-  QVector3D stone_light{0.88F, 0.79F, 0.63F};
-  QVector3D stone_dark{0.38F, 0.32F, 0.24F};
-  QVector3D stone_base{0.74F, 0.64F, 0.48F};
-  QVector3D brick{0.71F, 0.43F, 0.27F};
-  QVector3D brick_dark{0.40F, 0.18F, 0.11F};
-  QVector3D tile_red{0.57F, 0.21F, 0.12F};
-  QVector3D tile_dark{0.43F, 0.18F, 0.11F};
-  QVector3D wood{0.46F, 0.30F, 0.16F};
-  QVector3D wood_dark{0.23F, 0.16F, 0.09F};
-  QVector3D bronze{0.72F, 0.43F, 0.12F};
+  QVector3D stone_light = BuildingPalette::k_sandstone_light;
+  QVector3D stone_dark = BuildingPalette::k_sandstone_dark;
+  QVector3D stone_base = BuildingPalette::k_sandstone;
+  QVector3D brick = BuildingPalette::k_brick;
+  QVector3D brick_dark = BuildingPalette::k_brick_dark;
+  QVector3D tile_red = BuildingPalette::k_tile_red;
+  QVector3D tile_dark = BuildingPalette::k_tile_dark;
+  QVector3D wood = BuildingPalette::k_wood;
+  QVector3D wood_dark = BuildingPalette::k_wood_dark;
+  QVector3D bronze = BuildingPalette::k_bronze;
   QVector3D ember{0.68F, 0.22F, 0.045F};
   QVector3D team{0.8F, 0.9F, 1.0F};
   QVector3D team_trim{0.48F, 0.54F, 0.60F};
@@ -53,9 +52,7 @@ inline auto make_palette(const QVector3D& team) -> CarthagePalette {
 auto home_palette_slots(const QVector3D& team)
     -> std::array<QVector3D, k_home_palette_slots> {
   const auto palette = make_palette(team);
-  const QVector3D roof = clamp_vec_01(palette.tile_red * (1.0F - k_roof_owner_blend) +
-                                      palette.team * k_roof_owner_blend);
-  return {palette.team, roof};
+  return {palette.team, palette.tile_red};
 }
 
 auto build_home_archetype(BuildingState state) -> RenderArchetype {

--- a/render/entity/nations/carthage/home_renderer.cpp
+++ b/render/entity/nations/carthage/home_renderer.cpp
@@ -29,14 +29,12 @@ struct CarthagePalette {
   QVector3D stone_light = BuildingPalette::k_sandstone_light;
   QVector3D stone_dark = BuildingPalette::k_sandstone_dark;
   QVector3D stone_base = BuildingPalette::k_sandstone;
-  QVector3D brick = BuildingPalette::k_brick;
-  QVector3D brick_dark = BuildingPalette::k_brick_dark;
+  QVector3D plaster = BuildingPalette::k_plaster;
+  QVector3D indigo = BuildingPalette::k_indigo;
   QVector3D tile_red = BuildingPalette::k_tile_red;
-  QVector3D tile_dark = BuildingPalette::k_tile_dark;
   QVector3D wood = BuildingPalette::k_wood;
   QVector3D wood_dark = BuildingPalette::k_wood_dark;
   QVector3D bronze = BuildingPalette::k_bronze;
-  QVector3D ember{0.68F, 0.22F, 0.045F};
   QVector3D team{0.8F, 0.9F, 1.0F};
   QVector3D team_trim{0.48F, 0.54F, 0.60F};
 };
@@ -78,32 +76,23 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
   float const wall_cy = wall_height * 0.5F * height_multiplier + 0.20F;
   float const wall_hy = wall_height * 0.5F * height_multiplier;
   desc.add_box(
-      QVector3D(0.0F, wall_cy, -0.92F), QVector3D(0.88F, wall_hy, 0.10F), c.brick);
+      QVector3D(0.0F, wall_cy, -0.92F), QVector3D(0.88F, wall_hy, 0.10F), c.plaster);
   desc.add_box(
-      QVector3D(0.0F, wall_cy, 0.92F), QVector3D(0.88F, wall_hy, 0.10F), c.brick);
+      QVector3D(0.0F, wall_cy, 0.92F), QVector3D(0.88F, wall_hy, 0.10F), c.plaster);
   desc.add_box(
-      QVector3D(-0.92F, wall_cy, 0.0F), QVector3D(0.10F, wall_hy, 0.82F), c.brick);
+      QVector3D(-0.92F, wall_cy, 0.0F), QVector3D(0.10F, wall_hy, 0.82F), c.plaster);
   desc.add_box(
-      QVector3D(0.92F, wall_cy, 0.0F), QVector3D(0.10F, wall_hy, 0.82F), c.brick);
+      QVector3D(0.92F, wall_cy, 0.0F), QVector3D(0.10F, wall_hy, 0.82F), c.plaster);
 
-  float const lower_band_y = wall_height * 0.25F * height_multiplier + 0.20F;
-  float const upper_band_y = wall_height * 0.65F * height_multiplier + 0.20F;
-  for (float const band_y : {lower_band_y, upper_band_y}) {
-    desc.add_box(QVector3D(0.0F, band_y, -0.92F),
-                 QVector3D(0.90F, 0.03F, 0.12F),
-                 c.stone_light,
+  // A single sandstone base course keeps the plaster facades quiet.
+  for (const float side : {-1.0F, 1.0F}) {
+    desc.add_box(QVector3D(0.0F, 0.28F, side * 0.92F),
+                 QVector3D(0.90F, 0.06F, 0.12F),
+                 c.stone_base,
                  k_building_state_mask_intact);
-    desc.add_box(QVector3D(0.0F, band_y, 0.92F),
-                 QVector3D(0.90F, 0.03F, 0.12F),
-                 c.stone_light,
-                 k_building_state_mask_intact);
-    desc.add_box(QVector3D(-0.92F, band_y, 0.0F),
-                 QVector3D(0.12F, 0.03F, 0.86F),
-                 c.stone_light,
-                 k_building_state_mask_intact);
-    desc.add_box(QVector3D(0.92F, band_y, 0.0F),
-                 QVector3D(0.12F, 0.03F, 0.86F),
-                 c.stone_light,
+    desc.add_box(QVector3D(side * 0.92F, 0.28F, 0.0F),
+                 QVector3D(0.12F, 0.06F, 0.86F),
+                 c.stone_base,
                  k_building_state_mask_intact);
   }
 
@@ -128,55 +117,26 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
                        QVector3D(1.02F, 0.05F, 1.02F),
                        k_home_roof_slot,
                        k_building_state_mask_intact);
-  add_tile_rows_z(
-      [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-        desc.add_box(center, size, color, k_building_state_mask_intact);
-      },
-      roof_y + 0.06F,
-      -0.82F,
-      0.82F,
-      0.28F,
-      QVector3D(0.98F, 0.02F, 0.05F),
-      c.tile_dark);
-
-  float const parapet_y = roof_y + 0.08F;
-  float const merlon_h = 0.13F;
-  auto add_merlon =
-      [&](const QVector3D& center, const QVector3D& size, const QVector3D& color) {
-        desc.add_box(center, size, color, k_building_state_mask_intact);
-      };
-  add_merlon_strip_x(add_merlon,
-                     parapet_y,
-                     -0.94F,
-                     -0.68F,
-                     0.34F,
-                     5,
-                     QVector3D(0.12F, merlon_h, 0.08F),
-                     c.brick);
-  add_merlon_strip_x(add_merlon,
-                     parapet_y,
-                     0.94F,
-                     -0.68F,
-                     0.34F,
-                     5,
-                     QVector3D(0.12F, merlon_h, 0.08F),
-                     c.brick);
-  add_merlon_strip_z(add_merlon,
-                     -0.94F,
-                     parapet_y,
-                     -0.68F,
-                     0.34F,
-                     5,
-                     QVector3D(0.08F, merlon_h, 0.12F),
-                     c.brick);
-  add_merlon_strip_z(add_merlon,
-                     0.94F,
-                     parapet_y,
-                     -0.68F,
-                     0.34F,
-                     5,
-                     QVector3D(0.08F, merlon_h, 0.12F),
-                     c.brick);
+  // Domestic terraces use continuous low parapets, not military battlements.
+  const float parapet_y = roof_y + 0.13F;
+  for (const float side : {-1.0F, 1.0F}) {
+    desc.add_box(QVector3D(0.0F, parapet_y, side * 0.96F),
+                 QVector3D(1.00F, 0.10F, 0.055F),
+                 c.plaster,
+                 k_building_state_mask_intact);
+    desc.add_box(QVector3D(side * 0.96F, parapet_y, 0.0F),
+                 QVector3D(0.055F, 0.10F, 0.90F),
+                 c.plaster,
+                 k_building_state_mask_intact);
+    desc.add_box(QVector3D(0.0F, parapet_y + 0.11F, side * 0.96F),
+                 QVector3D(1.02F, 0.025F, 0.065F),
+                 c.stone_light,
+                 k_building_state_mask_intact);
+    desc.add_box(QVector3D(side * 0.96F, parapet_y + 0.11F, 0.0F),
+                 QVector3D(0.065F, 0.025F, 0.92F),
+                 c.stone_light,
+                 k_building_state_mask_intact);
+  }
 
   desc.add_box(
       QVector3D(0.0F, 0.44F, 0.97F), QVector3D(0.32F, 0.44F, 0.06F), c.wood_dark);
@@ -199,7 +159,7 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
   desc.add_box(
       QVector3D(0.0F, 0.16F, 1.02F), QVector3D(0.36F, 0.02F, 0.10F), c.stone_base);
 
-  for (float const xw : {-0.95F, 0.95F}) {
+  for (float const xw : {-1.025F, 1.025F}) {
     desc.add_box(QVector3D(xw, 0.58F, -0.32F),
                  QVector3D(0.015F, 0.22F, 0.06F),
                  c.wood_dark,
@@ -239,58 +199,32 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
                     QVector3D(0.25F, 0.42F, 0.55F),
                     k_building_state_mask_intact);
 
-  if (state != BuildingState::Destroyed) {
-    desc.add_box(QVector3D(0.0F, 0.78F, 1.04F),
-                 QVector3D(0.44F, 0.05F, 0.10F),
-                 c.ember,
-                 k_building_state_mask_intact);
-
-    desc.add_box(QVector3D(-0.38F, 0.62F, 1.00F),
-                 QVector3D(0.02F, 0.20F, 0.02F),
-                 c.wood_dark,
-                 k_building_state_mask_intact);
-    desc.add_box(QVector3D(0.38F, 0.62F, 1.00F),
-                 QVector3D(0.02F, 0.20F, 0.02F),
-                 c.wood_dark,
-                 k_building_state_mask_intact);
-
-    desc.add_box(QVector3D(0.0F, roof_y + 0.22F, -0.10F),
-                 QVector3D(0.26F, 0.12F, 0.26F),
-                 c.stone_light,
-                 k_building_state_mask_intact);
-    desc.add_box(QVector3D(0.0F, roof_y + 0.38F, -0.10F),
-                 QVector3D(0.22F, 0.04F, 0.22F),
-                 c.tile_red,
-                 k_building_state_mask_intact);
-    if (state == BuildingState::Normal) {
-      desc.add_box(QVector3D(0.0F, roof_y + 0.46F, -0.10F),
-                   QVector3D(0.08F, 0.06F, 0.08F),
-                   c.ember,
-                   BuildingStateMask::Normal);
-      for (float x : {-0.76F, 0.76F}) {
-        for (float z : {-0.76F, 0.76F}) {
-          desc.add_cylinder(QVector3D(x, roof_y + 0.04F, z),
-                            QVector3D(x, roof_y + 0.34F, z),
-                            0.028F,
-                            c.bronze,
-                            BuildingStateMask::Normal);
-          desc.add_cone(QVector3D(x, roof_y + 0.32F, z),
-                        QVector3D(x, roof_y + 0.58F, z),
-                        0.075F,
-                        c.wood_dark,
+  // A small roof-access room and shaded terrace replace the oversized crown.
+  desc.add_box(QVector3D(0.48F, roof_y + 0.22F, -0.46F),
+               QVector3D(0.24F, 0.17F, 0.24F),
+               c.plaster,
+               k_building_state_mask_intact);
+  desc.add_box(QVector3D(0.48F, roof_y + 0.41F, -0.46F),
+               QVector3D(0.27F, 0.025F, 0.27F),
+               c.stone_light,
+               k_building_state_mask_intact);
+  desc.add_box(QVector3D(0.48F, roof_y + 0.19F, -0.214F),
+               QVector3D(0.075F, 0.14F, 0.008F),
+               c.wood_dark,
+               k_building_state_mask_intact);
+  for (const float x : {-0.70F, 0.0F}) {
+    for (const float z : {-0.46F, 0.30F}) {
+      desc.add_cylinder(QVector3D(x, roof_y + 0.05F, z),
+                        QVector3D(x, roof_y + 0.48F, z),
+                        0.025F,
+                        c.wood,
                         BuildingStateMask::Normal);
-        }
-      }
     }
   }
-
-  for (float x : {-0.72F, 0.72F}) {
-    desc.add_cylinder(QVector3D(x * 1.12F, 0.20F, 1.00F),
-                      QVector3D(x, roof_y - 0.08F, 1.00F),
-                      0.038F,
-                      c.wood_dark,
-                      k_building_state_mask_intact);
-  }
+  desc.add_box(QVector3D(-0.35F, roof_y + 0.49F, -0.08F),
+               QVector3D(0.40F, 0.012F, 0.43F),
+               c.indigo,
+               BuildingStateMask::Normal);
 
   desc.add_box(QVector3D(0.0F, 0.52F, -0.94F),
                QVector3D(0.22F, 0.28F, 0.02F),
@@ -307,18 +241,11 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
                        BuildingStateMask::All);
 
   add_punic_tanit_relief(desc,
-                         QVector3D(0.985F, 0.94F, 0.0F),
+                         QVector3D(1.025F, 0.80F, 0.0F),
                          BuildingFacadePlane::ZY,
-                         0.46F,
-                         c.ember,
-                         c.stone_dark);
-  add_punic_horned_crown(desc,
-                         QVector3D(0.0F, roof_y + 0.10F, -0.10F),
-                         0.62F,
-                         c.wood_dark,
+                         0.28F,
                          c.bronze,
-                         c.ember);
-
+                         c.stone_dark);
   add_ruin_dressing(desc,
                     RuinDressing{.extent = QVector3D(0.94F, 0.0F, 0.94F),
                                  .stone = c.stone_base,

--- a/render/entity/nations/carthage/marketplace_renderer.cpp
+++ b/render/entity/nations/carthage/marketplace_renderer.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstdint>
 
+#include "building_palette.h"
 #include "game/core/component.h"
 #include "game/visuals/team_colors.h"
 #include "render/entity/building_archetype_desc.h"
@@ -28,25 +29,25 @@ namespace Render::GL::Carthage {
 namespace {
 
 struct CarthageMarketPalette {
-  QVector3D sandstone{0.82F, 0.70F, 0.52F};
-  QVector3D sandstone_light{0.92F, 0.84F, 0.68F};
-  QVector3D sandstone_dark{0.55F, 0.44F, 0.31F};
+  QVector3D sandstone = BuildingPalette::k_sandstone;
+  QVector3D sandstone_light = BuildingPalette::k_sandstone_light;
+  QVector3D sandstone_dark = BuildingPalette::k_sandstone_dark;
   QVector3D mortar{0.63F, 0.55F, 0.42F};
-  QVector3D wood_dark{0.25F, 0.16F, 0.08F};
-  QVector3D wood_medium{0.45F, 0.29F, 0.14F};
-  QVector3D wood_light{0.60F, 0.42F, 0.21F};
-  QVector3D cloth_oxblood{0.47F, 0.10F, 0.08F};
+  QVector3D wood_dark = BuildingPalette::k_wood_dark;
+  QVector3D wood_medium = BuildingPalette::k_wood;
+  QVector3D wood_light = BuildingPalette::k_wood_light;
+  QVector3D cloth_oxblood = BuildingPalette::k_oxblood;
   QVector3D cloth_oxblood_faded{0.64F, 0.17F, 0.13F};
   QVector3D cloth_gold{0.66F, 0.38F, 0.085F};
-  QVector3D indigo{0.10F, 0.12F, 0.30F};
-  QVector3D brick{0.64F, 0.36F, 0.19F};
-  QVector3D brick_dark{0.42F, 0.18F, 0.10F};
-  QVector3D stone_light{0.86F, 0.76F, 0.60F};
-  QVector3D tile_red{0.58F, 0.21F, 0.11F};
+  QVector3D indigo = BuildingPalette::k_indigo;
+  QVector3D brick = BuildingPalette::k_brick;
+  QVector3D brick_dark = BuildingPalette::k_brick_dark;
+  QVector3D stone_light = BuildingPalette::k_sandstone_light;
+  QVector3D tile_red = BuildingPalette::k_tile_red;
   QVector3D ceramic{0.61F, 0.28F, 0.085F};
-  QVector3D bronze{0.48F, 0.27F, 0.075F};
+  QVector3D bronze = BuildingPalette::k_bronze;
   QVector3D rope{0.51F, 0.38F, 0.20F};
-  QVector3D saffron{0.76F, 0.36F, 0.035F};
+  QVector3D saffron = BuildingPalette::k_saffron;
   QVector3D spice_red{0.54F, 0.095F, 0.032F};
   QVector3D herb{0.20F, 0.29F, 0.085F};
   QVector3D ember{0.76F, 0.19F, 0.025F};

--- a/render/entity/nations/carthage/marketplace_renderer.cpp
+++ b/render/entity/nations/carthage/marketplace_renderer.cpp
@@ -121,48 +121,6 @@ void add_spice_basket(BuildingArchetypeDesc& desc,
                 BuildingStateMask::Normal);
 }
 
-void add_stall_canopy(BuildingArchetypeDesc& desc,
-                      const CarthageMarketPalette& c,
-                      const QVector3D& center,
-                      float half_x,
-                      float half_z,
-                      float post_h,
-                      const QVector3D& cloth,
-                      const QVector3D& cloth_shade) {
-  constexpr float post_r = 0.016F;
-  float const top = center.y() + post_h;
-
-  for (float const sx : {-1.0F, 1.0F}) {
-    for (float const sz : {-1.0F, 1.0F}) {
-      desc.add_cylinder(
-          QVector3D(center.x() + sx * half_x, center.y(), center.z() + sz * half_z),
-          QVector3D(center.x() + sx * half_x, top, center.z() + sz * half_z),
-          post_r,
-          c.wood_dark,
-          k_building_state_mask_intact);
-    }
-  }
-
-  desc.add_cylinder(QVector3D(center.x(), top + 0.055F, center.z() - half_z),
-                    QVector3D(center.x(), top + 0.055F, center.z() + half_z),
-                    0.010F,
-                    c.wood_medium,
-                    k_building_state_mask_intact);
-  for (float const side : {-1.0F, 1.0F}) {
-    desc.add_rotated_box(
-        QVector3D(center.x() + side * half_x * 0.52F, top + 0.028F, center.z()),
-        QVector3D(half_x * 0.60F, 0.011F, half_z * 1.04F),
-        QVector3D(0.0F, 0.0F, side * 15.0F),
-        side < 0.0F ? cloth : cloth_shade,
-        BuildingStateMask::Normal | BuildingStateMask::Damaged);
-  }
-
-  desc.add_box(QVector3D(center.x() - half_x * 0.98F, top + 0.006F, center.z()),
-               QVector3D(0.012F, 0.026F, half_z * 1.02F),
-               c.cloth_gold,
-               BuildingStateMask::Normal | BuildingStateMask::Damaged);
-}
-
 auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
   CarthageMarketPalette const c;
   float height_multiplier = 1.0F;
@@ -260,25 +218,33 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                       k_building_state_mask_intact);
   }
 
-  float const post_h = 0.88F * height_multiplier;
-  float const awning_y = post_h + 0.04F;
-  for (float const z : {-0.56F, 0.0F, 0.56F}) {
-    add_stall_canopy(desc,
-                     c,
-                     QVector3D(-0.32F, counter_h + 0.06F, z),
-                     0.27F,
-                     0.18F,
-                     0.30F * height_multiplier,
-                     c.cloth_oxblood,
-                     c.cloth_oxblood_faded);
+  // One shaded bazaar aisle echoes the flat-roofed domestic terraces.
+  const float canopy_y = 0.24F + 0.92F * height_multiplier;
+  for (const float x : {-0.96F, 0.34F}) {
+    for (const float z : {-0.90F, 0.90F}) {
+      desc.add_box(QVector3D(x, (0.14F + canopy_y) * 0.5F, z),
+                   QVector3D(0.055F, (canopy_y - 0.14F) * 0.5F, 0.055F),
+                   c.sandstone,
+                   k_building_state_mask_intact);
+      desc.add_box(QVector3D(x, canopy_y, z),
+                   QVector3D(0.085F, 0.045F, 0.085F),
+                   c.sandstone_light,
+                   k_building_state_mask_intact);
+    }
+    desc.add_box(QVector3D(x, canopy_y + 0.025F, 0.0F),
+                 QVector3D(0.035F, 0.035F, 1.00F),
+                 c.wood_dark,
+                 k_building_state_mask_intact);
   }
-
-  for (float const z : {-0.80F, 0.80F}) {
-    desc.add_cylinder(QVector3D(-0.88F, awning_y - 0.02F, z),
-                      QVector3D(-0.82F, 0.16F, z),
-                      0.009F,
-                      c.rope,
-                      k_building_state_mask_intact);
+  desc.add_box(QVector3D(-0.31F, canopy_y + 0.065F, 0.0F),
+               QVector3D(0.72F, 0.012F, 1.00F),
+               c.indigo,
+               k_building_state_mask_intact);
+  for (const float side : {-1.0F, 1.0F}) {
+    desc.add_box(QVector3D(-0.31F, canopy_y + 0.03F, side * 1.00F),
+                 QVector3D(0.72F, 0.045F, 0.012F),
+                 c.cloth_oxblood,
+                 k_building_state_mask_intact);
   }
 
   desc.add_box(QVector3D(0.70F, wall_h * 0.52F + 0.14F, -0.82F),
@@ -298,27 +264,6 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                  QVector3D(0.025F, 0.30F, 0.15F),
                  c.wood_dark,
                  k_building_state_mask_intact);
-  }
-
-  for (float const z : {-0.48F, 0.48F}) {
-    for (int panel = 0; panel < 5; ++panel) {
-      float const x = -0.94F + static_cast<float>(panel) * 0.28F;
-      desc.add_rotated_box(QVector3D(x, 0.70F - (panel == 2 ? 0.018F : 0.0F), z),
-                           QVector3D(0.132F, 0.012F, 0.26F),
-                           QVector3D(z < 0.0F ? 4.0F : -4.0F, 0.0F, 0.0F),
-                           (panel % 2 == 0) ? c.cloth_oxblood : c.cloth_oxblood_faded,
-                           BuildingStateMask::Normal | BuildingStateMask::Damaged);
-    }
-    desc.add_box(QVector3D(-0.38F, 0.665F, z + (z < 0.0F ? -0.23F : 0.23F)),
-                 QVector3D(0.72F, 0.025F, 0.035F),
-                 c.cloth_gold,
-                 BuildingStateMask::Normal | BuildingStateMask::Damaged);
-    for (float const x : {-0.98F, 0.22F}) {
-      desc.add_box(QVector3D(x, 0.40F, z),
-                   QVector3D(0.035F, 0.40F, 0.035F),
-                   c.wood_dark,
-                   k_building_state_mask_intact);
-    }
   }
 
   add_punic_amphora(desc, QVector3D(-0.80F, 0.14F, 0.84F), c.ceramic, c.indigo);
@@ -349,14 +294,6 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                    c.wood_dark,
                    k_building_state_mask_intact);
     }
-    add_stall_canopy(desc,
-                     c,
-                     QVector3D(0.46F, 0.14F, z),
-                     0.24F,
-                     0.20F,
-                     0.56F * height_multiplier,
-                     c.indigo,
-                     c.cloth_oxblood);
   }
 
   add_spice_basket(desc, QVector3D(-0.53F, counter_h + 0.06F, -0.36F), c.saffron, c);

--- a/render/entity/nations/carthage/temple_renderer.cpp
+++ b/render/entity/nations/carthage/temple_renderer.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdint>
 
+#include "building_palette.h"
 #include "render/entity/building_archetype_desc.h"
 #include "render/entity/building_decay.h"
 #include "render/entity/building_ornaments.h"
@@ -19,21 +20,21 @@ namespace Render::GL::Carthage {
 namespace {
 
 struct CarthageTemplePalette {
-  QVector3D sandstone{0.82F, 0.70F, 0.52F};
-  QVector3D sandstone_light{0.92F, 0.84F, 0.68F};
-  QVector3D sandstone_dark{0.55F, 0.44F, 0.31F};
+  QVector3D sandstone = BuildingPalette::k_sandstone;
+  QVector3D sandstone_light = BuildingPalette::k_sandstone_light;
+  QVector3D sandstone_dark = BuildingPalette::k_sandstone_dark;
   QVector3D rubble{0.79F, 0.67F, 0.50F};
   QVector3D screed{0.77F, 0.71F, 0.59F};
   QVector3D mortar{0.63F, 0.55F, 0.42F};
   QVector3D basalt{0.22F, 0.21F, 0.22F};
   QVector3D basalt_light{0.34F, 0.33F, 0.34F};
-  QVector3D cedar{0.34F, 0.21F, 0.10F};
-  QVector3D cedar_light{0.52F, 0.35F, 0.17F};
-  QVector3D bronze{0.48F, 0.27F, 0.075F};
+  QVector3D cedar = BuildingPalette::k_wood;
+  QVector3D cedar_light = BuildingPalette::k_wood_light;
+  QVector3D bronze = BuildingPalette::k_bronze;
   QVector3D gold{0.70F, 0.47F, 0.13F};
-  QVector3D indigo{0.21F, 0.25F, 0.45F};
-  QVector3D oxblood{0.47F, 0.10F, 0.08F};
-  QVector3D saffron{0.76F, 0.36F, 0.035F};
+  QVector3D indigo = BuildingPalette::k_indigo;
+  QVector3D oxblood = BuildingPalette::k_oxblood;
+  QVector3D saffron = BuildingPalette::k_saffron;
   QVector3D ember{0.76F, 0.19F, 0.025F};
   QVector3D soot{0.15F, 0.13F, 0.12F};
   QVector3D verdigris{0.26F, 0.44F, 0.39F};

--- a/render/entity/nations/carthage/wall_renderer.cpp
+++ b/render/entity/nations/carthage/wall_renderer.cpp
@@ -1,5 +1,6 @@
 #include "wall_renderer.h"
 
+#include "building_palette.h"
 #include "render/entity/building_render_common.h"
 #include "render/entity/registry.h"
 #include "render/entity/wall_gate_renderer_common.h"
@@ -8,14 +9,14 @@
 namespace Render::GL::Carthage {
 namespace {
 
-const WallPalette k_wall_palette{.wood_light = QVector3D(0.34F, 0.22F, 0.11F),
-                                 .wood_mid = QVector3D(0.23F, 0.14F, 0.07F),
-                                 .wood_dark = QVector3D(0.11F, 0.065F, 0.035F),
+const WallPalette k_wall_palette{.wood_light = BuildingPalette::k_wood_light,
+                                 .wood_mid = BuildingPalette::k_wood,
+                                 .wood_dark = BuildingPalette::k_wood_dark,
                                  .rope = QVector3D(0.42F, 0.29F, 0.13F),
                                  .masonry_accent = QVector3D(0.58F, 0.34F, 0.09F),
                                  .earth_light = QVector3D(0.34F, 0.24F, 0.15F),
                                  .earth_dark = QVector3D(0.23F, 0.16F, 0.10F),
-                                 .rubble = QVector3D(0.33F, 0.30F, 0.27F),
+                                 .rubble = BuildingPalette::k_sandstone_dark,
                                  .alternate_starts_light = false,
                                  .horned_masonry = false};
 const WallGeometry k_wall_geometry{.earthwork_base = true,

--- a/render/entity/nations/roman/barracks_renderer.cpp
+++ b/render/entity/nations/roman/barracks_renderer.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cmath>
 
+#include "building_palette.h"
 #include "game/core/component.h"
 #include "game/visuals/team_colors.h"
 #include "math/math_utils.h"
@@ -39,23 +40,22 @@ constexpr auto k_mask_damaged = BuildingStateMask::Damaged;
 constexpr float k_pi = 3.14159265F;
 
 struct RomanPalette {
-  QVector3D plaster{0.93F, 0.90F, 0.82F};
-  QVector3D plaster_shade{0.84F, 0.80F, 0.71F};
-  QVector3D limestone{0.96F, 0.94F, 0.88F};
-  QVector3D limestone_shade{0.88F, 0.85F, 0.78F};
-  QVector3D limestone_dark{0.66F, 0.62F, 0.55F};
-  QVector3D cedar{0.52F, 0.38F, 0.26F};
-  QVector3D cedar_dark{0.38F, 0.26F, 0.16F};
+  QVector3D plaster = BuildingPalette::k_plaster;
+  QVector3D plaster_shade = BuildingPalette::k_plaster_shade;
+  QVector3D limestone = BuildingPalette::k_limestone;
+  QVector3D limestone_shade = BuildingPalette::k_limestone_shade;
+  QVector3D limestone_dark = BuildingPalette::k_limestone_dark;
+  QVector3D cedar = BuildingPalette::k_cedar;
+  QVector3D cedar_dark = BuildingPalette::k_cedar_dark;
   QVector3D oak{0.46F, 0.39F, 0.30F};
-  QVector3D oak_pale{0.62F, 0.55F, 0.44F};
-  QVector3D terracotta{0.76F, 0.32F, 0.18F};
-  QVector3D terracotta_dark{0.46F, 0.12F, 0.07F};
-  QVector3D terracotta_light{0.84F, 0.42F, 0.25F};
+  QVector3D terracotta = BuildingPalette::k_terracotta;
+  QVector3D terracotta_dark = BuildingPalette::k_terracotta_dark;
+  QVector3D terracotta_light = BuildingPalette::k_terracotta_light;
   QVector3D dado{0.53F, 0.10F, 0.07F};
-  QVector3D blue_accent{0.28F, 0.48F, 0.68F};
+  QVector3D blue_accent = BuildingPalette::k_blue_accent;
   QVector3D iron{0.30F, 0.30F, 0.32F};
-  QVector3D bronze{0.62F, 0.46F, 0.24F};
-  QVector3D gold{0.85F, 0.72F, 0.35F};
+  QVector3D bronze = BuildingPalette::k_bronze;
+  QVector3D gold = BuildingPalette::k_gold;
   QVector3D shadow{0.12F, 0.09F, 0.07F};
   QVector3D water{0.30F, 0.42F, 0.50F};
   QVector3D turf{0.40F, 0.42F, 0.22F};
@@ -598,125 +598,73 @@ void add_quarters(BuildingArchetypeDesc& desc,
 void add_watchtower(BuildingArchetypeDesc& desc,
                     const RomanPalette& c,
                     BuildingState state) {
+  // A compact masonry castrum tower, with an open lookout under a tiled roof.
+  // Keep its original footprint so it stays clear of the barracks range.
+  const float shaft_half = k_tower_half + 0.04F;
+  const float shaft_top = state == BuildingState::Destroyed
+                              ? k_platform_top + 0.60F
+                              : k_tower_deck_y;
+  desc.add_box(QVector3D(k_tower_x, k_platform_top + 0.06F, k_tower_z),
+               QVector3D(shaft_half + 0.04F, 0.06F, shaft_half + 0.04F),
+               c.limestone_dark);
+  desc.add_box(QVector3D(k_tower_x, mid(k_platform_top, shaft_top), k_tower_z),
+               QVector3D(shaft_half, half(k_platform_top, shaft_top), shaft_half),
+               c.plaster);
+  for (float y = k_platform_top + 0.28F; y < shaft_top; y += 0.42F) {
+    desc.add_box(QVector3D(k_tower_x, y, k_tower_z),
+                 QVector3D(shaft_half + 0.006F, 0.018F, shaft_half + 0.006F),
+                 c.limestone_shade);
+  }
   if (state == BuildingState::Destroyed) {
-    for (const float sx : {-k_tower_half, k_tower_half}) {
-      for (const float sz : {-k_tower_half, k_tower_half}) {
-        desc.add_cylinder(QVector3D(k_tower_x + sx, k_platform_top, k_tower_z + sz),
-                          QVector3D(k_tower_x + sx,
-                                    k_platform_top + 0.45F + (sx > 0.0F ? 0.25F : 0.0F),
-                                    k_tower_z + sz),
-                          0.045F,
-                          c.oak,
-                          BuildingStateMask::Destroyed);
-      }
-    }
     return;
   }
 
-  const float post_top = k_tower_eave_y + 0.02F;
-  for (const float sx : {-k_tower_half, k_tower_half}) {
-    for (const float sz : {-k_tower_half, k_tower_half}) {
-      desc.add_box(QVector3D(k_tower_x + sx, k_platform_top + 0.03F, k_tower_z + sz),
-                   QVector3D(0.075F, 0.03F, 0.075F),
-                   c.limestone_shade,
-                   k_mask_intact);
-      desc.add_cylinder(QVector3D(k_tower_x + sx, k_platform_top, k_tower_z + sz),
-                        QVector3D(k_tower_x + sx, post_top, k_tower_z + sz),
-                        0.045F,
-                        c.oak,
-                        k_mask_intact);
-    }
-  }
-
-  const float brace_len = std::sqrt(0.40F * 0.40F + 0.80F * 0.80F);
-  const float brace_deg = std::atan2(0.80F, 0.40F) * 180.0F / k_pi;
-  for (const float y_mid : {k_platform_top + 0.60F, k_platform_top + 1.44F}) {
-    for (const float fz : {-k_tower_half, k_tower_half}) {
-      for (const float sign : {1.0F, -1.0F}) {
-        desc.add_rotated_box(QVector3D(k_tower_x, y_mid, k_tower_z + fz),
-                             QVector3D(brace_len * 0.5F, 0.02F, 0.02F),
-                             QVector3D(0.0F, 0.0F, sign * brace_deg),
-                             c.oak,
-                             k_mask_intact);
-      }
-    }
-    for (const float fx : {-k_tower_half, k_tower_half}) {
-      for (const float sign : {1.0F, -1.0F}) {
-        desc.add_rotated_box(QVector3D(k_tower_x + fx, y_mid, k_tower_z),
-                             QVector3D(0.02F, 0.02F, brace_len * 0.5F),
-                             QVector3D(sign * brace_deg, 0.0F, 0.0F),
-                             c.oak,
-                             k_mask_intact);
-      }
-    }
-  }
-  for (const float ty : {k_platform_top + 1.02F, k_platform_top + 1.86F}) {
-    desc.add_box(QVector3D(k_tower_x, ty, k_tower_z),
-                 QVector3D(k_tower_half + 0.03F, 0.025F, 0.025F),
-                 c.cedar_dark,
+  // Narrow recessed openings and a red dado tie the tower to the quarters.
+  for (const float y : {1.08F, 1.78F}) {
+    desc.add_box(QVector3D(k_tower_x, y, k_tower_z + shaft_half + 0.006F),
+                 QVector3D(0.045F, 0.14F, 0.008F),
+                 c.shadow,
                  k_mask_intact);
-    desc.add_box(QVector3D(k_tower_x, ty, k_tower_z),
-                 QVector3D(0.025F, 0.025F, k_tower_half + 0.03F),
-                 c.cedar_dark,
+    desc.add_box(QVector3D(k_tower_x + shaft_half + 0.006F, y, k_tower_z),
+                 QVector3D(0.008F, 0.14F, 0.045F),
+                 c.shadow,
                  k_mask_intact);
   }
-
-  const float rail_x = k_tower_x - k_tower_half - 0.045F;
-  for (const float lz : {k_tower_z - 0.09F, k_tower_z + 0.09F}) {
-    desc.add_box(QVector3D(rail_x, mid(k_platform_top, k_tower_deck_y), lz),
-                 QVector3D(0.015F, half(k_platform_top, k_tower_deck_y), 0.015F),
-                 c.cedar,
-                 k_mask_normal);
-  }
-  for (float ry = k_platform_top + 0.24F; ry < k_tower_deck_y - 0.05F; ry += 0.26F) {
-    desc.add_box(QVector3D(rail_x, ry, k_tower_z),
-                 QVector3D(0.012F, 0.012F, 0.09F),
-                 c.cedar,
-                 k_mask_normal);
-  }
-
+  desc.add_box(QVector3D(k_tower_x, k_platform_top + 0.18F, k_tower_z),
+               QVector3D(shaft_half + 0.008F, 0.055F, shaft_half + 0.008F),
+               c.dado,
+               k_mask_intact);
   desc.add_box(QVector3D(k_tower_x, k_tower_deck_y, k_tower_z),
-               QVector3D(k_tower_half + 0.13F, 0.03F, k_tower_half + 0.13F),
-               c.cedar,
+               QVector3D(k_tower_half + 0.13F, 0.045F, k_tower_half + 0.13F),
+               c.limestone_shade,
                k_mask_intact);
-  desc.add_box(QVector3D(k_tower_x, k_tower_deck_y - 0.05F, k_tower_z),
-               QVector3D(k_tower_half + 0.08F, 0.025F, k_tower_half + 0.08F),
-               c.cedar_dark,
-               k_mask_intact);
-  const float par_half = k_tower_half + 0.13F;
-  const float par_y = k_tower_deck_y + 0.18F;
+
+  const float par_half = k_tower_half + 0.10F;
+  const float par_y = k_tower_deck_y + 0.14F;
   for (const float side : {-1.0F, 1.0F}) {
     desc.add_box(QVector3D(k_tower_x, par_y, k_tower_z + side * par_half),
-                 QVector3D(par_half, 0.15F, 0.012F),
-                 c.oak_pale,
+                 QVector3D(par_half, 0.10F, 0.035F),
+                 c.plaster,
                  k_mask_intact);
     desc.add_box(QVector3D(k_tower_x + side * par_half, par_y, k_tower_z),
-                 QVector3D(0.012F, 0.15F, par_half),
-                 c.oak_pale,
+                 QVector3D(0.035F, 0.10F, par_half),
+                 c.plaster,
                  k_mask_intact);
-    desc.add_box(QVector3D(k_tower_x, par_y + 0.17F, k_tower_z + side * par_half),
-                 QVector3D(par_half + 0.01F, 0.02F, 0.022F),
-                 c.cedar_dark,
-                 k_mask_intact);
-    desc.add_box(QVector3D(k_tower_x + side * par_half, par_y + 0.17F, k_tower_z),
-                 QVector3D(0.022F, 0.02F, par_half + 0.01F),
-                 c.cedar_dark,
-                 k_mask_intact);
+    for (const float other : {-1.0F, 1.0F}) {
+      desc.add_box(
+          QVector3D(k_tower_x + side * k_tower_half,
+                    mid(k_tower_deck_y, k_tower_eave_y),
+                    k_tower_z + other * k_tower_half),
+          QVector3D(0.04F, half(k_tower_deck_y, k_tower_eave_y), 0.04F),
+          c.limestone,
+          k_mask_intact);
+    }
   }
-
   desc.add_palette_box(
-      QVector3D(k_tower_x, par_y + 0.02F, k_tower_z + par_half + 0.03F),
-      QVector3D(0.17F, 0.13F, 0.010F),
+      QVector3D(k_tower_x, par_y, k_tower_z + par_half + 0.045F),
+      QVector3D(0.12F, 0.10F, 0.010F),
       k_team_slot,
       k_mask_normal);
-  desc.add_box(QVector3D(k_tower_x, par_y - 0.12F, k_tower_z + par_half + 0.03F),
-               QVector3D(0.17F, 0.018F, 0.012F),
-               c.gold,
-               k_mask_normal);
-  desc.add_box(QVector3D(k_tower_x, par_y + 0.16F, k_tower_z + par_half + 0.03F),
-               QVector3D(0.20F, 0.015F, 0.015F),
-               c.cedar_dark,
-               k_mask_normal);
 
   const float roof_half = k_tower_half + 0.18F;
   const float roof_rise = 0.26F;

--- a/render/entity/nations/roman/barracks_renderer.cpp
+++ b/render/entity/nations/roman/barracks_renderer.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cmath>
 
+#include "building_architecture.h"
 #include "building_palette.h"
 #include "game/core/component.h"
 #include "game/visuals/team_colors.h"
@@ -601,9 +602,8 @@ void add_watchtower(BuildingArchetypeDesc& desc,
   // A compact masonry castrum tower, with an open lookout under a tiled roof.
   // Keep its original footprint so it stays clear of the barracks range.
   const float shaft_half = k_tower_half + 0.04F;
-  const float shaft_top = state == BuildingState::Destroyed
-                              ? k_platform_top + 0.60F
-                              : k_tower_deck_y;
+  const float shaft_top =
+      state == BuildingState::Destroyed ? k_platform_top + 0.60F : k_tower_deck_y;
   desc.add_box(QVector3D(k_tower_x, k_platform_top + 0.06F, k_tower_z),
                QVector3D(shaft_half + 0.04F, 0.06F, shaft_half + 0.04F),
                c.limestone_dark);
@@ -651,43 +651,26 @@ void add_watchtower(BuildingArchetypeDesc& desc,
                  c.plaster,
                  k_mask_intact);
     for (const float other : {-1.0F, 1.0F}) {
-      desc.add_box(
-          QVector3D(k_tower_x + side * k_tower_half,
-                    mid(k_tower_deck_y, k_tower_eave_y),
-                    k_tower_z + other * k_tower_half),
-          QVector3D(0.04F, half(k_tower_deck_y, k_tower_eave_y), 0.04F),
-          c.limestone,
-          k_mask_intact);
+      desc.add_box(QVector3D(k_tower_x + side * k_tower_half,
+                             mid(k_tower_deck_y, k_tower_eave_y),
+                             k_tower_z + other * k_tower_half),
+                   QVector3D(0.04F, half(k_tower_deck_y, k_tower_eave_y), 0.04F),
+                   c.limestone,
+                   k_mask_intact);
     }
   }
-  desc.add_palette_box(
-      QVector3D(k_tower_x, par_y, k_tower_z + par_half + 0.045F),
-      QVector3D(0.12F, 0.10F, 0.010F),
-      k_team_slot,
-      k_mask_normal);
+  desc.add_palette_box(QVector3D(k_tower_x, par_y, k_tower_z + par_half + 0.045F),
+                       QVector3D(0.12F, 0.10F, 0.010F),
+                       k_team_slot,
+                       k_mask_normal);
 
-  const float roof_half = k_tower_half + 0.18F;
-  const float roof_rise = 0.26F;
-  add_gable_roof_x(
-      [&](const QVector3D& center,
-          const QVector3D& scale,
-          const QVector3D& euler,
-          const QVector3D& color) {
-        desc.add_rotated_box(center, scale, euler, color, k_mask_normal);
-      },
-      k_tower_x,
-      k_tower_z,
-      k_tower_eave_y,
-      roof_half,
-      roof_half,
-      roof_rise,
-      0.035F,
-      c.terracotta,
-      0.02F);
-  desc.add_box(QVector3D(k_tower_x, k_tower_eave_y + roof_rise + 0.02F, k_tower_z),
-               QVector3D(roof_half + 0.04F, 0.03F, 0.05F),
-               c.terracotta_dark,
-               k_mask_normal);
+  add_tiled_roof(desc,
+                 QVector3D(k_tower_x, k_tower_eave_y, k_tower_z),
+                 k_tower_half + 0.18F,
+                 k_tower_half + 0.18F,
+                 0.26F,
+                 false,
+                 k_mask_normal);
   desc.add_box(QVector3D(k_tower_x, k_tower_eave_y - 0.01F, k_tower_z),
                QVector3D(k_tower_half + 0.04F, 0.025F, k_tower_half + 0.04F),
                c.cedar_dark,

--- a/render/entity/nations/roman/building_architecture.h
+++ b/render/entity/nations/roman/building_architecture.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+#include "building_palette.h"
+#include "render/entity/building_ornaments.h"
+
+namespace Render::GL::Roman {
+
+// Dimensions are measured at the eaves; the caller chooses the ridge axis.
+// Use the same tile pitch, ridge caps and restrained highlights at every scale.
+inline void add_tiled_roof(BuildingArchetypeDesc& desc,
+                           const QVector3D& eave_center,
+                           float half_length,
+                           float half_depth,
+                           float rise,
+                           bool ridge_along_z,
+                           BuildingStateMask states = k_building_state_mask_intact,
+                           bool close_gables = false) {
+  const float theta = std::atan2(rise, half_depth);
+  const float angle = theta * 180.0F / 3.14159265F;
+  const float slope = std::sqrt(half_depth * half_depth + rise * rise);
+  const float thickness = std::min(0.035F, half_depth * 0.08F);
+  auto point = [&](float along, float y, float across) {
+    return eave_center +
+           (ridge_along_z ? QVector3D(across, y, along) : QVector3D(along, y, across));
+  };
+  auto size = [&](float along, float y, float across) {
+    return ridge_along_z ? QVector3D(across, y, along) : QVector3D(along, y, across);
+  };
+  for (const float side : {-1.0F, 1.0F}) {
+    desc.add_rotated_box(point(0.0F, rise * 0.5F, side * half_depth * 0.5F),
+                         size(half_length, thickness, slope * 0.5F),
+                         ridge_along_z ? QVector3D(0.0F, 0.0F, -side * angle)
+                                       : QVector3D(side * angle, 0.0F, 0.0F),
+                         BuildingPalette::k_terracotta,
+                         states);
+    const int rolls = std::max(3, static_cast<int>(half_length * 2.0F / 0.22F));
+    const float lift = thickness / std::cos(theta) + 0.012F;
+    for (int i = 0; i <= rolls; ++i) {
+      const float along = -half_length + 0.04F +
+                          (2.0F * half_length - 0.08F) * static_cast<float>(i) /
+                              static_cast<float>(rolls);
+      desc.add_cylinder(point(along, lift, side * half_depth),
+                        point(along, rise + lift, 0.0F),
+                        thickness * 0.40F,
+                        BuildingPalette::k_terracotta_light,
+                        states);
+    }
+    desc.add_box(point(0.0F, -0.01F, side * half_depth),
+                 size(half_length, thickness, thickness),
+                 BuildingPalette::k_terracotta_dark,
+                 states);
+  }
+  desc.add_cylinder(point(-half_length, rise + thickness, 0.0F),
+                    point(half_length, rise + thickness, 0.0F),
+                    thickness * 1.2F,
+                    BuildingPalette::k_terracotta_dark,
+                    states);
+
+  if (close_gables) {
+    // Fine courses fill the triangle without the old oversized stair-step blocks.
+    constexpr int k_courses = 16;
+    const float course_h = rise / static_cast<float>(k_courses);
+    for (const float end : {-1.0F, 1.0F}) {
+      for (int i = 0; i < k_courses; ++i) {
+        const float top = static_cast<float>(i + 1) * course_h;
+        const float width = half_depth * (1.0F - top / rise);
+        if (width <= 0.0F) {
+          continue;
+        }
+        desc.add_box(point(end * (half_length - 0.06F), top - course_h * 0.5F, 0.0F),
+                     size(0.025F, course_h * 0.5F, width),
+                     BuildingPalette::k_plaster,
+                     states);
+      }
+    }
+  }
+}
+
+} // namespace Render::GL::Roman

--- a/render/entity/nations/roman/building_palette.h
+++ b/render/entity/nations/roman/building_palette.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QVector3D>
+
+namespace Render::GL::Roman::BuildingPalette {
+
+// Shared architectural materials keep civilian and military buildings cohesive.
+// Player colors belong on banners and trim, never on the roof materials.
+inline constexpr QVector3D k_limestone{0.96F, 0.94F, 0.88F};
+inline constexpr QVector3D k_limestone_shade{0.88F, 0.85F, 0.78F};
+inline constexpr QVector3D k_limestone_dark{0.66F, 0.62F, 0.55F};
+inline constexpr QVector3D k_plaster{0.93F, 0.90F, 0.82F};
+inline constexpr QVector3D k_plaster_shade{0.84F, 0.80F, 0.71F};
+inline constexpr QVector3D k_marble{0.98F, 0.97F, 0.95F};
+inline constexpr QVector3D k_marble_shade{0.88F, 0.85F, 0.78F};
+inline constexpr QVector3D k_cedar{0.52F, 0.38F, 0.26F};
+inline constexpr QVector3D k_cedar_light{0.62F, 0.48F, 0.34F};
+inline constexpr QVector3D k_cedar_dark{0.38F, 0.26F, 0.16F};
+inline constexpr QVector3D k_terracotta{0.76F, 0.32F, 0.18F};
+inline constexpr QVector3D k_terracotta_dark{0.46F, 0.12F, 0.07F};
+inline constexpr QVector3D k_terracotta_light{0.84F, 0.42F, 0.25F};
+inline constexpr QVector3D k_blue_accent{0.28F, 0.48F, 0.68F};
+inline constexpr QVector3D k_blue_light{0.40F, 0.60F, 0.80F};
+inline constexpr QVector3D k_gold{0.85F, 0.72F, 0.35F};
+inline constexpr QVector3D k_bronze{0.62F, 0.46F, 0.24F};
+
+} // namespace Render::GL::Roman::BuildingPalette

--- a/render/entity/nations/roman/defense_tower_renderer.cpp
+++ b/render/entity/nations/roman/defense_tower_renderer.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <numbers>
 
+#include "building_palette.h"
 #include "game/core/component.h"
 #include "math/math_utils.h"
 #include "render/entity/barracks_flag_renderer.h"
@@ -26,21 +27,21 @@ namespace {
 using Render::Geom::clamp_vec_01;
 
 struct TowerPalette {
-  QVector3D limestone{0.96F, 0.94F, 0.88F};
-  QVector3D limestone_shade{0.88F, 0.85F, 0.78F};
-  QVector3D limestone_dark{0.80F, 0.76F, 0.70F};
+  QVector3D limestone = BuildingPalette::k_limestone;
+  QVector3D limestone_shade = BuildingPalette::k_limestone_shade;
+  QVector3D limestone_dark = BuildingPalette::k_limestone_dark;
   QVector3D sandstone_light{0.82F, 0.75F, 0.62F};
   QVector3D sandstone_dark{0.70F, 0.62F, 0.50F};
   QVector3D sandstone_base{0.75F, 0.68F, 0.56F};
-  QVector3D marble{0.98F, 0.97F, 0.95F};
-  QVector3D terracotta{0.78F, 0.32F, 0.18F};
-  QVector3D terracotta_dark{0.46F, 0.12F, 0.07F};
-  QVector3D cedar{0.52F, 0.38F, 0.26F};
-  QVector3D cedar_dark{0.38F, 0.26F, 0.16F};
-  QVector3D blue_accent{0.28F, 0.48F, 0.68F};
-  QVector3D blue_light{0.40F, 0.60F, 0.80F};
-  QVector3D bronze{0.60F, 0.45F, 0.25F};
-  QVector3D gold{0.85F, 0.72F, 0.35F};
+  QVector3D marble = BuildingPalette::k_marble;
+  QVector3D terracotta = BuildingPalette::k_terracotta;
+  QVector3D terracotta_dark = BuildingPalette::k_terracotta_dark;
+  QVector3D cedar = BuildingPalette::k_cedar;
+  QVector3D cedar_dark = BuildingPalette::k_cedar_dark;
+  QVector3D blue_accent = BuildingPalette::k_blue_accent;
+  QVector3D blue_light = BuildingPalette::k_blue_light;
+  QVector3D bronze = BuildingPalette::k_bronze;
+  QVector3D gold = BuildingPalette::k_gold;
   QVector3D team{0.8F, 0.9F, 1.0F};
   QVector3D team_trim{0.48F, 0.54F, 0.60F};
 };

--- a/render/entity/nations/roman/defense_tower_renderer.cpp
+++ b/render/entity/nations/roman/defense_tower_renderer.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <numbers>
 
+#include "building_architecture.h"
 #include "building_palette.h"
 #include "game/core/component.h"
 #include "math/math_utils.h"
@@ -30,9 +31,9 @@ struct TowerPalette {
   QVector3D limestone = BuildingPalette::k_limestone;
   QVector3D limestone_shade = BuildingPalette::k_limestone_shade;
   QVector3D limestone_dark = BuildingPalette::k_limestone_dark;
-  QVector3D sandstone_light{0.82F, 0.75F, 0.62F};
-  QVector3D sandstone_dark{0.70F, 0.62F, 0.50F};
-  QVector3D sandstone_base{0.75F, 0.68F, 0.56F};
+  QVector3D sandstone_light = BuildingPalette::k_limestone_shade;
+  QVector3D sandstone_dark = BuildingPalette::k_limestone_dark;
+  QVector3D sandstone_base = BuildingPalette::k_limestone;
   QVector3D marble = BuildingPalette::k_marble;
   QVector3D terracotta = BuildingPalette::k_terracotta;
   QVector3D terracotta_dark = BuildingPalette::k_terracotta_dark;
@@ -143,7 +144,7 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
     const float angle = static_cast<float>(index) * 1.57F + 0.785F;
     const float ox = std::sin(angle) * (shaft_radius - 0.04F);
     const float oz = std::cos(angle) * (shaft_radius - 0.04F);
-    const float column_top = destroyed ? 0.0F : shaft_top - 0.15F;
+    const float column_top = destroyed ? 0.82F : shaft_top - 0.15F;
 
     desc.add_cylinder(
         QVector3D(ox, 0.52F, oz), QVector3D(ox, column_top, oz), 0.09F, c.marble);
@@ -222,20 +223,13 @@ auto build_tower_archetype(BuildingState state) -> RenderArchetype {
                    c.cedar_dark,
                    BuildingStateMask::Normal);
 
-      constexpr int k_roof_steps = 6;
-      const QVector3D tile = c.terracotta * 0.94F;
-      for (int i = 0; i < k_roof_steps; ++i) {
-        const float t = static_cast<float>(i) / static_cast<float>(k_roof_steps);
-        const float half = 1.14F - (1.14F - 0.26F) * t;
-        desc.add_box(QVector3D(0.0F, roof_y + 0.056F * static_cast<float>(i), 0.0F),
-                     QVector3D(half, 0.032F, half),
-                     (i % 2 == 0) ? tile : tile * 0.93F,
+      add_tiled_roof(desc,
+                     QVector3D(0.0F, roof_y, 0.0F),
+                     1.14F,
+                     1.14F,
+                     0.42F,
+                     false,
                      BuildingStateMask::Normal);
-      }
-      desc.add_box(QVector3D(0.0F, roof_y + 0.34F, 0.0F),
-                   QVector3D(0.14F, 0.04F, 0.14F),
-                   c.terracotta_dark,
-                   BuildingStateMask::Normal);
     }
   }
 

--- a/render/entity/nations/roman/farm_renderer.cpp
+++ b/render/entity/nations/roman/farm_renderer.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <string>
 
+#include "building_palette.h"
 #include "render/entity/building_archetype_desc.h"
 #include "render/entity/building_decay.h"
 #include "render/entity/building_ornaments.h"
@@ -18,16 +19,16 @@ namespace Render::GL::Roman {
 namespace {
 
 struct RomanFarmPalette {
-  QVector3D limestone{0.76F, 0.71F, 0.61F};
-  QVector3D limestone_shade{0.58F, 0.54F, 0.46F};
-  QVector3D limestone_dark{0.40F, 0.37F, 0.31F};
-  QVector3D plaster{0.84F, 0.80F, 0.69F};
-  QVector3D plaster_shade{0.70F, 0.65F, 0.54F};
-  QVector3D terracotta{0.58F, 0.25F, 0.12F};
-  QVector3D terracotta_dark{0.39F, 0.16F, 0.08F};
-  QVector3D cedar{0.38F, 0.24F, 0.13F};
-  QVector3D cedar_light{0.51F, 0.34F, 0.19F};
-  QVector3D cedar_dark{0.24F, 0.15F, 0.08F};
+  QVector3D limestone = BuildingPalette::k_limestone;
+  QVector3D limestone_shade = BuildingPalette::k_limestone_shade;
+  QVector3D limestone_dark = BuildingPalette::k_limestone_dark;
+  QVector3D plaster = BuildingPalette::k_plaster;
+  QVector3D plaster_shade = BuildingPalette::k_plaster_shade;
+  QVector3D terracotta = BuildingPalette::k_terracotta;
+  QVector3D terracotta_dark = BuildingPalette::k_terracotta_dark;
+  QVector3D cedar = BuildingPalette::k_cedar;
+  QVector3D cedar_light = BuildingPalette::k_cedar_light;
+  QVector3D cedar_dark = BuildingPalette::k_cedar_dark;
   QVector3D iron{0.16F, 0.16F, 0.16F};
   QVector3D straw{0.76F, 0.62F, 0.31F};
   QVector3D cloth{0.46F, 0.11F, 0.08F};

--- a/render/entity/nations/roman/farm_renderer.cpp
+++ b/render/entity/nations/roman/farm_renderer.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <string>
 
+#include "building_architecture.h"
 #include "building_palette.h"
 #include "render/entity/building_archetype_desc.h"
 #include "render/entity/building_decay.h"
@@ -131,32 +132,14 @@ void add_granary_shed(BuildingArchetypeDesc& desc, const RomanFarmPalette& c) {
                QVector3D(k_half_x + 0.05F, 0.012F, k_half_z + 0.05F),
                c.cedar,
                k_building_state_mask_intact);
-  add_gable_roof_x(
-      [&](const QVector3D& pos,
-          const QVector3D& scale,
-          const QVector3D& euler,
-          const QVector3D& color) {
-        desc.add_rotated_box(pos, scale, euler, color, k_building_state_mask_intact);
-      },
-      centre.x(),
-      centre.z(),
-      eave_y + 0.02F,
-      k_half_x + 0.05F,
-      k_half_z + 0.05F,
-      0.15F,
-      0.016F,
-      c.terracotta,
-      0.02F);
-  desc.add_box(centre + QVector3D(0.0F, eave_y + 0.02F + 0.15F, 0.0F),
-               QVector3D(k_half_x + 0.07F, 0.014F, 0.022F),
-               c.terracotta_dark,
-               k_building_state_mask_intact);
-  for (float const sx : {-1.0F, 1.0F}) {
-    desc.add_box(centre + QVector3D(sx * (k_half_x + 0.02F), eave_y + 0.08F, 0.0F),
-                 QVector3D(0.012F, 0.06F, k_half_z * 0.55F),
-                 c.plaster_shade,
-                 k_building_state_mask_intact);
-  }
+  add_tiled_roof(desc,
+                 centre + QVector3D(0.0F, eave_y + 0.02F, 0.0F),
+                 k_half_x + 0.07F,
+                 k_half_z + 0.07F,
+                 0.15F,
+                 false,
+                 k_building_state_mask_intact,
+                 true);
 
   for (int i = 0; i < 3; ++i) {
     float const x = centre.x() - k_half_x + 0.08F + static_cast<float>(i) * 0.11F;

--- a/render/entity/nations/roman/home_renderer.cpp
+++ b/render/entity/nations/roman/home_renderer.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 
+#include "building_palette.h"
 #include "game/core/component.h"
 #include "math/math_utils.h"
 #include "render/entity/building_archetype_desc.h"
@@ -24,20 +25,18 @@ using Render::Geom::clamp_vec_01;
 constexpr std::uint8_t k_home_team_slot = 0;
 constexpr std::uint8_t k_home_roof_slot = 1;
 
-constexpr float k_roof_owner_blend = 0.42F;
-
 struct RomanPalette {
-  QVector3D limestone{0.96F, 0.94F, 0.88F};
-  QVector3D limestone_shade{0.88F, 0.85F, 0.78F};
-  QVector3D limestone_dark{0.80F, 0.76F, 0.70F};
-  QVector3D marble{0.98F, 0.97F, 0.95F};
-  QVector3D cedar{0.52F, 0.38F, 0.26F};
-  QVector3D cedar_dark{0.38F, 0.26F, 0.16F};
-  QVector3D terracotta{0.76F, 0.32F, 0.18F};
-  QVector3D terracotta_dark{0.46F, 0.12F, 0.07F};
-  QVector3D blue_accent{0.28F, 0.48F, 0.68F};
-  QVector3D blue_light{0.40F, 0.60F, 0.80F};
-  QVector3D gold{0.85F, 0.72F, 0.35F};
+  QVector3D limestone = BuildingPalette::k_limestone;
+  QVector3D limestone_shade = BuildingPalette::k_limestone_shade;
+  QVector3D limestone_dark = BuildingPalette::k_limestone_dark;
+  QVector3D marble = BuildingPalette::k_marble;
+  QVector3D cedar = BuildingPalette::k_cedar;
+  QVector3D cedar_dark = BuildingPalette::k_cedar_dark;
+  QVector3D terracotta = BuildingPalette::k_terracotta;
+  QVector3D terracotta_dark = BuildingPalette::k_terracotta_dark;
+  QVector3D blue_accent = BuildingPalette::k_blue_accent;
+  QVector3D blue_light = BuildingPalette::k_blue_light;
+  QVector3D gold = BuildingPalette::k_gold;
   QVector3D team{0.8F, 0.9F, 1.0F};
   QVector3D team_trim{0.48F, 0.54F, 0.60F};
 };
@@ -53,9 +52,7 @@ inline auto make_palette(const QVector3D& team) -> RomanPalette {
 auto home_palette_slots(const QVector3D& team)
     -> std::array<QVector3D, k_home_palette_slots> {
   const auto palette = make_palette(team);
-  const QVector3D roof = clamp_vec_01(palette.terracotta * (1.0F - k_roof_owner_blend) +
-                                      palette.team * k_roof_owner_blend);
-  return {palette.team, roof};
+  return {palette.team, palette.terracotta};
 }
 
 auto build_home_archetype(BuildingState state) -> RenderArchetype {

--- a/render/entity/nations/roman/home_renderer.cpp
+++ b/render/entity/nations/roman/home_renderer.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 
+#include "building_architecture.h"
 #include "building_palette.h"
 #include "game/core/component.h"
 #include "math/math_utils.h"
@@ -23,20 +24,17 @@ namespace {
 using Render::Geom::clamp_vec_01;
 
 constexpr std::uint8_t k_home_team_slot = 0;
-constexpr std::uint8_t k_home_roof_slot = 1;
 
 struct RomanPalette {
   QVector3D limestone = BuildingPalette::k_limestone;
   QVector3D limestone_shade = BuildingPalette::k_limestone_shade;
   QVector3D limestone_dark = BuildingPalette::k_limestone_dark;
   QVector3D marble = BuildingPalette::k_marble;
-  QVector3D cedar = BuildingPalette::k_cedar;
   QVector3D cedar_dark = BuildingPalette::k_cedar_dark;
   QVector3D terracotta = BuildingPalette::k_terracotta;
   QVector3D terracotta_dark = BuildingPalette::k_terracotta_dark;
   QVector3D blue_accent = BuildingPalette::k_blue_accent;
   QVector3D blue_light = BuildingPalette::k_blue_light;
-  QVector3D gold = BuildingPalette::k_gold;
   QVector3D team{0.8F, 0.9F, 1.0F};
   QVector3D team_trim{0.48F, 0.54F, 0.60F};
 };
@@ -143,11 +141,9 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
 
   float const col_height = 0.88F;
   float const col_radius = 0.055F;
-  QVector3D const front_cols[6] = {QVector3D(-0.72F, 0.0F, 0.92F),
-                                   QVector3D(-0.43F, 0.0F, 0.92F),
-                                   QVector3D(-0.14F, 0.0F, 0.92F),
-                                   QVector3D(0.14F, 0.0F, 0.92F),
-                                   QVector3D(0.43F, 0.0F, 0.92F),
+  QVector3D const front_cols[4] = {QVector3D(-0.72F, 0.0F, 0.92F),
+                                   QVector3D(-0.38F, 0.0F, 0.92F),
+                                   QVector3D(0.38F, 0.0F, 0.92F),
                                    QVector3D(0.72F, 0.0F, 0.92F)};
 
   for (const QVector3D& col : front_cols) {
@@ -227,111 +223,21 @@ auto build_home_archetype(BuildingState state) -> RenderArchetype {
                c.blue_light,
                k_building_state_mask_intact);
 
-  auto add_rot = [&](const QVector3D& center,
-                     const QVector3D& scale,
-                     const QVector3D& euler,
-                     const QVector3D& color) {
-    desc.add_rotated_box(center, scale, euler, color, k_building_state_mask_intact);
-  };
+  // A low domestic roof and clear doorway distinguish homes from temples.
   float const eave_y = cornice_y + 0.02F;
-  float const roof_rise = 0.55F * height_multiplier;
-  auto add_roof_slab = [&](const QVector3D& center,
-                           const QVector3D& scale,
-                           const QVector3D& euler,
-                           const QVector3D&) {
-    desc.add_palette_rotated_box(
-        center, scale, euler, k_home_roof_slot, k_building_state_mask_intact);
-  };
-  add_gable_roof_z(add_roof_slab,
-                   0.0F,
-                   0.0F,
-                   eave_y,
-                   0.98F,
-                   0.98F,
-                   roof_rise,
-                   0.05F,
-                   c.terracotta,
-                   0.07F);
-
-  desc.add_box(QVector3D(0.0F, eave_y + roof_rise + 0.01F, 0.0F),
-               QVector3D(0.05F, 0.03F, 1.04F),
-               c.terracotta_dark,
-               k_building_state_mask_intact);
-
-  desc.add_box(QVector3D(0.99F, eave_y, 0.0F),
-               QVector3D(0.04F, 0.04F, 1.05F),
-               c.terracotta_dark,
-               k_building_state_mask_intact);
-  desc.add_box(QVector3D(-0.99F, eave_y, 0.0F),
-               QVector3D(0.04F, 0.04F, 1.05F),
-               c.terracotta_dark,
-               k_building_state_mask_intact);
-
-  desc.add_box(QVector3D(0.0F, eave_y + 0.14F, -0.97F),
-               QVector3D(0.68F, 0.14F, 0.05F),
-               c.limestone_shade,
-               k_building_state_mask_intact);
-  desc.add_box(QVector3D(0.0F, eave_y + 0.36F, -0.97F),
-               QVector3D(0.42F, 0.10F, 0.05F),
-               c.limestone,
-               k_building_state_mask_intact);
-  desc.add_box(QVector3D(0.0F, eave_y + 0.50F, -0.97F),
-               QVector3D(0.16F, 0.06F, 0.05F),
-               c.limestone_shade,
-               k_building_state_mask_intact);
-
-  desc.add_box(QVector3D(0.0F, eave_y + 0.18F, 0.93F),
-               QVector3D(0.60F, 0.16F, 0.05F),
-               c.limestone,
-               k_building_state_mask_intact);
-  desc.add_box(QVector3D(0.0F, eave_y + 0.42F, 0.93F),
-               QVector3D(0.30F, 0.10F, 0.05F),
-               c.limestone_shade,
-               k_building_state_mask_intact);
-
-  if (state != BuildingState::Destroyed) {
-    desc.add_box(QVector3D(0.0F, cornice_y + 0.20F, 0.96F),
-                 QVector3D(0.66F, 0.06F, 0.06F),
-                 c.terracotta_dark,
-                 k_building_state_mask_intact);
-    desc.add_box(QVector3D(0.0F, cornice_y + 0.28F, 0.96F),
-                 QVector3D(0.46F, 0.05F, 0.05F),
-                 c.terracotta,
-                 k_building_state_mask_intact);
-    if (state == BuildingState::Normal) {
-
-      desc.add_box(QVector3D(0.0F, cornice_y + 0.36F, 0.96F),
-                   QVector3D(0.22F, 0.05F, 0.04F),
-                   c.blue_accent,
-                   BuildingStateMask::Normal);
-
-      desc.add_box(QVector3D(-0.62F, cornice_y + 0.24F, 0.96F),
-                   QVector3D(0.05F, 0.07F, 0.05F),
-                   c.gold,
-                   BuildingStateMask::Normal);
-      desc.add_box(QVector3D(0.62F, cornice_y + 0.24F, 0.96F),
-                   QVector3D(0.05F, 0.07F, 0.05F),
-                   c.gold,
-                   BuildingStateMask::Normal);
-    }
-  }
+  add_tiled_roof(desc,
+                 QVector3D(0.0F, eave_y, 0.0F),
+                 1.05F,
+                 1.02F,
+                 0.40F * height_multiplier,
+                 true,
+                 k_building_state_mask_intact,
+                 true);
 
   desc.add_palette_box(QVector3D(0.0F, 0.76F, 0.97F),
                        QVector3D(0.28F, 0.12F, 0.02F),
                        k_home_team_slot,
                        BuildingStateMask::All);
-
-  add_roman_aquila_relief(desc,
-                          QVector3D(0.0F, cornice_y - 0.30F, 1.00F),
-                          BuildingFacadePlane::XY,
-                          0.46F,
-                          c.gold,
-                          c.terracotta_dark);
-  add_roman_roof_standard(desc,
-                          QVector3D(0.0F, eave_y + roof_rise + 0.04F, 0.0F),
-                          0.62F,
-                          c.gold,
-                          c.terracotta_dark);
 
   add_ruin_dressing(desc,
                     RuinDressing{.extent = QVector3D(0.98F, 0.0F, 0.98F),

--- a/render/entity/nations/roman/marketplace_renderer.cpp
+++ b/render/entity/nations/roman/marketplace_renderer.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstdint>
 
+#include "building_palette.h"
 #include "game/core/component.h"
 #include "game/visuals/team_colors.h"
 #include "render/entity/building_archetype_desc.h"
@@ -28,26 +29,26 @@ namespace Render::GL::Roman {
 namespace {
 
 struct RomanMarketPalette {
-  QVector3D limestone{0.78F, 0.74F, 0.65F};
-  QVector3D limestone_shade{0.60F, 0.56F, 0.49F};
-  QVector3D limestone_dark{0.43F, 0.40F, 0.35F};
-  QVector3D marble{0.86F, 0.84F, 0.78F};
+  QVector3D limestone = BuildingPalette::k_limestone;
+  QVector3D limestone_shade = BuildingPalette::k_limestone_shade;
+  QVector3D limestone_dark = BuildingPalette::k_limestone_dark;
+  QVector3D marble = BuildingPalette::k_marble;
   QVector3D mortar{0.52F, 0.49F, 0.43F};
-  QVector3D cedar{0.40F, 0.25F, 0.13F};
-  QVector3D cedar_light{0.56F, 0.37F, 0.20F};
-  QVector3D cedar_dark{0.27F, 0.16F, 0.09F};
+  QVector3D cedar = BuildingPalette::k_cedar;
+  QVector3D cedar_light = BuildingPalette::k_cedar_light;
+  QVector3D cedar_dark = BuildingPalette::k_cedar_dark;
   QVector3D cloth_red{0.53F, 0.075F, 0.052F};
   QVector3D cloth_red_faded{0.68F, 0.16F, 0.10F};
   QVector3D cloth_gold{0.72F, 0.52F, 0.16F};
-  QVector3D terracotta{0.63F, 0.25F, 0.105F};
-  QVector3D terracotta_dark{0.43F, 0.15F, 0.08F};
-  QVector3D blue_accent{0.15F, 0.31F, 0.47F};
-  QVector3D bronze{0.48F, 0.30F, 0.11F};
+  QVector3D terracotta = BuildingPalette::k_terracotta;
+  QVector3D terracotta_dark = BuildingPalette::k_terracotta_dark;
+  QVector3D blue_accent = BuildingPalette::k_blue_accent;
+  QVector3D bronze = BuildingPalette::k_bronze;
   QVector3D iron{0.12F, 0.13F, 0.13F};
   QVector3D olive{0.25F, 0.31F, 0.10F};
   QVector3D grape{0.24F, 0.08F, 0.18F};
   QVector3D ochre{0.66F, 0.38F, 0.09F};
-  QVector3D gold{0.72F, 0.53F, 0.20F};
+  QVector3D gold = BuildingPalette::k_gold;
 };
 
 constexpr std::uint8_t k_marketplace_team_slot = 0;

--- a/render/entity/nations/roman/marketplace_renderer.cpp
+++ b/render/entity/nations/roman/marketplace_renderer.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstdint>
 
+#include "building_architecture.h"
 #include "building_palette.h"
 #include "game/core/component.h"
 #include "game/visuals/team_colors.h"
@@ -128,48 +129,6 @@ void add_produce_basket(BuildingArchetypeDesc& desc,
   }
 }
 
-void add_stall_canopy(BuildingArchetypeDesc& desc,
-                      const RomanMarketPalette& c,
-                      const QVector3D& center,
-                      float half_x,
-                      float half_z,
-                      float post_h,
-                      const QVector3D& cloth,
-                      const QVector3D& cloth_shade) {
-  constexpr float post_r = 0.016F;
-  float const top = center.y() + post_h;
-
-  for (float const sx : {-1.0F, 1.0F}) {
-    for (float const sz : {-1.0F, 1.0F}) {
-      desc.add_cylinder(
-          QVector3D(center.x() + sx * half_x, center.y(), center.z() + sz * half_z),
-          QVector3D(center.x() + sx * half_x, top, center.z() + sz * half_z),
-          post_r,
-          c.cedar_dark,
-          k_building_state_mask_intact);
-    }
-  }
-
-  desc.add_cylinder(QVector3D(center.x(), top + 0.055F, center.z() - half_z),
-                    QVector3D(center.x(), top + 0.055F, center.z() + half_z),
-                    0.010F,
-                    c.cedar,
-                    k_building_state_mask_intact);
-  for (float const side : {-1.0F, 1.0F}) {
-    desc.add_rotated_box(
-        QVector3D(center.x() + side * half_x * 0.52F, top + 0.028F, center.z()),
-        QVector3D(half_x * 0.60F, 0.011F, half_z * 1.04F),
-        QVector3D(0.0F, 0.0F, side * 15.0F),
-        side < 0.0F ? cloth : cloth_shade,
-        BuildingStateMask::Normal | BuildingStateMask::Damaged);
-  }
-
-  desc.add_box(QVector3D(center.x() - half_x * 0.98F, top + 0.006F, center.z()),
-               QVector3D(0.012F, 0.026F, half_z * 1.02F),
-               c.cloth_gold,
-               BuildingStateMask::Normal | BuildingStateMask::Damaged);
-}
-
 auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
   RomanMarketPalette const c;
   float height_multiplier = 1.0F;
@@ -287,25 +246,28 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                       k_building_state_mask_intact);
   }
 
-  float const awning_y = col_height + 0.20F;
-  for (float const z : {-0.56F, 0.0F, 0.56F}) {
-    add_stall_canopy(desc,
-                     c,
-                     QVector3D(-0.20F, counter_h + 0.06F, z),
-                     0.27F,
-                     0.18F,
-                     0.30F * height_multiplier,
-                     c.cloth_gold,
-                     c.ochre);
-  }
-
-  for (float const z : {-0.86F, 0.86F}) {
-    desc.add_cylinder(QVector3D(-0.83F, awning_y - 0.02F, z),
-                      QVector3D(-0.76F, 0.20F, z),
-                      0.009F,
-                      c.cloth_gold,
+  // One tiled portico gives the market a civic Roman silhouette.
+  // The side tables remain open so their produce can be read from above.
+  const float portico_eave = entab_y + 0.08F;
+  for (const float z : {-0.80F, 0.80F}) {
+    desc.add_box(
+        QVector3D(0.32F, 0.18F, z), QVector3D(0.085F, 0.04F, 0.085F), c.marble);
+    desc.add_cylinder(QVector3D(0.32F, 0.20F, z),
+                      QVector3D(0.32F, portico_eave - 0.05F, z),
+                      0.055F,
+                      c.limestone,
                       k_building_state_mask_intact);
+    desc.add_box(QVector3D(0.32F, portico_eave - 0.04F, z),
+                 QVector3D(0.085F, 0.04F, 0.085F),
+                 c.marble,
+                 k_building_state_mask_intact);
   }
+  desc.add_box(QVector3D(0.32F, portico_eave - 0.025F, 0.0F),
+               QVector3D(0.08F, 0.035F, 0.94F),
+               c.limestone,
+               k_building_state_mask_intact);
+  add_tiled_roof(
+      desc, QVector3D(-0.32F, portico_eave, 0.0F), 1.02F, 0.72F, 0.32F, true);
 
   for (float const z : {-0.74F, 0.0F, 0.74F}) {
     desc.add_box(
@@ -316,14 +278,6 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                    c.cedar_dark,
                    k_building_state_mask_intact);
     }
-    add_stall_canopy(desc,
-                     c,
-                     QVector3D(0.46F, 0.16F, z),
-                     0.24F,
-                     0.21F,
-                     0.58F * height_multiplier,
-                     c.cloth_red,
-                     c.cloth_red_faded);
   }
 
   for (float const z : {-0.52F, 0.52F}) {
@@ -418,14 +372,6 @@ auto build_marketplace_archetype(BuildingState state) -> RenderArchetype {
                           0.72F,
                           c.gold,
                           c.terracotta_dark);
-
-  desc.add_cylinder(QVector3D(0.92F, wall_h + 0.20F, -1.02F),
-                    QVector3D(0.92F, wall_h + 0.86F, -1.02F),
-                    0.020F,
-                    c.cedar_dark,
-                    k_building_state_mask_intact);
-  add_roman_roof_standard(
-      desc, QVector3D(0.92F, wall_h + 0.86F, -1.02F), 0.58F, c.gold, c.cloth_red);
 
   add_ruin_dressing(desc,
                     RuinDressing{.extent = QVector3D(1.16F, 0.0F, 1.16F),

--- a/render/entity/nations/roman/temple_renderer.cpp
+++ b/render/entity/nations/roman/temple_renderer.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdint>
 
+#include "building_palette.h"
 #include "render/entity/building_archetype_desc.h"
 #include "render/entity/building_decay.h"
 #include "render/entity/building_ornaments.h"
@@ -22,18 +23,18 @@ constexpr float k_pi = 3.14159265F;
 constexpr float k_rad_to_deg = 180.0F / k_pi;
 
 struct RomanTemplePalette {
-  QVector3D marble{0.94F, 0.92F, 0.85F};
-  QVector3D marble_shade{0.81F, 0.78F, 0.70F};
-  QVector3D limestone{0.84F, 0.78F, 0.66F};
-  QVector3D limestone_dark{0.50F, 0.46F, 0.38F};
+  QVector3D marble = BuildingPalette::k_marble;
+  QVector3D marble_shade = BuildingPalette::k_marble_shade;
+  QVector3D limestone = BuildingPalette::k_limestone;
+  QVector3D limestone_dark = BuildingPalette::k_limestone_dark;
   QVector3D mortar{0.56F, 0.52F, 0.45F};
-  QVector3D terracotta{0.70F, 0.32F, 0.15F};
-  QVector3D terracotta_light{0.81F, 0.45F, 0.24F};
-  QVector3D terracotta_dark{0.44F, 0.17F, 0.085F};
+  QVector3D terracotta = BuildingPalette::k_terracotta;
+  QVector3D terracotta_light = BuildingPalette::k_terracotta_light;
+  QVector3D terracotta_dark = BuildingPalette::k_terracotta_dark;
   QVector3D cloth_red{0.53F, 0.075F, 0.052F};
-  QVector3D gold{0.72F, 0.53F, 0.20F};
-  QVector3D bronze{0.48F, 0.30F, 0.11F};
-  QVector3D blue_accent{0.24F, 0.40F, 0.55F};
+  QVector3D gold = BuildingPalette::k_gold;
+  QVector3D bronze = BuildingPalette::k_bronze;
+  QVector3D blue_accent = BuildingPalette::k_blue_accent;
   QVector3D soot{0.16F, 0.14F, 0.12F};
   QVector3D flame{0.88F, 0.47F, 0.12F};
 };

--- a/render/entity/nations/roman/wall_renderer.cpp
+++ b/render/entity/nations/roman/wall_renderer.cpp
@@ -1,5 +1,6 @@
 #include "wall_renderer.h"
 
+#include "building_palette.h"
 #include "render/entity/building_render_common.h"
 #include "render/entity/registry.h"
 #include "render/entity/wall_gate_renderer_common.h"
@@ -8,14 +9,14 @@
 namespace Render::GL::Roman {
 namespace {
 
-const WallPalette k_wall_palette{.wood_light = QVector3D(0.62F, 0.43F, 0.23F),
-                                 .wood_mid = QVector3D(0.46F, 0.30F, 0.15F),
-                                 .wood_dark = QVector3D(0.27F, 0.17F, 0.085F),
+const WallPalette k_wall_palette{.wood_light = BuildingPalette::k_cedar_light,
+                                 .wood_mid = BuildingPalette::k_cedar,
+                                 .wood_dark = BuildingPalette::k_cedar_dark,
                                  .rope = QVector3D(0.55F, 0.44F, 0.25F),
                                  .masonry_accent = QVector3D(0.46F, 0.30F, 0.15F),
                                  .earth_light = QVector3D(0.41F, 0.31F, 0.20F),
                                  .earth_dark = QVector3D(0.29F, 0.21F, 0.13F),
-                                 .rubble = QVector3D(0.42F, 0.39F, 0.35F),
+                                 .rubble = BuildingPalette::k_limestone_dark,
                                  .alternate_starts_light = true};
 const WallGeometry k_wall_geometry{.earthwork_base = true,
                                    .cross_braced = false,


### PR DESCRIPTION
Buildings within each nation used inconsistent materials and unrelated architectural details. Homes tinted roofs with player colors, Rome's barracks used an exposed scaffold tower, and domestic buildings carried oversized military or temple ornaments.

This expands the initial palette fix into a broader architectural cleanup:

- Share nation materials across homes, barracks, farms, marketplaces, temples, defense towers, walls, and gates. Keep player colors on banners and trim.
- Give Roman homes lower tiled gables, a clear four-column entrance, and simpler facades; remove roof standards and oversized pediment decorations.
- Use a shared Roman roof builder for homes, farm granaries, defense towers, the barracks lookout, and marketplace. It supplies matching terracotta slopes, tile rolls, ridge caps, and optional plaster gables.
- Replace Rome's barracks scaffold with a masonry lookout and its defense tower's stepped pyramid roof with a tiled gable. Correct downward-pointing tower columns in the destroyed state.
- Replace the Roman market's cluster of miniature tents with one supported tiled portico and exposed side tables.
- Rework Carthaginian homes into plaster-and-sandstone terrace houses with continuous low parapets, a roof-access room, and a modest indigo shade canopy. Remove domestic battlements and oversized rooftop crowns; bring side windows out to the wall surface.
- Consolidate Carthage's market shades into a single indigo canopy on sandstone piers. Give farm storehouses matching flat roof finishes and continuous coping.
- Simplify Carthage's military skyline: remove oversized crowns from barracks and defense towers and leave the tower's stepped observation terrace open.

Validation: clang-format 18.1.3 checks, git diff --check, C++ syntax parsing, palette-reference checks, and roof-profile dimension checks passed. No compilation or in-game visual verification was run, as requested. Both commits include [skip ci]. Iron Sepulcher's separate style is unchanged.