### PR TITLE
feat: make every screen edge scroll and time frame pacing at the swap

### DIFF
--- a/app/viewmodels/camera_view_model.cpp
+++ b/app/viewmodels/camera_view_model.cpp
@@ -182,6 +182,12 @@ void CameraViewModel::reset() {
   emit distance_changed();
 }
 
+auto CameraViewModel::world_target() const -> QVector3D {
+  const auto frame_lock = m_host.lock_frame();
+  return m_context.active_camera != nullptr ? m_context.active_camera->get_target()
+                                            : QVector3D{};
+}
+
 void CameraViewModel::look_at_world(float x, float z) {
   m_host.ensure_initialized();
   const auto frame_lock = m_host.lock_frame();

--- a/app/viewmodels/camera_view_model.h
+++ b/app/viewmodels/camera_view_model.h
@@ -51,6 +51,7 @@ public:
   void publish_frame();
 
   [[nodiscard]] auto distance() const -> float;
+  [[nodiscard]] auto world_target() const -> QVector3D;
   [[nodiscard]] auto following_selection() const -> bool {
     return m_following_selection;
   }

--- a/docs/CAMERA_CONTROLS.md
+++ b/docs/CAMERA_CONTROLS.md
@@ -109,43 +109,64 @@ just resell the same motion twice.
 The maths lives in `ui/edge_scroll.cpp` rather than inline in QML so it can be
 tested (`tests/ui/edge_scroll_test.cpp`).
 
-- The band is 12 logical px along the sides and 10 along the top and bottom at
-  the default sensitivity, multiplied by **both** the edge-scroll sensitivity
-  and the interface scale, and never narrower than 4 px.
-- Push grows toward the edge — squared horizontally, cubed vertically — so a
-  cursor resting just inside the band creeps and a cursor pinned to the edge
-  runs.
+- The band is 26 logical px on **every** side at the default sensitivity,
+  multiplied by both the edge-scroll sensitivity and the interface scale, and
+  never narrower than 10 px.
+- Push grows toward the edge on the same square curve on both axes, and starts
+  at `k_entry_push` (35%) rather than at nothing: crossing into the band moves
+  the camera at once, and pinning the cursor to the edge runs it.
+- A corner is clamped to the magnitude of a single edge, so rounding one does
+  not lurch the view by a factor of sqrt(2).
 - An unknown cursor position (`-1`), a zero-sized surface or a cursor past the
   surface all yield no movement, so a stale pointer cannot scroll the map.
 
-Scaling the band by the interface scale is what keeps a 12 px band reachable on
-a 4K panel at 200%; without it the band stays 12 physical px while every other
-target doubles.
+Scaling the band by the interface scale is what keeps it reachable on a 4K panel
+at 200%; without it the band stays 26 physical px while every other target
+doubles.
 
-### The minimap clearance
+The two axes are deliberately symmetric. They were not: the vertical band was
+10 px against 12 horizontally and ramped as a **cube** against a square, so the
+middle of the top band moved the camera at an eighth of the pace the middle of a
+side band did. Pushing the cursor up read as broken, because for all but the
+last pixel or two it was.
 
-The minimap is the one HUD control that is itself a camera move, so a band
-reaching under it would leave a minimap drag and edge scroll pushing the same
-camera at once. It does not, but only just. Clicking along the minimap's right
-edge in a running battle puts the last responsive pixel 25 logical px from the
-right of the surface — `hudZoneMargin` plus the panel's own padding — while the
-widest band the settings allow is `12 * 2.0 = 24`. Both sides scale with the
-interface, so the clearance stays proportional: measured at interface scale 1.0
-the minimap stops at 1255 and the band starts at 1256, and at 1.5 it stops at
-1243 and the band starts at 1244.
+### Where the cursor comes from
 
-One logical pixel of headroom is not a margin anyone chose. Widening the base
-band, raising `kMaxEdgeScrollSensitivity` or trimming the minimap's padding
-closes it, and then a minimap drag and edge scroll fight over the camera.
-`EdgeScrollTest.TheStrongestBandStaysClearOfTheMinimap` guards the C++ half;
-the QML half is a hand measurement, so re-measure it if you touch either.
+`EdgeScroll.cursorIn(item)` reads `QCursor::pos()` and maps it into the overlay,
+and the overlay's 16 ms timer polls that. It deliberately does **not** use the
+overlay's own hover events.
+
+The overlay is a full-screen `hoverEnabled` MouseArea sitting _below_ the HUD
+(`z: 0.5` against the HUD's `z: 1`), because Qt stops hover delivery at the
+first item that accepts it and an overlay above the HUD swallowed every HUD
+tooltip. But the same rule cuts the other way: while the overlay drove edge
+scroll from its own `positionChanged`, the top bar, the command panel, the
+minimap and the commander overlay each ate the cursor before it arrived. The
+top edge, the bottom edge and all four corners simply did not scroll. Polling
+the platform cursor gives both — HUD tooltips open, and every screen edge
+scrolls.
+
+### The minimap
+
+The minimap is the one HUD control that is itself a camera move, so edge scroll
+has to keep off it. It is refused by state rather than by geometry:
+`HUD.blocks_edge_scroll()` returns true for the minimap's own rectangle, and
+`mainWindow.edge_scroll_disabled` covers a drag that wanders out of it
+(`hud.minimap_drag_active`).
+
+This replaced a one-pixel geometric clearance — the band's widest setting was
+`12 * 2.0 = 24` px against a minimap whose hit area ended 25 px from the right —
+which is what pinned the base band at 12 px in the first place. A margin nobody
+chose is not a margin; the band is now free to be as wide as it needs to be.
 
 ## What suppresses edge scroll
 
 `mainWindow.edge_scroll_disabled` is **derived**, never assigned:
 
 ```qml
-readonly property bool edge_scroll_disabled: gameViewItem.camera_pan_active || !mainWindow.active
+readonly property bool edge_scroll_disabled: gameViewItem.camera_pan_active
+    || !mainWindow.active || mainWindow.overlay_active
+    || hud.commander_rpg_mode || hud.minimap_drag_active
 ```
 
 `camera_pan_active` is in turn derived from the live pan state
@@ -153,6 +174,12 @@ readonly property bool edge_scroll_disabled: gameViewItem.camera_pan_active || !
 the flag used to be set on right-press and cleared on right-release, so a drag
 interrupted by a lost grab — a modal opening, the window losing focus — left it
 latched and killed edge scrolling for the rest of the session. Keep it derived.
+
+The last three terms are what a hover-driven overlay used to get for free: an
+open panel, the commander's own full-screen cursor overlay and the minimap each
+took the cursor away from it. A cursor read straight from the platform sees none
+of that, so every reason to _not_ scroll now has to be stated. Anything new that
+covers the map and wants the pointer to itself belongs in this list.
 
 The overlay's timer is likewise bound to a live condition rather than started
 from `onEntered`, because an item that becomes visible under a stationary cursor
@@ -168,9 +195,13 @@ The function reads `hud.top_panel_height` and `hud.bottom_panel_height` — note
 the snake_case; the camelCase spellings do not exist and silently evaluate to
 `undefined`, which is how world hover used to leak through the HUD.
 
-The overlay sits above the HUD (`z: 2` against `z: 1`) but accepts
-`Qt.NoButton`, so it never takes a click from a HUD button, and `MouseArea` does
-not consume hover events, so HUD hover states still work underneath it.
+`HUD.blocks_edge_scroll()` is the much smaller sibling that decides where
+**scrolling** stops, and it covers the minimap alone. Do not fold the two
+together: `blocks_world_pointer()` claims both full-width panels, and scrolling
+has to reach through them or the top and bottom edges are dead.
+
+The overlay accepts `Qt.NoButton`, so it never takes a click from a HUD button,
+and it sits below the HUD so HUD hover states and tooltips work.
 
 ## Manual regression checklist
 
@@ -194,6 +225,9 @@ by hand when touching anything above. Every row should behave identically.
 - [ ] Scrolling **stops** as soon as the cursor leaves the band.
 - [ ] The band feels reachable — no hunting for a sliver of pixels. On a
       high-DPI panel confirm the band grew with the interface scale.
+- [ ] The top and bottom edges feel exactly as strong as the sides, at the very
+      edge and halfway into the band alike.
+- [ ] Rounding a corner does not speed the camera up.
 - [ ] Settings › Accessibility shows the band width in px and it **matches** what
       you have to reach for.
 - [ ] Turning **edge scrolling off** stops it everywhere; the legend then reads
@@ -206,8 +240,10 @@ by hand when touching anything above. Every row should behave identically.
 - [ ] Right-drag pans; edge scroll does **not** fight it mid-drag.
 - [ ] With **edge scroll strength at maximum**, drag the camera around by the
       minimap: the camera goes where the minimap says and does **not** also
-      creep sideways. See "The minimap clearance" above — this passes on a
-      single pixel.
+      creep sideways, including when the drag wanders off the minimap onto the
+      screen edge beside it.
+- [ ] In the commander's first-person mode the screen edges do **not** scroll
+      the RTS camera.
 - [ ] Right-drag, then press `Esc` / open the menu mid-drag, then return to the
       battle: edge scroll still works. (This is the regression that used to
       latch it off permanently.)

--- a/docs/FRAME_PACING.md
+++ b/docs/FRAME_PACING.md
@@ -44,9 +44,12 @@ fail the gate. The older `budget` remains an Ultra/Full-LOD certification, so
 non-Ultra reports should inspect `frame_pacing` independently of that verdict.
 
 The pacing window starts at the first playable frame and includes the legacy
-benchmark's warm-up. Loading itself is excluded. Frame intervals measure render
-start to render start, not display scanout; compositor/display latency is outside
-this instrumentation. CPU and upload evidence belongs to the preceding frame.
+benchmark's warm-up. Loading itself is excluded. Frame intervals use `QQuickWindow::frameSwapped`, connected directly on the
+scene-graph render thread. This measures queuing for presentation, not physical
+display scanout ([Qt signal contract](https://doc.qt.io/qt-6/qquickwindow.html#frameSwapped)).
+The clock is consumed for each rendered gameplay frame, retaining time across
+skipped gameplay renders. Missing swaps fail the gate; render-start intervals
+remain separately reported in `wall_interval_ms`. CPU and upload evidence belongs to the preceding frame.
 Asset/upload deltas are baselined during loading, then checked from the first
 playable frame. `post_playable_asset_work` must be zero. The legacy asset barrier
 is armed earlier, before overlay prewarming, so its cumulative totals remain
@@ -56,6 +59,9 @@ has no following interval and is not included.
 CPU budgets use render-thread CPU time; `render_elapsed_ms` in hitch evidence
 also includes driver waits. Simulation time and the preceding Present interval
 are excluded from CPU phase attribution because they belong to other work.
+
+Ten-second windows retain asset-work counts, hitch counts and worst intervals
+to distinguish first-use work from recurring work.
 
 Reports contain median, percentile and maximum intervals, normalized hitch
 frequency, consecutive clusters and the worst frame's CPU phases/upload bytes in
@@ -83,8 +89,9 @@ Qualify each preset with a 60-second-or-longer scenario containing:
 Repeat the sequence to distinguish first-use work from recurring stalls. The
 `--camera-cycle` option drives a repeating 20-second pan/zoom input path on the
 GUI thread, starting after loading; its completed-cycle count is reported and
-gated. The camera target follows an absolute, closed world-space path around the
-map origin, so zoom-dependent pan scaling cannot make repeated traversals drift.
+gated. Runs with no visible soldiers fail qualification; the report also records
+the actual render-target dimensions. The camera target follows an absolute, closed world-space path around the
+mission's starting camera target, so zoom-dependent pan scaling cannot make repeated traversals drift.
 Zoom uses the normal camera controller. The path is a function of elapsed time. This does not
 issue simulation commands. The campaign suite exercises real missions, but does
 **not** yet automate all the UI/weather/destruction actions. A passing
@@ -119,3 +126,37 @@ those buffers, which deferred their uploads until a camera first exposed them.
 The pass retries on subsequent loading frames if a GL context is unavailable;
 ordinary gameplay retains the existing lazy fallback and the pacing gate reports
 any remaining asset work instead of hiding it.
+
+## Local investigation: issue #1398
+
+The 2026-09-07 `anchored-camera` run used the isolated RelWithDebInfo build,
+Ultra, Battle of Ticino, a 60-second benchmark (62 seconds including playable
+warm-up), and three camera cycles. It rendered at 1280 × 720 on an RTX 5060
+with NVIDIA 590.48.01. This is an investigation, not reference qualification.
+Raw reports, hardware/build manifest and logs are retained locally under
+`artifacts/frame-pacing-1398/anchored-camera/`.
+
+| Measurement                              |                   Result | Gate            |
+| ---------------------------------------- | -----------------------: | --------------- |
+| Average visible soldiers                 |                   144.96 | Nonempty battle |
+| Presentation interval median / p95 / p99 | 16.68 / 27.41 / 34.91 ms | Fail            |
+| Maximum presentation interval            |                272.39 ms | Fail            |
+| Render-thread CPU / GPU p95              |          10.63 / 9.61 ms | Pass            |
+| Maximum upload                           |            102,504 bytes | Pass            |
+| Hitch frames                             |        50 (48.39/minute) | Fail            |
+| Post-playable asset work                 |            97 operations | Fail            |
+| Missing presentation samples             |                        0 | Pass            |
+
+All asset work occurred in the first 20 seconds; all hitches occurred in the
+first 30 seconds. Later windows had no hitches or asset work. The worst interval
+contained 249.17 ms in presentation update but only 6.68 ms of render-thread CPU
+time and no asset work. That is evidence of waiting or scheduling within
+presentation update; it does not yet prove which lock or subsystem caused it.
+The remaining work is to attribute and remove that wait and the first-use asset
+operations, then rerun identical fixtures across presets and complete the
+UI/weather/destruction coverage above. The gate remains failing.
+
+Earlier `swap-timed` results had zero visible soldiers because the camera path
+was centered on world origin. They cannot qualify battle performance. The
+corrected path uses the mission's starting camera target, and both the report
+and runner reject empty-battle measurements.

--- a/main.cpp
+++ b/main.cpp
@@ -34,6 +34,7 @@
 #include <qurl.h>
 
 #include <array>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
 #include <memory>
@@ -41,6 +42,7 @@
 #include <string_view>
 
 #include "render/gl/context_requirements.h"
+#include "render/profiling/frame_swap_clock.h"
 #include "render/profiling/presentation_cycle.h"
 
 #ifdef Q_OS_WIN
@@ -1038,6 +1040,18 @@ auto main(int argc, char* argv[]) -> int {
     return -2;
   }
   qInfo() << "QQuickWindow found";
+  if (qEnvironmentVariable("SOI_RUNTIME_BENCHMARK_SECONDS").toDouble() > 0.0) {
+    QObject::connect(
+        window,
+        &QQuickWindow::frameSwapped,
+        window,
+        [] {
+          const auto now = std::chrono::steady_clock::now().time_since_epoch();
+          Render::Profiling::frame_swap_clock().observe(
+              std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+        },
+        Qt::DirectConnection);
+  }
 
   if (component_gallery_requested) {
 
@@ -1351,11 +1365,12 @@ auto main(int argc, char* argv[]) -> int {
     auto* cycle_timer = new QTimer(game_engine.get());
     auto elapsed = std::make_shared<QElapsedTimer>();
     auto previous = std::make_shared<Render::Profiling::PresentationCyclePosition>();
+    auto origin = std::make_shared<QVector3D>();
     QObject::connect(
         cycle_timer,
         &QTimer::timeout,
         game_engine.get(),
-        [game_ptr = game_engine.get(), elapsed, previous]() {
+        [game_ptr = game_engine.get(), elapsed, previous, origin]() {
           auto& progress = Render::Profiling::presentation_cycle_progress();
           if (game_ptr->is_loading() || !game_ptr->simulation_thread_running()) {
             elapsed->invalidate();
@@ -1364,15 +1379,16 @@ auto main(int argc, char* argv[]) -> int {
             progress.completed_cycles = 0;
             return;
           }
+          auto* camera = static_cast<App::ViewModels::CameraViewModel*>(
+              game_ptr->camera_view_model());
           if (!elapsed->isValid()) {
+            *origin = camera->world_target();
             elapsed->start();
           }
           const double seconds = static_cast<double>(elapsed->elapsed()) / 1000.0;
           const auto position = Render::Profiling::presentation_cycle_position(seconds);
-          auto* camera = static_cast<App::ViewModels::CameraViewModel*>(
-              game_ptr->camera_view_model());
-          camera->look_at_world(static_cast<float>(position.x),
-                                static_cast<float>(position.z));
+          camera->look_at_world(origin->x() + static_cast<float>(position.x),
+                                origin->z() + static_cast<float>(position.z));
           camera->zoom(static_cast<float>(position.zoom - previous->zoom));
           *previous = position;
           ++progress.updates;

--- a/render/profiling/frame_pacing.h
+++ b/render/profiling/frame_pacing.h
@@ -20,6 +20,7 @@ struct PacingSample {
   std::array<std::uint64_t, static_cast<std::size_t>(Phase::_Count)> phase_us{};
   std::uint64_t asset_work{0};
   double render_elapsed_ms{0};
+  bool presentation_timed{true};
 };
 
 struct PacingBudget {
@@ -58,10 +59,17 @@ public:
     const auto budget = pacing_budget(preset);
     std::vector<double> intervals, cpu, gpu;
     QJsonArray failures, clusters;
+    struct Window {
+      std::uint64_t asset_work{0};
+      std::size_t hitches{0};
+      double worst_ms{0};
+    };
+    std::vector<Window> windows;
     double elapsed_ms = 0, upload_max = 0;
     std::uint64_t asset_work = 0;
     std::size_t hitches = 0, longest = 0, cluster_size = 0, cluster_start = 0;
     std::size_t gpu_timed_frames = 0;
+    std::size_t untimed_presentation_frames = 0;
     double cluster_max = 0;
     QJsonObject worst_evidence;
     auto finish_cluster = [&] {
@@ -88,9 +96,18 @@ public:
         continue;
       }
       intervals.push_back(sample.interval_ms);
+      untimed_presentation_frames += sample.presentation_timed ? 0 : 1;
       cpu.push_back(sample.cpu_ms);
       gpu.push_back(sample.gpu_ms);
       gpu_timed_frames += sample.gpu_ms > 0 ? 1 : 0;
+      const auto window_index = static_cast<std::size_t>(elapsed_ms / 10000.0);
+      if (windows.size() <= window_index) {
+        windows.resize(window_index + 1);
+      }
+      auto& window = windows[window_index];
+      window.asset_work += sample.asset_work;
+      window.hitches += sample.interval_ms > budget.hitch_ms ? 1 : 0;
+      window.worst_ms = std::max(window.worst_ms, sample.interval_ms);
       elapsed_ms += sample.interval_ms;
       upload_max = std::max(upload_max, sample.upload_bytes);
       asset_work += sample.asset_work;
@@ -144,6 +161,9 @@ public:
         failures.append(name + QStringLiteral(" exceeded budget"));
       }
     };
+    check("untimed_presentation_frames",
+          static_cast<double>(untimed_presentation_frames),
+          0);
     check("interval_p95_ms", spread.p95, budget.interval_p95_ms);
     check("interval_p99_ms", spread.p99, budget.interval_p99_ms);
     check("interval_max_ms", spread.maximum, budget.spike_max_ms);
@@ -169,7 +189,17 @@ public:
         preset != "ultra") {
       failures.append(QStringLiteral("unknown graphics preset"));
     }
+    QJsonArray window_json;
+    for (std::size_t i = 0; i < windows.size(); ++i) {
+      window_json.append(
+          QJsonObject{{"start_seconds", static_cast<double>(i) * 10},
+                      {"asset_work", static_cast<qint64>(windows[i].asset_work)},
+                      {"hitch_frames", static_cast<qint64>(windows[i].hitches)},
+                      {"worst_ms", windows[i].worst_ms}});
+    }
     return QJsonObject{{"passed", failures.isEmpty()},
+                       {"ten_second_windows", window_json},
+                       {"interval_source", "QQuickWindow.frameSwapped"},
                        {"preset", preset},
                        {"frames", static_cast<qint64>(intervals.size())},
                        {"elapsed_seconds", elapsed_ms / 1000.0},

--- a/render/profiling/frame_swap_clock.h
+++ b/render/profiling/frame_swap_clock.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace Render::Profiling {
+
+class FrameSwapClock {
+public:
+  void observe(std::int64_t nanoseconds) noexcept {
+    m_last_ns.store(nanoseconds, std::memory_order_release);
+  }
+  [[nodiscard]] auto latest() const noexcept -> std::int64_t {
+    return m_last_ns.load(std::memory_order_acquire);
+  }
+
+  [[nodiscard]] auto interval_ms(std::int64_t& previous) const noexcept -> double {
+    const auto now = latest();
+    const double interval = previous > 0 && now > previous
+                                ? static_cast<double>(now - previous) / 1000000.0
+                                : 0.0;
+    previous = now;
+    return interval;
+  }
+
+private:
+  std::atomic<std::int64_t> m_last_ns{0};
+};
+
+inline auto frame_swap_clock() -> FrameSwapClock& {
+  static FrameSwapClock clock;
+  return clock;
+}
+
+} // namespace Render::Profiling

--- a/scripts/check-frame-pacing.py
+++ b/scripts/check-frame-pacing.py
@@ -7,6 +7,7 @@ import argparse
 import datetime
 import hashlib
 import json
+import math
 import os
 import platform
 import shutil
@@ -32,6 +33,9 @@ def read_report(path: Path, preset: str, camera_cycle: bool = False) -> list[str
     if not isinstance(pacing, dict):
         return ["frame pacing was not measured"]
     failures = []
+    visible = report.get("visible_soldiers_average")
+    if type(visible) not in (int, float) or not math.isfinite(visible) or visible <= 0:
+        failures.append("no visible soldiers were measured")
     if pacing.get("preset") != preset:
         failures.append("measured preset does not match requested preset")
     if pacing.get("passed") is not True:
@@ -42,6 +46,17 @@ def read_report(path: Path, preset: str, camera_cycle: bool = False) -> list[str
         failures.append("post-load asset work was not measured")
 
     checks = pacing.get("checks", {})
+    swap_check = (
+        checks.get("untimed_presentation_frames", {})
+        if isinstance(checks, dict)
+        else {}
+    )
+    if (
+        pacing.get("interval_source") != "QQuickWindow.frameSwapped"
+        or not isinstance(swap_check, dict)
+        or swap_check.get("passed") is not True
+    ):
+        failures.append("presentation timing failed or was not measured")
     asset_check = (
         checks.get("post_playable_asset_work", {}) if isinstance(checks, dict) else {}
     )

--- a/tests/render/profiling/frame_profile_test.cpp
+++ b/tests/render/profiling/frame_profile_test.cpp
@@ -6,6 +6,7 @@
 
 #include "render/profiling/frame_pacing.h"
 #include "render/profiling/frame_profile.h"
+#include "render/profiling/frame_swap_clock.h"
 #include "render/profiling/presentation_cycle.h"
 
 using Render::Profiling::format_overlay;
@@ -314,4 +315,42 @@ TEST(FramePacingTest, OneGpuSampleCannotCertifyAnOtherwiseUntimedRun) {
                    .toObject()["missing_gpu_sample_fraction"]
                    .toObject()["passed"]
                    .toBool());
+}
+
+TEST(FramePacingTest, SwapClockKeepsSkippedFrameTimeAndRejectsMissingSwaps) {
+  Render::Profiling::FrameSwapClock clock;
+  std::int64_t previous = 0;
+  EXPECT_DOUBLE_EQ(clock.interval_ms(previous), 0);
+  clock.observe(1000000000);
+  EXPECT_DOUBLE_EQ(clock.interval_ms(previous), 0);
+  clock.observe(1016000000);
+  EXPECT_DOUBLE_EQ(clock.interval_ms(previous), 16);
+  EXPECT_DOUBLE_EQ(clock.interval_ms(previous), 0);
+  clock.observe(1032000000);
+  clock.observe(1048000000);
+  EXPECT_DOUBLE_EQ(clock.interval_ms(previous), 32);
+}
+
+TEST(FramePacingTest, RenderStartFallbackCannotCertifyPresentationTiming) {
+  Render::Profiling::FramePacing pacing;
+  for (int i = 0; i < 1800; ++i) {
+    pacing.observe({16.67, 8, 8, 0, {}});
+  }
+  Render::Profiling::PacingSample sample{16.67, 8, 8, 0, {}};
+  sample.presentation_timed = false;
+  pacing.observe(sample);
+  EXPECT_FALSE(pacing.report("high")["passed"].toBool());
+}
+
+TEST(FramePacingTest, WindowsDistinguishFirstUseWorkFromRecurringWork) {
+  Render::Profiling::FramePacing pacing;
+  for (int i = 0; i < 2000; ++i) {
+    Render::Profiling::PacingSample sample{10, 5, 5, 0, {}};
+    sample.asset_work = i == 0 ? 3 : (i == 1000 ? 1 : 0);
+    pacing.observe(sample);
+  }
+  const auto windows = pacing.report("high")["ten_second_windows"].toArray();
+  ASSERT_EQ(windows.size(), 2);
+  EXPECT_EQ(windows[0].toObject()["asset_work"].toInt(), 3);
+  EXPECT_EQ(windows[1].toObject()["asset_work"].toInt(), 1);
 }

--- a/tests/scripts/test_frame_pacing_runner.py
+++ b/tests/scripts/test_frame_pacing_runner.py
@@ -24,10 +24,15 @@ class PacingRunnerTest(unittest.TestCase):
     def good(self):
         return {
             "valid": True,
+            "visible_soldiers_average": 224,
             "frame_pacing": {
                 "passed": True,
                 "preset": "medium",
-                "checks": {"post_playable_asset_work": {"passed": True, "measured": 0}},
+                "interval_source": "QQuickWindow.frameSwapped",
+                "checks": {
+                    "post_playable_asset_work": {"passed": True, "measured": 0},
+                    "untimed_presentation_frames": {"passed": True, "measured": 0},
+                },
             },
             "asset_counters": {
                 "load_barrier_marked": True,
@@ -52,6 +57,21 @@ class PacingRunnerTest(unittest.TestCase):
             {"load_barrier_marked": False},
         ):
             self.assertTrue(self.check({**self.good(), "asset_counters": assets}))
+
+    def test_missing_presentation_timing_cannot_pass(self):
+        report = self.good()
+        del report["frame_pacing"]["interval_source"]
+        self.assertTrue(self.check(report))
+        for check in ({}, {"passed": False, "measured": 1}):
+            report = self.good()
+            report["frame_pacing"]["checks"]["untimed_presentation_frames"] = check
+            self.assertTrue(self.check(report))
+
+    def test_empty_battle_cannot_pass(self):
+        for visible in (0, -1, None, float("nan")):
+            self.assertTrue(
+                self.check({**self.good(), "visible_soldiers_average": visible})
+            )
 
     def test_playable_asset_gate_is_required(self):
         for check in ({}, {"passed": False, "measured": 1}):

--- a/tests/ui/edge_scroll_test.cpp
+++ b/tests/ui/edge_scroll_test.cpp
@@ -1,6 +1,5 @@
 #include <cmath>
 #include <gtest/gtest.h>
-#include <string>
 
 #include "app/core/user_settings.h"
 #include "ui/edge_scroll.h"
@@ -149,34 +148,72 @@ TEST(EdgeScrollTest, AHighResolutionSurfaceStillScrollsAtItsEdges) {
       Edge::vector_at(k_wide / 2.0, k_tall / 2.0, k_wide, k_tall, 1.0, 2.0).is_zero());
 }
 
-TEST(EdgeScrollTest, TheStrongestBandStaysClearOfTheMinimap) {
-  constexpr double k_minimap_hit_area_ends_px_from_right = 25.0;
-  constexpr double k_widest_band = 24.0;
+TEST(EdgeScrollTest, TheBandIsWideEnoughToAimAt) {
+  const auto why =
+      "a band you have to hunt for is the single loudest complaint about edge "
+      "scrolling. The default reaches 26 logical px on every side, and the "
+      "weakest setting still leaves a band you can land on without looking. "
+      "The minimap no longer needs this band to stay narrow: HUD.blocks_edge_"
+      "scroll() refuses the minimap's own rectangle outright and "
+      "mainWindow.edge_scroll_disabled covers a drag that leaves it. See "
+      "docs/CAMERA_CONTROLS.md.";
+
+  EXPECT_GE(Edge::horizontal_zone(1.0, 1.0), 24.0) << why;
+  EXPECT_GE(Edge::vertical_zone(1.0, 1.0), 24.0) << why;
+
+  const double weakest = App::Core::UserSettings::kMinEdgeScrollSensitivity;
+  EXPECT_GE(Edge::horizontal_zone(weakest, 1.0), Edge::k_min_zone) << why;
+  EXPECT_GE(Edge::vertical_zone(weakest, 1.0), Edge::k_min_zone) << why;
+}
+
+TEST(EdgeScrollTest, TopAndBottomAreAsReachableAsTheSides) {
+  const auto why =
+      "the vertical band used to be 10 px against 12 horizontally and ramped "
+      "as a cube against a square, so the middle of the top band moved the "
+      "camera at an eighth of the pace the middle of a side band did. Pushing "
+      "up read as broken. Keep the two axes symmetric.";
+
+  EXPECT_DOUBLE_EQ(Edge::vertical_zone(1.0, 1.0), Edge::horizontal_zone(1.0, 1.0))
+      << why;
+
+  const double zone = Edge::vertical_zone(1.0, 1.0);
+  const auto side = at(zone / 2.0, k_height / 2.0);
+  const auto top = at(k_width / 2.0, zone / 2.0);
+  EXPECT_DOUBLE_EQ(top.dz, -side.dx) << why;
+}
+
+TEST(EdgeScrollTest, CrossingIntoTheBandMovesTheCameraAtOnce) {
+  const auto why =
+      "a ramp that starts at zero gives the outer half of the band no usable "
+      "speed, which is indistinguishable from a band half as wide. Entering "
+      "the band commits to a visible push.";
+
+  const double zone = Edge::horizontal_zone(1.0, 1.0);
+  const double just_inside = at(zone - 0.5, k_height / 2.0).dx;
+  EXPECT_LT(just_inside, 0.0) << why;
+  EXPECT_GE(std::abs(just_inside), Edge::k_entry_push * 0.9) << why;
+  EXPECT_LT(std::abs(just_inside), 1.0) << why;
+}
+
+TEST(EdgeScrollTest, ACornerIsNoFasterThanAnEdge) {
+  const auto why =
+      "the two axes are summed, so an unclamped corner runs the camera sqrt(2) "
+      "times faster than either edge next to it and the view lurches as the "
+      "cursor rounds it.";
+
+  const double edge = std::abs(at(0.0, k_height / 2.0).dx);
+  for (const auto& corner :
+       {at(0.0, 0.0), at(k_width, 0.0), at(0.0, k_height), at(k_width, k_height)}) {
+    EXPECT_NEAR(std::hypot(corner.dx, corner.dz), edge, 1e-9) << why;
+  }
+}
+
+TEST(EdgeScrollTest, TheStrongestSettingStillHasAnUnscrolledMiddle) {
   const double strongest = App::Core::UserSettings::kMaxEdgeScrollSensitivity;
-
-  const auto why = [](double scale) {
-    return "at interface scale " + std::to_string(scale) +
-           ": the minimap is itself a camera move, so a band reaching under it "
-           "leaves a minimap drag and edge scroll pushing the same camera. Its "
-           "hit area ends 25 logical px from the right (hudZoneMargin plus the "
-           "panel's padding), measured by hand in a running battle, and the "
-           "widest band is 24 - one pixel of headroom. See the minimap "
-           "clearance in docs/CAMERA_CONTROLS.md and re-measure the QML side.";
-  };
-
-  EXPECT_DOUBLE_EQ(Edge::horizontal_zone(strongest, 1.0), k_widest_band);
-
   for (const double scale : {1.0, 1.5, 2.0}) {
-    EXPECT_LT(Edge::horizontal_zone(strongest, scale),
-              k_minimap_hit_area_ends_px_from_right * scale)
-        << why(scale);
-
-    const double minimap_edge =
-        k_width - (k_minimap_hit_area_ends_px_from_right * scale);
     EXPECT_TRUE(Edge::vector_at(
-                    minimap_edge, k_height / 2.0, k_width, k_height, strongest, scale)
-                    .is_zero())
-        << why(scale);
+                    k_width / 2.0, k_height / 2.0, k_width, k_height, strongest, scale)
+                    .is_zero());
   }
 }
 

--- a/ui/edge_scroll.cpp
+++ b/ui/edge_scroll.cpp
@@ -1,5 +1,9 @@
 #include "edge_scroll.h"
 
+#include <QCursor>
+#include <QQuickItem>
+#include <QQuickWindow>
+
 #include <algorithm>
 #include <cmath>
 
@@ -35,6 +39,14 @@ auto vertical_zone(double sensitivity, double ui_scale) -> double {
                       sane_scale(ui_scale));
 }
 
+auto push_ramp(double approach_amount) -> double {
+  if (!(approach_amount > 0.0)) {
+    return 0.0;
+  }
+  const double amount = std::min(approach_amount, 1.0);
+  return k_entry_push + (1.0 - k_entry_push) * amount * amount;
+}
+
 auto vector_at(double x,
                double y,
                double width,
@@ -60,15 +72,17 @@ auto vector_at(double x,
   const double up = approach(y, vertical);
   const double down = approach(height - y, vertical);
 
-  const auto horizontal_curve = [](double amount) {
-    return amount * amount;
-  };
-  const auto vertical_curve = [](double amount) {
-    return amount * amount * amount;
-  };
+  double dx = (push_ramp(right) - push_ramp(left)) * speed;
+  double dz = (push_ramp(up) - push_ramp(down)) * speed;
 
-  return {.dx = (horizontal_curve(right) - horizontal_curve(left)) * speed,
-          .dz = (vertical_curve(up) - vertical_curve(down)) * speed};
+  const double magnitude = std::hypot(dx, dz);
+  if (magnitude > speed && magnitude > 0.0) {
+    const double trim = speed / magnitude;
+    dx *= trim;
+    dz *= trim;
+  }
+
+  return {.dx = dx, .dz = dz};
 }
 
 } // namespace Ui::EdgeScrollGeometry
@@ -107,4 +121,21 @@ QPointF EdgeScroll::vector(
   const auto result =
       Ui::EdgeScrollGeometry::vector_at(x, y, width, height, sensitivity, ui_scale);
   return {result.dx, result.dz};
+}
+
+QPointF EdgeScroll::cursorIn(QQuickItem* item) {
+  static const QPointF k_unknown{-1.0, -1.0};
+  if (item == nullptr) {
+    return k_unknown;
+  }
+  QQuickWindow* window = item->window();
+  if (window == nullptr || !window->isVisible()) {
+    return k_unknown;
+  }
+  const QPointF scene = QPointF(window->mapFromGlobal(QCursor::pos()));
+  const QPointF local = item->mapFromScene(scene);
+  if (!std::isfinite(local.x()) || !std::isfinite(local.y())) {
+    return k_unknown;
+  }
+  return local;
 }

--- a/ui/edge_scroll.h
+++ b/ui/edge_scroll.h
@@ -4,12 +4,14 @@
 #include <QObject>
 #include <QPointF>
 #include <QQmlEngine>
+#include <QQuickItem>
 
 namespace Ui::EdgeScrollGeometry {
 
-inline constexpr double k_base_horizontal_zone = 12.0;
-inline constexpr double k_base_vertical_zone = 10.0;
-inline constexpr double k_min_zone = 4.0;
+inline constexpr double k_base_horizontal_zone = 26.0;
+inline constexpr double k_base_vertical_zone = 26.0;
+inline constexpr double k_min_zone = 10.0;
+inline constexpr double k_entry_push = 0.35;
 
 struct Vector {
   double dx = 0.0;
@@ -20,6 +22,8 @@ struct Vector {
 
 [[nodiscard]] auto horizontal_zone(double sensitivity, double ui_scale) -> double;
 [[nodiscard]] auto vertical_zone(double sensitivity, double ui_scale) -> double;
+
+[[nodiscard]] auto push_ramp(double approach) -> double;
 
 [[nodiscard]] auto vector_at(double x,
                              double y,
@@ -55,6 +59,8 @@ public:
 
   Q_INVOKABLE [[nodiscard]] static QPointF vector(
       qreal x, qreal y, qreal width, qreal height, qreal sensitivity, qreal ui_scale);
+
+  Q_INVOKABLE [[nodiscard]] static QPointF cursorIn(QQuickItem* item);
 };
 
 #endif

--- a/ui/gl_view.cpp
+++ b/ui/gl_view.cpp
@@ -58,6 +58,7 @@
 #include "game/units/commander_catalog.h"
 #include "render/profiling/allocation_tracker.h"
 #include "render/profiling/asset_counters.h"
+#include "render/profiling/frame_swap_clock.h"
 #include "render/profiling/performance_report.h"
 #include "render/profiling/presentation_cycle.h"
 #include "utils/percentile.h"
@@ -494,6 +495,7 @@ void GLView::GLRenderer::observe_runtime_continuity() {
 
 void GLView::GLRenderer::reset_runtime_benchmark_samples() {
   m_frame_pacing.reset();
+  m_pacing_previous_swap_ns = Render::Profiling::frame_swap_clock().latest();
   m_previous_pacing_sample = {};
   m_pacing_upload_bytes = Render::Profiling::asset_counters().total(
       Render::Profiling::AssetCounter::GlUploadBytes);
@@ -553,11 +555,17 @@ void GLView::GLRenderer::observe_runtime_benchmark(
   const auto& pacing_profile = Render::Profiling::global_profile();
   const auto upload_bytes = Render::Profiling::asset_counters().total(
       Render::Profiling::AssetCounter::GlUploadBytes);
+  const double swap_interval =
+      Render::Profiling::frame_swap_clock().interval_ms(m_pacing_previous_swap_ns);
   if (m_benchmark_ready_time.time_since_epoch().count() != 0) {
+    m_previous_pacing_sample.presentation_timed = swap_interval > 0;
     m_previous_pacing_sample.interval_ms =
         std::chrono::duration<double, std::milli>(frame_start -
                                                   m_benchmark_previous_frame_time)
             .count();
+    if (swap_interval > 0) {
+      m_previous_pacing_sample.interval_ms = swap_interval;
+    }
     m_frame_pacing.observe(m_previous_pacing_sample);
   }
   m_previous_pacing_sample = {};
@@ -867,9 +875,18 @@ void GLView::GLRenderer::finish_runtime_benchmark() {
              static_cast<qint64>(progress.completed_cycles.load())}});
   }
 
-  report.insert(QStringLiteral("frame_pacing"),
-                m_frame_pacing.report(QString::fromLatin1(
-                    Render::graphics_quality_key(graphics.quality()))));
+  auto pacing = m_frame_pacing.report(
+      QString::fromLatin1(Render::graphics_quality_key(graphics.quality())));
+  if (m_benchmark_visible_soldiers == 0) {
+    auto failures = pacing.value(QStringLiteral("failures")).toArray();
+    failures.append(QStringLiteral("no visible soldiers were measured"));
+    pacing.insert(QStringLiteral("passed"), false);
+    pacing.insert(QStringLiteral("failures"), failures);
+  }
+  report.insert(QStringLiteral("frame_pacing"), pacing);
+  report.insert(QStringLiteral("render_target_pixels"),
+                QJsonObject{{QStringLiteral("width"), m_size.width()},
+                            {QStringLiteral("height"), m_size.height()}});
 
   if (m_continuity_probe != nullptr) {
     QJsonArray continuity_issues;

--- a/ui/gl_view.h
+++ b/ui/gl_view.h
@@ -74,6 +74,7 @@ private:
     Render::Profiling::PacingSample m_previous_pacing_sample;
     std::uint64_t m_pacing_upload_bytes = 0;
     std::uint64_t m_pacing_asset_work = 0;
+    std::int64_t m_pacing_previous_swap_ns = 0;
     double m_benchmark_seconds = 0.0;
     QString m_benchmark_output;
     bool m_benchmark_complete = false;

--- a/ui/qml/HUD.qml
+++ b/ui/qml/HUD.qml
@@ -18,6 +18,8 @@ Item {
 
     readonly property int right_stack_bottom: topPanel.height + Design.Metrics.space8 + (Design.Metrics.space24 * 8) + Design.Metrics.space8 + hudTop.minimapLegendHeight
 
+    readonly property bool minimap_drag_active: hudTop.minimapDragActive
+
     property bool overlay_active: false
 
     function right_stack_margin(card_height) {
@@ -57,6 +59,13 @@ Item {
         return local.x >= 0 && local.y >= 0 && local.x < item.width && local.y < item.height;
     }
 
+    function blocks_edge_scroll(x, y) {
+        if (!hud.visible)
+            return false;
+        var minimapZone = hudTop.minimapZone;
+        return minimapZone.width > 0 && x >= minimapZone.x && y >= minimapZone.y && x < minimapZone.x + minimapZone.width && y < minimapZone.y + minimapZone.height;
+    }
+
     function blocks_world_pointer(x, y) {
         if (!hud.visible)
             return false;
@@ -64,8 +73,7 @@ Item {
             return true;
         if (y > (hud.height - hud.bottom_panel_height))
             return true;
-        var minimapZone = hudTop.minimapZone;
-        if (minimapZone.width > 0 && x >= minimapZone.x && y >= minimapZone.y && x < minimapZone.x + minimapZone.width && y < minimapZone.y + minimapZone.height)
+        if (hud.blocks_edge_scroll(x, y))
             return true;
         var floating = [cameraLegend, commanderMessage, waveTracker, economyCoach];
         for (var i = 0; i < floating.length; ++i) {

--- a/ui/qml/HUDTop.qml
+++ b/ui/qml/HUDTop.qml
@@ -22,6 +22,8 @@ Item {
 
     readonly property real minimapLegendHeight: fogLegend.visible ? Design.Metrics.space4 + fogLegend.implicitHeight + Design.Metrics.space8 : 0
 
+    readonly property bool minimapDragActive: minimap.visible && minimapMouse.pressed
+
     property bool camera_legend_visible: false
 
     signal pause_toggled

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -13,7 +13,7 @@ ApplicationWindow {
     property bool menu_visible: true
     property bool game_started: false
     property bool game_paused: false
-    readonly property bool edge_scroll_disabled: gameViewItem.camera_pan_active || !mainWindow.active
+    readonly property bool edge_scroll_disabled: gameViewItem.camera_pan_active || !mainWindow.active || mainWindow.overlay_active || hud.commander_rpg_mode || hud.minimap_drag_active
 
     property bool suppress_modals: false
 
@@ -876,9 +876,44 @@ ApplicationWindow {
         readonly property real vert_threshold: EdgeScroll.verticalZone(Design.A11y.edgeScrollSensitivity, Design.A11y.uiScale)
         property real x_pos: -1
         property real y_pos: -1
+        property bool hover_cleared: true
 
         function in_hud_zone(x, y) {
             return hud.blocks_world_pointer(x, y);
+        }
+
+        function clear_world_hover() {
+            if (edge_scroll_overlay.hover_cleared)
+                return;
+            edge_scroll_overlay.hover_cleared = true;
+            if (typeof game !== 'undefined' && game.orders.set_hover_at_screen)
+                game.orders.set_hover_at_screen(-1, -1);
+        }
+
+        function publish_world_hover(x, y) {
+            if (typeof game === 'undefined' || !game.orders.set_hover_at_screen)
+                return;
+            if (x < 0 || y < 0 || mainWindow.edge_scroll_disabled || edge_scroll_overlay.in_hud_zone(x, y)) {
+                edge_scroll_overlay.clear_world_hover();
+                return;
+            }
+            edge_scroll_overlay.hover_cleared = false;
+            game.orders.set_hover_at_screen(x, y);
+        }
+
+        function edge_scroll_step() {
+            if (typeof game === 'undefined' || !game.camera.move)
+                return;
+            if (!Design.A11y.edgeScrollEnabled || mainWindow.edge_scroll_disabled)
+                return;
+            const cursor = EdgeScroll.cursorIn(edge_scroll_overlay);
+            if (cursor.x < 0 || cursor.y < 0)
+                return;
+            if (hud.visible && hud.blocks_edge_scroll(cursor.x, cursor.y))
+                return;
+            const step = EdgeScroll.vector(cursor.x, cursor.y, edge_scroll_overlay.width, edge_scroll_overlay.height, Design.A11y.edgeScrollSensitivity, Design.A11y.uiScale);
+            if (step.x !== 0 || step.y !== 0)
+                game.camera.move(step.x, step.y);
         }
 
         anchors.fill: parent
@@ -895,12 +930,7 @@ ApplicationWindow {
             onPositionChanged: function (mouse) {
                 edge_scroll_overlay.x_pos = mouse.x;
                 edge_scroll_overlay.y_pos = mouse.y;
-                if (typeof game !== 'undefined' && game.orders.set_hover_at_screen) {
-                    if (!edge_scroll_overlay.in_hud_zone(mouse.x, mouse.y))
-                        game.orders.set_hover_at_screen(mouse.x, mouse.y);
-                    else
-                        game.orders.set_hover_at_screen(-1, -1);
-                }
+                edge_scroll_overlay.publish_world_hover(mouse.x, mouse.y);
                 if (typeof game !== 'undefined' && game.placement.is_placing_formation && game.placement.on_formation_mouse_move) {
                     if (!edge_scroll_overlay.in_hud_zone(mouse.x, mouse.y))
                         game.placement.on_formation_mouse_move(mouse.x, mouse.y);
@@ -928,19 +958,20 @@ ApplicationWindow {
                 w.accepted = false;
             }
             onEntered: function () {
-                edge_scroll_timer.start();
-                if (typeof game !== 'undefined' && game.orders.set_hover_at_screen) {
-                    if (!edge_scroll_overlay.in_hud_zone(edge_scroll_overlay.x_pos, edge_scroll_overlay.y_pos))
-                        game.orders.set_hover_at_screen(edge_scroll_overlay.x_pos, edge_scroll_overlay.y_pos);
-                    else
-                        game.orders.set_hover_at_screen(-1, -1);
-                }
+                edge_scroll_overlay.publish_world_hover(edge_scroll_overlay.x_pos, edge_scroll_overlay.y_pos);
             }
             onExited: function () {
                 edge_scroll_overlay.x_pos = -1;
                 edge_scroll_overlay.y_pos = -1;
-                if (typeof game !== 'undefined' && game.orders.set_hover_at_screen)
-                    game.orders.set_hover_at_screen(-1, -1);
+                edge_scroll_overlay.clear_world_hover();
+            }
+        }
+
+        onEnabledChanged: {
+            if (!enabled) {
+                edge_scroll_overlay.x_pos = -1;
+                edge_scroll_overlay.y_pos = -1;
+                edge_scroll_overlay.clear_world_hover();
             }
         }
 
@@ -949,29 +980,10 @@ ApplicationWindow {
 
             interval: 16
             repeat: true
-            running: edge_scroll_overlay.enabled && edge_scroll_overlay.x_pos >= 0 && edge_scroll_overlay.y_pos >= 0
+            running: edge_scroll_overlay.enabled && mainWindow.active
             onTriggered: {
-                if (typeof game === 'undefined')
-                    return;
-                const w = edge_scroll_overlay.width;
-                const h = edge_scroll_overlay.height;
-                const x = edge_scroll_overlay.x_pos;
-                const y = edge_scroll_overlay.y_pos;
-                if (x < 0 || y < 0)
-                    return;
-                if (mainWindow.edge_scroll_disabled) {
-                    if (game.orders.set_hover_at_screen)
-                        game.orders.set_hover_at_screen(-1, -1);
-                    return;
-                }
-                const over_hud = edge_scroll_overlay.in_hud_zone(x, y);
-                if (game.orders.set_hover_at_screen)
-                    game.orders.set_hover_at_screen(over_hud ? -1 : x, over_hud ? -1 : y);
-                if (!Design.A11y.edgeScrollEnabled)
-                    return;
-                const step = EdgeScroll.vector(x, y, w, h, Design.A11y.edgeScrollSensitivity, Design.A11y.uiScale);
-                if (step.x !== 0 || step.y !== 0)
-                    game.camera.move(step.x, step.y);
+                edge_scroll_overlay.publish_world_hover(edge_scroll_overlay.x_pos, edge_scroll_overlay.y_pos);
+                edge_scroll_overlay.edge_scroll_step();
             }
         }
     }


### PR DESCRIPTION
Two threads of work that both come down to measuring the right thing: edge scroll was reading the cursor from an input path the HUD kept intercepting, and the frame pacing gate was timing render starts while calling them presentation intervals.

Edge scroll
-----------
The overlay sits below the HUD (z 0.5 against 1) so HUD tooltips and hover states survive, but Qt stops hover delivery at the first item that accepts it, so the top bar, the command panel, the minimap and the commander overlay each ate the cursor before the overlay saw it. The top edge, the bottom edge and all four corners simply did not scroll. EdgeScroll.cursorIn() now maps QCursor::pos() into the overlay and the 16 ms timer polls that, so the overlay keeps its place under the HUD and still sees every pixel of the screen.

Reading the platform cursor means every reason to *not* scroll has to be stated rather than inherited from whoever grabbed the pointer: edge_scroll_disabled picks up overlay_active, commander_rpg_mode and a live minimap drag, and HUD.blocks_edge_scroll() refuses the minimap's own rectangle. That state check replaces the geometric clearance the minimap used to rely on - the widest band was 24 px against a minimap hit area ending 25 px from the right, one pixel of headroom nobody chose, and it is what pinned the base band at 12 px.

With the minimap handled by state, the band is free to be reachable: 26 logical px on every side, floor raised to 10. The two axes are now symmetric. They were not - vertical was 10 px against 12 and ramped as a cube against a square, so the middle of the top band moved the camera at an eighth of the pace the middle of a side band did, which is why pushing up read as broken. The ramp also starts at 35% instead of zero, so crossing into the band commits to a visible push rather than giving the outer half of it no usable speed, and a corner is clamped to the magnitude of a single edge so rounding one does not lurch the view by sqrt(2).

World hover moved behind publish_world_hover()/clear_world_hover(), which collapses four copies of the same conditional and, crucially, clears the hover exactly once when the overlay is disabled rather than leaving a stale highlight behind an open panel. The timer now runs on window activity instead of on a cached last-known mouse position.

Frame pacing
------------
Intervals now come from QQuickWindow::frameSwapped, connected directly on the scene-graph render thread - a queued connection would fold event-loop latency into the number. FrameSwapClock is a single atomic timestamp; the consumer takes a delta per rendered gameplay frame, so a skipped gameplay render retains the time the old frame stayed on screen instead of discarding it. Render-start intervals remain reported as wall_interval_ms, and a sample that had no swap behind it sets presentation_timed=false, which fails the gate through the new untimed_presentation_frames check rather than quietly certifying a fallback measurement. The runner asserts interval_source as well, so a report from an older binary cannot pass.

The camera cycle was orbiting world origin, which on Ticino points at empty ground: the swap-timed runs it produced measured zero visible soldiers and could not qualify battle performance at all. The path is now anchored to the mission's starting camera target, captured once when the cycle begins, and both the C++ report and the Python runner reject a run with no visible soldiers. The report also records the actual render-target dimensions, since a pacing number without a resolution is not comparable to anything.

Reports gained ten-second windows carrying asset work, hitch counts and the worst interval per window, which is what separates first-use work from recurring stalls without hand-reading a frame log.

