### PR TITLE
Add luminous completion effects for the current player's production

### DIFF
--- a/app/core/frame_ui_coordinator.cpp
+++ b/app/core/frame_ui_coordinator.cpp
@@ -22,6 +22,7 @@
 #include "render/entity/combat_dust_renderer.h"
 #include "render/entity/commander_aura_renderer.h"
 #include "render/entity/healer_aura_renderer.h"
+#include "render/entity/production_completion_renderer.h"
 #include "render/entity/healing_beam_renderer.h"
 #include "render/entity/healing_waves_renderer.h"
 #include "render/geom/arrow.h"
@@ -300,6 +301,9 @@ void render_effects(const RenderEffectsContext& context,
     }
   }
 
+  Render::GL::render_production_completions(
+      context.renderer, context.world, context.local_owner_id,
+      Game::Accessibility::MotionSettings::reduced_motion());
   Render::GL::render_healer_auras(context.renderer, res, context.world);
   Render::GL::render_commander_auras(context.renderer, res, context.world);
   Render::GL::render_combat_dust(context.renderer, res, context.world);

--- a/game/core/component_presentation.h
+++ b/game/core/component_presentation.h
@@ -31,6 +31,14 @@ class RouteFollowSystem;
 
 namespace Engine::Core {
 
+// Transient presentation state: only successful production starts this effect.
+class ProductionCompletionComponent {
+public:
+  static constexpr float k_duration = 2.2F;
+  float remaining{k_duration};
+  float radius{1.0F};
+};
+
 class MovementIntentComponent {
 public:
   MovementIntentComponent() = default;

--- a/game/systems/production_system.cpp
+++ b/game/systems/production_system.cpp
@@ -12,6 +12,7 @@
 
 #include "../core/ambient_session.h"
 #include "../core/component_economy.h"
+#include "../core/component_presentation.h"
 #include "../core/event_manager.h"
 #include "../core/ownership_constants.h"
 #include "../core/world.h"
@@ -41,6 +42,23 @@
 namespace Game::Systems {
 
 namespace {
+
+void start_completion_effect(Engine::Core::World& world,
+                             const Game::Units::Unit& unit,
+                             Game::Units::SpawnType spawn_type) {
+  auto* entity = world.get_entity(unit.id());
+  if (entity == nullptr) {
+    return;
+  }
+  auto* effect = entity->add_component<Engine::Core::ProductionCompletionComponent>();
+  effect->radius = std::max(
+      1.0F, Game::Units::TroopConfig::instance().get_selection_ring_size(spawn_type));
+  if (entity->has_component<Engine::Core::BuildingComponent>()) {
+    const auto size = BuildingCollisionRegistry::get_building_size(
+        Game::Units::spawn_typeToString(spawn_type));
+    effect->radius = std::max(effect->radius, 0.6F * std::hypot(size.width, size.depth));
+  }
+}
 
 void face_work_target(Engine::Core::TransformComponent& transform,
                       const Engine::Core::BuilderProductionComponent& builder) {
@@ -550,6 +568,16 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
     return;
   }
 
+  // Collect before removing components so expiration cannot invalidate a view.
+  for (auto* entity :
+       world->collect_entities_with<Engine::Core::ProductionCompletionComponent>()) {
+    auto* effect = entity->get_component<Engine::Core::ProductionCompletionComponent>();
+    effect->remaining -= std::max(delta_time, 0.0F);
+    if (effect->remaining <= 0.0F) {
+      entity->remove_component<Engine::Core::ProductionCompletionComponent>();
+    }
+  }
+
   for (auto [entity_ref, prod_ref] :
        world->entity_view<Engine::Core::ProductionComponent>()) {
     Engine::Core::Entity* e = &entity_ref;
@@ -633,6 +661,7 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
                                       rally);
           }
           if (unit) {
+            start_completion_effect(*world, *unit, sp.spawn_type);
             Engine::Core::EventManager::instance().publish(
                 Engine::Core::AudioCueEvent::for_owner(u->owner_id,
                                                        "build.unit_ready"));
@@ -1075,7 +1104,9 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
                          << sp.position.x() << sp.position.z() << "yaw"
                          << sp.rotation_y;
             }
-            reg->create(sp.spawn_type, *world, sp);
+            if (auto completed = reg->create(sp.spawn_type, *world, sp)) {
+              start_completion_effect(*world, *completed, sp.spawn_type);
+            }
 
             if (is_wall_network_product(builder_prod->product_type) &&
                 builder_prod->construction_site_entity_id != 0) {

--- a/render/entity/production_completion_renderer.cpp
+++ b/render/entity/production_completion_renderer.cpp
@@ -1,0 +1,72 @@
+#include "production_completion_renderer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+#include "game/core/component_presentation.h"
+#include "game/core/world.h"
+#include "game/core/ownership_constants.h"
+#include "render/scene_renderer.h"
+
+namespace Render::GL {
+
+void render_production_completions(Renderer* renderer,
+                                   Engine::Core::World* world,
+                                   int local_owner_id,
+                                   bool reduced_motion) {
+  if (renderer == nullptr || world == nullptr ||
+      Game::Core::is_neutral_owner(local_owner_id)) {
+    return;
+  }
+
+  for (auto [entity, effect, transform, unit] :
+       world->entity_view<Engine::Core::ProductionCompletionComponent,
+                          Engine::Core::TransformComponent,
+                          Engine::Core::UnitComponent>()) {
+    if (unit.owner_id != local_owner_id || unit.health <= 0 ||
+        entity.has_component<Engine::Core::PendingRemovalComponent>() ||
+        effect.remaining <= 0.0F) {
+      continue;
+    }
+
+    const float age = Engine::Core::ProductionCompletionComponent::k_duration -
+                      effect.remaining;
+    const float progress = std::clamp(
+        age / Engine::Core::ProductionCompletionComponent::k_duration, 0.0F, 1.0F);
+    const float fade_in = std::clamp(age / 0.18F, 0.0F, 1.0F);
+    const float fade_out = 1.0F - progress * progress * (3.0F - 2.0F * progress);
+    const float intensity = fade_in * fade_out;
+    const QVector3D position(transform.position.x,
+                             transform.position.y + 0.08F,
+                             transform.position.z);
+    const QVector3D gold(1.0F, 0.76F, 0.28F);
+    const float time = reduced_motion ? 0.0F : age;
+    const float radius =
+        effect.radius * (reduced_motion ? 1.0F : 1.0F + 0.18F * progress);
+
+    // Existing additive, depth-tested effects also enforce visible-only fog rules.
+    renderer->healer_aura(position, gold, radius, intensity, time);
+    renderer->healer_aura(position, QVector3D(1.0F, 0.94F, 0.70F),
+                          radius * 0.78F, intensity * 0.65F, time);
+    if (reduced_motion) {
+      continue;
+    }
+
+    // A bounded crown of rising glints follows the entity as it leaves production.
+    constexpr int k_glint_count = 10;
+    for (int i = 0; i < k_glint_count; ++i) {
+      const float phase = static_cast<float>(i) / k_glint_count;
+      const float angle = phase * 2.0F * std::numbers::pi_v<float> + age * 0.65F;
+      const float orbit = radius * (0.65F + 0.12F * std::sin(phase * 19.0F));
+      const float height = effect.radius * (0.15F + progress * 1.5F + phase * 0.35F);
+      const QVector3D glint = position +
+          QVector3D(std::cos(angle) * orbit, height, std::sin(angle) * orbit);
+      const float shimmer = 0.65F + 0.35F * std::sin(age * 7.0F + phase * 23.0F);
+      renderer->metal_spark(glint, gold, 0.12F, intensity * shimmer * 0.7F,
+                             0.0F, QVector3D(0.0F, 1.0F, 0.0F));
+    }
+  }
+}
+
+} // namespace Render::GL

--- a/render/entity/production_completion_renderer.h
+++ b/render/entity/production_completion_renderer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace Engine::Core {
+class World;
+}
+
+namespace Render::GL {
+class Renderer;
+
+void render_production_completions(Renderer* renderer,
+                                   Engine::Core::World* world,
+                                   int local_owner_id,
+                                   bool reduced_motion);
+
+} // namespace Render::GL

--- a/render/sources_entity.cmake
+++ b/render/sources_entity.cmake
@@ -1,5 +1,6 @@
 # Entity/nation renderers (Phase 2 owner). Edit ONLY this file for render/entity/* sources.
 set(RENDER_ENTITY_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/entity/production_completion_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/registry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/formation_instance_layout.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity/humanoid_pose_policies.cpp

--- a/tests/systems/production_system_test.cpp
+++ b/tests/systems/production_system_test.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 
 #include "core/component_economy.h"
+#include "core/component_presentation.h"
 #include "core/world.h"
 #include "game/command/command_dispatcher.h"
 #include "game/map/map_definition.h"
@@ -425,6 +426,13 @@ TEST_F(ProductionSystemTest, BuilderCompletesMarketplaceConstruction) {
 
   ASSERT_NE(marketplace, nullptr);
   EXPECT_TRUE(marketplace->has_component<Engine::Core::BuildingComponent>());
+  auto* completion =
+      marketplace->get_component<Engine::Core::ProductionCompletionComponent>();
+  ASSERT_NE(completion, nullptr);
+  EXPECT_FLOAT_EQ(completion->remaining,
+                  Engine::Core::ProductionCompletionComponent::k_duration);
+  EXPECT_GT(completion->radius, 1.0F);
+  EXPECT_FALSE(builder->has_component<Engine::Core::ProductionCompletionComponent>());
   EXPECT_TRUE(Game::Systems::MarketplaceSystem::owner_has_marketplace(world, 1));
 
   auto* marketplace_transform =
@@ -670,3 +678,44 @@ TEST_F(ProductionSystemTest, ACollectOrderStandsTheCrewOnTheNodeAndLeavesItThere
 }
 
 } // namespace
+
+TEST_F(ProductionSystemTest, CompletionEffectExpiresAndIgnoresNegativeDelta) {
+  Engine::Core::World world;
+  auto* entity = world.create_entity();
+  auto* effect = entity->add_component<Engine::Core::ProductionCompletionComponent>();
+  Game::Systems::ProductionSystem system;
+  system.update(&world, -1.0F);
+  EXPECT_FLOAT_EQ(effect->remaining,
+                  Engine::Core::ProductionCompletionComponent::k_duration);
+  system.update(&world, 0.5F);
+  EXPECT_FLOAT_EQ(effect->remaining,
+                  Engine::Core::ProductionCompletionComponent::k_duration - 0.5F);
+  system.update(&world, 10.0F);
+  EXPECT_FALSE(entity->has_component<Engine::Core::ProductionCompletionComponent>());
+}
+
+TEST_F(ProductionSystemTest, RecruitmentGlowsOnTheRecruitOnly) {
+  Engine::Core::World world;
+  auto* barracks = world.create_entity();
+  barracks->add_component<Engine::Core::TransformComponent>();
+  auto* unit = barracks->add_component<Engine::Core::UnitComponent>();
+  unit->owner_id = 1;
+  unit->spawn_type = Game::Units::SpawnType::Barracks;
+  auto* production = barracks->add_component<Engine::Core::ProductionComponent>();
+  production->product_type = Game::Units::TroopType::Swordsman;
+  production->in_progress = true;
+  production->time_remaining = 0.0F;
+
+  Game::Systems::ProductionSystem system;
+  system.update(&world, 0.1F);
+
+  const auto glowing =
+      world.collect_entities_with<Engine::Core::ProductionCompletionComponent>();
+  ASSERT_EQ(glowing.size(), 1U);
+  EXPECT_NE(glowing.front()->get_id(), barracks->get_id());
+  const auto* recruit = glowing.front()->get_component<Engine::Core::UnitComponent>();
+  ASSERT_NE(recruit, nullptr);
+  EXPECT_EQ(recruit->owner_id, 1);
+  EXPECT_EQ(recruit->spawn_type, Game::Units::SpawnType::Swordsman);
+  EXPECT_FALSE(barracks->has_component<Engine::Core::ProductionCompletionComponent>());
+}


### PR DESCRIPTION
Successful recruitment and construction should visibly announce that the new troop, building, or siege equipment is ready.

This adds a short gold aura with rising white-gold glints to the completed entity. Rendering checks the current local owner's ID, so other players' production never displays the effect. The glow follows the entity, respects fog of war and depth testing, fades over 2.2 seconds, and skips dead or pending-removal entities. Reduced-motion mode uses a stationary aura without moving sparkles.

The effect starts only after successful creation in the recruitment and builder completion paths; initial map spawns, repairs, and harvesting do not trigger it. Transient state expires in the production system, and building glows scale to their footprint.

Validation: git diff --check, scripts/check-render-boundary.py, and scripts/check-layering.py passed. Added regression coverage for recruitment, marketplace construction, and expiration. No build or compiled tests were run, per request; visual appearance remains unverified in-game. The commit includes [skip ci] to avoid triggering standard build workflows.