### PR TITLE
perf: prewarm render resources and harden frame pacing diagnostics

### DIFF
--- a/app/core/game_engine.cpp
+++ b/app/core/game_engine.cpp
@@ -178,8 +178,10 @@
 #include "game/util/selection_utils.h"
 #include "game/visuals/team_colors.h"
 #include "render/camera_visibility.h"
+#include "render/geom/projectile_renderer.h"
 #include "render/geom/stone.h"
 #include "render/gl/bootstrap.h"
+#include "render/gl/shared_geometry_cache.h"
 #include "render/ground/ambient_fog_renderer.h"
 #include "render/ground/biome_renderer.h"
 #include "render/ground/firecamp_renderer.h"
@@ -194,6 +196,7 @@
 #include "render/ground/terrain_surface_manager.h"
 #include "render/ground/tree_renderer.h"
 #include "render/profiling/frame_profile.h"
+#include "render/profiling/performance_report.h"
 #include "render/scene_renderer.h"
 #include "render/terrain_scene_proxy.h"
 #include "scene/camera.h"
@@ -590,11 +593,24 @@ void GameEngine::note_dropped_simulation_ticks(std::uint64_t dropped, float real
              << m_dropped_simulation_ticks << "since the mission started";
 }
 
+auto GameEngine::simulation_profile_report() -> QJsonObject {
+  const auto frame_lock = lock_frame();
+  if (m_world == nullptr || !m_world->system_profiler().enabled()) {
+    return {};
+  }
+  return Render::Profiling::system_profiler_json(m_world->system_profiler());
+}
+
 void GameEngine::update_active_runtime_simulation(float dt) {
   if (m_world == nullptr) {
     return;
   }
 
+  static const bool profile_simulation =
+      qEnvironmentVariableIntValue("SOI_PROFILE_SIMULATION") != 0;
+  if (profile_simulation) {
+    m_world->system_profiler().set_enabled(true);
+  }
   if (m_commander_view_model->active()) {
     m_commander_view_model->update_control_mode(dt);
     m_world->update(dt);
@@ -809,6 +825,9 @@ void GameEngine::update_presentation(float dt) {
     const FrameLockWaiter waiter(m_frame_lock_waiters);
     m_frame_lock_stats.forced_presentation_waits.fetch_add(1,
                                                            std::memory_order_relaxed);
+    const Render::Profiling::PhaseScope wait_scope(
+        &Render::Profiling::global_profile(),
+        Render::Profiling::Phase::PresentationLockWait);
     frame_lock.lock();
   }
   dt = std::min(dt + m_deferred_presentation_dt, k_simulation_max_frame_seconds);
@@ -958,11 +977,26 @@ void GameEngine::render(int pixel_width, int pixel_height) {
   if (m_loading_overlay_active) {
 
     (void)m_renderer->rigged_mesh_cache().prewarm_gpu_resources();
+    (void)Render::GL::prewarm_projectile_geometry();
+    (void)Render::GL::SharedGeometryCache::instance().prewarm_gpu_resources();
+    if (m_fog != nullptr) {
+      (void)m_fog->prewarm_gpu_resources();
+    }
+    if (m_features != nullptr) {
+      (void)m_features->prewarm_gpu_resources();
+    }
+    if (m_surface != nullptr && m_surface->terrain() != nullptr) {
+      (void)m_surface->terrain()->prewarm_gpu_resources();
+    }
   }
   m_renderer->begin_frame();
 
   if (m_terrain_scene) {
     m_terrain_scene->submit(*m_renderer, m_renderer->resources());
+    if (m_loading_overlay_active && m_scatter != nullptr) {
+
+      (void)m_scatter->prewarm_gpu_resources();
+    }
   }
 
   if (m_renderer && m_hover_tracker) {
@@ -978,6 +1012,9 @@ void GameEngine::render(int pixel_width, int pixel_height) {
     std::unique_lock<std::recursive_mutex> frame_lock(m_frame_mutex, std::defer_lock);
     {
       const FrameLockWaiter waiter(m_frame_lock_waiters);
+      const Render::Profiling::PhaseScope wait_scope(
+          &Render::Profiling::global_profile(),
+          Render::Profiling::Phase::EffectsLockWait);
       auto const deadline =
           std::chrono::steady_clock::now() + k_render_effects_lock_budget;
       while (!frame_lock.try_lock()) {

--- a/app/core/game_engine.h
+++ b/app/core/game_engine.h
@@ -341,6 +341,8 @@ public:
     std::atomic<std::uint64_t> forced_presentation_waits{0};
   };
 
+  [[nodiscard]] auto simulation_profile_report() -> QJsonObject;
+
   [[nodiscard]] auto frame_lock_stats() const -> const FrameLockStats& {
     return m_frame_lock_stats;
   }

--- a/docs/FRAME_PACING.md
+++ b/docs/FRAME_PACING.md
@@ -7,6 +7,8 @@ run fails pacing or lacks a pacing verdict. Never average away a failed repeat.
 `scripts/check-frame-pacing.py` is the dedicated lane for all four presets,
 independent of the older Ultra-only budget. Run on an idle GPU-equipped machine,
 with a Release/RelWithDebInfo build, a fixed 60 Hz display, resolution and driver.
+The dedicated runner requests swap interval 1 regardless of saved preferences
+and records graphics environment overrides in the manifest.
 
 ```sh
 python3 scripts/check-frame-pacing.py --binary build/bin/standard_of_iron \
@@ -15,12 +17,19 @@ python3 scripts/check-frame-pacing.py --binary build/bin/standard_of_iron \
 
 Retain the entire `artifacts/frame-pacing/<run-id>/` directory, including the
 manifest, logs, summary and individual reports. Each process has a watchdog;
-missing/invalid reports, wrong presets, unmeasured asset barriers and failed
+the Linux lane samples `/proc` once per second for competing games and build
+workers and rejects contaminated runs. It skips a run when a competitor is
+already present; `--allow-contended` collects diagnostics but still fails the
+gate. Competitor PIDs and executable names are retained per run.
+Missing/invalid reports, wrong presets, unmeasured asset barriers and failed
 repeats fail the lane. The existing `run-perf-suite.sh` additionally records
 simulation replays for repeat comparisons. Pass `--replay path/to/mission.soireplay`
 to this runner to measure an identical recorded simulation across presets and
 repeats. Replays are copied into the artifact directory and SHA-256 hashed in the
-manifest; live campaign mode is useful for investigation but does not certify
+manifest. `--mission-file path/to/mission.json` also accepts custom scenarios;
+the runner retains the original mission, copies a local map relative to the
+mission file, and records their hashes. Embedded `:/` maps remain tied to the
+binary and its bundled assets. Live campaign mode is useful for investigation but does not certify
 identical simulation inputs across runs. Software-rendered CI cannot certify GPU
 budgets. Existing simulation and replay-determinism checks remain separate;
 profiling does not alter simulation stepping or drop simulation work.
@@ -160,3 +169,55 @@ Earlier `swap-timed` results had zero visible soldiers because the camera path
 was centered on world origin. They cannot qualify battle performance. The
 corrected path uses the mission's starting camera target, and both the report
 and runner reject empty-battle measurements.
+
+The follow-up `wait-attribution` run did not reproduce the earlier long hitches:
+maximum 24.64 ms, p95 23.47 ms, p99 23.90 ms, and zero hitch frames. It still
+failed p95 and the asset gate. New `playable_asset_counters` identified exactly
+65 buffers and 32 vertex arrays, with no playable shader compilation, texture
+creation, or mesh baking. Presentation and effects mutex waits now have separate
+phases in cluster evidence; `frame_lock_stats` provides process-lifetime lock
+statistics (including startup), distinct from the playable phase measurements.
+Terrain chunk buffers are now prewarmed under the loading overlay because their
+previous first-draw allocation allowed camera traversal to trigger uploads.
+
+The `terrain-prewarmed` run reduced playable GPU creation from 97 to 52
+operations (35 buffers, 17 vertex arrays). It still failed p95 at 23.66 ms and
+recorded seven hitches. Its worst interval, 71.19 ms, contained 56.63 ms in
+`presentation_lock_wait` and 8 ms in `effects_lock_wait`, with no asset work.
+This directly attributes that particular hitch to lock waiting; the waiting
+thread's total CPU time was 13.01 ms.
+
+Set `SOI_PROFILE_SIMULATION=1` for a diagnostic run to include per-system
+simulation times in `simulation_profile`. The report is read under the frame
+lock after timing collection finishes. This opt-in profiler adds simulation
+instrumentation overhead; rerun without it for acceptance measurements.
+
+The `shared-prewarmed-profiled` diagnostic reduced playable asset operations
+further to 40 (27 buffers and 13 vertex arrays). A separate game process was
+active during this run, so its timing is **not** an acceptance result. This
+observation prompted the runner's continuous competitor check. Resource
+initialization and remaining scenario coverage can still be investigated under
+contention, but timing qualification requires an idle machine.
+
+The `features-prewarmed` diagnostic reduced playable resource creation from 40
+to 10 operations by uploading authored road, water, shoreline, and bridge meshes
+under the loading overlay. `projectiles-prewarmed` reduced this to seven.
+Both runs detected competing compiler processes and cannot qualify timing.
+The loading pass now also prepares projectile geometry. Fog buffers are retained
+when no fog patches are visible, and their GL handles are explicitly initialized
+under the overlay. The resource manager prepares its basic meshes during
+initialization rather than waiting for their first draw.
+
+The final `scatter-prewarmed` diagnostic recorded three playable creation
+operations (two buffers and one vertex array), down from four in
+`basic-resources-prewarmed`. Scatter handles are now prepared during loading
+and retained through visibility changes. The hidden-chunk regression test
+verifies that retention does not submit stale instances. The focused rendering
+suite passed 89 tests and the Python runner suite passed 14 tests.
+
+The final diagnostic detected competing games and build workers, including a
+concurrent test build, and failed the gate. It cannot qualify presentation timing.
+Remaining resource creation and presentation waits are unresolved. Direct GL
+uploads in backend pipelines still need a coverage audit: wrapper counters alone
+do not account for all GPU transfers or prove absence of runtime allocation.
+The ordered remaining tasks and acceptance commands are in `todo.md`.

--- a/render/geom/projectile_renderer.cpp
+++ b/render/geom/projectile_renderer.cpp
@@ -1,6 +1,7 @@
 #include "projectile_renderer.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <numbers>
 
@@ -8,12 +9,25 @@
 #include "game/systems/arrow_projectile.h"
 #include "game/systems/projectile_system.h"
 #include "game/systems/stone_projectile.h"
+#include "render/gl/mesh_prewarmer.h"
 #include "render/gl/primitives.h"
 #include "render/gl/resources.h"
 #include "render/scene_renderer.h"
 #include "stone.h"
 
 namespace Render::GL {
+
+auto prewarm_projectile_geometry() -> bool {
+  if (QOpenGLContext::currentContext() == nullptr) {
+    return false;
+  }
+  std::array meshes{Geom::Arrow::get_shaft(),
+                    Geom::Arrow::get_tip(),
+                    Geom::Arrow::get_fletching(),
+                    Geom::Stone::get(),
+                    get_unit_sphere()};
+  return prewarm_mesh_buffers(meshes, [](auto* mesh) { return mesh; });
+}
 
 auto classify_projectile_relation(int local_owner_id,
                                   int attacker_owner_id,

--- a/render/geom/projectile_renderer.h
+++ b/render/geom/projectile_renderer.h
@@ -21,6 +21,8 @@ class StoneProjectile;
 
 namespace Render::GL {
 
+[[nodiscard]] auto prewarm_projectile_geometry() -> bool;
+
 enum class ProjectileRelation : std::uint8_t {
   Neutral,
   Outgoing,

--- a/render/gl/mesh_prewarmer.h
+++ b/render/gl/mesh_prewarmer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QOpenGLContext>
+
+#include "render/gl/mesh.h"
+
+namespace Render::GL {
+
+template <typename Range, typename MeshOf>
+[[nodiscard]] auto prewarm_mesh_buffers(Range& meshes, MeshOf mesh_of) -> bool {
+  if (QOpenGLContext::currentContext() == nullptr) {
+    return false;
+  }
+  bool ready = true;
+  for (auto& entry : meshes) {
+    auto* mesh = mesh_of(entry);
+    if (mesh == nullptr) {
+      continue;
+    }
+    if (mesh->bind_vao()) {
+      mesh->unbind_vao();
+    } else {
+      ready = false;
+    }
+  }
+  return ready;
+}
+
+} // namespace Render::GL

--- a/render/gl/resources.cpp
+++ b/render/gl/resources.cpp
@@ -3,6 +3,7 @@
 #include <QVector3D>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <memory>
@@ -11,6 +12,7 @@
 #include "gl/mesh.h"
 #include "gl/texture.h"
 #include "platform_gl.h"
+#include "render/gl/mesh_prewarmer.h"
 #include "render_constants.h"
 
 namespace Render::GL {
@@ -74,6 +76,10 @@ auto ResourceManager::initialize() -> bool {
   m_quad_mesh = create_quad_mesh();
   m_ground_mesh = create_plane_mesh(1.0F, 1.0F, ground_plane_subdivisions);
   m_unit_mesh = create_cube_mesh();
+  std::array meshes{m_quad_mesh.get(), m_ground_mesh.get(), m_unit_mesh.get()};
+  if (!prewarm_mesh_buffers(meshes, [](auto* mesh) { return mesh; })) {
+    return false;
+  }
 
   m_white_texture = std::make_unique<Texture>();
   m_white_texture->create_empty(1, 1, Texture::Format::RGBA);

--- a/render/gl/shared_geometry_cache.cpp
+++ b/render/gl/shared_geometry_cache.cpp
@@ -1,5 +1,7 @@
 #include "render/gl/shared_geometry_cache.h"
 
+#include <QOpenGLContext>
+
 #include <utility>
 
 #include "render/gl/mesh.h"
@@ -23,6 +25,22 @@ auto SharedGeometryCache::get_or_build(std::uint64_t key,
     return nullptr;
   }
   return m_meshes.emplace(key, std::move(mesh)).first->second.get();
+}
+
+auto SharedGeometryCache::prewarm_gpu_resources() -> bool {
+  if (QOpenGLContext::currentContext() == nullptr) {
+    return false;
+  }
+  std::lock_guard<std::mutex> const lock(m_mutex);
+  bool ready = true;
+  for (auto& [key, mesh] : m_meshes) {
+    if (mesh->bind_vao()) {
+      mesh->unbind_vao();
+    } else {
+      ready = false;
+    }
+  }
+  return ready;
 }
 
 void SharedGeometryCache::release_all() {

--- a/render/gl/shared_geometry_cache.h
+++ b/render/gl/shared_geometry_cache.h
@@ -31,6 +31,8 @@ public:
 
   [[nodiscard]] auto get_or_build(std::uint64_t key, const Builder& build) -> Mesh*;
 
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
+
   void release_all();
 
   [[nodiscard]] auto size() const -> std::size_t;

--- a/render/ground/bridge_renderer.cpp
+++ b/render/ground/bridge_renderer.cpp
@@ -19,10 +19,15 @@
 #include "linear_feature_visibility.h"
 #include "map/terrain.h"
 #include "render/gl/mesh.h"
+#include "render/gl/mesh_prewarmer.h"
 #include "render/gl/resources.h"
 #include "render/scene_renderer.h"
 
 namespace Render::GL {
+
+auto BridgeRenderer::prewarm_gpu_resources() -> bool {
+  return prewarm_mesh_buffers(m_meshes, [](auto& entry) { return entry.get(); });
+}
 
 BridgeRenderer::BridgeRenderer() = default;
 BridgeRenderer::~BridgeRenderer() = default;

--- a/render/ground/bridge_renderer.h
+++ b/render/ground/bridge_renderer.h
@@ -28,6 +28,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
+
 private:
   void build_meshes();
   [[nodiscard]] auto segment_cull_options(float longest_segment) const

--- a/render/ground/fog_renderer.cpp
+++ b/render/ground/fog_renderer.cpp
@@ -345,9 +345,21 @@ void FogRenderer::submit(Renderer& renderer, ResourceManager* resources) {
   }
 }
 
+auto FogRenderer::prewarm_gpu_resources() -> bool {
+  if (QOpenGLContext::currentContext() == nullptr) {
+    return false;
+  }
+  if (!m_instance_buffer) {
+    m_instance_buffer = std::make_unique<Buffer>(Buffer::Type::Vertex);
+  }
+  m_instance_buffer->bind();
+  m_instance_buffer->unbind();
+  return m_instance_buffer->id() != 0U;
+}
+
 void FogRenderer::upload_instances() {
   if (m_instances.empty()) {
-    m_instance_buffer.reset();
+
     m_instances_dirty = false;
     return;
   }

--- a/render/ground/fog_renderer.h
+++ b/render/ground/fog_renderer.h
@@ -36,6 +36,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
+
   auto prepare_mask(Renderer& renderer) -> FogMaskResources;
 
   void advance_reveal(float dt_seconds);

--- a/render/ground/i_scatter_pass.h
+++ b/render/ground/i_scatter_pass.h
@@ -17,6 +17,8 @@ struct IScatterPass : IRenderPass {
 
   virtual void clear() = 0;
 
+  [[nodiscard]] virtual auto prewarm_gpu_resources() -> bool { return true; }
+
   virtual void set_light_direction(const QVector3D& dir) { (void)dir; }
 };
 

--- a/render/ground/river_renderer.cpp
+++ b/render/ground/river_renderer.cpp
@@ -19,10 +19,15 @@
 #include "map/terrain.h"
 #include "render/draw_commands.h"
 #include "render/gl/mesh.h"
+#include "render/gl/mesh_prewarmer.h"
 #include "render/gl/resources.h"
 #include "render/scene_renderer.h"
 
 namespace Render::GL {
+
+auto WaterRenderer::prewarm_gpu_resources() -> bool {
+  return prewarm_mesh_buffers(m_meshes, [](auto& entry) { return entry.mesh.get(); });
+}
 
 WaterRenderer::WaterRenderer() = default;
 WaterRenderer::~WaterRenderer() = default;

--- a/render/ground/river_renderer.h
+++ b/render/ground/river_renderer.h
@@ -25,6 +25,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
+
 private:
   void build_meshes();
 

--- a/render/ground/riverbank_renderer.cpp
+++ b/render/ground/riverbank_renderer.cpp
@@ -18,10 +18,15 @@
 #include "linear_feature_geometry.h"
 #include "map/terrain.h"
 #include "render/gl/mesh.h"
+#include "render/gl/mesh_prewarmer.h"
 #include "render/gl/resources.h"
 #include "render/scene_renderer.h"
 
 namespace Render::GL {
+
+auto ShorelineRenderer::prewarm_gpu_resources() -> bool {
+  return prewarm_mesh_buffers(m_meshes, [](auto& entry) { return entry.get(); });
+}
 
 ShorelineRenderer::ShorelineRenderer() = default;
 ShorelineRenderer::~ShorelineRenderer() = default;

--- a/render/ground/riverbank_renderer.h
+++ b/render/ground/riverbank_renderer.h
@@ -28,6 +28,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
+
 private:
   void build_meshes(const Game::Map::TerrainHeightMap& height_map);
 

--- a/render/ground/road_renderer.cpp
+++ b/render/ground/road_renderer.cpp
@@ -17,11 +17,16 @@
 #include "game/map/visibility_service.h"
 #include "render/draw_commands.h"
 #include "render/gl/mesh.h"
+#include "render/gl/mesh_prewarmer.h"
 #include "render/gl/resources.h"
 #include "render/scene_renderer.h"
 #include "road_network_geometry.h"
 
 namespace Render::GL {
+
+auto RoadRenderer::prewarm_gpu_resources() -> bool {
+  return prewarm_mesh_buffers(m_surfaces, [](auto& entry) { return entry.mesh.get(); });
+}
 
 namespace {
 

--- a/render/ground/road_renderer.h
+++ b/render/ground/road_renderer.h
@@ -24,6 +24,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
+
   [[nodiscard]] auto surface_count() const -> std::size_t { return m_surfaces.size(); }
 
 private:

--- a/render/ground/scatter_renderer_base.h
+++ b/render/ground/scatter_renderer_base.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QOpenGLContext>
 #include <QVector3D>
 #include <QVector4D>
 
@@ -34,6 +35,22 @@ public:
   }
 
   void clear() override { m_state.reset_instances(); }
+
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool override {
+    if (QOpenGLContext::currentContext() == nullptr) {
+      return false;
+    }
+    bool ready = true;
+    for (auto& chunk : m_state.spatial_chunks) {
+      if (chunk.buffer == nullptr) {
+        chunk.buffer = std::make_unique<Buffer>(Buffer::Type::Vertex);
+      }
+      chunk.buffer->bind();
+      chunk.buffer->unbind();
+      ready = chunk.buffer->id() != 0U && ready;
+    }
+    return ready;
+  }
 
 protected:
   using State = Render::Ground::Scatter::FilteredRendererState<Instance, Params>;

--- a/render/ground/scatter_renderer_state.h
+++ b/render/ground/scatter_renderer_state.h
@@ -275,10 +275,7 @@ auto sync_filtered_state(FilteredRendererState<Instance, Params>& state,
     any_chunk_changed = true;
 
     if (chunk.visible_count == 0) {
-      if (chunk.buffer != nullptr) {
-        chunk.buffer.reset();
-        ++state.last_sync_stats.buffer_resets;
-      }
+
       continue;
     }
     if (!chunk.buffer) {

--- a/render/ground/terrain_feature_manager.cpp
+++ b/render/ground/terrain_feature_manager.cpp
@@ -18,6 +18,14 @@ TerrainFeatureManager::TerrainFeatureManager()
 
 TerrainFeatureManager::~TerrainFeatureManager() = default;
 
+auto TerrainFeatureManager::prewarm_gpu_resources() -> bool {
+  bool ready = m_water->prewarm_gpu_resources();
+  ready = m_road->prewarm_gpu_resources() && ready;
+  ready = m_shoreline->prewarm_gpu_resources() && ready;
+  ready = m_bridge->prewarm_gpu_resources() && ready;
+  return ready;
+}
+
 void TerrainFeatureManager::configure(
     const Game::Map::TerrainHeightMap& height_map,
     const std::vector<Game::Map::RoadSegment>& road_segments,

--- a/render/ground/terrain_feature_manager.h
+++ b/render/ground/terrain_feature_manager.h
@@ -28,6 +28,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
+
   [[nodiscard]] auto water() const -> WaterRenderer*;
   [[nodiscard]] auto road() const -> RoadRenderer*;
   [[nodiscard]] auto shoreline() const -> ShorelineRenderer*;

--- a/render/ground/terrain_renderer.cpp
+++ b/render/ground/terrain_renderer.cpp
@@ -1,5 +1,7 @@
 #include "terrain_renderer.h"
 
+#include <QOpenGLContext>
+
 #include <algorithm>
 #include <cstddef>
 
@@ -67,6 +69,24 @@ auto TerrainRenderer::compute_ground_fog(const std::vector<float>& heights)
   fog.strength = std::clamp(
       (relief - k_ground_fog_min_relief) / k_ground_fog_full_relief, 0.0F, 1.0F);
   return fog;
+}
+
+auto TerrainRenderer::prewarm_gpu_resources() -> bool {
+  if (QOpenGLContext::currentContext() == nullptr) {
+    return false;
+  }
+  bool ready = true;
+  for (auto& chunk : m_chunks) {
+    if (chunk.mesh == nullptr) {
+      continue;
+    }
+    if (chunk.mesh->bind_vao()) {
+      chunk.mesh->unbind_vao();
+    } else {
+      ready = false;
+    }
+  }
+  return ready;
 }
 
 void TerrainRenderer::set_light_direction(const QVector3D& dir) {

--- a/render/ground/terrain_renderer.h
+++ b/render/ground/terrain_renderer.h
@@ -48,6 +48,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
+
   void set_wireframe(bool enable) { m_wireframe = enable; }
 
 private:

--- a/render/ground/terrain_scatter_manager.cpp
+++ b/render/ground/terrain_scatter_manager.cpp
@@ -198,6 +198,15 @@ void TerrainScatterManager::submit(Renderer& renderer, ResourceManager* resource
       previous_filter);
 }
 
+auto TerrainScatterManager::prewarm_gpu_resources() -> bool {
+  std::lock_guard<std::mutex> const lock(m_mutex);
+  bool ready = true;
+  for (const auto& entry : m_scatter_passes) {
+    ready = entry.pass->prewarm_gpu_resources() && ready;
+  }
+  return ready;
+}
+
 void TerrainScatterManager::clear() {
   std::lock_guard<std::mutex> const lock(m_mutex);
 

--- a/render/ground/terrain_scatter_manager.h
+++ b/render/ground/terrain_scatter_manager.h
@@ -53,6 +53,7 @@ public:
   void refresh_grass();
 
   [[nodiscard]] bool is_gpu_ready() const;
+  [[nodiscard]] auto prewarm_gpu_resources() -> bool;
 
   [[nodiscard]] auto biome() const -> BiomeRenderer*;
   [[nodiscard]] auto stone() const -> StoneRenderer*;

--- a/render/profiling/frame_profile.h
+++ b/render/profiling/frame_profile.h
@@ -24,6 +24,8 @@ enum class Phase : std::uint8_t {
   Playback = 7,
   Present = 8,
   PortraitPrewarm = 9,
+  PresentationLockWait = 10,
+  EffectsLockWait = 11,
   _Count
 };
 
@@ -49,6 +51,10 @@ enum class Phase : std::uint8_t {
     return "present";
   case Phase::PortraitPrewarm:
     return "portrait_prewarm";
+  case Phase::PresentationLockWait:
+    return "presentation_lock_wait";
+  case Phase::EffectsLockWait:
+    return "effects_lock_wait";
   case Phase::_Count:
     break;
   }

--- a/scripts/check-frame-pacing.py
+++ b/scripts/check-frame-pacing.py
@@ -13,6 +13,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 MISSIONS = (
@@ -80,6 +81,92 @@ def capture(command: list[str]) -> str:
         return str(error)
 
 
+def copy_mission_fixture(source: Path, output: Path, index: int):
+    source = source.resolve()
+    raw = source.read_bytes()
+    mission = json.loads(raw)
+    map_path = mission.get("map_path") if isinstance(mission, dict) else None
+    if not isinstance(map_path, str) or not map_path:
+        raise ValueError(f"mission has no map_path: {source}")
+    original = output / f"fixture{index}.source.json"
+    original.write_bytes(raw)
+    dependencies = []
+    if not map_path.startswith(":/"):
+        map_source = Path(map_path)
+        if not map_source.is_absolute():
+            map_source = source.parent / map_source
+        map_bytes = map_source.read_bytes()
+        map_artifact = output / f"fixture{index}.map.json"
+        map_artifact.write_bytes(map_bytes)
+        mission["map_path"] = str(map_artifact.resolve())
+        dependencies.append(
+            {
+                "artifact": map_artifact.name,
+                "sha256": hashlib.sha256(map_bytes).hexdigest(),
+            }
+        )
+    destination = output / f"fixture{index}.mission.json"
+    destination.write_text(json.dumps(mission, indent=2) + "\n")
+    return destination, {
+        "source": str(source),
+        "original": original.name,
+        "source_sha256": hashlib.sha256(raw).hexdigest(),
+        "artifact": destination.name,
+        "sha256": hashlib.sha256(destination.read_bytes()).hexdigest(),
+        "maps": dependencies,
+    }
+
+
+def competing_processes(excluded=(), proc_root=Path("/proc")) -> list[dict]:
+    """Linux qualification lane: detect competing games and build workers."""
+    names = {
+        "standard_of_iron",
+        "arena_app",
+        "soi_pacing_probe",
+        "cc1plus",
+        "cc1",
+        "lto1",
+        "ninja",
+        "make",
+        "ld",
+        "ld.lld",
+    }
+    found = []
+    if not proc_root.is_dir():
+        return found
+    for entry in proc_root.iterdir():
+        if not entry.name.isdigit() or int(entry.name) in excluded:
+            continue
+        try:
+            executable = Path(os.readlink(entry / "exe")).name.removesuffix(
+                " (deleted)"
+            )
+        except OSError:
+            continue
+        if executable in names:
+            found.append({"pid": int(entry.name), "executable": executable})
+    return sorted(found, key=lambda item: item["pid"])
+
+
+def run_monitored(command, log, environment, timeout, competitors) -> int:
+    with subprocess.Popen(
+        command, stdout=log, stderr=subprocess.STDOUT, env=environment
+    ) as process:
+        deadline = time.monotonic() + timeout
+        while True:
+            for rival in competing_processes({process.pid}):
+                competitors[rival["pid"]] = rival
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                process.kill()
+                process.wait()
+                raise subprocess.TimeoutExpired(command, timeout)
+            try:
+                return process.wait(timeout=min(1.0, remaining))
+            except subprocess.TimeoutExpired:
+                pass
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -98,8 +185,19 @@ def main() -> int:
         type=Path,
         help="recorded runtime replay; repeatable, copied into artifacts",
     )
+    fixtures.add_argument(
+        "--mission-file",
+        action="append",
+        type=Path,
+        help="custom mission JSON; copied and hashed with its local map",
+    )
     parser.add_argument(
         "--camera-cycle", action="store_true", help="repeat a 20-second pan/zoom path"
+    )
+    parser.add_argument(
+        "--allow-contended",
+        action="store_true",
+        help="collect diagnostic data despite competitors; the gate still fails",
     )
     parser.add_argument("--seconds", type=int, default=60)
     parser.add_argument("--repeats", type=int, default=3)
@@ -125,6 +223,16 @@ def main() -> int:
     presets = args.preset or ["low", "medium", "high", "ultra"]
     missions = args.mission or list(MISSIONS)
     replay_manifest = []
+    mission_manifest = []
+    if args.mission_file:
+        missions = []
+        for index, source in enumerate(args.mission_file):
+            try:
+                destination, metadata = copy_mission_fixture(source, output, index)
+            except (OSError, ValueError) as error:
+                parser.error(str(error))
+            missions.append(str(destination))
+            mission_manifest.append(metadata)
     if args.replay:
         missions = []
         for index, source in enumerate(args.replay):
@@ -141,12 +249,29 @@ def main() -> int:
                 }
             )
             missions.append(str(destination))
+    environment = os.environ.copy()
+    environment["SOI_BENCHMARK_CAMERA_CYCLE"] = "1" if args.camera_cycle else "0"
+    environment["SOI_SWAP_INTERVAL"] = "1"
     manifest = {
         "utc": stamp,
         "binary": str(binary),
         "binary_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
         "load_average": os.getloadavg() if hasattr(os, "getloadavg") else None,
         "platform": platform.platform(),
+        "graphics_environment": {
+            key: environment.get(key)
+            for key in (
+                "DISPLAY",
+                "WAYLAND_DISPLAY",
+                "SOI_SWAP_INTERVAL",
+                "QSG_RENDER_LOOP",
+                "QT_XCB_GL_INTEGRATION",
+                "__GL_SYNC_TO_VBLANK",
+                "__GL_MaxFramesAllowed",
+                "vblank_mode",
+                "SOI_PROFILE_SIMULATION",
+            )
+        },
         "cpu": capture(["lscpu"]),
         "gpu": capture(["glxinfo", "-B"]),
         "display": capture(["xrandr", "--current"]),
@@ -155,17 +280,16 @@ def main() -> int:
         "presets": presets,
         "missions": missions,
         "replays": replay_manifest,
+        "mission_files": mission_manifest,
         "seconds": args.seconds,
         "repeats": args.repeats,
         "coverage": {
-            "campaign": True,
+            "campaign": not bool(args.replay or args.mission_file),
             "camera_cycle": args.camera_cycle,
             "ui_actions": False,
         },
     }
     (output / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
-    environment = os.environ.copy()
-    environment["SOI_BENCHMARK_CAMERA_CYCLE"] = "1" if args.camera_cycle else "0"
     rows = []
     for mission_index, mission in enumerate(missions):
         for repeat in range(args.repeats):
@@ -174,7 +298,15 @@ def main() -> int:
                 report_path = output / f"{label}.json"
                 command = [
                     str(binary),
-                    "--replay" if args.replay else "--campaign-mission",
+                    (
+                        "--replay"
+                        if args.replay
+                        else (
+                            "--mission-file"
+                            if args.mission_file
+                            else "--campaign-mission"
+                        )
+                    ),
                     mission,
                     "--skip-briefing",
                     "--graphics-preset",
@@ -189,19 +321,23 @@ def main() -> int:
                 )
                 failures = []
                 load_before = os.getloadavg() if hasattr(os, "getloadavg") else None
+                competitors = {item["pid"]: item for item in competing_processes()}
                 with (output / f"{label}.log").open("w") as log:
-                    try:
-                        result = subprocess.run(
-                            command,
-                            stdout=log,
-                            stderr=subprocess.STDOUT,
-                            timeout=args.timeout,
-                            env=environment,
+                    if competitors and not args.allow_contended:
+                        log.write(
+                            "Skipped: competing game or build processes detected.\n"
                         )
-                        if result.returncode != 0:
-                            failures.append(f"process exited {result.returncode}")
-                    except (OSError, subprocess.TimeoutExpired) as error:
-                        failures.append(str(error))
+                    else:
+                        try:
+                            returncode = run_monitored(
+                                command, log, environment, args.timeout, competitors
+                            )
+                            if returncode != 0:
+                                failures.append(f"process exited {returncode}")
+                        except (OSError, subprocess.TimeoutExpired) as error:
+                            failures.append(str(error))
+                if competitors:
+                    failures.append("competing game or build processes detected")
                 failures.extend(read_report(report_path, preset, args.camera_cycle))
                 rows.append(
                     {
@@ -213,6 +349,7 @@ def main() -> int:
                         "load_average_after": (
                             os.getloadavg() if hasattr(os, "getloadavg") else None
                         ),
+                        "competing_workloads": list(competitors.values()),
                         "report": report_path.name,
                         "passed": not failures,
                         "failures": failures,

--- a/tests/render/profiling/frame_profile_test.cpp
+++ b/tests/render/profiling/frame_profile_test.cpp
@@ -354,3 +354,20 @@ TEST(FramePacingTest, WindowsDistinguishFirstUseWorkFromRecurringWork) {
   EXPECT_EQ(windows[0].toObject()["asset_work"].toInt(), 3);
   EXPECT_EQ(windows[1].toObject()["asset_work"].toInt(), 1);
 }
+
+TEST(FramePacingTest, PresentationWaitIsAttributedSeparatelyFromCpuWork) {
+  Render::Profiling::FramePacing pacing;
+  Render::Profiling::PacingSample hitch{270, 7, 8, 0, {}};
+  hitch.phase_us[static_cast<std::size_t>(Phase::Frame)] = 1000;
+  hitch.phase_us[static_cast<std::size_t>(Phase::PresentationLockWait)] = 249000;
+  hitch.render_elapsed_ms = 265;
+  pacing.observe(hitch);
+  const auto evidence = pacing.report("high")["clusters"]
+                            .toArray()[0]
+                            .toObject()["worst_frame_evidence"]
+                            .toObject();
+  EXPECT_EQ(evidence["largest_cpu_phase"].toString(), "presentation_lock_wait");
+  EXPECT_DOUBLE_EQ(evidence["cpu_ms"].toDouble(), 7);
+  EXPECT_DOUBLE_EQ(evidence["phase_ms"].toObject()["presentation_lock_wait"].toDouble(),
+                   249);
+}

--- a/tests/render/scatter_runtime_test.cpp
+++ b/tests/render/scatter_runtime_test.cpp
@@ -788,3 +788,35 @@ TEST(StoneGroundFit, RockFieldsAreNotOneColour) {
   EXPECT_GT(max_spread, 0.08F)
       << "iron stains and lichen greys should split the palette";
 }
+
+TEST(ScatterRuntimeTest, HidingAChunkRetainsItsBufferWithoutDrawingStaleInstances) {
+  Render::Ground::Scatter::FilteredRendererState<QVector3D, int> state;
+  state.instances = {QVector3D{0, 0, 0}};
+  state.visible_instances = state.instances;
+  state.track_visible_instances = true;
+  state.instance_count = 1;
+  state.cached_visibility_version = 1;
+  auto& chunk = state.spatial_chunks.emplace_back();
+  chunk.count = 1;
+  chunk.accepted = {1};
+  chunk.visible_count = 1;
+  chunk.all_accepted = true;
+  chunk.buffer = std::make_unique<Render::GL::Buffer>(Render::GL::Buffer::Type::Vertex);
+  auto* retained_buffer = chunk.buffer.get();
+
+  Game::Map::VisibilityService::Snapshot hidden;
+  hidden.initialized = true;
+  hidden.version = 2;
+  hidden.width = hidden.height = 4;
+  hidden.half_width = hidden.half_height = 2;
+  hidden.cells.assign(16,
+                      static_cast<std::uint8_t>(Game::Map::VisibilityState::Unseen));
+  const auto count = Render::Ground::Scatter::sync_filtered_state(
+      state, [](const QVector3D& position) { return position; }, &hidden);
+
+  EXPECT_EQ(count, 0U);
+  EXPECT_TRUE(state.visible_instances.empty());
+  EXPECT_EQ(chunk.visible_count, 0U);
+  EXPECT_EQ(chunk.buffer.get(), retained_buffer);
+  EXPECT_EQ(state.last_sync_stats.buffer_resets, 0U);
+}

--- a/tests/scripts/test_frame_pacing_runner.py
+++ b/tests/scripts/test_frame_pacing_runner.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 SPEC = importlib.util.spec_from_file_location(
     "pacing_runner",
@@ -39,6 +40,90 @@ class PacingRunnerTest(unittest.TestCase):
                 "post_load_asset_work": 0,
             },
         }
+
+    def test_competitor_detection_excludes_benchmark_and_handles_exits(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for pid, executable in (
+                (1, "standard_of_iron"),
+                (2, "standard_of_iron"),
+                (3, "ninja"),
+                (4, "python3"),
+                (5, "cc1plus (deleted)"),
+            ):
+                entry = root / str(pid)
+                entry.mkdir()
+                (entry / "exe").symlink_to("/bin/" + executable)
+            (root / "6").mkdir()
+            self.assertEqual(
+                runner.competing_processes({1}, root),
+                [
+                    {"pid": 2, "executable": "standard_of_iron"},
+                    {"pid": 3, "executable": "ninja"},
+                    {"pid": 5, "executable": "cc1plus"},
+                ],
+            )
+
+    def test_monitor_retains_competitor_that_starts_during_run(self):
+        process = MagicMock(pid=123)
+        process.__enter__.return_value = process
+        process.wait.side_effect = [runner.subprocess.TimeoutExpired(["game"], 1), 0]
+        rivals = {}
+        with (
+            patch.object(runner.subprocess, "Popen", return_value=process),
+            patch.object(
+                runner,
+                "competing_processes",
+                side_effect=[[], [{"pid": 456, "executable": "ninja"}]],
+            ),
+        ):
+            self.assertEqual(runner.run_monitored(["game"], None, {}, 30, rivals), 0)
+        self.assertEqual(rivals, {456: {"pid": 456, "executable": "ninja"}})
+
+    def test_monitor_kills_and_reaps_timed_out_benchmark(self):
+        process = MagicMock(pid=123)
+        process.__enter__.return_value = process
+        with (
+            patch.object(runner.subprocess, "Popen", return_value=process),
+            patch.object(runner, "competing_processes", return_value=[]),
+            patch.object(runner.time, "monotonic", side_effect=[0, 31]),
+        ):
+            with self.assertRaises(runner.subprocess.TimeoutExpired):
+                runner.run_monitored(["game"], None, {}, 30, {})
+        process.kill.assert_called_once()
+        process.wait.assert_called_once()
+
+    def test_custom_mission_copies_and_hashes_local_map(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "artifacts"
+            output.mkdir()
+            source = root / "mission.json"
+            source.write_text(json.dumps({"id": "fixture", "map_path": "map.json"}))
+            (root / "map.json").write_text('{"name":"test map"}')
+            destination, metadata = runner.copy_mission_fixture(source, output, 0)
+            copied_map = Path(json.loads(destination.read_text())["map_path"])
+            self.assertEqual(copied_map.parent, output)
+            self.assertEqual(copied_map.read_bytes(), (root / "map.json").read_bytes())
+            self.assertEqual(
+                (output / metadata["original"]).read_bytes(), source.read_bytes()
+            )
+            self.assertEqual(
+                metadata["maps"][0]["sha256"],
+                runner.hashlib.sha256(copied_map.read_bytes()).hexdigest(),
+            )
+
+    def test_custom_mission_preserves_embedded_map_reference(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "mission.json"
+            source.write_text('{"map_path":":/assets/maps/map_forest.json"}')
+            destination, metadata = runner.copy_mission_fixture(source, root, 0)
+            self.assertEqual(
+                json.loads(destination.read_text())["map_path"],
+                ":/assets/maps/map_forest.json",
+            )
+            self.assertEqual(metadata["maps"], [])
 
     def test_non_ultra_does_not_require_ultra_budget(self):
         self.assertEqual(self.check(self.good()), [])

--- a/todo.md
+++ b/todo.md
@@ -1,514 +1,140 @@
-# RPG commander quality tasks
-
-## Objective
-
-Make direct commander control feel stable, responsive, grounded, and readable at third-person RPG distance. The user's primary complaint is **persistent camera shake and poor movement even without enemies**. Start with an empty scene. Combat animation and combos follow once the basic camera and body work together.
-
-This file is a work queue for other AI models. Pick an unchecked task, inspect the current implementation, implement the repair, and attach verification evidence before marking it complete. Creating this queue does not mean any repair below is already complete.
-
-## Instructions for the model taking a task
-
-- Read applicable `AGENTS.md` files, [RPG_PLAYABILITY.md](docs/RPG_PLAYABILITY.md), and the relevant sections of [the Arena guide](tools/arena/README.md).
-- Record your task ID, owner/session, status, and files being edited here before implementation. Preserve existing workspace changes. Coordinate overlapping edits, particularly in `commander_control_controller.cpp`, `commander_camera_rig.cpp`, and the Arena catalog.
-- Reproduce against a freshly built executable. Record commit, dirty state, build type, executable identity, display/GPU, scenario, and settings. An older executable cannot establish whether today's source is fixed.
-- Keep rendering scenarios sequential. Do not terminate another model's processes or run competing Arena performance captures. Use separate build directories when builds would otherwise conflict.
-- Distinguish measured defects, visual assessments, and hypotheses. Do not turn a suspected cause into a stated diagnosis.
-- Implement focused repairs using the production path. Preserve the shared RTS/RPG traversal and collision rules; do not add another commander-only body-separation loop.
-- Add regression coverage that would fail for the demonstrated defect. Do not relax thresholds, remove assertions, or mislabel an incomplete run to obtain a green result.
-- Review normal-speed motion as well as traces and individual frames. State whether input was manual, injected through the actual input layer, or scripted through the controller.
-- Do not add abilities, cinematic camera effects, or spectacle before the empty-ground camera/movement acceptance passes. Do not conceal motion defects with additional smoothing, shake, blur, or VFX.
-- Finish with changed files, reproduction, actual checks/results, before/after artifacts, remaining limitations, and the next dependent task. Do not mark visual quality complete solely because tests pass.
-
-## Evidence and limitations from the initial review
-
-The local [inspection report](artifacts/commander-review-20260906/REVIEW.md) contains details and links to captures. `artifacts/` is ignored; these files may not exist in another checkout. The essential findings are copied here so this queue remains usable without them.
-
-- Five scenarios completed using the executable available on 6 September 2026 at 00:40: `rpg_locomotion`, `rpg_motor_start_stop`, `rpg_motor_figure_eight`, `rpg_commander_sword_grammar`, and `rpg_attack_buffer_window`.
-- These were rendered scripted inspections, not a full manual playthrough of the main game. Interactive takeover was attempted but not verified.
-- The later rebuild succeeded but `rpg_locomotion` crashed with SIGSEGV on both software rendering and NVIDIA. Recheck this against the current source; other work was in progress.
-- At 60 Hz, empty-ground locomotion reversed from **+5.375 m/s to -4.570 m/s in one step**, at 4.400–4.417 seconds. Backward-to-sideways movement also changed direction in one step.
-- During sideways travel, each foot's position relative to the body spanned about **0.738 m front-to-back and only 0.018 m sideways**, while body yaw remained zero. The lateral movement reused a forward stride.
-- The same empty-ground run changed FOV from 75° on entry to 68°, then back to 75° during sprint. Camera anchor lag reached 0.293 m. Bob, sway, breathing, strafe roll, and FOV changes are likely contributors, not a complete diagnosis of the reported constant shake.
-- Default framing put feet near the bottom edge and gave substantial space to distant scenery. Close combat poses looked rigid and needed clearer weight transfer and recovery. These are visual assessments.
-- Sword grammar passed: 708 frames / 11.8 seconds, eleven accepted actions, one buffered action, no refused or expired intents at the end. Do not assume the combo problem is dropped input.
-- The other four completed runs met behavioral checks but reported `performance_gpu_timing_missing`. Missing timing is not proof of stutter or proof of good performance. Software-rendered frame times are not reference-hardware results.
-
-## Task order
-
-Complete T01 and T02 first. T03–T06 form the basic movement/camera milestone and require integrated verification. T07–T08 follow that milestone. T09 verifies integration; T10 closes the work. Add each defect's regression coverage with its repair rather than postponing all tests until T10.
-
-### T01 — Restore a reproducible, inspectable current build
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P0
-- Depends on: none
-- Start in: `tools/arena/arena_viewport.cpp`, `tools/arena/arena_scenario.cpp`, `tools/arena/main.cpp`, current crash logs and debugger output.
-
-Work:
-
-1. Build and launch current `rpg_locomotion` in interactive and batch modes. Reproduce the reported crash if it still exists, obtain a symbolized stack, identify its cause, and fix it without discarding ongoing work.
-2. Verify commander takeover with the Arena's documented keyboard/mouse controls. If takeover fails, diagnose focus and input routing. Make the manual review path usable.
-3. Confirm that assets and runtime settings match the actual executable. Record the executable used for all subsequent captures.
-
-Done when: the current build repeatedly completes locomotion without crashing, and a reviewer can verifiably move, look, stop, and attack using the real input path. If the crash has already been fixed, provide fresh reproduction results and identify the relevant change instead of inventing a new repair.
-
-Two results, one of them a repair.
-
-**The crash is not reproducible on the current source.** Commit `b1d5625a` plus
-this branch, Release build in `build/`, `build/bin/arena_app`, DISPLAY `:0`
-(NVIDIA, 1920x1080). `rpg_locomotion` completed on every run of the day --
-three repeats inside each full gate, several standalone batch runs and every
-capture run. No SIGSEGV, no watchdog, `completed: true` throughout. The relevant
-change is most likely `15cbdda9` ("fix: unify RPG and RTS commander traversal"),
-which landed after the 6 September executable; that is a date, not a proof.
-
-**Takeover was genuinely broken, and is fixed.** Tab is the takeover key, and
-`QWidget::event()` hands a Tab press to `focusNextPrevChild()` before
-`keyPressEvent` is ever called -- with panels either side of the viewport there
-is always a next widget, so the press was eaten as focus navigation and quietly
-moved focus into the terrain panel. That is why takeover "was attempted but not
-verified": it never happened. `ArenaViewport::focusNextPrevChild` refuses
-navigation now.
-
-Interactive control also writes no `trace.jsonl` (batch only), so
-`SOI_ARENA_RPG_TRACE=1` prints the commander's position, view angles and input
-edge counters once a second. Driven through XTEST into a nested display, one
-run: Tab took control, W held moved him 20 m and he then held still, the mouse
-moved yaw and pitch (pitch clamping at its limit), D held moved him 6.8 m
-sideways with facing unchanged, and three clicks took the attack edges from 3 to
-6 with consumed matching press exactly. Move, look, stop, strafe and attack,
-each observed. `ArenaInteractiveTakeoverTest` pins the focus override and the
-trace; `tools/arena/README.md` documents how to drive it.
-
-Limitation: this is the Arena's commander, not the shipped game's. Nobody has
-taken over a commander in a live match by hand.
-
-### T02 — Isolate the persistent empty-ground shake
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P0
-- Depends on: T01
-- Start in: `ui/qml/CommanderInputLayer.qml`, `app/viewmodels/commander_view_model.cpp`, `app/core/game_engine.cpp`, `app/commander/commander_control_controller.cpp`, `app/commander/commander_presentation_trace.h`, `render/humanoid/runtime/instance_prepare.cpp`.
-
-Work:
-
-1. Capture the **main-game commander view** on empty, flat ground: idle, slow mouse orbit, straight walk/run, stop, reversal, strafe, and camera-mode entry/exit. Include the HUD. Arena alone does not exercise the same input/frame orchestration.
-2. Trace input deltas and cursor warps, simulation timestamps, authoritative and presented body poses, camera anchor/eye/target/up/FOV, animation sample time, and frame duration. Add missing diagnostics through an opt-in path.
-3. Compare normal settings with a truly neutral camera: no bob, idle breathing, roll, impulses, or sprint FOV animation. The existing head-bob toggle alone is insufficient. Use this comparison to distinguish authored motion from irregular jitter.
-4. Check cursor recentering, input consumption, multiple camera writers, update order, interpolation/extrapolation, and camera/body/animation clock agreement. These are investigation targets, not established causes.
-
-Done when: there is a repeatable reproduction of the user's shake and evidence identifying its producing stage, with a failing regression or deterministic input replay where practical. If the main-game symptom remains unreproduced, keep that limitation explicit and do not mark the diagnosis complete based only on authored bob.
-
-Producing stage identified: **presentation, not the motor and not authored bob.**
-See [RPG_PLAYABILITY.md](docs/RPG_PLAYABILITY.md) "The shake was in the
-presentation clock".
-
-- Both consumers of `CommanderPresentationSampleComponent` aged it as "time into
-  this frame" rather than "time into this tick", so the presented step depended
-  on where a frame fell inside a tick. Modelled against a 60 Hz tick at a
-  constant 5.375 m/s, presented speed swung 2.00-6.00 m/s at 72 Hz, 3.33-8.33 at
-  100 Hz, 2.00-7.00 at 144 Hz and 3.75-8.75 at 165 Hz. Integer ratios (30, 60, 120) are clean, which is why no test box saw it. At a nominal 60 Hz with
-  +/-15 per cent frame-time jitter the same model swings 2.08-9.59 m/s.
-- Deterministic reproductions, both of which fail on the old rule:
-  `CommanderPresentationPoseTest.PresentedSpeedIsUniformAtEveryDisplayRate` and
-  `UnitRenderCacheTest.ThePresentedStepIsUniformAtANonMultipleDisplayRate`.
-- The camera and the renderer were also two independent clocks. The gate
-  measured the lens framing a point **0.1926 m** from the body it was drawing on
-  `rpg_locomotion_hitch`. They share one published pose now.
-- Separately measured and separately fixed, all on flat empty ground with no
-  look input: a 75 -> 68 degree unrequested zoom on every mode entry, idle
-  breathing that ran at _full_ amplitude when head bob was switched off, a
-  per-axis anchor clamp that trailed sqrt(2) further on a diagonal, and
-  40-54 mm of authored eye travel per stride. Numbers before and after are in
-  the doc.
-
-Limitation, stated plainly: **the main-game view was not captured.** The
-diagnosis is from the Arena trace, the source, and a deterministic model of the
-frame/tick alignment, backed by regressions that fail on the old code. Nobody
-has yet confirmed on a recording of the shipped game that this is the shake the
-user sees, and the user's display is currently at 60 Hz (it supports 180/165/
-144/120/75), so the jitter path rather than the ratio path would be the one
-acting.
-
-### T03 — Establish a stable, calm camera baseline
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P0
-- Depends on: T02; integrate with T04 and T05 before accepting the milestone
-- Start in: `app/commander/commander_camera_rig.*`, `app/commander/commander_control_controller.cpp`, `game/accessibility/commander_input_settings.*`, `game/accessibility/motion_settings.*`.
-
-Work:
-
-1. Repair the actual jitter source identified in T02. Ensure the camera follows the same presented body pose and time as the rendered commander.
-2. Establish a calm default and a complete motion-free option. Review all independent sources of unsolicited translation, roll, and zoom, including idle breathing and mode-entry FOV settling.
-3. Keep look response immediate and predictable. Avoid fixing instability by introducing excessive follow lag or filtering intentional mouse input.
-4. Give collision corrections an explicit role: safety may move the camera, but free-space movement must not inherit collision-like snapping or oscillation.
-
-Done when: on flat empty ground, idle with the neutral camera has no unexplained eye/target/up/FOV drift; steady input has continuous output; entry, stopping, strafing, and reversals do not cause visible shake or unwanted horizon roll. Verify at 30/60/120 Hz presentation and under controlled hitches, recording actual simulation and presentation rates. Document numeric tolerances and visual evidence.
-
-Numbers before and after for entry, walk, run, strafe and halt are tabulated in
-[RPG_PLAYABILITY.md](docs/RPG_PLAYABILITY.md) "A calm camera, and what was moving
-it". Summary on `rpg_locomotion`, eye against pivot, no look input:
-
-- mode entry no longer zooms (75 -> 68 gone; FOV constant at 68.00),
-- halted residual eye motion 0.0037 m -> 0.0005 m,
-- walk 0.040 m vertical -> 0.024, run 0.054 -> 0.032,
-- anchor lag 0.293 m -> 0.182 m, and radial, so a diagonal trails the same as an
-  axis (`TheAnchorTrailsTheSameDistanceInEveryDirection`),
-- `camera_motion_scale = 0` is a complete motion-free camera, held to 1e-4 on
-  eye, FOV and horizon across 240 idle and 240 running frames
-  (`TheNeutralCameraIsCompletelyStill`),
-- head bob off now also stops the breathing
-  (`TurningOffHeadBobAlsoStopsTheIdleBreathing`),
-- look response is untouched: no smoothing was added anywhere.
-
-Presentation rates 30/60/72/100/120/144/165 Hz are covered by the presentation
-tests; controlled hitches by `rpg_locomotion_hitch`, which passes.
-
-Limitation: this is measured, not accepted. **No human has looked at it.** The
-visual half of the acceptance -- "does it feel calm" -- is still owed.
-
-### T04 — Repair movement redirection and start/stop behavior
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P0
-- Depends on: T02
-- Start in: ordinary movement in `app/commander/commander_control_controller.cpp`, `app/commander/commander_motor.*`, `game/core/movement_facts.*`, shared traversal/body-contact systems.
-
-Work:
-
-1. Replace instantaneous redirection of a smoothed scalar speed with controlled acceleration/deceleration of the planar velocity or an equivalent continuous movement model.
-2. Cover forward/back reversal, left/right reversal, 90° turns, diagonal changes, sprint release, short taps, and full release. Retain responsive steering; movement weight must not become input delay.
-3. Preserve collision-safe movement, wall sliding, slopes, and shared dynamic-body handling. Publish actual accepted movement for presentation and gait selection.
-
-Done when: the measured +5.375 to -4.570 m/s single-step reversal no longer occurs, direction changes respect documented acceleration limits across tested frame rates, and release/diagonal input introduces neither drift nor unintended speed gain. Verify with the existing start/stop, diagonal, figure-eight, and traversal fixtures plus the new regression.
-
-The measured +5.375 to -4.570 m/s single-step reversal is gone: the same
-`rpg_locomotion` run now reports a largest single-tick planar velocity change of
-**0.600 m/s**, which is exactly `k_commander_ground_deceleration_mps2` for one
-tick. The motor holds a planar velocity vector and limits changes on the vector,
-so a reversal passes through zero instead of teleporting across it.
-
-Regressions: `AReversalPassesThroughZeroAtTheAccelerationLimit`,
-`TheAccelerationLimitDoesNotDependOnTheTickRate` (30/60/120 Hz build the same
-speed in the same tenth of a second), and
-`TurningAwayFromAWallStartsAtTheAccelerationLimit`, which replaces an assertion
-that demanded the _opposite_ -- it required turning away from a wall to be
-faster than a standing start, which is the instantaneous redirection itself.
-That change of contract is written up in the doc rather than done quietly.
-
-`rpg_motor_start_stop` (3 repeats), `rpg_motor_diagonal`,
-`rpg_motor_figure_eight` (3 repeats), `rpg_obstacle_slide`, `rpg_close_quarters`
-and all five `rpg_friendly_*` traversal scenarios pass.
-
-One threshold moved and it needs naming: `MovementIsContinuous`'s default
-multiplier, 2.5 -> 2.75. A commander's sprint is exactly 2.5 times
-`unit->speed`, so the old bound had zero margin and only passed because the old
-motor never actually reached its own top speed.
-
-### T05 — Make directional locomotion match body travel
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P0
-- Depends on: T04's movement/presentation contract
-- Start in: `animation/locomotion_manifest.*`, `render/humanoid/runtime/instance_prepare.cpp`, commander presentation data, `tests/core/commander_presentation_pose_test.cpp`.
-
-Work:
-
-1. Drive gait from actual presented velocity relative to body facing, including lateral and diagonal components. Do not select motion from requested input while the body is blocked.
-2. Implement convincing forward, backward, lateral, and diagonal steps; coordinate facing, hips, feet, and supporting-leg weight transfer.
-3. Improve starts, stops, directional transitions, and turn-in-place without phase resets or foot popping. Avoid stretching the existing forward gait into sideways translation.
-
-Done when: side travel visibly uses lateral stepping, planted feet do not skate beyond a documented tolerance, and speed/cadence/stride agree. Recheck forward locomotion and shared RTS consumers. Provide front, side, and commander-camera captures plus foot trajectories that demonstrate the original 0.738 m forward stride mismatch is resolved.
-
-The 0.738 m forward stride during sideways travel is gone. `rpg_locomotion`'s
-strafe leg, foot span relative to the root: **front-to-back 0.7379 -> 0.0162 m,
-sideways 0.1443 -> 1.1500 m.** Body yaw is zero throughout, so this is genuine
-lateral stepping rather than a turned body.
-
-The earlier note in the playability doc was right that this is a clip problem,
-not a code problem: humanoid bone palettes come from baked `.bpat` clips and
-`resolve_humanoid_locomotion_pose` only runs in `bpat_baker`. Four clips are
-baked now (`walk_strafe_left/right`, `run_strafe_left/right`), with four new
-`StateId`s, selected and blended by `resolve_locomotion_crossfade` from the
-lateral share of travel. Feet do not cross: the stance opens along the travel
-axis by half a stride.
-
-Gait is also driven from accepted movement rather than requested input -- a
-commander pressed into a wall stands still instead of walking on the spot -- and
-the strafe clips are offered only to a body whose facing is driven independently
-of its travel, so a turning RTS soldier still turns instead of side-stepping.
-
-Regressions: `SideTravelStepsSidewaysInsteadOfForwards`,
-`SideSteppingFeetDoNotCross`, `DiagonalTravelStepsOnBothAxes`,
-`TheLateralShareIsSignedAgainstTheBodyAxis`.
-
-Limitations: the fore/aft and lateral captures exist as Arena frames only, not
-as a front/side/commander-camera set for review; and residual foot slip _during_
-locomotion is still unmeasured by any gate (`NoPlantedFootSliding` only looks at
-a planted root). Measured by hand on the strafe leg the more-planted foot still
-moves a median 0.039 m per frame, against 0.010 walking forward, so the side-step
-plants worse than the stride does. Eight-way clips are not baked.
-
-### T06 — Reframe the commander for readable third-person control
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P1
-- Depends on: T03–T05 integrated baseline
-- Start in: `CommanderCameraRig::framing_for`, commander camera mode setup, main-game HUD layout.
-
-Work:
-
-1. Tune camera distance, height, shoulder offset, pitch, and FOV together using the actual commander body and HUD.
-2. Keep supporting feet, weapon action, and nearby terrain readable during ordinary play. Verify default and close modes and supported aspect ratios.
-3. Check looking up/down, changes of elevation, walls, and mode transitions. Separate deliberate player framing from automatic corrections.
-
-Done when: the ordinary view no longer parks the feet at the bottom edge, the HUD does not obscure essential motion/footing, and framing transitions do not introduce new camera motion defects. Include comparable before/after screenshots and motion captures.
-
-Measured by projecting the body against the eye, target and field of view the
-rig resolves, at the rest pitch. Before, the feet landed at screen y **1.000**
-in the explore framing -- exactly the bottom edge -- **1.005** in close melee and
-**1.000** in a close duel lock, with the head at 0.710: the commander had the
-bottom 29 per cent of the shot and the rest was sky.
-
-`look_drop` was zero in four of the six framings. They now land:
-
-| framing         | feet  | head  |
-| --------------- | ----- | ----- |
-| explore         | 0.841 | 0.585 |
-| explore close   | 0.869 | 0.512 |
-| melee           | 0.828 | 0.570 |
-| melee close     | 0.889 | 0.576 |
-| duel lock       | 0.865 | 0.555 |
-| duel lock close | 0.874 | 0.522 |
-
-The drop is applied after the lock-on focus blend rather than before it: a
-locked duel blends 60 per cent of the target toward the enemy and used to dilute
-the drop by the same 60 per cent. Bow aim keeps a drop of zero on purpose --
-the reticle is the camera axis.
-
-`TheOrdinaryViewKeepsTheWholeCommanderInFrame` checks all six framings at 16:9,
-21:9 and 4:3. `LookingUpAndDownKeepsTheCommanderOnScreen` covers -60 to +10
-degrees of pitch.
-
-Limitations: the boom does not orbit with pitch, so looking steeply up still
-puts the body under the frame -- that is the rig's design and changing it would
-move every camera-collision scenario. And **the HUD was not checked**: this is
-the Arena's viewport, and whether the shipped HUD covers the feet at this
-framing is unverified.
-
-### T07 — Improve basic attack weight and whole-body animation
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P1
-- Depends on: T03–T06 accepted
-- Start in: `animation/attack_pose_manifest.*`, `animation/melee_swing_manifest.*`, `animation/commander_spear_manifest.*`, `render/humanoid/runtime/instance_prepare.cpp`, `game/systems/combat_actions/`.
-
-Work:
-
-1. Start with a small basic sword sequence and a spear strike. Make preparation, supporting foot, hip/torso rotation, weapon acceleration, contact, follow-through, and recovery visibly coherent.
-2. Address rigid close-up silhouettes and abrupt transitions using the existing rendering/animation architecture. Existing blending and root motion must be inspected before replacement is proposed.
-3. Keep the rendered weapon, root travel, contact trace, damage timing, and hurtbox synchronized. Improve misses and recovery as well as successful hits.
-
-Done when: basic attacks visibly carry body weight and recover into a useful stance at normal speed, without pose pops or foot sliding. Contact and one-hit-per-contact regressions pass. Demonstrate both planted attacks and attacks with travel; do not claim success from an `AttackAnimationObserved` assertion alone.
-
-The measurable defect was foot sliding, and it was in the baked art rather than
-in blending. The authored sword poses are keys of foot _position_ and say
-nothing about whether a foot is airborne, so a step covered its whole distance
-flat on the floor: the left slash slid the right foot 0.44 m forward between
-phase 0.38 and 0.54 and the same 0.44 m back between 0.76 and 1.00.
-
-`sample_authored_sword_pose_key` lifts a foot by its own horizontal speed along
-the curve that moves it. Read back off the baked clips, worst travel by a foot
-the clip keeps on the ground, per sampled step:
-
-| clip                    | before  | after   |
-| ----------------------- | ------- | ------- |
-| `rpg_sword_slash_left`  | 0.057 m | 0.005 m |
-| `rpg_sword_slash_right` | 0.057 m | 0.005 m |
-| `rpg_sword_overhead`    | 0.082 m | 0.006 m |
-| `rpg_sword_thrust`      | 0.078 m | 0.005 m |
-| `rpg_sword_finisher`    | 0.123 m | 0.033 m |
-
-`AuthoredSwordStepsLeaveTheGroundInsteadOfSkating` holds it and fires on all five
-clips with the lift removed. On a planted whiff swing the drawn foot now lifts to
-0.092 m and the median down-foot step is 0.000 m.
-
-Contact and one-hit-per-contact regressions are unchanged and green
-(`rpg_melee_contact`, `rpg_attack_whiff_recovery`, `rpg_attack_wall_contact`,
-`rpg_strike_lunge`, `rpg_defense_contact`), so this did not buy the step with a
-contact.
-
-Limitations, stated rather than papered over: **this is one defect, not the
-whole task.** Nobody has judged whether the swings now "visibly carry body
-weight" -- there is no reviewer and no normal-speed capture with a person
-watching it. Preparation, hip and torso rotation and weapon acceleration were
-read from the clip strips and left as authored. The finisher still lands with
-some ground speed because its return has no key between 0.86 and 1.00 to ease
-out on; that is authoring work. The spear clips were not touched.
-
-### T08 — Make combos feel connected and predictable
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P1
-- Depends on: T07
-- Start in: `app/commander/commander_control_controller.cpp`, `game/systems/combat_actions/combat_action_definition.*`, `combat_action_service.*`, `melee_intent_solver.*`, existing attack-buffer and one-press fixtures.
-
-Work:
-
-1. Exercise real tap, hold, release, repeated taps, heavy follow-up, guard, dodge, and stamina-refusal inputs. Trace the action selected and the exact buffer/cancel outcome.
-2. Improve the connection between the previous recovery and the next preparation: stance, weapon trajectory, supporting feet, facing authority, and body travel must form a readable chain.
-3. Preserve intentional commitment and the existing hold-to-chain behavior unless a concrete defect requires a documented adjustment. Do not equate an authored recovery window with input latency.
-4. Review existing launchers and aerial/special branches only after the basic chain works. Add no new moves in this task.
-
-Done when: a short basic combo is predictable and visually connected, releasing prevents unwanted future links, valid buffered input executes once, expired/refused input remains accountable, and defensive transitions match their authored windows. Include normal-speed input-annotated captures; the initial review did not establish dropped inputs.
-
-The mechanical half was already green and stayed green:
-`rpg_one_press_one_attack` (three isolated taps, a held input sustaining the
-chain at recovery boundaries, release stopping the next link),
-`rpg_attack_buffer_window` (a clean press, a late press the 0.15 s buffer
-carries, a press early enough that the buffer must let it expire),
-`rpg_stamina_refusal_and_recovery`, and `CommanderInputEdgesAllConsumed` on
-every RPG scenario.
-
-The visual half was not. Tracing `rpg_one_press_one_attack`, every
-action-to-action link moved the submitted arm reach **0.21 to 0.26 m in a single
-frame**: the commander's authored action phase snaps from its recovery straight
-back to zero when he links, and nothing remembered where the body had been. The
-interrupted clip is now held at the phase it was cut on and faded out under the
-incoming one over 0.14 s. The same links measure **0.000 m**, and the fade moves
-at most 0.03 m per frame with nothing at its end.
-
-`AComboLinkFadesOutOfTheActionItInterrupted` pins the selection behaviour, and
-the Arena trace carries `action_link_weight` per soldier so a link is visible in
-an artifact rather than inferred.
-
-Limitations: **the idle-to-action and action-to-idle seams still jump 0.19 to
-0.21 m** -- that is the base-against-action blend the combat transaction policy
-owns, and it is untouched. Guard, dodge and stamina-refusal transitions were
-exercised only through the existing scenarios, not re-timed. And as with T07,
-"visually connected" has not been judged by a person at normal speed.
-
-### T09 — Validate the repaired baseline in the surrounding game
-
-- [x] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P1
-- Depends on: T06 and T08
-- Start in: Arena RPG scenario catalog/manifest, `game/systems/camera_obstruction.*`, commander lock-on and engagement code, main-game commander mode.
-
-Work:
-
-1. Recheck terrain, walls, narrow spaces, friendly ranks/workers/livestock, and movement through crowds using the shared traversal path.
-2. Recheck lock-on, target loss, enemy pressure, guard, dodge, bow aim, and camera-mode transitions for new framing or control conflicts.
-3. Verify that fixes to empty-ground control survive these conditions; enemy behavior is a secondary integration concern, not a substitute explanation for the baseline shake.
-
-Done when: collision safety, existing combat rules, and shared RTS behavior remain correct, and added context does not restore camera oscillation or directional skating. Use the current scenario list; the older executable lacked `rpg_camera_wall_pocket`.
-
-Every scenario in the manifest is green with all of T02-T08 in, which is the
-integration check this task asks for:
-
-- terrain and elevation: `rpg_camera_hill_bank`
-- walls and narrow spaces: `rpg_close_quarters`, `rpg_obstacle_slide`,
-  `rpg_camera_wall_pocket`, `rpg_attack_wall_contact`, `rpg_friendly_gauntlet`
-- props: `rpg_camera_prop_gauntlet`
-- friendly ranks, workers, livestock, crossing streams and passing through a
-  line: the five `rpg_friendly_*` scenarios and `rpg_pass_ranks`
-- crowds and enemy pressure: `rpg_escort_crowd`, `rpg_skirmish_three_attackers`
-- lock-on, occlusion and target loss: `rpg_lock_occlusion_death_cycle`
-- guard, dodge and projectiles: `rpg_defense_contact`, `rpg_projectile_block`
-- bow aim: `rpg_bow_volley`
-- the shared RTS path: `CommanderSharedTraversalTest`, plus `simulation_tests`
-  (741), `combat_balance_tests` (772) and `campaign_tests` (183) all green.
-
-Nothing restored camera oscillation or directional skating: the camera scenarios
-report zero occluded frames and zero boom reversals beyond their declared ones,
-and the traversal scenarios still cover their travel contracts.
-
-Limitations: the camera-mode toggle is covered by unit tests across all six
-framings rather than by a scenario -- no `rpg_*` scenario toggles close mode --
-and none of this is a live match. `rpg_melee_contact` remains the only place a
-struck body is checked, and enemy behaviour under the repaired baseline was not
-re-examined beyond the existing scenarios.
-
-### T10 — Close with regression, performance, and visual evidence
-
-- [ ] Complete
-- Owner: Claude Opus 5 session `session_01REEwJ7xwWQ6yVh5WtgTHEp`, 7 Sep 2026
-- Priority: P1
-- Depends on: T01–T09
-- Start in: `tests/core/commander_*`, `tests/tools/arena_commander_metrics_test.cpp`, `tools/arena/rpg_gate_manifest.json`, `scripts/run-rpg-gates.sh`, `docs/RPG_PLAYABILITY.md`.
-
-Work:
-
-1. Run the relevant focused tests and the complete RPG gate against the final build. Keep new fixtures and the manifest consistent. Update expected-red status only when evidence supports the change.
-2. Measure presentation pacing on declared GPU hardware/settings with valid timing. Report missing measurements and incomplete runs explicitly; never substitute software-rendered performance or fixed simulation dt for measured frame pacing.
-3. Repeat the main-game empty-ground input sequence, then the short basic fight. Preserve normal-speed before/after captures with inputs and executable metadata.
-4. Update this checklist and playability documentation to reflect actual completed work and remaining issues.
-
-Done when: regression checks pass, performance evidence is attributable, and final visual/interactive inspection demonstrates stable camera motion, continuous redirection, directional foot contact, readable framing, and coherent basic combat. If the original persistent shake remains, leave the owning task open even if every existing gate is green.
-
-Mostly done, and the shortfalls are named rather than smoothed over.
-
-**Regression.** The full RPG gate is green with every repair in: **32 of 32
-scenarios matched the manifest**, 0 known-red, 0 undeclared flakes, 0 incomplete.
-Unit suites: `app_tests` 982, `render_tests` 1758, `arena_tests` 161,
-`simulation_tests` 741, `combat_balance_tests` 772 (1 skipped),
-`campaign_tests` 183, `persistence_tests` 159, `tools_tests` 103 -- all passing.
-Format, frame-lock, portability and entity-access gates pass. New coverage: nine
-commander/camera/motor tests, three locomotion tests, two presentation-clock
-tests, the sword-step and combo-link tests, and the Arena takeover test.
-
-**Performance.** `arena_app --batch --profile --scenario rpg_locomotion` reports
-**494 of 494 post-prewarm frames GPU-timed and zero issues** -- p50 8.65, p95
-12.15, p99 12.89, max 13.88 ms -- with the RPG systems themselves at 0.011 ms
-p95. That is attributable, and it is inside a 16.67 ms frame at p95. Two caveats
-that matter: GPU timer queries serialise the pipeline, so these are instrumented
-numbers rather than free-running frame pacing (the same scenario unprofiled runs
-p50 3.85 ms with no GPU attribution at all); and the box was not quiet -- another
-session was building throughout, load average between 10 and 37. These are not
-reference-hardware results.
-
-**The gate's performance axis is still vacuous as shipped.**
-`scripts/run-rpg-gates.sh` never passes `--profile`, so every row reports
-`performance_gpu_timing_missing`. Wiring `--profile` in would inflate every frame
-time roughly fourfold and make the existing budgets meaningless, so it needs a
-separate profiled pass rather than a flag. Not designed here.
-
-**Still owed, and why this task stays open:**
-
-- **No normal-speed, input-annotated captures reviewed by a person.** Every
-  visual claim in T03, T05, T06, T07 and T08 is a measurement -- screen
-  fractions, foot travel, arm reach per frame -- plus stills. Nobody has watched
-  the result move.
-- **Nothing was verified in the shipped game.** T01's takeover was proven in the
-  Arena; the main-game empty-ground sequence and the short basic fight were not
-  repeated, and the HUD was never checked against the new framing.
-- **`check_world_scans` fails** (`game/mission` 7 against a budget of 5). It is
-  pre-existing: nothing in `game/mission` was touched.
-- The idle-to-action animation seam (0.19-0.21 m of arm reach in a frame), the
-  finisher's landing skid, eight-way strafe clips, and foot slip during
-  locomotion all remain measured and unfixed.
-
-## Verification starting points
-
-Use the current supported build directory and actual graphical session. Full-duration scenarios are required for acceptance; shortened runs are diagnostics only.
+# Frame pacing remaining work — issue #1398
+
+Issue: https://github.com/djeada/Standard-of-Iron/issues/1398
+
+## Status
+
+The issue is not complete. Loading-time GPU preparation and benchmark diagnostics
+have been improved, but presentation pacing has not passed qualification.
+This file replaces the previous queue at the user's request.
+
+Implemented in the current changes:
+
+- Prepare terrain, shared geometry, roads, water, shorelines, bridges, projectile
+  geometry and basic meshes before gameplay, while loading is active.
+- Initialize fog and scatter buffer handles during loading. Retain hidden scatter
+  buffers without submitting stale instances when visibility changes.
+- Attribute presentation and effects mutex waits separately from render CPU work;
+  report playable resource counters and optional simulation profiling.
+- Detect competing games/builds throughout benchmark runs, retain fixture hashes,
+  support copied custom missions/maps, and record graphics environment settings.
+
+## Verification at handoff
+
+The game and rendering tests built successfully. All 89 focused rendering tests
+and 14 Python tests passed; Ruff, workflow YAML lint and `git diff --check` passed.
+The final `scatter-prewarmed` native diagnostic recorded three playable resource
+creations (two buffers and one VAO), down from four before the scatter fix.
+It failed the gate and detected competing games/builds, including the concurrent
+test build. Its timings are not qualification evidence. Three resource creations
+and the known presentation waits remain unresolved.
+
+## Instructions
+
+Read `docs/FRAME_PACING.md` and applicable repository instructions first. Preserve
+existing workspace changes. Use an isolated build directory and do not terminate
+other sessions' processes. Complete tasks below in order, attach evidence, and
+only mark a task done when its acceptance condition is met.
+
+Do not relax budgets or skip battlefield presentation updates to make a report
+pass. Debugger runs, profiled simulation runs and contended runs are diagnostics;
+repeat without those conditions for performance acceptance. Process scanning is
+an additional check, not proof that the whole machine is idle.
+
+## Remaining tasks
+
+### 1. Complete resource measurement and remove remaining first-use work
+
+- [ ] Audit direct GL buffer creation/upload calls in `render/gl/backend` and
+      instrument paths that bypass the wrapper counters. Include texture/shader paths
+      where relevant. Distinguish storage allocation/orphaning from transferred bytes
+      and avoid double counting. Document measurement boundaries, including Qt.
+- [ ] Trace remaining playable buffer/VAO creation, including the first playable
+      frame before benchmark observation. Prewarm the owning resources while loading;
+      do not suppress counters or hide the first frame.
+- [ ] Verify scatter reveal/hide/reveal and camera traversal across chunk boundaries
+      with an actual GL context; prove hidden instances stay hidden and known resources
+      do not allocate again. Measure retained memory and uploads.
+
+Start in `render/gl/buffer.cpp`, `render/gl/mesh.cpp`,
+`render/ground/scatter_renderer_state.h`, `render/ground/scatter_renderer_base.h`,
+`app/core/game_engine.cpp` and `ui/gl_view.cpp`.
+
+Evidence: before the scatter fix, `basic-resources-prewarmed` recorded four
+playable creation operations (three buffers, one VAO). A debugger traced a later
+buffer allocation to Cypress scatter visibility. The remaining mesh owner was
+not identified. Existing counters do not cover every raw backend upload, so a
+zero count alone cannot establish completion.
+
+Done when: coverage is documented and representative repeated traversals have
+zero prohibited post-playable asset work with complete relevant instrumentation.
+
+### 2. Resolve presentation stalls and pacing failures
+
+- [ ] Reproduce on an idle native display with a freshly built executable.
+- [ ] Use wait attribution and optional `SOI_PROFILE_SIMULATION=1` diagnostics to
+      identify long world-lock holders; separate scheduling delays from actual CPU
+      work. Fix the demonstrated cause while preserving simulation/presentation
+      correctness, then rerun without diagnostic profiling.
+- [ ] Verify p95/p99, maximum intervals, hitch frequency and clusters across the
+      full measurement window, including the first playable seconds.
+
+Evidence: `terrain-prewarmed` captured a 71.19 ms interval containing 56.63 ms
+of presentation lock wait and 8 ms of effects lock wait. That wait is attributed,
+but not fixed. Later contended runs cannot establish improvement or regression.
+
+Done when: repeated native runs satisfy the existing pacing and resource gates;
+rendered battlefield state continues to advance correctly under simulation load.
+
+### 3. Complete reproducible battle and UI coverage
+
+- [ ] Add versioned mission/replay/action fixtures for formation movement, first
+      contact, dense projectiles, destruction, weather, fog reveal, selection,
+      production and build panels. Camera-only runs do not cover these interactions.
+- [ ] Record observed events and reject fixtures that never exercise their required
+      behavior. Keep fixture/map hashes and executable/settings metadata in artifacts.
+- [ ] Compare simulation/replay outcomes under different rendering loads to verify
+      that pacing changes preserve orders, combat, destruction and production.
+
+Done when: every required behavior has a reproducible fixture and observable
+coverage evidence, with relevant correctness checks passing.
+
+### 4. Qualify presets and provision the performance lane
+
+- [ ] Designate reference CPU/GPU tiers and resolution/display settings. The local
+      RTX 5060 measurements at 1280 × 720 are investigations, not a reference matrix.
+- [ ] Run all four presets, representative missions and action fixtures for at least
+      three repeats of 60 seconds. Investigate failures without discarding bad runs.
+- [ ] Validate the proposed per-preset CPU/GPU/upload/spike budgets against that
+      matrix; document any justified changes with evidence.
+- [ ] Provision the `soi-performance` self-hosted runner required by
+      `.github/workflows/frame-pacing.yml`, execute the workflow and verify retained
+      manifests, logs, reports and summaries. The workflow alone does not provision it.
+
+Done when: the agreed hardware/scenario matrix passes, artifacts are reproducible,
+and the dedicated lane demonstrably runs the same acceptance checks.
+
+## Commands
+
+Use the existing isolated build if configured; otherwise configure it using the
+repository build instructions. Local diagnosis used RelWithDebInfo and
+`SOI_KEEP_SYMBOLS=ON`. Run builds and native performance captures sequentially.
 
 ```sh
-cmake --build build --target arena_app -j4
-build/bin/arena_app --list-scenarios
-build/bin/arena_app --scenario rpg_locomotion
-scripts/run-rpg-gates.sh --scenario rpg_locomotion
-scripts/run-rpg-gates.sh --scenario rpg_motor_start_stop --scenario rpg_motor_figure_eight
-scripts/run-rpg-gates.sh --scenario rpg_commander_sword_grammar --scenario rpg_attack_buffer_window
+cmake --build build-frame-pacing --target standard_of_iron render_tests -j 4
+build-frame-pacing/bin/render_tests --gtest_filter='FramePacingTest.*:FrameProfileTest.*:RiggedMeshCache.*:ProjectileRelationTest.*:TerrainSceneProxyTest.*:TerrainSceneProxyServiceTest.*:RoadNetworkGeometryTest.*:FogRenderer.*:ScatterRuntimeTest.*' --gtest_brief=1
+python3 -m unittest discover -s tests/scripts
+ruff check scripts/check-frame-pacing.py scripts/summarize-perf-suite.py tests/scripts
+yamllint .github/workflows/frame-pacing.yml
+git diff --check
+python3 scripts/check-frame-pacing.py --binary build-frame-pacing/bin/standard_of_iron --mission second_punic_war/battle_of_ticino --preset ultra --seconds 60 --repeats 3 --camera-cycle --output artifacts/frame-pacing-1398/qualification-next
 ```
 
-Use `--skip-build` only when the gate's required binaries have already been built from the source under review. For exported motion comparisons, use a recording path with known simulation-time sampling; periodic Arena PNG captures are wall-clock samples and must not be assembled into a supposedly exact normal-speed comparison without accounting for that.
+Use a fresh output directory each time. Omit `--mission` and `--preset` for the
+runner's default campaign/preset matrix. Use `--mission-file PATH` or
+`--replay PATH` for explicit fixtures. `--allow-contended` collects diagnostics but still
+fails qualification when competitors are detected.
+
+Local artifacts live under `artifacts/frame-pacing-1398/` and are ignored by git;
+they may not exist in another checkout. Preserve or export needed evidence with
+the final handoff. Do not infer that an absent artifact passed.

--- a/ui/gl_view.cpp
+++ b/ui/gl_view.cpp
@@ -500,6 +500,10 @@ void GLView::GLRenderer::reset_runtime_benchmark_samples() {
   m_pacing_upload_bytes = Render::Profiling::asset_counters().total(
       Render::Profiling::AssetCounter::GlUploadBytes);
   m_pacing_asset_work = Render::Profiling::asset_counters().post_barrier_asset_work();
+  for (std::size_t i = 0; i < m_playable_asset_baseline.size(); ++i) {
+    m_playable_asset_baseline[i] = Render::Profiling::asset_counters().total(
+        static_cast<Render::Profiling::AssetCounter>(i));
+  }
   m_benchmark_ready_time = {};
   m_benchmark_render_ms.clear();
   m_benchmark_update_ms.clear();
@@ -839,6 +843,31 @@ void GLView::GLRenderer::finish_runtime_benchmark() {
                    static_cast<qint64>(m_benchmark_last_post_load_frame)}});
   report.insert(QStringLiteral("asset_counters"),
                 Render::Profiling::asset_counters_json());
+  report.insert(QStringLiteral("simulation_profile"),
+                m_engine->simulation_profile_report());
+  QJsonObject playable_assets;
+  for (std::size_t i = 0; i < m_playable_asset_baseline.size(); ++i) {
+    const auto counter = static_cast<Render::Profiling::AssetCounter>(i);
+    const auto now = Render::Profiling::asset_counters().total(counter);
+    const auto name = Render::Profiling::asset_counter_name(counter);
+    playable_assets.insert(
+        QString::fromLatin1(name.data(), static_cast<qsizetype>(name.size())),
+        static_cast<qint64>(now >= m_playable_asset_baseline[i]
+                                ? now - m_playable_asset_baseline[i]
+                                : 0));
+  }
+  report.insert(QStringLiteral("playable_asset_counters"), playable_assets);
+  const auto& lock_stats = m_engine->frame_lock_stats();
+  report.insert(
+      QStringLiteral("frame_lock_stats"),
+      QJsonObject{
+          {"contended", static_cast<qint64>(lock_stats.contended.load())},
+          {"waited_us", static_cast<qint64>(lock_stats.waited_us.load())},
+          {"longest_wait_us", static_cast<qint64>(lock_stats.longest_wait_us.load())},
+          {"deferred_presentations",
+           static_cast<qint64>(lock_stats.deferred_presentations.load())},
+          {"forced_presentation_waits",
+           static_cast<qint64>(lock_stats.forced_presentation_waits.load())}});
   report.insert(QStringLiteral("navigation"),
                 Render::Profiling::navigation_counters_json());
   const auto& graphics = Render::GraphicsSettings::instance();

--- a/ui/gl_view.h
+++ b/ui/gl_view.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "render/profiling/asset_counters.h"
+
 class QOpenGLDebugLogger;
 
 #include <QPointer>
@@ -74,6 +76,8 @@ private:
     Render::Profiling::PacingSample m_previous_pacing_sample;
     std::uint64_t m_pacing_upload_bytes = 0;
     std::uint64_t m_pacing_asset_work = 0;
+    std::array<std::uint64_t, Render::Profiling::AssetCounters::k_count>
+        m_playable_asset_baseline{};
     std::int64_t m_pacing_previous_swap_ns = 0;
     double m_benchmark_seconds = 0.0;
     QString m_benchmark_output;


### PR DESCRIPTION
Prepare known static and scenario-specific meshes, fog and scatter buffers, shared geometry, projectile geometry, terrain features, and basic resources while the loading overlay is active. Retain scatter buffers through hidden chunks while keeping visibility submission correct, and expose reusable prewarm operations across ground renderers and geometry caches.

Extend runtime pacing reports with optional simulation-system profiling, presentation and effects lock-wait attribution, playable asset-counter baselines, and process-lifetime frame-lock statistics so startup and gameplay stalls remain distinguishable from ordinary render work.

Make the frame-pacing runner reproducible by forcing swap interval one, copying and hashing custom mission and local-map fixtures, recording graphics-environment overrides, and monitoring competing games and build workers throughout each run. Add regression coverage for competitor detection, timeout cleanup, fixture copying, and hidden scatter retention.

Update the frame-pacing documentation and remaining-work checklist with the new evidence, diagnostic behavior, resource-preparation coverage, and acceptance criteria.