### PR TITLE
fix: show unexplored ground as neutral haze instead of a blue floor

### DIFF
--- a/assets/shaders/include/fog_reveal.glsl
+++ b/assets/shaders/include/fog_reveal.glsl
@@ -3,9 +3,9 @@ uniform vec2 u_fog_mask_size;
 uniform float u_fog_mask_tile_size;
 uniform int u_has_fog_mask;
 
-const vec3 k_fog_reveal_shade = vec3(0.22, 0.23, 0.25);
-const vec3 k_fog_reveal_lift = vec3(0.030, 0.036, 0.048);
-const float k_fog_reveal_chroma = 0.70;
+const vec3 k_fog_reveal_shade = vec3(0.50, 0.50, 0.51);
+const vec3 k_fog_reveal_lift = vec3(0.012, 0.012, 0.013);
+const float k_fog_reveal_chroma = 0.55;
 
 bool fog_reveal_active() {
   return u_has_fog_mask == 1 && u_fog_mask_size.x > 0.0 && u_fog_mask_size.y > 0.0;

--- a/assets/shaders/include/visibility_mask.glsl
+++ b/assets/shaders/include/visibility_mask.glsl
@@ -11,9 +11,9 @@ const float k_visibility_unseen_cutoff = 0.06;
 
 const float k_visibility_unseen_blend_end = 0.52;
 
-const vec3 k_visibility_unseen_shade = vec3(0.22, 0.23, 0.25);
-const vec3 k_visibility_unseen_lift = vec3(0.030, 0.036, 0.048);
-const float k_visibility_unseen_chroma = 0.70;
+const vec3 k_visibility_unseen_shade = vec3(0.50, 0.50, 0.51);
+const vec3 k_visibility_unseen_lift = vec3(0.012, 0.012, 0.013);
+const float k_visibility_unseen_chroma = 0.55;
 
 struct VisibilityMask {
   float seen_now;

--- a/render/entity/unseen_submitter.h
+++ b/render/entity/unseen_submitter.h
@@ -6,9 +6,9 @@
 
 namespace Render::GL {
 
-inline constexpr float k_unseen_chroma = 0.70F;
-inline constexpr QVector3D k_unseen_shade{0.32F, 0.33F, 0.36F};
-inline constexpr QVector3D k_unseen_lift{0.040F, 0.046F, 0.058F};
+inline constexpr float k_unseen_chroma = 0.55F;
+inline constexpr QVector3D k_unseen_shade{0.50F, 0.50F, 0.51F};
+inline constexpr QVector3D k_unseen_lift{0.012F, 0.012F, 0.013F};
 
 [[nodiscard]] inline auto unseen_surface_color(const QVector3D& color) -> QVector3D {
   const float luminance =

--- a/render/ground/fog_renderer.cpp
+++ b/render/ground/fog_renderer.cpp
@@ -21,13 +21,13 @@ namespace {
 
 constexpr int k_chunk_cells = 14;
 constexpr float k_fog_y = 0.62F;
-constexpr float k_fog_alpha = 0.30F;
+constexpr float k_fog_alpha = 0.14F;
 constexpr float k_reveal_seconds = 0.22F;
 constexpr float k_soft_reveal_seconds = 0.55F;
 
 constexpr float k_fog_epsilon = 0.004F;
 
-const QVector3D k_fog_color{0.15F, 0.18F, 0.24F};
+const QVector3D k_fog_color{0.48F, 0.49F, 0.50F};
 
 auto chunk_count(int cells) -> int {
   return (std::max(0, cells) + k_chunk_cells - 1) / k_chunk_cells;

--- a/render/ground/fog_renderer.h
+++ b/render/ground/fog_renderer.h
@@ -41,6 +41,9 @@ public:
   void advance_reveal(float dt_seconds);
 
   [[nodiscard]] auto patch_count() const -> std::size_t { return m_instances.size(); }
+  [[nodiscard]] auto patch_at(std::size_t index) const -> FogInstanceData {
+    return index < m_instances.size() ? m_instances[index] : FogInstanceData{};
+  }
   [[nodiscard]] auto fog_amount_at(int grid_x, int grid_z) const -> float;
   [[nodiscard]] auto is_settled() const -> bool { return m_settled; }
 

--- a/tests/render/fog_renderer_test.cpp
+++ b/tests/render/fog_renderer_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <gtest/gtest.h>
 #include <vector>
@@ -104,4 +105,25 @@ TEST(FogRenderer, EmptyGridClearsEverything) {
   fog.update_mask(0, 0, 1.0F, {});
 
   EXPECT_EQ(fog.patch_count(), 0U);
+}
+
+TEST(FogRenderer, UnexploredPatchesAreNeutralHazeNotABlueSlab) {
+  FogRenderer fog;
+  fog.update_mask(28, 28, 1.0F, filled_grid(28, 28, VisibilityState::Unseen));
+  ASSERT_GT(fog.patch_count(), 0U);
+
+  const auto patch = fog.patch_at(0);
+  const float red = patch.color.x();
+  const float green = patch.color.y();
+  const float blue = patch.color.z();
+  const float widest = std::max({red, green, blue}) - std::min({red, green, blue});
+
+  EXPECT_LE(widest, 0.06F)
+      << "the haze over unexplored ground must be a neutral grey; a saturated tint "
+         "paints the map's own terrain a flat colour instead of shading it";
+  EXPECT_LE(blue - red, 0.06F)
+      << "a blue-dominant haze is the dark-blue floor players reported instead of "
+         "the real ground seen through fog";
+  EXPECT_LE(patch.alpha, 0.30F)
+      << "the haze is a veil over readable terrain, not a cover that replaces it";
 }

--- a/tests/render/shader_source_test.cpp
+++ b/tests/render/shader_source_test.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <filesystem>
 #include <fstream>
@@ -165,6 +166,52 @@ auto parse_std140_block(const std::string& glsl,
     parsed.float_count += elements * slots_per_element * 4U;
   }
   return parsed;
+}
+
+auto parse_vec3(const std::string& source,
+                const std::string& pattern) -> std::array<float, 3> {
+  std::smatch match;
+  const std::regex declaration(pattern);
+  if (!std::regex_search(source, match, declaration)) {
+    return {-1.0F, -1.0F, -1.0F};
+  }
+  return {parse_glsl_float(match[1].str()),
+          parse_glsl_float(match[2].str()),
+          parse_glsl_float(match[3].str())};
+}
+
+auto glsl_vec3_constant(const std::string& glsl,
+                        const std::string& name) -> std::array<float, 3> {
+  return parse_vec3(
+      glsl,
+      R"(const\s+vec3\s+)" + name +
+          R"(\s*=\s*vec3\(\s*([0-9.]+)\s*,\s*([0-9.]+)\s*,\s*([0-9.]+)\s*\)\s*;)");
+}
+
+auto cpp_vec3_constant(const std::string& source,
+                       const std::string& name) -> std::array<float, 3> {
+  return parse_vec3(source,
+                    R"(QVector3D\s+)" + name +
+                        R"(\{\s*([0-9.]+)F\s*,\s*([0-9.]+)F\s*,\s*([0-9.]+)F\s*\})");
+}
+
+auto glsl_float_constant(const std::string& glsl, const std::string& name) -> float {
+  std::smatch match;
+  const std::regex declaration(R"(const\s+float\s+)" + name +
+                               R"(\s*=\s*([0-9.]+)\s*;)");
+  if (!std::regex_search(glsl, match, declaration)) {
+    return -1.0F;
+  }
+  return parse_glsl_float(match[1].str());
+}
+
+auto cpp_float_constant(const std::string& source, const std::string& name) -> float {
+  std::smatch match;
+  const std::regex declaration(R"(float\s+)" + name + R"(\s*=\s*([0-9.]+)F\s*;)");
+  if (!std::regex_search(source, match, declaration)) {
+    return -1.0F;
+  }
+  return parse_glsl_float(match[1].str());
 }
 
 auto glsl_int_constant(const std::string& glsl, const std::string& name) -> int {
@@ -884,6 +931,70 @@ TEST(ShaderSource, FogRevealShadesWhateverStoneItStarted) {
   EXPECT_NE(flat.find("smoothstep(0.04, 0.94, reveal)"), std::string::npos)
       << "the fade must reach full brightness before the tile is completely clear, or "
          "a settled fog frontier leaves the far end permanently dimmed";
+}
+
+TEST(ShaderSource, UnexploredGroundShadesTheMapInsteadOfPaintingItBlue) {
+  const auto root = find_repo_root();
+  const auto glsl =
+      read_text(root / "assets" / "shaders" / "include" / "visibility_mask.glsl");
+  ASSERT_FALSE(glsl.empty());
+
+  const auto shade = glsl_vec3_constant(glsl, "k_visibility_unseen_shade");
+  const auto lift = glsl_vec3_constant(glsl, "k_visibility_unseen_lift");
+  const float chroma = glsl_float_constant(glsl, "k_visibility_unseen_chroma");
+  ASSERT_GE(shade[0], 0.0F);
+  ASSERT_GE(lift[0], 0.0F);
+  ASSERT_GE(chroma, 0.0F);
+
+  const float darkest = *std::min_element(shade.begin(), shade.end());
+  EXPECT_GE(darkest, 0.35F)
+      << "unexplored ground is the map's own terrain dimmed, not a slab: crushing it "
+         "below a third of its lit value hides the grass, rock and soil underneath";
+
+  const float shade_spread = *std::max_element(shade.begin(), shade.end()) - darkest;
+  EXPECT_LE(shade_spread, 0.05F)
+      << "the dimming must be neutral; a cool-biased shade is what turned fogged "
+         "ground into a blue floor";
+
+  const float lift_spread = *std::max_element(lift.begin(), lift.end()) -
+                            *std::min_element(lift.begin(), lift.end());
+  EXPECT_LE(lift_spread, 0.01F)
+      << "the black lift keeps dark stone off zero; a blue-heavy lift tints every "
+         "unexplored tile instead";
+  EXPECT_LE(*std::max_element(lift.begin(), lift.end()), 0.05F)
+      << "a large lift washes the terrain out into flat haze";
+
+  EXPECT_GE(chroma, 0.40F)
+      << "fogged ground stays recognisably the same terrain, so it keeps a good part "
+         "of its colour rather than going fully grey";
+}
+
+TEST(ShaderSource, EveryUnexploredSurfaceUsesTheSameShading) {
+  const auto root = find_repo_root();
+  const auto mask =
+      read_text(root / "assets" / "shaders" / "include" / "visibility_mask.glsl");
+  const auto reveal =
+      read_text(root / "assets" / "shaders" / "include" / "fog_reveal.glsl");
+  const auto submitter = read_text(root / "render" / "entity" / "unseen_submitter.h");
+  ASSERT_FALSE(mask.empty());
+  ASSERT_FALSE(reveal.empty());
+  ASSERT_FALSE(submitter.empty());
+
+  const auto ground_shade = glsl_vec3_constant(mask, "k_visibility_unseen_shade");
+  const auto ground_lift = glsl_vec3_constant(mask, "k_visibility_unseen_lift");
+  const float ground_chroma = glsl_float_constant(mask, "k_visibility_unseen_chroma");
+
+  EXPECT_EQ(glsl_vec3_constant(reveal, "k_fog_reveal_shade"), ground_shade)
+      << "a bridge deck in the fog must dim exactly as far as the ground it crosses";
+  EXPECT_EQ(glsl_vec3_constant(reveal, "k_fog_reveal_lift"), ground_lift);
+  EXPECT_EQ(glsl_float_constant(reveal, "k_fog_reveal_chroma"), ground_chroma);
+
+  EXPECT_EQ(cpp_vec3_constant(submitter, "k_unseen_shade"), ground_shade)
+      << "meshes shaded on the CPU for unexplored ground must match the terrain "
+         "shader, or a remembered building sits at a different brightness than the "
+         "tile it stands on";
+  EXPECT_EQ(cpp_vec3_constant(submitter, "k_unseen_lift"), ground_lift);
+  EXPECT_EQ(cpp_float_constant(submitter, "k_unseen_chroma"), ground_chroma);
 }
 
 TEST(ShaderSource, DirectionalShadowBlockMatchesTheUploadedStruct) {


### PR DESCRIPTION
Fogged ground read as a flat dark-blue slab rather than the map's own terrain seen dimly through fog. The cause was two independent layers stacking, each dark and each blue-biased:

1. The terrain shading term. `unseen_surface_color()` crushed unexplored tiles to a 0.22 shade with a blue-heavy lift (0.030, 0.036, 0.048) at 0.70 chroma. `terrain_chunk.frag` takes an early-out for unseen tiles, so this cheap path is the entire look of unexplored ground - there are no shadows or field textures underneath it to rescue the read.
2. The mist volume. `FogRenderer` draws chunk quads over the same tiles in a saturated dark blue (0.15, 0.18, 0.24) at 0.30 alpha, which flattens whatever survives step 1.

Tuning either half alone is misleading: fixing only the shader leaves a blue cast from the quads, and fixing only the quads leaves a near-black slab underneath.

Both halves now move together:

- The shading term lifts to a neutral (0.50, 0.50, 0.51) shade with a near-achromatic (0.012, 0.012, 0.013) lift and 0.55 chroma, so an unexplored tile is recognisably the same grass, rock or soil as when lit, just dimmed. The lift still keeps dark stone off zero without tinting everything above it.
- The mist drops to a neutral (0.48, 0.49, 0.50) at 0.14 alpha, so it reads as a veil over terrain rather than a cover replacing it.
- The same three constants are duplicated for bridges (`fog_reveal.glsl`) and for CPU-shaded meshes (`render/entity/unseen_submitter.h`); all three copies are updated in lockstep, and `unseen_submitter.h` in particular was carrying a brighter shade (0.32, 0.33, 0.36) than the terrain it sat on.

Coverage for both halves, so this cannot silently drift back:

- `ShaderSource.UnexploredGroundShadesTheMapInsteadOfPaintingItBlue` parses the GLSL constants and bounds them - the shade may not crush below a third of the lit value, shade and lift must stay neutral within a tight spread, the lift must stay small, and the chroma must stay high enough that fogged terrain keeps its identity.
- `ShaderSource.EveryUnexploredSurfaceUsesTheSameShading` asserts the GLSL, the bridge include and the C++ header agree exactly, so a remembered building can never sit at a different brightness than the tile it stands on.
- `FogRenderer.UnexploredPatchesAreNeutralHazeNotABlueSlab` checks the mist instance itself for a neutral, non-blue-dominant colour and a modest alpha.

Supporting changes: `FogRenderer::patch_at()` exposes a single instance so the mist tint is assertable without a GL context, and the shader-source test gains `vec3`/`float` constant parsers for both GLSL and C++ spellings.
