### PR TITLE
feat: make AI settlements grow as connected defended circuits

### DIFF
--- a/assets/data/ai/town_plans.json
+++ b/assets/data/ai/town_plans.json
@@ -13,7 +13,9 @@
     "A step's optional 'rotation' is degrees in that same frame: 0 runs a wall",
     "along x (parallel to the front), 90 runs it along z. Wall links stand 2m",
     "apart along their line; a wall_gate spans 9m of a run and is the only way",
-    "through a closed ring. The front wall and its towers come first in the list.",
+    "through a closed ring. A circuit is listed as one growing run: the front",
+    "gate, then links outward along both arms, round the corners, down the",
+    "flanks, closing at the rear, so any prefix of it is a wall with two ends.",
     "Caps: 128 wall links, 12 towers, 12 homes, 4 gates per plan.",
     "An unknown building name is skipped with a warning; an unknown plan name",
     "falls back to the built-in layout table."
@@ -21,17 +23,17 @@
   "plans": {
     "roman_bulwark": {
       "display_name": "Fabian Bulwark",
-      "silhouette_steps": 34,
+      "silhouette_steps": 33,
       "steps": [
         {
           "building": "home",
-          "x": -12,
-          "z": 14
+          "x": -16.8,
+          "z": 12.5
         },
         {
           "building": "home",
-          "x": 12,
-          "z": 14
+          "x": 16.8,
+          "z": 12.5
         },
         {
           "building": "marketplace",
@@ -54,170 +56,20 @@
           "z": -14
         },
         {
-          "building": "wall_segment",
-          "x": -4.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 4.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -20.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -22.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 22.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -22.0,
-          "z": -16.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 22.0,
-          "z": -16.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 22.0,
-          "z": -14.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -22.0,
-          "z": -12.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 22.0,
-          "z": -6.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -22.0,
-          "z": -4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 22.0,
-          "z": 2.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -22.0,
-          "z": 4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 22.0,
-          "z": 10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -22.0,
-          "z": 12.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -4.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 4.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 6.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -20.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 20.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -22.0,
-          "z": 18.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 22.0,
-          "z": 18.0,
-          "rotation": 90.0
-        },
-        {
           "building": "wall_gate",
           "x": 0.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -4.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 4.0,
           "z": -18.0,
           "rotation": 0.0
         },
@@ -248,6 +100,18 @@
         {
           "building": "wall_segment",
           "x": -10.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 10.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -12.0,
           "z": -18.0,
           "rotation": 0.0
         },
@@ -289,6 +153,18 @@
         },
         {
           "building": "wall_segment",
+          "x": 18.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -20.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
           "x": 20.0,
           "z": -18.0,
           "rotation": 0.0
@@ -296,7 +172,43 @@
         {
           "building": "wall_segment",
           "x": -22.0,
+          "z": -16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": -16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
           "z": -14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": -14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
+          "z": -12.0,
           "rotation": 90.0
         },
         {
@@ -338,6 +250,18 @@
         {
           "building": "wall_segment",
           "x": 22.0,
+          "z": -6.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
+          "z": -4.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
           "z": -4.0,
           "rotation": 90.0
         },
@@ -369,6 +293,18 @@
           "building": "wall_segment",
           "x": -22.0,
           "z": 2.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": 2.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
+          "z": 4.0,
           "rotation": 90.0
         },
         {
@@ -410,6 +346,18 @@
         {
           "building": "wall_segment",
           "x": 22.0,
+          "z": 10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
+          "z": 12.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
           "z": 12.0,
           "rotation": 90.0
         },
@@ -439,43 +387,37 @@
         },
         {
           "building": "wall_segment",
-          "x": -6.0,
+          "x": -22.0,
+          "z": 18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -20.0,
           "z": 18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": -8.0,
+          "x": 20.0,
           "z": 18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 8.0,
+          "x": 22.0,
+          "z": 18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
           "z": 18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": -10.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": 18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
+          "x": 18.0,
           "z": 18.0,
           "rotation": 0.0
         },
@@ -493,13 +435,73 @@
         },
         {
           "building": "wall_segment",
-          "x": -18.0,
+          "x": -14.0,
           "z": 18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 18.0,
+          "x": 14.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -12.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -10.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 10.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -8.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 8.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -6.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 6.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -4.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 4.0,
           "z": 18.0,
           "rotation": 0.0
         },
@@ -511,13 +513,19 @@
         },
         {
           "building": "defense_tower",
-          "x": -17,
-          "z": 14
+          "x": -13.0,
+          "z": 14.0
         },
         {
           "building": "defense_tower",
-          "x": 17,
-          "z": 14
+          "x": 13.0,
+          "z": 14.0
+        },
+        {
+          "building": "wall_gate",
+          "x": 0.0,
+          "z": -10.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
@@ -570,26 +578,26 @@
         {
           "building": "wall_segment",
           "x": -12.0,
-          "z": -10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": -10.0,
-          "rotation": 0.0
+          "z": -8.0,
+          "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": -12.0,
-          "z": -8.0,
-          "rotation": 90.0
+          "z": -10.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 12.0,
           "z": -8.0,
           "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": -10.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
@@ -689,7 +697,61 @@
         },
         {
           "building": "wall_segment",
-          "x": 0.0,
+          "x": -12.0,
+          "z": 10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -10.0,
+          "z": 10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 10.0,
+          "z": 10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": 10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -8.0,
+          "z": 10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 8.0,
+          "z": 10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -6.0,
+          "z": 10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 6.0,
+          "z": 10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -4.0,
+          "z": 10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 4.0,
           "z": 10.0,
           "rotation": 0.0
         },
@@ -707,68 +769,8 @@
         },
         {
           "building": "wall_segment",
-          "x": -4.0,
-          "z": 10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 4.0,
-          "z": 10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -6.0,
-          "z": 10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 6.0,
-          "z": 10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -8.0,
-          "z": 10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 8.0,
-          "z": 10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -10.0,
-          "z": 10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": 10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": 10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": 10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_gate",
           "x": 0.0,
-          "z": -10.0,
+          "z": 10.0,
           "rotation": 0.0
         },
         {
@@ -793,13 +795,13 @@
         },
         {
           "building": "home",
-          "x": -17,
-          "z": 9
+          "x": -17.0,
+          "z": 8.0
         },
         {
           "building": "home",
-          "x": 17,
-          "z": 9
+          "x": 17.0,
+          "z": 8.0
         },
         {
           "building": "ballista",
@@ -815,259 +817,157 @@
     },
     "roman_assault_camp": {
       "display_name": "Consular Star Camp",
-      "silhouette_steps": 43,
+      "silhouette_steps": 42,
       "steps": [
         {
           "building": "home",
-          "x": -9.8,
-          "z": 3.9
+          "x": -10.4,
+          "z": 1.4
         },
         {
           "building": "home",
-          "x": 9.8,
-          "z": 3.9
+          "x": 11.0,
+          "z": 0.0
         },
         {
           "building": "marketplace",
-          "x": 8.0,
+          "x": 7.0,
           "z": 8.0
         },
         {
           "building": "defense_tower",
-          "x": 9.4,
-          "z": -7.4
+          "x": 11.4,
+          "z": -9.3
         },
         {
           "building": "defense_tower",
-          "x": -9.4,
-          "z": -7.4
+          "x": -11.4,
+          "z": -9.3
         },
         {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": -16.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
-          "z": -16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": -16.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": -14.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
+          "building": "wall_gate",
+          "x": 0.0,
           "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -4.0,
-          "z": -12.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 4.0,
-          "z": -12.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -6.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 6.0,
-          "z": -12.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -8.0,
-          "z": -12.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": -10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": -10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": -8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -6.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": 0.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": 2.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": 8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": 10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": 10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": 10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": 10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -4.0,
-          "z": 12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 4.0,
-          "z": 12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 6.0,
-          "z": 12.0,
+          "x": 8.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -10.0,
-          "z": 12.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 12.0,
-          "z": 12.0,
+          "x": 10.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -12.0,
-          "z": 14.0,
-          "rotation": 90.0
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -14.0,
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -14.0,
+          "z": -14.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 14.0,
-          "z": 14.0,
-          "rotation": 90.0
+          "z": -16.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 18.0,
-          "z": 14.0,
-          "rotation": 90.0
+          "x": 14.0,
+          "z": -14.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -16.0,
-          "z": 16.0,
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -12.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": -12.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": 16.0,
-          "z": 16.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": 16.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
-          "z": 18.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_gate",
-          "x": 0.0,
-          "z": -12.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
@@ -1075,6 +975,60 @@
           "x": -18.0,
           "z": -18.0,
           "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
+          "z": -12.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": -10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": -18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": -16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": -14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": -12.0,
+          "rotation": 90.0
         },
         {
           "building": "wall_segment",
@@ -1084,227 +1038,169 @@
         },
         {
           "building": "wall_segment",
+          "x": -20.0,
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": -8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
           "x": 20.0,
           "z": -18.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -16.0,
-          "z": -16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
           "x": 20.0,
           "z": -16.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 12.0,
-          "z": -14.0,
-          "rotation": 0.0
+          "x": -22.0,
+          "z": -20.0,
+          "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": -14.0,
+          "x": -22.0,
+          "z": -18.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": -16.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -6.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 8.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -10.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": -12.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": -10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "defense_tower",
-          "x": 18.0,
-          "z": 6.2
-        },
-        {
-          "building": "defense_tower",
-          "x": -8.0,
-          "z": 7.7
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
           "z": -6.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
+          "x": 16.0,
+          "z": -6.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": -20.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": -18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
           "z": -4.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -14.0,
+          "x": 16.0,
           "z": -4.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
+          "x": -16.0,
           "z": -2.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -14.0,
+          "x": 16.0,
           "z": -2.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -14.0,
+          "x": -16.0,
           "z": 0.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
+          "x": 16.0,
+          "z": 0.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
           "z": 2.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
+          "x": 16.0,
+          "z": 2.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
           "z": 4.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -14.0,
+          "x": 16.0,
           "z": 4.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
+          "x": -16.0,
           "z": 6.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -14.0,
+          "x": 16.0,
           "z": 6.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -14.0,
+          "x": -16.0,
           "z": 8.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
+          "x": 16.0,
+          "z": 8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
           "z": 10.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -6.0,
-          "z": 12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -8.0,
-          "z": 12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 8.0,
-          "z": 12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": 12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": 12.0,
+          "x": 16.0,
+          "z": 10.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
+          "x": -18.0,
           "z": 12.0,
           "rotation": 90.0
         },
@@ -1316,9 +1212,39 @@
         },
         {
           "building": "wall_segment",
+          "x": 14.0,
+          "z": 12.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
           "x": 16.0,
           "z": 12.0,
           "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": 12.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
+          "z": 14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": 14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -14.0,
+          "z": 14.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
@@ -1328,31 +1254,67 @@
         },
         {
           "building": "wall_segment",
+          "x": 14.0,
+          "z": 14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": 14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -20.0,
+          "z": 16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
+          "z": 16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": 16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
           "x": -14.0,
+          "z": 16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -12.0,
           "z": 14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": -16.0,
+          "x": 10.0,
           "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 14.0,
+          "z": 16.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": 16.0,
-          "z": 14.0,
-          "rotation": 90.0
+          "z": 16.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": -18.0,
-          "z": 14.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
+          "x": 18.0,
           "z": 16.0,
           "rotation": 90.0
         },
@@ -1364,7 +1326,7 @@
         },
         {
           "building": "wall_segment",
-          "x": 20.0,
+          "x": -22.0,
           "z": 18.0,
           "rotation": 90.0
         },
@@ -1372,43 +1334,126 @@
           "building": "wall_segment",
           "x": -20.0,
           "z": 18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
+          "z": 18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -10.0,
+          "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 8.0,
+          "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": 18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 20.0,
+          "z": 18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": 18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
+          "z": 20.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -8.0,
+          "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 6.0,
+          "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": 20.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -6.0,
+          "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 4.0,
+          "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -4.0,
+          "z": 14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_gate",
           "x": 0.0,
-          "z": 12.0,
+          "z": 14.0,
           "rotation": 0.0
         },
         {
-          "building": "home",
-          "x": -8.0,
-          "z": -16.0
+          "building": "defense_tower",
+          "x": 10.6,
+          "z": 8.7
+        },
+        {
+          "building": "defense_tower",
+          "x": -11.4,
+          "z": 9.3
         },
         {
           "building": "home",
-          "x": 8.0,
-          "z": -16.0
+          "x": -9.0,
+          "z": -6.0
         },
         {
           "building": "home",
-          "x": 8.5,
-          "z": 16.2
+          "x": 9.0,
+          "z": -6.0
         },
         {
           "building": "home",
-          "x": 5.2,
-          "z": -19.0
+          "x": -7.4,
+          "z": 7.9
         },
         {
           "building": "catapult",
-          "x": -18.0,
+          "x": -10.0,
           "z": 5.0
         },
         {
           "building": "catapult",
-          "x": 18.0,
-          "z": 0.4
+          "x": 10.0,
+          "z": 5.0
         }
       ]
     },
@@ -1449,14 +1494,8 @@
         },
         {
           "building": "wall_segment",
-          "x": 6.0,
-          "z": -20.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 8.0,
-          "z": -20.0,
+          "x": -2.0,
+          "z": -18.0,
           "rotation": 0.0
         },
         {
@@ -1467,8 +1506,14 @@
         },
         {
           "building": "wall_segment",
-          "x": 10.0,
-          "z": -18.0,
+          "x": 2.0,
+          "z": -20.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -4.0,
+          "z": -16.0,
           "rotation": 0.0
         },
         {
@@ -1479,20 +1524,56 @@
         },
         {
           "building": "wall_segment",
+          "x": 4.0,
+          "z": -20.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
           "x": -6.0,
           "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 12.0,
+          "x": -4.0,
           "z": -14.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 16.0,
+          "x": 6.0,
+          "z": -20.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -8.0,
           "z": -12.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -6.0,
+          "z": -12.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 8.0,
+          "z": -20.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 8.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -10.0,
+          "z": -10.0,
           "rotation": 0.0
         },
         {
@@ -1503,20 +1584,68 @@
         },
         {
           "building": "wall_segment",
+          "x": 10.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 10.0,
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
           "x": -12.0,
           "z": -8.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 18.0,
+          "x": -10.0,
           "z": -8.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 22.0,
+          "x": 12.0,
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -14.0,
           "z": -6.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -12.0,
+          "z": -6.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 14.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 14.0,
+          "z": -12.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -4.0,
           "rotation": 0.0
         },
         {
@@ -1527,14 +1656,74 @@
         },
         {
           "building": "wall_segment",
-          "x": -16.0,
-          "z": -2.0,
+          "x": 16.0,
+          "z": -12.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": -10.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -18.0,
           "z": -2.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -2.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": -10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": -8.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -20.0,
+          "z": -2.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 20.0,
+          "z": -8.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 20.0,
+          "z": -6.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
+          "z": -2.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": -6.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 22.0,
+          "z": -4.0,
           "rotation": 0.0
         },
         {
@@ -1546,156 +1735,12 @@
         {
           "building": "wall_segment",
           "x": 24.0,
-          "z": -2.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 2.0,
-          "z": -20.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 4.0,
-          "z": -20.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -2.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 8.0,
-          "z": -18.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -4.0,
-          "z": -16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": -16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": -16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -4.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -6.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -8.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -10.0,
-          "z": -10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": -10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": -10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -10.0,
-          "z": -8.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 20.0,
-          "z": -8.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": -6.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -6.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 20.0,
-          "z": -6.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": -4.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 22.0,
           "z": -4.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 24.0,
-          "z": -4.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -20.0,
-          "z": -2.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -22.0,
           "z": -2.0,
           "rotation": 0.0
         },
@@ -1747,181 +1792,43 @@
       "steps": [
         {
           "building": "marketplace",
-          "x": 5.8,
-          "z": -9.4
+          "x": 6.6,
+          "z": -8.7
         },
         {
           "building": "home",
-          "x": -9.2,
-          "z": -6.4
+          "x": -8.0,
+          "z": -7.0
         },
         {
           "building": "home",
-          "x": 9.2,
-          "z": -6.4
+          "x": 10.0,
+          "z": -5.0
         },
         {
           "building": "defense_tower",
-          "x": -5.9,
-          "z": -8.8
+          "x": -11.0,
+          "z": -4.9
         },
         {
           "building": "defense_tower",
-          "x": -11.8,
-          "z": -3.4
+          "x": 9.6,
+          "z": -18.5
         },
         {
           "building": "defense_tower",
-          "x": 11.8,
-          "z": -3.4
+          "x": -13.5,
+          "z": -0.0
         },
         {
-          "building": "wall_segment",
-          "x": -4.0,
+          "building": "wall_gate",
+          "x": 0.0,
           "z": -16.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 6.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -8.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": -12.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": -10.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -8.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": -6.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": -4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
-          "z": -4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": -4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": -2.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
-          "z": 0.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": 4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
-          "z": 4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": 4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": 8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": 8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": 10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": 12.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -8.0,
-          "z": 14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": 14.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
           "x": -4.0,
-          "z": 16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 6.0,
-          "z": 16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_gate",
-          "x": 0.0,
           "z": -16.0,
           "rotation": 0.0
         },
@@ -1934,7 +1841,19 @@
         {
           "building": "wall_segment",
           "x": -6.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -6.0,
           "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 6.0,
+          "z": -14.0,
           "rotation": 0.0
         },
         {
@@ -1945,7 +1864,7 @@
         },
         {
           "building": "wall_segment",
-          "x": -6.0,
+          "x": -8.0,
           "z": -14.0,
           "rotation": 0.0
         },
@@ -1963,41 +1882,38 @@
         },
         {
           "building": "wall_segment",
-          "x": 10.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
           "x": -10.0,
           "z": -12.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": 12.0,
+          "x": 10.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 10.0,
           "z": -12.0,
           "rotation": 0.0
         },
         {
-          "building": "defense_tower",
-          "x": -10.8,
-          "z": 5.4
-        },
-        {
-          "building": "defense_tower",
-          "x": 10.8,
-          "z": 5.4
-        },
-        {
-          "building": "defense_tower",
-          "x": -6.3,
-          "z": 9.5
+          "building": "wall_segment",
+          "x": -12.0,
+          "z": -12.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -12.0,
           "z": -10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": -12.0,
           "rotation": 0.0
         },
         {
@@ -2009,6 +1925,18 @@
         {
           "building": "wall_segment",
           "x": -14.0,
+          "z": -10.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -14.0,
+          "z": -8.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 14.0,
           "z": -10.0,
           "rotation": 0.0
         },
@@ -2026,14 +1954,32 @@
         },
         {
           "building": "wall_segment",
+          "x": -16.0,
+          "z": -6.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
           "x": 16.0,
           "z": -8.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": -16.0,
+          "x": 16.0,
           "z": -6.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
+          "z": -4.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -4.0,
           "rotation": 90.0
         },
         {
@@ -2044,8 +1990,26 @@
         },
         {
           "building": "wall_segment",
+          "x": 18.0,
+          "z": -4.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
           "x": -18.0,
           "z": -2.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": -2.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
+          "z": 0.0,
           "rotation": 90.0
         },
         {
@@ -2068,7 +2032,25 @@
         },
         {
           "building": "wall_segment",
+          "x": -18.0,
+          "z": 4.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": 4.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
           "x": 16.0,
+          "z": 4.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
           "z": 4.0,
           "rotation": 90.0
         },
@@ -2086,20 +2068,26 @@
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
-          "z": 8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
           "x": -16.0,
           "z": 8.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -12.0,
-          "z": 10.0,
+          "x": -14.0,
+          "z": 8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 14.0,
+          "z": 8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": 8.0,
           "rotation": 90.0
         },
         {
@@ -2110,8 +2098,26 @@
         },
         {
           "building": "wall_segment",
+          "x": -12.0,
+          "z": 10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": 10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
           "x": 14.0,
           "z": 10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -12.0,
+          "z": 12.0,
           "rotation": 90.0
         },
         {
@@ -2134,8 +2140,38 @@
         },
         {
           "building": "wall_segment",
+          "x": -10.0,
+          "z": 14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -8.0,
+          "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 8.0,
+          "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 10.0,
+          "z": 14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
           "x": -6.0,
           "z": 14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -6.0,
+          "z": 16.0,
           "rotation": 0.0
         },
         {
@@ -2146,25 +2182,19 @@
         },
         {
           "building": "wall_segment",
-          "x": 8.0,
-          "z": 14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -10.0,
-          "z": 14.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 4.0,
+          "x": 6.0,
           "z": 16.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": -6.0,
+          "x": -4.0,
+          "z": 16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 4.0,
           "z": 16.0,
           "rotation": 0.0
         },
@@ -2175,44 +2205,49 @@
           "rotation": 0.0
         },
         {
-          "building": "home",
-          "x": -13,
-          "z": 1
+          "building": "defense_tower",
+          "x": 13.5,
+          "z": 0.0
+        },
+        {
+          "building": "defense_tower",
+          "x": -6.1,
+          "z": 9.2
+        },
+        {
+          "building": "defense_tower",
+          "x": 6.1,
+          "z": 9.2
         },
         {
           "building": "home",
-          "x": 13,
-          "z": 1
+          "x": -10.4,
+          "z": 2.5
         },
         {
           "building": "home",
-          "x": -14.2,
-          "z": 15.4
+          "x": 10.9,
+          "z": 3.1
         },
         {
           "building": "home",
-          "x": 8.0,
-          "z": 8.0
+          "x": -9.0,
+          "z": 6.0
         },
         {
           "building": "home",
-          "x": -22.0,
+          "x": 16.6,
+          "z": 14.5
+        },
+        {
+          "building": "home",
+          "x": -23.0,
           "z": -3.0
         },
         {
           "building": "home",
-          "x": 22.0,
+          "x": 23.0,
           "z": -3.0
-        },
-        {
-          "building": "home",
-          "x": -9.3,
-          "z": 18.7
-        },
-        {
-          "building": "home",
-          "x": 9.9,
-          "z": 18.3
         },
         {
           "building": "ballista",
@@ -2304,12 +2339,12 @@
     },
     "punic_grand_camp": {
       "display_name": "Hannibalic Hexagon",
-      "silhouette_steps": 34,
+      "silhouette_steps": 30,
       "steps": [
         {
           "building": "home",
-          "x": 8.4,
-          "z": 6.8
+          "x": 9.2,
+          "z": 7.4
         },
         {
           "building": "home",
@@ -2318,41 +2353,59 @@
         },
         {
           "building": "defense_tower",
-          "x": 7.2,
-          "z": -10.9
+          "x": -7.8,
+          "z": -12.4
         },
         {
           "building": "defense_tower",
-          "x": -7.2,
-          "z": -10.9
+          "x": 7.8,
+          "z": -12.4
         },
         {
           "building": "defense_tower",
-          "x": 13.5,
+          "x": 15.1,
           "z": 0.0
+        },
+        {
+          "building": "wall_gate",
+          "x": 0.0,
+          "z": -18.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -4.0,
-          "z": -16.0,
+          "z": -18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 4.0,
-          "z": -16.0,
+          "z": -18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -6.0,
-          "z": -16.0,
+          "z": -18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 6.0,
-          "z": -16.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -8.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 8.0,
+          "z": -18.0,
           "rotation": 0.0
         },
         {
@@ -2363,44 +2416,134 @@
         },
         {
           "building": "wall_segment",
+          "x": -10.0,
+          "z": -18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
           "x": 10.0,
           "z": -16.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
-          "x": -10.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
           "x": 10.0,
-          "z": -14.0,
+          "z": -18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": -12.0,
-          "z": -10.0,
-          "rotation": 90.0
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -12.0,
+          "z": -14.0,
+          "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 12.0,
+          "z": -16.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -14.0,
+          "z": -14.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -14.0,
+          "z": -12.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 14.0,
+          "z": -14.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 14.0,
+          "z": -12.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
           "z": -10.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": -14.0,
-          "z": -6.0,
+          "z": -10.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": 14.0,
+          "z": -10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": -10.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": -8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -18.0,
           "z": -6.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
+          "z": -6.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": -6.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 18.0,
+          "z": -6.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -20.0,
+          "z": -4.0,
           "rotation": 90.0
         },
         {
@@ -2417,7 +2560,31 @@
         },
         {
           "building": "wall_segment",
-          "x": -18.0,
+          "x": 20.0,
+          "z": -4.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -20.0,
+          "z": -2.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 20.0,
+          "z": -2.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -22.0,
+          "z": 0.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -20.0,
           "z": 0.0,
           "rotation": 90.0
         },
@@ -2425,235 +2592,53 @@
           "building": "wall_segment",
           "x": 20.0,
           "z": 0.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": 4.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 16.0,
-          "z": 4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
-          "z": 4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": 4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": 8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": 8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": 12.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": 12.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -4.0,
-          "z": 16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 4.0,
-          "z": 16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -10.0,
-          "z": 16.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 10.0,
-          "z": 16.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_gate",
-          "x": 0.0,
-          "z": -16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -8.0,
-          "z": -16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 8.0,
-          "z": -16.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": -14.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": -14.0,
-          "rotation": 0.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -12.0,
-          "z": -12.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 12.0,
-          "z": -12.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": -10.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "defense_tower",
-          "x": -11.3,
-          "z": -3.0
-        },
-        {
-          "building": "defense_tower",
-          "x": 7.2,
-          "z": 10.9
-        },
-        {
-          "building": "defense_tower",
-          "x": -7.2,
-          "z": 10.9
-        },
-        {
-          "building": "marketplace",
-          "x": 11.0,
-          "z": 3.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -14.0,
-          "z": -8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 14.0,
-          "z": -8.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": -6.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": -6.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -16.0,
-          "z": -4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 16.0,
-          "z": -4.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": -18.0,
-          "z": -2.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
-          "z": -2.0,
-          "rotation": 90.0
-        },
-        {
-          "building": "wall_segment",
-          "x": 18.0,
+          "x": 22.0,
           "z": 0.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -20.0,
+          "z": 2.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 20.0,
+          "z": 2.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": -20.0,
-          "z": 0.0,
-          "rotation": 0.0
+          "z": 4.0,
+          "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": -18.0,
-          "z": 2.0,
+          "z": 4.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": 18.0,
-          "z": 2.0,
+          "z": 4.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": -14.0,
-          "z": 6.0,
+          "x": 20.0,
+          "z": 4.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 14.0,
+          "x": -18.0,
           "z": 6.0,
           "rotation": 90.0
         },
@@ -2671,13 +2656,25 @@
         },
         {
           "building": "wall_segment",
-          "x": -12.0,
-          "z": 10.0,
+          "x": 18.0,
+          "z": 6.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 12.0,
+          "x": -16.0,
+          "z": 8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 16.0,
+          "z": 8.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -16.0,
           "z": 10.0,
           "rotation": 90.0
         },
@@ -2695,13 +2692,25 @@
         },
         {
           "building": "wall_segment",
-          "x": -10.0,
-          "z": 14.0,
+          "x": 16.0,
+          "z": 10.0,
           "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 10.0,
+          "x": -14.0,
+          "z": 12.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 14.0,
+          "z": 12.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -14.0,
           "z": 14.0,
           "rotation": 90.0
         },
@@ -2719,63 +2728,137 @@
         },
         {
           "building": "wall_segment",
-          "x": -6.0,
-          "z": 16.0,
-          "rotation": 0.0
+          "x": 14.0,
+          "z": 14.0,
+          "rotation": 90.0
         },
         {
           "building": "wall_segment",
-          "x": 6.0,
+          "x": -12.0,
           "z": 16.0,
-          "rotation": 0.0
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -10.0,
+          "z": 16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 10.0,
+          "z": 16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 12.0,
+          "z": 16.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -10.0,
+          "z": 18.0,
+          "rotation": 90.0
         },
         {
           "building": "wall_segment",
           "x": -8.0,
-          "z": 16.0,
+          "z": 18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_segment",
           "x": 8.0,
-          "z": 16.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 10.0,
+          "z": 18.0,
+          "rotation": 90.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -6.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 6.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": -4.0,
+          "z": 18.0,
+          "rotation": 0.0
+        },
+        {
+          "building": "wall_segment",
+          "x": 4.0,
+          "z": 18.0,
           "rotation": 0.0
         },
         {
           "building": "wall_gate",
           "x": 0.0,
-          "z": 16.0,
+          "z": 18.0,
           "rotation": 0.0
         },
         {
-          "building": "barracks",
-          "x": -28,
-          "z": 4
+          "building": "defense_tower",
+          "x": -15.1,
+          "z": 0.0
         },
         {
-          "building": "barracks",
-          "x": 28,
-          "z": 4
-        },
-        {
-          "building": "home",
-          "x": -9.2,
-          "z": -6.8
-        },
-        {
-          "building": "home",
-          "x": -7.8,
-          "z": 20.1
-        },
-        {
-          "building": "home",
+          "building": "defense_tower",
           "x": 7.8,
-          "z": 20.1
+          "z": 12.4
+        },
+        {
+          "building": "defense_tower",
+          "x": -7.8,
+          "z": 12.4
+        },
+        {
+          "building": "marketplace",
+          "x": 11,
+          "z": 1
+        },
+        {
+          "building": "barracks",
+          "x": -30,
+          "z": 4
+        },
+        {
+          "building": "barracks",
+          "x": 30,
+          "z": 4
+        },
+        {
+          "building": "home",
+          "x": -10,
+          "z": -5
+        },
+        {
+          "building": "home",
+          "x": -5.5,
+          "z": 9.3
+        },
+        {
+          "building": "home",
+          "x": 5.5,
+          "z": 9.3
         },
         {
           "building": "catapult",
-          "x": -8.0,
-          "z": 7.0
+          "x": -8.8,
+          "z": 7.8
         },
         {
           "building": "catapult",

--- a/assets/shaders/include/character_shading.glsl
+++ b/assets/shaders/include/character_shading.glsl
@@ -64,8 +64,6 @@ vec3 shade_readable_character(vec3 base,
   vec3 sun_color = environment_primary_color();
   vec3 sky_color = environment_sky_color();
 
-  // Warm sunlight should not turn every armor/cloth surface the same gold as
-  // masonry. Preserve light intensity and authored team hues at tactical zoom.
   if (material_id == 0) {
     float sun_luma = dot(sun_color, vec3(0.299, 0.587, 0.114));
     sun_color = mix(sun_color, vec3(sun_luma), 0.30 * zoom);
@@ -231,8 +229,7 @@ vec3 soi_finish_character(vec3 color,
   }
 #endif
   if (material_id == 0) {
-    // Keep cloth identifiable without saturating skin, leather and armor into
-    // competing orange/yellow flecks. Leave other creature materials unchanged.
+
     bool cloth =
         color_role == k_humanoid_role_cloth || color_role == k_humanoid_role_cloth_dark;
     float luma = dot(color, vec3(0.299, 0.587, 0.114));
@@ -248,9 +245,7 @@ vec3 soi_finish_character(vec3 color,
     color = mix(vec3(hide_luma), color, k_elephant_hide_saturation);
   }
 #endif
-  // Preserve wool's light/dark modeling while removing the warm cast introduced
-  // by sunlight, ground bounce and the generic wildlife finish. The material
-  // mask excludes brown coats, dirty wool, faces and hooves.
+
 #if SOI_CHARACTER_WANTS(SOI_CHARACTER_WILDLIFE)
   if (material_id == k_wildlife_material) {
     float white_coat = wildlife_white_coat_weight(base);

--- a/assets/shaders/include/character_wear.glsl
+++ b/assets/shaders/include/character_wear.glsl
@@ -54,8 +54,7 @@ vec4 soi_wear_fetch(vec3 lattice, vec4 salts) {
 }
 
 #if SOI_CHARACTER_WANTS(SOI_CHARACTER_WILDLIFE)
-// Select pale neutral coats by authored color, not by shared wildlife role IDs
-// (wolves and sheep use the same material). Brown fur and dirt remain colored.
+
 float wildlife_white_coat_weight(vec3 base) {
   float luma = dot(base, vec3(0.299, 0.587, 0.114));
   float chroma = max(max(base.r, base.g), base.b) - min(min(base.r, base.g), base.b);

--- a/assets/shaders/include/environment_lighting.glsl
+++ b/assets/shaders/include/environment_lighting.glsl
@@ -51,9 +51,7 @@ float environment_cloud_cover() {
 }
 
 vec3 environment_shadow_tint() {
-  // Shadow receivers multiply their complete lighting result by this tint.
-  // Retain some indirect-light value instead of crushing it a second time.
-  // Preserve the authored night palette and the tint's relative channel balance.
+
   vec3 primary = environment_primary_color();
   float daylight = 1.0 - smoothstep(0.05, 0.40, primary.b - primary.r);
   return mix(u_env_shadow_tint_strength.rgb, vec3(1.0), 0.20 * daylight);

--- a/assets/shaders/include/ground_readability.glsl
+++ b/assets/shaders/include/ground_readability.glsl
@@ -1,5 +1,5 @@
-// Keep small ground features subordinate to units at normal gameplay distances.
-// Shared by terrain and scatter so their detail transitions stay in step.
+
+
 float ground_tactical_distance(float view_distance) {
   return smoothstep(32.0, 85.0, view_distance);
 }

--- a/assets/shaders/include/material_detail.glsl
+++ b/assets/shaders/include/material_detail.glsl
@@ -102,8 +102,7 @@ vec3 soi_material_variation(vec3 base_color,
                             vec3 normal,
                             int material_id) {
   float tactical = ground_tactical_distance(length(u_camera_pos - world_pos));
-  // Mineral and wood surfaces should support, rather than compete with, troop
-  // cloth colors. Apply this even when material-detail textures are disabled.
+
   if (material_id == k_material_mineral || material_id == k_material_wood) {
     float luma = dot(base_color, vec3(0.299, 0.587, 0.114));
     float saturation = material_id == k_material_mineral ? 0.86 : 0.92;
@@ -126,7 +125,7 @@ vec3 soi_material_variation(vec3 base_color,
   } else if (material_id == k_material_leather) {
     variation = soi_leather_variation(base_color, uv);
   }
-  // Retain close-up texture while reducing grain and sheen at army-view scale.
+
   variation = mix(base_color, variation, mix(1.0, 0.55, tactical));
   return clamp(variation, 0.0, 1.0);
 }

--- a/assets/shaders/include/tonemap.glsl
+++ b/assets/shaders/include/tonemap.glsl
@@ -42,8 +42,7 @@ vec3 soi_split_tone(vec3 color, float strength) {
 }
 
 vec3 soi_grade(vec3 mapped_color) {
-  // Keep contrast in the midtones without clipping shaded equipment and faces
-  // to black before the shadow lift. Scene lighting already supplies the mood.
+
   float mapped_luma = max(dot(mapped_color, k_soi_grade_luma), 0.0);
   float contrast_weight =
       smoothstep(0.04, 0.24, mapped_luma) * (1.0 - smoothstep(0.72, 1.0, mapped_luma));
@@ -51,15 +50,14 @@ vec3 soi_grade(vec3 mapped_color) {
   vec3 contrasted = (mapped_color - k_soi_grade_pivot) * contrast + k_soi_grade_pivot;
   contrasted = max(contrasted, vec3(0.0));
   float luma = dot(contrasted, k_soi_grade_luma);
-  // Avoid turning bright cloth and metal into clipped patches of primary color.
+
   float saturation = mix(k_soi_grade_saturation, 1.0, smoothstep(0.55, 0.95, luma));
   vec3 saturated = mix(vec3(luma), contrasted, saturation);
   saturated = max(saturated, vec3(0.0));
   vec3 tinted =
       mix(saturated, saturated * k_soi_grade_highlight_tint, clamp(luma, 0.0, 1.0));
   tinted = soi_split_tone(tinted, k_soi_grade_split_strength);
-  // Neutral materials (notably white wool) must survive the artistic warm
-  // grade as neutral. Retain the grade's luminance and leave colored cloth alone.
+
   float chroma = max(max(mapped_color.r, mapped_color.g), mapped_color.b) -
                  min(min(mapped_color.r, mapped_color.g), mapped_color.b);
   float neutral = 1.0 - smoothstep(0.015, 0.06, chroma);

--- a/assets/shaders/post_composite.frag
+++ b/assets/shaders/post_composite.frag
@@ -39,8 +39,7 @@ const int k_ao_ring_count = 3;
 const float k_ao_ring_spread[3] = float[3](2.5, 6.0, 12.0);
 const float k_ao_ring_weight[3] = float[3](1.0, 0.65, 0.24);
 const float k_ao_ring_reach = 1.7;
-// Depth-separated buildings must not cast broad screen-space occlusion halos.
-// Directional shadows handle their cast shadow; AO supplies local grounding.
+
 const float k_ao_far_cutoff = 4.0;
 const vec3 k_ao_tint = vec3(0.80, 0.83, 0.89);
 

--- a/assets/shaders/road.frag
+++ b/assets/shaders/road.frag
@@ -185,8 +185,6 @@ void main() {
     material_roughness = 0.94;
   }
 
-  // Derivative filtering handles subpixel edges; distance attenuation also
-  // prevents resolved paving/gravel contrast from competing with small troops.
   float ground_detail =
       mix(1.0, 0.40, ground_tactical_distance(length(u_camera_pos - v_world_pos)));
   base_color = mix(u_color * 0.92, base_color, ground_detail);

--- a/assets/shaders/stone_instanced.frag
+++ b/assets/shaders/stone_instanced.frag
@@ -113,7 +113,7 @@ void main() {
   float rim = pow(1.0 - max(dot(N, V), 0.0), 4.0) * 0.055;
 
   vec3 color = stone * illumination * crevice_ao;
-  // Tiny scatter should not retain full-strength bright rims and specular dots.
+
   color += soi_rim_light(N_face, V) * (1.0 - skirt * 0.6) * detail_weight;
   color += sun * (dry_spec + wet_spec) * detail_weight;
   color += sky * rim * detail_weight;

--- a/docs/AI_ARCHITECTURE.md
+++ b/docs/AI_ARCHITECTURE.md
@@ -650,7 +650,7 @@ and the front wall ordered first:
 | Plan id               | Commander                           | Form          | Shape                                                                             |
 | --------------------- | ----------------------------------- | ------------- | --------------------------------------------------------------------------------- |
 | `roman_bulwark`       | roman_legion_organizer (Fabius)     | `closed_fort` | 22x18 outer rectangle round a 12x10 keep, five towers, three gates, two ballistae |
-| `roman_assault_camp`  | roman_veteran_consul (Scipio)       | `closed_fort` | bastioned star trace, curtain 15x13, four towers, two gates, two catapults        |
+| `roman_assault_camp`  | roman_veteran_consul (Scipio)       | `closed_fort` | bastioned star trace, curtain 17x15, four towers, two gates, two catapults        |
 | `roman_vanguard_camp` | roman_field_commander (Marcellus)   | `open_camp`   | an open V of wall toward the enemy, three barracks behind it, no ring             |
 | `punic_trade_town`    | carthage_spear_commander (Hanno)    | `ring_town`   | 19x17 oval, six towers on the ring, two gates, a ballista                         |
 | `punic_raider_camp`   | carthage_bow_commander (Hasdrubal)  | `open_camp`   | no walls: three barracks and three towers, a camp that fights in the field        |
@@ -663,21 +663,24 @@ settlement; construction, the army's stations, the diagnostics and the tests all
 read the same slots. `TownPlan::front_gate()`, `front_line_z()` and
 `muster_offset()` are likewise computed from the slots.
 
-**The silhouette comes first.** A settle raises twenty-odd buildings in half an
-hour, a fifth of a hundred-step plan, so the _order_ of the first fifth is what a
-player sees. The generator emits each walled plan as: front towers, then the
-skeleton of every wall run (every corner and a post every so often round the
-trace), then the front gate - and records how many steps that took as
-`silhouette_steps`. The infill of the front wall, the rear towers, the rest of
-the wall and the homes follow. Twenty posts laid this way already show a dotted
-rectangle, a star or a ring; the same twenty laid end to end showed one straight
-wall. The builder lets a silhouette step go up as soon as the town can feed
-itself (a farm and two homes) and holds the infill behind the four-roof rule;
-`AIDoctrineCatalogTest.ASilhouetteAlreadyDrawsTheOutline` pins the silhouette to
-at least 70% of the compass for every closed plan, and
-`AiTownPlanTest.EveryCommanderRaisesItsOwnTownFromAnEmptyField` checks the
-outline a real settle draws, sector for sector, against the fortification it
-raised.
+**A wall is one growing run.** A settle raises twenty-odd buildings in half an
+hour, a fifth of a hundred-step plan, so the _order_ of the steps is what a
+player sees for most of a match. The generator lists each circuit as a walk
+outward from the front gate: the gate, then links along both arms at once,
+round the front corners, down the flanks, closing at the rear where the rear
+gate is cut when the arms reach it. Whatever has been paid for at any moment is
+therefore a solid wall with two ends. (Until Sep 2026 the generator laid a
+"skeleton" first - every corner and a post every so often round the whole
+trace - and filled in behind it; after fifty unopposed minutes not one ring had
+closed, and every partial ring read as a fence with a gap between each pair of
+posts. That was what the player saw the whole game.) The front towers, the
+front gate and the front third of the walk are the plan's `silhouette_steps`;
+the builder lets those go up as soon as the town can feed itself (a farm and
+two homes) and holds the rest of the ring behind the four-roof rule.
+`AIDoctrineCatalogTest.AWallGoesUpAsOneGrowingRunNotAsPosts` checks every
+prefix of every plan's wall steps is one connected run (two for the bulwark,
+whose keep starts after the outer ring), and `ASilhouetteAlreadyDrawsTheOutline`
+that the silhouette is the front and carries the gate.
 
 `Blueprint.add` nudges a building off the 9 m anchor circle, off other
 buildings and off the wall lines (a gate reaches 4.5 m either side), so a plan
@@ -703,16 +706,49 @@ How the builder walks a plan (`behaviors/builder_behavior.cpp`), and why:
   while the rest of the town waits.
 - **Slot clearance.** A wall link's slot counts as filled by a wall within
   1.45 m (the lattice pitch is 2 m; 1.0 m let two links stack on one cell) and a
-  gate's by anything within its 4.5 m half span.
+  gate's by anything within its 4.5 m half span. A gate whose ground a house
+  took slides along its own run; a gate whose slot already holds a wall piece
+  does not - sliding past a standing gate once raised three gates side by side
+  and left the plan's other gate slots counted as met.
+- **A wall link is never nudged.** The command applier moves a refused site up
+  to 12 m to find clear ground, but a link a metre off its lattice slot reads
+  as occupying the next slot too, and the ring closed with a one-metre hole
+  where that neighbour should stand. A link's slot is exact; if it is not clear
+  the order is refused and the plan retries or clears the ground.
+- **The wall line is kept.** Every other construction order carries the plan's
+  unbuilt wall, gate and tower footprints as `construction_keep_out`
+  (`site_keep_out.h`), which `find_clear_site` refuses to nudge into; and the
+  wishlist's own site search never sites a home, field or barracks on that
+  ground even in the pass that otherwise ignores the plan. Before this, homes,
+  a 13.6 m farm and an outpost barracks stood on ring slots in every soak and
+  those slots read `occupied` for the rest of the match.
+- **Clearing the line.** A planned wall, gate or tower slot with a tree,
+  boulder or ore node standing on it (measured with the same footprint-plus-
+  margin geometry the ground check refuses with, at the prop's authored scale)
+  gets that node cut by the crew instead of being ordered, refused four times
+  and abandoned; the link goes up once the ground is clear.
+- **Arrival at a link.** A crew raises a link on its site, not where it stands,
+  so it may start from within 1 m of the slot centre (other buildings need
+  15 cm). The slot between two standing links is a metre-wide notch, and crews
+  hovered 16-19 cm out until the approach timer gave the link up.
 - The gate exists at all since 2 Sep 2026: `production_system.cpp` spawned the
   `wall_gate` product as a plain wall segment before, so no AI town ever had a
   way out of its own ring.
 
-`tests/headless/ai_town_plan_test.cpp` raises every commander's town from an
-empty field and, in `AWalledCommanderClosesItsCircuitGivenTime`, gives Fabius,
-Scipio and Hannibal fifty minutes and expects at least 15% of the plan's links,
-three towers and a gate. `SOI_TOWN_MAP=1` makes that test print an ASCII map of
-what stood; `SOI_BUILD_TRACE=1` traces each build order and its verdict.
+`tests/headless/ai_town_plan_test.cpp` raises every commander's town from a
+barracks and a handful of builders and, in
+`AWalledCommanderClosesItsCircuitGivenTime`, gives Fabius, Scipio and Hannibal
+fifty minutes and expects half the plan's links, two towers, a gate and a
+**closed ring**: a flood fill over the nav grid from inside the anchor
+clearance, with gates treated as shut, must not reach the field. The
+empty-field test checks a part-built wall stands as at most three runs
+(boulders and trees still standing in the line count as part of it).
+`SOI_TOWN_MAP=1` prints a per-minute census, a 1 m nav map of the town, the
+run count and the enclosure verdict; `SOI_TOWN_ONLY=<name>` runs one castle;
+`SOI_TOWN_ENEMY_BEARING=<degrees>` plants a rival barracks 54 m out on that
+bearing so the plan is laid facing a different axis; `SOI_BUILD_TRACE=1`
+traces each build order and its verdict, and names the nearest prop when a
+site is refused.
 
 ### Where the army stands
 

--- a/game/audio/audio_event_handler.cpp
+++ b/game/audio/audio_event_handler.cpp
@@ -1,5 +1,8 @@
 #include "audio_event_handler.h"
 
+#include <QDebug>
+#include <QString>
+
 #include <algorithm>
 #include <chrono>
 #include <random>
@@ -450,20 +453,33 @@ void AudioEventHandler::on_unit_died(const Engine::Core::UnitDiedEvent& event) {
   }
 }
 
+auto AudioEventHandler::rotate_ambient_music(Engine::Core::AmbientState state) -> bool {
+  auto it = m_ambient_music_map.find(state);
+  if (it == m_ambient_music_map.end() || it->second.empty()) {
+    return false;
+  }
+
+  const std::string group_key = ambient_music_group_key(state);
+  const std::string last_id = m_current_music_id.empty()
+                                  ? m_last_sound_group_id[group_key]
+                                  : m_current_music_id;
+  const std::string music_id = choose_loaded_variant(it->second, last_id);
+  if (music_id.empty() || music_id == m_current_music_id) {
+    return false;
+  }
+
+  AudioSystem::get_instance().play_music(music_id);
+  m_last_sound_group_id[group_key] = music_id;
+  m_current_music_id = music_id;
+  qInfo().noquote() << QStringLiteral("Ambient music: %1 (%2)")
+                           .arg(QString::fromStdString(music_id),
+                                QString::fromStdString(group_key));
+  return true;
+}
+
 void AudioEventHandler::on_ambient_state_changed(
     const Engine::Core::AmbientStateChangedEvent& event) {
-  auto it = m_ambient_music_map.find(event.new_state);
-  if (it != m_ambient_music_map.end() && !it->second.empty()) {
-    const std::string group_key = ambient_music_group_key(event.new_state);
-    const std::string last_id = m_last_sound_group_id[group_key];
-    const std::string music_id = choose_loaded_variant(it->second, last_id);
-
-    if (!music_id.empty() && music_id != m_current_music_id) {
-      AudioSystem::get_instance().play_music(music_id);
-      m_last_sound_group_id[group_key] = music_id;
-      m_current_music_id = music_id;
-    }
-  }
+  rotate_ambient_music(event.new_state);
 
   auto sfx_it = m_ambient_state_sfx_map.find(event.new_state);
   if (sfx_it != m_ambient_state_sfx_map.end() && !sfx_it->second.empty()) {

--- a/game/audio/audio_event_handler.h
+++ b/game/audio/audio_event_handler.h
@@ -37,6 +37,8 @@ public:
   void load_ambient_state_sfx(Engine::Core::AmbientState state,
                               const std::vector<std::string>& sound_ids);
 
+  auto rotate_ambient_music(Engine::Core::AmbientState state) -> bool;
+
   void set_voice_sound_category(bool use_voice_category);
   void set_local_owner_id(int owner_id);
 

--- a/game/audio/audio_system.cpp
+++ b/game/audio/audio_system.cpp
@@ -247,6 +247,22 @@ void AudioSystem::set_ambience_volume(float volume) {
   Game::Audio::Settings::save_ambience_volume(ambience_volume.load());
 }
 
+void AudioSystem::apply_offline_reference_mix() {
+  const auto reference = Game::Audio::Settings::first_run_volumes();
+  master_volume = reference.master;
+  sound_volume = reference.sound;
+  music_volume = reference.music;
+  voice_volume = reference.voice;
+  ambience_volume = reference.ambience;
+
+  if (m_music_player != nullptr) {
+    m_music_player->set_volume(master_volume.load() * music_volume.load());
+  }
+
+  qInfo() << "AudioSystem: offline reference mix, master" << master_volume.load()
+          << "music" << music_volume.load() << "ambience" << ambience_volume.load();
+}
+
 void AudioSystem::load_persisted_volumes() {
   listening_preset = Game::Audio::Settings::load_listening_preset();
   const auto volumes = Game::Audio::Settings::load_volumes();

--- a/game/audio/audio_system.h
+++ b/game/audio/audio_system.h
@@ -117,6 +117,8 @@ public:
   void set_music_volume(float volume);
   void set_voice_volume(float volume);
   void set_ambience_volume(float volume);
+
+  void apply_offline_reference_mix();
   auto load_sound(const std::string& sound_id,
                   const std::string& file_path,
                   const AudioResourceConfig& config = {}) -> bool;

--- a/game/systems/ai_system/ai_command_applier.cpp
+++ b/game/systems/ai_system/ai_command_applier.cpp
@@ -4,7 +4,9 @@
 #include <QVector3D>
 #include <qvectornd.h>
 
+#include <cmath>
 #include <cstddef>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -12,6 +14,7 @@
 #include "../../command/command.h"
 #include "../../command/command_dispatcher.h"
 #include "../../command/command_queue.h"
+#include "../../core/ambient_session.h"
 #include "../../core/component_structures.h"
 #include "../../core/world.h"
 #include "../../game_config.h"
@@ -273,7 +276,7 @@ auto AICommandApplier::apply(Engine::Core::World& world,
 
       constexpr float k_site_nudge_radius = 12.0F;
 
-      constexpr float k_wall_link_nudge_radius = 1.0F;
+      constexpr float k_wall_link_nudge_radius = 0.0F;
       const bool wall_link =
           Game::Systems::is_wall_link_building_type(command.construction_type);
       const auto site = Game::Systems::find_clear_site(
@@ -282,7 +285,8 @@ auto AICommandApplier::apply(Engine::Core::World& world,
           QVector3D(command.construction_site_x, 0.0F, command.construction_site_z),
           wall_link ? k_wall_link_nudge_radius : k_site_nudge_radius,
           command.construction_rotation_y,
-          command.units);
+          command.units,
+          command.construction_keep_out);
       if (!site.has_value()) {
 
         ++report.refused_construction;
@@ -296,6 +300,23 @@ auto AICommandApplier::apply(Engine::Core::World& world,
                                                          command.construction_type,
                                                          command.construction_site_x,
                                                          command.construction_site_z));
+          const auto& terrain = *Game::Session::services_for(world).terrain;
+          float nearest = std::numeric_limits<float>::infinity();
+          const Game::Map::WorldProp* culprit = nullptr;
+          for (const auto& prop : terrain.world_props()) {
+            const QVector3D at = terrain.world_prop_world_position(prop);
+            const float d = std::hypot(at.x() - command.construction_site_x,
+                                       at.z() - command.construction_site_z);
+            if (d < nearest) {
+              nearest = d;
+              culprit = &prop;
+            }
+          }
+          if (culprit != nullptr) {
+            qWarning() << "BUILDTRACE p" << ai_owner_id << "  nearest prop type"
+                       << static_cast<int>(culprit->type) << "scale" << culprit->scale
+                       << "at" << nearest << "m";
+          }
         }
         break;
       }

--- a/game/systems/ai_system/ai_snapshot_builder.cpp
+++ b/game/systems/ai_system/ai_snapshot_builder.cpp
@@ -182,12 +182,12 @@ auto AISnapshotBuilder::build(const Engine::Core::World& world,
       continue;
     }
     const QVector3D position = terrain_service.world_prop_world_position(prop);
-    snapshot.resource_nodes.push_back(
-        {prop.id,
-         prop.type,
-         position.x(),
-         position.z(),
-         terrain_service.is_world_prop_reserved(prop.id)});
+    snapshot.resource_nodes.push_back({prop.id,
+                                       prop.type,
+                                       position.x(),
+                                       position.z(),
+                                       terrain_service.is_world_prop_reserved(prop.id),
+                                       prop.scale});
   }
 
   auto friendlies = world.get_units_owned_by(ai_owner_id);

--- a/game/systems/ai_system/ai_types.h
+++ b/game/systems/ai_system/ai_types.h
@@ -12,6 +12,7 @@
 #include "../../units/spawn_type.h"
 #include "../../units/troop_type.h"
 #include "../resource_types.h"
+#include "../site_keep_out.h"
 
 namespace Engine::Core {
 using EntityID = std::uint64_t;
@@ -116,6 +117,7 @@ struct ResourceNodeSnapshot {
   float pos_x = 0.0F;
   float pos_z = 0.0F;
   bool reserved = false;
+  float scale = 1.0F;
 };
 
 enum class BehaviorPriority {
@@ -551,6 +553,8 @@ struct AICommand {
   float construction_site_z = 0.0F;
   float construction_rotation_y = 0.0F;
   std::uint64_t resource_target_id = 0;
+
+  std::vector<Game::Systems::SiteKeepOut> construction_keep_out;
 
   float rally_x = 0.0F;
   float rally_z = 0.0F;

--- a/game/systems/ai_system/behaviors/builder_behavior.cpp
+++ b/game/systems/ai_system/behaviors/builder_behavior.cpp
@@ -464,7 +464,10 @@ auto authored_plan_step(const AIContext& context,
     float occupied_z = 0.0F;
     bool too_close_to_the_anchor = false;
 
-    for (std::size_t placement = 0; placement < placements && occupied; ++placement) {
+    bool occupied_by_the_wall_itself = false;
+    for (std::size_t placement = 0;
+         placement < placements && occupied && !occupied_by_the_wall_itself;
+         ++placement) {
       constexpr float k_deg_to_rad = 3.14159265358979323846F / 180.0F;
       float const along = gate_slide.at(placement);
       float const run = step.rotation * k_deg_to_rad;
@@ -487,6 +490,8 @@ auto authored_plan_step(const AIContext& context,
                   entity.pos_x, 0.0F, entity.pos_z, world_x, 0.0F, world_z) <=
               clearance * clearance) {
             occupied = true;
+            occupied_by_the_wall_itself =
+                Game::Units::is_wall_network_spawn(entity.spawn_type);
             occupied_by = Game::Units::spawn_typeToString(entity.spawn_type);
             occupied_x = entity.pos_x;
             occupied_z = entity.pos_z;
@@ -507,6 +512,8 @@ auto authored_plan_step(const AIContext& context,
                              0.0F,
                              world_z) <= clearance * clearance) {
           occupied = true;
+          occupied_by_the_wall_itself =
+              Game::Units::is_wall_network_spawn(raising.building_under_way);
           occupied_by = Game::Units::spawn_typeToString(raising.building_under_way);
           occupied_x = raising.construction_site_x;
           occupied_z = raising.construction_site_z;
@@ -595,11 +602,17 @@ auto site_is_free(const AISnapshot& snapshot,
   return true;
 }
 
+auto is_fortification_or_tower(const std::string& building) -> bool {
+  return building == BUILDING_TYPE_WALL_SEGMENT ||
+         building == BUILDING_TYPE_WALL_GATE || building == BUILDING_TYPE_DEFENSE_TOWER;
+}
+
 auto plan_reserves_ground(const AIContext& context,
                           const AISnapshot& snapshot,
                           const char* building_type,
                           float world_x,
-                          float world_z) -> bool {
+                          float world_z,
+                          bool fortifications_only = false) -> bool {
   const auto* doctrine = context.strategy_config.doctrine;
   if (doctrine == nullptr || doctrine->town_plan == nullptr ||
       building_type == nullptr) {
@@ -621,6 +634,9 @@ auto plan_reserves_ground(const AIContext& context,
         resolved == BUILDING_TYPE_BALLISTA) {
       continue;
     }
+    if (fortifications_only && !is_fortification_or_tower(step.building)) {
+      continue;
+    }
     const QVector3D offset = plan_offset_to_world(facing, step.x, step.z);
     const float clearance = own_half + half_extent(step.building) + k_slot_gap;
     if (distance_squared(context.base_pos_x + offset.x(),
@@ -633,6 +649,36 @@ auto plan_reserves_ground(const AIContext& context,
     }
   }
   return false;
+}
+
+auto plan_keep_out(const AIContext& context,
+                   const AISnapshot& snapshot) -> std::vector<SiteKeepOut> {
+  std::vector<SiteKeepOut> keep_out;
+  const auto* doctrine = context.strategy_config.doctrine;
+  if (doctrine == nullptr || doctrine->town_plan == nullptr ||
+      !context.has_base_anchor) {
+    return keep_out;
+  }
+  constexpr float k_slot_gap = 0.2F;
+  const QVector2D facing = locked_settlement_facing(context, snapshot);
+  for (const auto& step : doctrine->town_plan->steps) {
+    if (!is_fortification_or_tower(step.building)) {
+      continue;
+    }
+    const QVector3D offset = plan_offset_to_world(facing, step.x, step.z);
+    const float x = context.base_pos_x + offset.x();
+    const float z = context.base_pos_z + offset.z();
+    const float half =
+        step.building == BUILDING_TYPE_WALL_GATE
+            ? k_gate_half_span
+            : 0.5F *
+                  std::max(
+                      BuildingCollisionRegistry::get_building_size(step.building).width,
+                      BuildingCollisionRegistry::get_building_size(step.building)
+                          .depth);
+    keep_out.push_back({x, z, half + k_slot_gap});
+  }
+  return keep_out;
 }
 
 auto plan_footprint_radius(const AIContext& context) -> float {
@@ -770,6 +816,48 @@ using SourNodes = std::unordered_map<std::uint64_t, float>;
 auto node_is_sour(const SourNodes& sour, std::uint64_t node_id, float now) -> bool {
   const auto it = sour.find(node_id);
   return it != sour.end() && now < it->second;
+}
+
+struct NodeOnTheGround {
+  const ResourceNodeSnapshot* node = nullptr;
+  ResourceType resource = ResourceType::Count;
+};
+
+auto node_on_the_ground(const AISnapshot& snapshot,
+                        const SourNodes& sour,
+                        const char* building_type,
+                        float world_x,
+                        float world_z) -> NodeOnTheGround {
+
+  const auto size = BuildingCollisionRegistry::get_building_size(building_type);
+  constexpr float k_site_margin = 0.35F;
+  constexpr float k_root_margin = 0.1F;
+  const float own_reach = std::hypot((0.5F * size.width) + k_site_margin,
+                                     (0.5F * size.depth) + k_site_margin);
+  NodeOnTheGround found;
+  float nearest_sq = std::numeric_limits<float>::infinity();
+  for (const auto& node : snapshot.resource_nodes) {
+    if (node.reserved || node_is_sour(sour, node.id, snapshot.game_time)) {
+      continue;
+    }
+    const float reach = own_reach +
+                        Game::Map::world_prop_ground_radius(node.type, node.scale) +
+                        k_root_margin;
+    const float distance_sq =
+        distance_squared(node.pos_x, 0.0F, node.pos_z, world_x, 0.0F, world_z);
+    if (distance_sq > reach * reach || distance_sq >= nearest_sq) {
+      continue;
+    }
+    for (const ResourceType resource :
+         {ResourceType::Wood, ResourceType::Stone, ResourceType::Iron}) {
+      if (node_matches_resource(node, resource)) {
+        found = {&node, resource};
+        nearest_sq = distance_sq;
+        break;
+      }
+    }
+  }
+  return found;
 }
 
 auto entity_is_worked(const AISnapshot& snapshot,
@@ -1607,9 +1695,13 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
                   snapshot, building_to_construct, candidate_x, candidate_z)) {
             continue;
           }
-          if (honour_plan &&
-              plan_reserves_ground(
-                  context, snapshot, building_to_construct, candidate_x, candidate_z)) {
+          if (plan_reserves_ground(context,
+                                   snapshot,
+                                   building_to_construct,
+                                   candidate_x,
+                                   candidate_z,
+                                   !honour_plan)) {
+
             continue;
           }
           construction_x = candidate_x;
@@ -1631,6 +1723,35 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
   order_field_work(
       snapshot, context, available_builders, 1, take_builder, out_commands);
   order_repairs(snapshot, available_builders, 1, take_builder, out_commands);
+
+  if (building_to_construct != nullptr && site_resolved && plan_slot >= 0 &&
+      is_fortification_or_tower(building_to_construct)) {
+
+    const auto in_the_way = node_on_the_ground(
+        snapshot, m_sour_nodes, building_to_construct, construction_x, construction_z);
+    if (in_the_way.node != nullptr) {
+      const auto builder = take_builder(in_the_way.node->pos_x, in_the_way.node->pos_z);
+      if (builder != 0) {
+        if (qEnvironmentVariableIsSet("SOI_BUILD_TRACE")) {
+          qWarning() << "BUILDTRACE p" << context.player_id << "clears the line for"
+                     << building_to_construct << "at" << construction_x
+                     << construction_z << "node" << in_the_way.node->pos_x
+                     << in_the_way.node->pos_z;
+        }
+        AICommand clearing;
+        clearing.type = AICommandType::StartBuilderHarvest;
+        clearing.units.push_back(builder);
+        clearing.construction_type = harvest_type_for_resource(in_the_way.resource);
+        clearing.construction_site_x = in_the_way.node->pos_x;
+        clearing.construction_site_z = in_the_way.node->pos_z;
+        clearing.resource_target_id = in_the_way.node->id;
+        out_commands.push_back(std::move(clearing));
+      } else {
+        wanted_a_builder = true;
+      }
+      building_to_construct = nullptr;
+    }
+  }
 
   if (building_to_construct != nullptr && site_resolved) {
     clamp_to_map_bounds(snapshot, construction_x, construction_z);
@@ -1662,6 +1783,10 @@ void BuilderBehavior::execute(const AISnapshot& snapshot,
       command.construction_site_x = construction_x;
       command.construction_site_z = construction_z;
       command.construction_rotation_y = construction_rotation_y;
+      if (!is_fortification_or_tower(building_to_construct)) {
+
+        command.construction_keep_out = plan_keep_out(context, snapshot);
+      }
       out_commands.push_back(std::move(command));
 
       if (expansion_order) {

--- a/game/systems/build_site.cpp
+++ b/game/systems/build_site.cpp
@@ -329,12 +329,24 @@ auto find_clear_site(const Engine::Core::World& world,
                      const QVector3D& wanted,
                      float search_radius,
                      float facing_degrees,
-                     std::span<const Engine::Core::EntityID> crew)
+                     std::span<const Engine::Core::EntityID> crew,
+                     std::span<const SiteKeepOut> keep_out)
     -> std::optional<QVector3D> {
   const auto reserved = pending_sites(world, crew);
-  if (assess_ground(
+  const auto size = BuildingCollisionRegistry::get_building_size(building_type);
+  const float own_reach = (0.5F * std::max(size.width, size.depth)) + k_site_margin;
+  const auto kept_out = [&](float x, float z) {
+    return std::any_of(keep_out.begin(), keep_out.end(), [&](const SiteKeepOut& disc) {
+      const float dx = disc.x - x;
+      const float dz = disc.z - z;
+      const float reach = disc.radius + own_reach;
+      return (dx * dx) + (dz * dz) < reach * reach;
+    });
+  };
+  if (!kept_out(wanted.x(), wanted.z()) &&
+      assess_ground(
           world, reserved, building_type, wanted.x(), wanted.z(), 0, facing_degrees) ==
-      GroundVerdict::Clear) {
+          GroundVerdict::Clear) {
     return wanted;
   }
   if (search_radius <= 0.0F) {
@@ -353,7 +365,8 @@ auto find_clear_site(const Engine::Core::World& world,
       const QVector3D candidate(wanted.x() + (radius * std::cos(angle)),
                                 wanted.y(),
                                 wanted.z() + (radius * std::sin(angle)));
-      if (assess_ground(world,
+      if (!kept_out(candidate.x(), candidate.z()) &&
+          assess_ground(world,
                         reserved,
                         building_type,
                         candidate.x(),

--- a/game/systems/build_site.h
+++ b/game/systems/build_site.h
@@ -8,6 +8,7 @@
 
 #include "../core/entity.h"
 #include "ground_verdict.h"
+#include "site_keep_out.h"
 #include "wall_network_service.h"
 
 namespace Engine::Core {
@@ -25,13 +26,14 @@ assess_ground(const Engine::Core::World& world,
               float facing_degrees = 0.0F,
               std::span<const Engine::Core::EntityID> crew = {}) -> GroundVerdict;
 
-[[nodiscard]] auto find_clear_site(const Engine::Core::World& world,
-                                   const std::string& building_type,
-                                   const QVector3D& wanted,
-                                   float search_radius,
-                                   float facing_degrees = 0.0F,
-                                   std::span<const Engine::Core::EntityID> crew = {})
-    -> std::optional<QVector3D>;
+[[nodiscard]] auto
+find_clear_site(const Engine::Core::World& world,
+                const std::string& building_type,
+                const QVector3D& wanted,
+                float search_radius,
+                float facing_degrees = 0.0F,
+                std::span<const Engine::Core::EntityID> crew = {},
+                std::span<const SiteKeepOut> keep_out = {}) -> std::optional<QVector3D>;
 
 [[nodiscard]] auto wall_ground_probe(const Engine::Core::World& world) -> GroundProbe;
 

--- a/game/systems/production_system.cpp
+++ b/game/systems/production_system.cpp
@@ -691,6 +691,8 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
 
   constexpr float CONSTRUCTION_ARRIVAL_DISTANCE_SQ = 0.0225F;
 
+  constexpr float k_wall_site_arrival_distance_sq = 1.0F * 1.0F;
+
   constexpr float k_site_approach_limit_seconds = 30.0F;
 
   constexpr float k_orphaned_task_limit_seconds = 8.0F;
@@ -788,7 +790,10 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
         float const dz = builder_prod->construction_site_z - transform->position.z;
         float const dist_sq = dx * dx + dz * dz;
 
-        if (dist_sq < CONSTRUCTION_ARRIVAL_DISTANCE_SQ) {
+        const float arrival_sq = is_wall_network_product(builder_prod->product_type)
+                                     ? k_wall_site_arrival_distance_sq
+                                     : CONSTRUCTION_ARRIVAL_DISTANCE_SQ;
+        if (dist_sq < arrival_sq) {
 
           builder_prod->at_construction_site = true;
           builder_prod->in_progress = true;

--- a/game/systems/site_keep_out.h
+++ b/game/systems/site_keep_out.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace Game::Systems {
+
+struct SiteKeepOut {
+  float x = 0.0F;
+  float z = 0.0F;
+  float radius = 0.0F;
+};
+
+} // namespace Game::Systems

--- a/scripts/generate-town-plans.py
+++ b/scripts/generate-town-plans.py
@@ -5,10 +5,16 @@ Each commander raises its own settlement at runtime from a town plan: an
 ordered list of buildings at offsets in the settlement's frame (x right, -z
 toward the enemy, origin on the primary barracks, which nothing may stand within
 9 m of). The builder walks the steps in order, skipping any that already stand
-or cannot be afforded, so the *order* is the shape of a half-built town - the
-front wall and its gate first, then the towers that cover it, then the flanks,
-then the rear, then the keep. A player who sees two towers and a gate knows
-which commander is behind them before the rest goes up.
+or cannot be afforded, so the *order* is the shape of a half-built town.
+
+A circuit is laid the way a wall is actually built: as one growing run. The
+walk starts at the front gate and adds links outward along both arms, round
+the front corners, down the flanks, and closes at the rear, where the rear
+gate is cut when the arms reach it. Whatever the economy has paid for at any
+moment is therefore a solid wall with two ends, never a ring of posts with a
+gap between every pair - a half-built castle is half a castle, not a fence
+with holes. The front towers and the front gate go first, so the enemy-facing
+side is the part that exists earliest.
 
 The circuits come from settlement_geometry, the same rasteriser that stamps the
 campaign maps' pre-built towns, so a commander's runtime castle and its authored
@@ -31,7 +37,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from settlement_geometry import (
+    WALL_SEGMENT_SPACING,
     Cell,
+    Point,
     Region,
     bastion_apexes,
     bastioned_polygon,
@@ -57,20 +65,24 @@ FOOTPRINT = {
 
 STANDOFF = {
     "defense_tower": 4.0,
-    "home": 4.0,
-    "marketplace": 4.0,
-    "barracks": 6.0,
+    "home": 5.0,
+    "marketplace": 4.5,
+    "barracks": 6.5,
     "catapult": 4.0,
     "ballista": 4.0,
 }
 """How far a building keeps from a wall link in the plan frame.
 
-The runtime snaps every link to its own 2 m lattice, which can move it a metre
-and a half from where the plan put it; a building that stood 3 m from the
-link on paper then finds its slot occupied and is never raised."""
+A crew raises a link standing within a metre of its centre, and reaches that
+spot along the wall's own line only while the run is still open; once the
+neighbours stand it must come at the slot from inside or outside the ring. A
+house (4.4 m across, plus the nav grid's padding) 4 m off the line left no
+walkable cell on the inside, and Scipio's crews abandoned the same front slots
+thirty times in a row while standing six metres from them."""
 ANCHOR_CLEARANCE = 9.0
-CORNER_RUN_CELLS = 4
-SKELETON_POSTS = 18
+FRONT_SHARE = 1.0 / 3.0
+"""How much of a circuit, walked outward from the front gate, is its silhouette:
+the front curtain, its corners and the start of the flanks."""
 WALL_CAP = 128
 TOWER_CAP = 12
 HOME_CAP = 12
@@ -82,8 +94,8 @@ class Step:
     x: float
     z: float
     rotation: float | None = None
-    corner: bool = False
-    """A link at the end of a straight run: where the outline turns."""
+    dist: int = 0
+    """How many links along the circuit this stands from the front gate."""
 
     def to_json(self) -> dict:
         entry: dict = {
@@ -104,9 +116,9 @@ class Blueprint:
     links: list[Step] = field(default_factory=list)
     silhouette_steps: int = 0
     """How many opening steps carry the town's identity: the front towers, the
-    skeleton of every wall run and the front gate. The builder lets these go up
-    as soon as the town can feed itself, and holds the infill behind them until
-    the roofs are on, so a fifth of a plan already reads as its shape."""
+    front gate and the front third of the circuit walked outward from it. The
+    builder lets these go up as soon as the town can feed itself, and holds the
+    rest of the ring behind them until the roofs are on."""
 
     def close_silhouette(self) -> None:
         self.silhouette_steps = len(self.steps)
@@ -162,10 +174,19 @@ class Blueprint:
         return sum(1 for step in self.steps if step.building == building)
 
 
-def wall_steps(
-    cells: set[Cell], gates: list[tuple[float, float]]
-) -> tuple[list[Step], list[Step]]:
-    """Cut the gates, then order the wall so the enemy-facing side goes up first."""
+def circuit_walk(
+    cells: set[Cell], gates: list[tuple[float, float]], root: Point | None = None
+) -> list[Step]:
+    """Cut the gates, then order the circuit as a walk outward from the front gate.
+
+    Every link and gate comes back in build order with ``dist`` set to its
+    distance along the trace from the walk's root: the first gate if there is
+    one, else the cell nearest ``root``, else the front-most cell. Links at the
+    same distance on the two arms alternate, left arm first, so the wall grows
+    symmetrically and stays one connected run at every prefix. A gate other
+    than the root is emitted the moment the walk reaches it, so the arms close
+    through it rather than leaving a hole for it.
+    """
     runs = partition_runs(cells)
     gate_steps: list[Step] = []
     for target in gates:
@@ -183,38 +204,70 @@ def wall_steps(
     links: list[Step] = []
     for run in runs:
         rotation = 0.0 if run_is_horizontal(run) else 90.0
-        ordered = sorted(run)
-        for cell in ordered:
-            corner = len(run) >= CORNER_RUN_CELLS and cell in (ordered[0], ordered[-1])
-            links.append(
-                Step("wall_segment", float(cell[0]), float(cell[1]), rotation, corner)
-            )
+        for cell in sorted(run):
+            links.append(Step("wall_segment", float(cell[0]), float(cell[1]), rotation))
 
-    links.sort(key=lambda step: (step.z, abs(step.x)))
-    return links, gate_steps
+    if gate_steps:
+        origin: Cell = (int(gate_steps[0].x), int(gate_steps[0].z))
+    elif root is not None:
+        origin = min(
+            cells, key=lambda cell: math.hypot(cell[0] - root[0], cell[1] - root[1])
+        )
+    else:
+        origin = min(cells, key=lambda cell: (cell[1], abs(cell[0])))
+
+    distance: dict[Cell, int] = {origin: 0}
+    frontier = [origin]
+    while frontier:
+        following: list[Cell] = []
+        for x, z in frontier:
+            for dx in (-WALL_SEGMENT_SPACING, 0, WALL_SEGMENT_SPACING):
+                for dz in (-WALL_SEGMENT_SPACING, 0, WALL_SEGMENT_SPACING):
+                    neighbour = (x + dx, z + dz)
+                    if neighbour == (x, z) or neighbour not in cells:
+                        continue
+                    if neighbour in distance:
+                        continue
+                    distance[neighbour] = distance[(x, z)] + 1
+                    following.append(neighbour)
+        frontier = following
+
+    far = len(cells) + 1
+    for step in links + gate_steps:
+        step.dist = distance.get((int(step.x), int(step.z)), far)
+    walk = links + gate_steps
+
+    walk.sort(key=lambda step: (step.dist, step.building != "wall_gate", step.x))
+    return walk
 
 
-def skeleton(
-    links: list[Step], posts: int = SKELETON_POSTS
+def split_front(
+    walk: list[Step], share: float = FRONT_SHARE
 ) -> tuple[list[Step], list[Step]]:
-    """Split a circuit into the few links that draw its outline and the infill.
-
-    The outline is every corner plus a post every so often round the trace,
-    front first. Twenty links laid this way already show a rectangle, a star or
-    a ring; the same twenty laid end to end show one straight wall."""
-    if not links:
-        return [], []
-    by_angle = sorted(links, key=lambda step: math.atan2(step.x, -step.z))
-    stride = max(3, len(by_angle) // posts)
-    chosen = {id(step) for index, step in enumerate(by_angle) if index % stride == 0}
-    chosen.update(id(step) for step in links if step.corner)
-    outline = [step for step in links if id(step) in chosen]
-    infill = [step for step in links if id(step) not in chosen]
-    return outline, infill
+    """The front of a circuit walk - the gate and the nearest ``share`` of the
+    links either side of it - and everything behind that."""
+    links = [step for step in walk if step.building == "wall_segment"]
+    wanted = max(1, math.ceil(len(links) * share))
+    cutoff = links[wanted - 1].dist if links else 0
+    front = [step for step in walk if step.dist <= cutoff]
+    rest = [step for step in walk if step.dist > cutoff]
+    return front, rest
 
 
 def ring_cells(region: Region) -> set[Cell]:
     return region_cells(region, None)
+
+
+def inside_corner(region: Region, x: float, z: float, clearance: float) -> Point:
+    """The spot on the line from a polygon corner to the anchor that stands
+    ``clearance`` inside the trace: where a corner tower goes, whatever the
+    corner's angle. The wall's links sit within a lattice step of the polygon
+    edge, so callers add that step to the standoff they want from the links."""
+    px, pz = x, z
+    while region.edge_distance(px, pz) < clearance and math.hypot(px, pz) > 1.0:
+        px -= x * 0.02
+        pz -= z * 0.02
+    return px, pz
 
 
 def fabian_bulwark() -> Blueprint:
@@ -224,30 +277,21 @@ def fabian_bulwark() -> Blueprint:
     keep = ring_cells(Region([rectangle_polygon(0, 0, 12, 10)]))
     """Outer 40x32, keep 24x20: the keep's links stand 10 m off the anchor, which
     is the least the builder will accept, and the ward between is one house deep."""
-    outer_links, outer_gates = wall_steps(outer, [(0, -18), (0, 18)])
-    keep_links, keep_gates = wall_steps(keep, [(0, -10)])
-    plan.links = outer_links + outer_gates + keep_links + keep_gates
+    outer_walk = circuit_walk(outer, [(0, -18), (0, 18)])
+    keep_walk = circuit_walk(keep, [(0, -10)])
+    plan.links = outer_walk + keep_walk
     for x, z in ((-12, 14), (12, 14)):
         plan.add("home", x, z)
     plan.add("marketplace", -17, 0)
-    outline, infill = skeleton(outer_links)
-    front = [s for s in infill if s.z <= -16]
-    rest = [s for s in infill if s.z > -16]
+    front, rest = split_front(outer_walk)
     for x, z in ((-17, -14), (17, -14), (-8, -14)):
         plan.add("defense_tower", x, z)
-    plan.steps.extend(outline)
-    plan.steps.extend(outer_gates[:1])
+    plan.steps.extend(front)
     plan.close_silhouette()
-    for step in front:
-        plan.steps.append(step)
-    for step in rest:
-        plan.steps.append(step)
-    plan.steps.extend(outer_gates[1:])
+    plan.steps.extend(rest)
     for x, z in ((-17, 14), (17, 14)):
         plan.add("defense_tower", x, z)
-    for step in keep_links:
-        plan.steps.append(step)
-    plan.steps.extend(keep_gates)
+    plan.steps.extend(keep_walk)
     for x, z in ((-17, 4), (17, 4), (-17, -4), (17, -4), (-17, 9), (17, 9)):
         plan.add("home", x, z)
     plan.add("ballista", -17, -9)
@@ -259,29 +303,27 @@ def consular_star() -> Blueprint:
     """A bastioned trace with a tower behind every point and engines inside."""
     plan = Blueprint("roman_assault_camp", "Consular Star Camp")
     stretch = 1.0 / math.cos(math.pi / 4)
-    half_x, half_z = 15.0 * stretch, 13.0 * stretch
+    half_x, half_z = 17.0 * stretch, 15.0 * stretch
+    """17x15: at 15x13 the ward could not hold two homes and a market five
+    metres off the curtain, and a house any nearer leaves no walkable cell
+    between it and the wall for the crew raising the last links."""
     cells = ring_cells(Region([bastioned_polygon(0, 0, half_x, half_z, 4, 9.0, 5.0)]))
-    links, gates = wall_steps(cells, [(0, -13), (0, 13)])
-    plan.links = links + gates
+    walk = circuit_walk(cells, [(0, -15), (0, 15)])
+    plan.links = walk
     for x, z in ((-9, 0), (9, 0)):
         plan.add("home", x, z)
     plan.add("marketplace", 0, 8)
-    outline, infill = skeleton(links)
-    front = [s for s in infill if s.z <= -9]
-    rest = [s for s in infill if s.z > -9]
+    front, rest = split_front(walk)
     towers = sorted(bastion_apexes(0, 0, half_x, half_z, 4, -5.0), key=lambda t: t[1])
     for x, z in towers[:2]:
         plan.add("defense_tower", x, z)
-    plan.steps.extend(outline)
-    plan.steps.extend(gates[:1])
-    plan.close_silhouette()
     plan.steps.extend(front)
+    plan.close_silhouette()
+    plan.steps.extend(rest)
     for x, z in towers[2:]:
         plan.add("defense_tower", x, z)
-    plan.steps.extend(rest)
-    plan.steps.extend(gates[1:])
 
-    for x, z in ((-8, -7), (8, -7), (0, 11), (6, -10)):
+    for x, z in ((-7, -6), (7, -6), (0, 11)):
         plan.add("home", x, z)
     plan.add("catapult", -8, 5)
     plan.add("catapult", 8, 5)
@@ -294,17 +336,17 @@ def vanguard_chevron() -> Blueprint:
     left = path_cells([(-24, -2), (0, -20)], None)
     right = path_cells([(0, -20), (24, -2)], None)
     cells = left | right
-    links, _gates = wall_steps(cells, [])
-    plan.links = links
+    walk = circuit_walk(cells, [], root=(0, -20))
+    plan.links = walk
     plan.add("barracks", -12, 6)
     plan.add("barracks", 12, 6)
     for x, z in ((-6, 12), (6, 12)):
         plan.add("home", x, z)
-    outline, infill = skeleton(links)
+    front, rest = split_front(walk)
     plan.add("defense_tower", 0, -13)
-    plan.steps.extend(outline)
+    plan.steps.extend(front)
     plan.close_silhouette()
-    plan.steps.extend(infill)
+    plan.steps.extend(rest)
     plan.add("defense_tower", -22, 3)
     plan.add("defense_tower", 22, 3)
     plan.add("barracks", 0, 16)
@@ -318,32 +360,33 @@ def punic_ring_town() -> Blueprint:
     """A round town: market at the heart, homes against the wall, towers all round."""
     plan = Blueprint("punic_trade_town", "Punic Ring Town")
     cells = ring_cells(Region([ellipse_polygon(0, 0, 19, 17)]))
-    links, gates = wall_steps(cells, [(0, -17), (0, 17)])
-    plan.links = links + gates
+    walk = circuit_walk(cells, [(0, -17), (0, 17)])
+    plan.links = walk
     plan.add("marketplace", 0, -11)
     for x, z in ((-10, -7), (10, -7)):
         plan.add("home", x, z)
     ring_towers = sorted(
         (
             (
-                math.cos(math.pi * 0.5 + 2.0 * math.pi * index / 6) * 14.5,
-                -math.sin(math.pi * 0.5 + 2.0 * math.pi * index / 6) * 12.5,
+                math.cos(math.pi * (0.5 + 1.0 / 6.0) + 2.0 * math.pi * index / 6)
+                * 14.5,
+                -math.sin(math.pi * (0.5 + 1.0 / 6.0) + 2.0 * math.pi * index / 6)
+                * 12.5,
             )
             for index in range(6)
         ),
         key=lambda t: t[1],
     )
-    outline, infill = skeleton(links)
+    """Towers thirty degrees off the gate axis: one on the axis stood between
+    the front gate and the market with room for neither."""
+    front, rest = split_front(walk)
     for x, z in ring_towers[:3]:
         plan.add("defense_tower", x, z)
-    plan.steps.extend(outline)
-    plan.steps.extend(gates[:1])
+    plan.steps.extend(front)
     plan.close_silhouette()
-    plan.steps.extend([s for s in infill if s.z <= -12])
+    plan.steps.extend(rest)
     for x, z in ring_towers[3:]:
         plan.add("defense_tower", x, z)
-    plan.steps.extend([s for s in infill if s.z > -12])
-    plan.steps.extend(gates[1:])
     for x, z in (
         (-13, 1),
         (13, 1),
@@ -351,8 +394,6 @@ def punic_ring_town() -> Blueprint:
         (9, 8),
         (-13, -3),
         (13, -3),
-        (-4, 9),
-        (4, 9),
     ):
         plan.add("home", x, z)
     plan.add("ballista", -7, -7)
@@ -381,34 +422,34 @@ def hannibalic_hexagon() -> Blueprint:
     """Six sides, six towers, engines inside; the gate faces the enemy."""
     plan = Blueprint("punic_grand_camp", "Hannibalic Hexagon")
     hexagon = [
-        (math.cos(math.pi * index / 3) * 21.0, math.sin(math.pi * index / 3) * 19.0)
+        (math.cos(math.pi * index / 3) * 23.0, math.sin(math.pi * index / 3) * 21.0)
         for index in range(6)
     ]
-    """Vertices on the x axis, so a flat side faces the enemy and carries the gate."""
-    cells = ring_cells(Region([hexagon]))
-    links, gates = wall_steps(cells, [(0, -19), (0, 19)])
-    plan.links = links + gates
+    """Vertices on the x axis, so a flat side faces the enemy and carries the gate.
+    23x21: the flat sides of a 21x19 hexagon stand only 16 m out, and a ward
+    that shallow could not hold the six towers, the homes and the engines at
+    the standoff a crew needs to reach the last links of the ring."""
+    region = Region([hexagon])
+    cells = ring_cells(region)
+    walk = circuit_walk(cells, [(0, -21), (0, 21)])
+    plan.links = walk
     plan.add("home", 10, 8)
     plan.add("home", -11, 1)
     corners = [
-        (math.cos(math.pi * index / 3) * 16.5, math.sin(math.pi * index / 3) * 14.5)
-        for index in range(6)
+        inside_corner(region, x, z, STANDOFF["defense_tower"] + 1.5) for x, z in hexagon
     ]
     corners.sort(key=lambda corner: corner[1])
-    outline, infill = skeleton(links)
+    front, rest = split_front(walk)
     for x, z in corners[:3]:
         plan.add("defense_tower", x, z)
-    plan.steps.extend(outline)
-    plan.steps.extend(gates[:1])
+    plan.steps.extend(front)
     plan.close_silhouette()
-    plan.steps.extend([s for s in infill if s.z <= -10])
+    plan.steps.extend(rest)
     for x, z in corners[3:]:
         plan.add("defense_tower", x, z)
     plan.add("marketplace", 11, 1)
-    plan.steps.extend([s for s in infill if s.z > -10])
-    plan.steps.extend(gates[1:])
-    plan.add("barracks", -28, 4)
-    plan.add("barracks", 28, 4)
+    plan.add("barracks", -30, 4)
+    plan.add("barracks", 30, 4)
     for x, z in ((-10, -5), (-4, 13), (4, 13)):
         plan.add("home", x, z)
     plan.add("catapult", -7, 7)

--- a/scripts/module_rules.json
+++ b/scripts/module_rules.json
@@ -30,6 +30,7 @@
       "files": [
         "game/systems/nation_id",
         "game/systems/ground_verdict",
+        "game/systems/site_keep_out",
         "game/systems/projectile_kind",
         "game/systems/resource_types",
         "game/systems/resource_json",

--- a/tests/headless/ai_town_plan_test.cpp
+++ b/tests/headless/ai_town_plan_test.cpp
@@ -1,13 +1,18 @@
 #include <QtGlobal>
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
+#include <deque>
 #include <gtest/gtest.h>
 #include <map>
 #include <memory>
+#include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
+#include "game/core/component_gameplay.h"
 #include "game/core/component_structures.h"
 #include "game/core/event_manager.h"
 #include "game/core/world.h"
@@ -48,6 +53,8 @@ struct Standing {
   std::string type;
   float x = 0.0F;
   float z = 0.0F;
+  float rotation_y = 0.0F;
+  float span = 0.0F;
 };
 
 struct TownCensus {
@@ -142,11 +149,31 @@ protected:
     economy.set(k_owner, Game::Systems::ResourceType::Stone, 300);
     economy.set(k_owner, Game::Systems::ResourceType::Iron, 200);
 
+    spawn(
+        session, Game::Units::SpawnType::Barracks, world_of(k_town_grid, k_town_grid));
     spawn(session, commander, world_of(k_town_grid + 2, k_town_grid + 2));
     for (int index = 0; index < k_opening_builders; ++index) {
       spawn(session,
             Game::Units::SpawnType::Builder,
             world_of(k_town_grid + 4, k_town_grid - 4 + index * 2));
+    }
+    if (const auto bearing = enemy_bearing_degrees(); bearing.has_value()) {
+
+      constexpr int k_enemy = 3;
+      constexpr float k_enemy_distance = 54.0F;
+      session.owners().register_owner_with_id(
+          k_enemy, Game::Systems::OwnerType::Player, "rival");
+      session.owners().set_owner_team(k_enemy, 2);
+      session.nations().set_player_nation(k_enemy, nation);
+      economy.ensure_owner(k_enemy);
+      const float radians = *bearing * 3.14159265F / 180.0F;
+      const QVector3D centre = world_of(k_town_grid, k_town_grid);
+      spawn(session,
+            Game::Units::SpawnType::Barracks,
+            QVector3D(centre.x() + std::cos(radians) * k_enemy_distance,
+                      0.0F,
+                      centre.z() + std::sin(radians) * k_enemy_distance),
+            k_enemy);
     }
 
     if (auto* ai = session.world().get_system<Game::Systems::AISystem>()) {
@@ -173,7 +200,7 @@ protected:
       map.world_props.push_back(prop);
     };
     for (int ring = 0; ring < 10; ++ring) {
-      const int offset = 22 + ring * 2;
+      const int offset = 26 + ring * 2;
       for (int lane = -3; lane <= 3; ++lane) {
         const int shift = lane * 3;
         add(Game::Map::WorldProp::Type::OliveTree, grid_x + offset, grid_z + shift);
@@ -186,16 +213,17 @@ protected:
 
   auto spawn(SessionContext& session,
              Game::Units::SpawnType type,
-             QVector3D position) -> EntityID {
+             QVector3D position,
+             int owner = k_owner) -> EntityID {
     Game::Units::SpawnParams params;
     params.position = position;
-    params.player_id = k_owner;
+    params.player_id = owner;
     params.spawn_type = type;
     params.ai_controlled = true;
     params.is_initial_spawn = true;
     params.max_population = 280;
     params.enables_production = true;
-    const auto* nation = session.nations().get_nation_for_player(k_owner);
+    const auto* nation = session.nations().get_nation_for_player(owner);
     params.nation_id =
         nation != nullptr ? nation->id : Game::Systems::NationID::RomanRepublic;
     auto unit = m_factory->create(type, session.world(), params);
@@ -204,6 +232,199 @@ protected:
 
   static auto world_of(int grid_x, int grid_z) -> QVector3D {
     return Game::Systems::NavGrid::grid_to_world(Game::Systems::Point(grid_x, grid_z));
+  }
+
+  static auto enemy_bearing_degrees() -> std::optional<float> {
+    if (!qEnvironmentVariableIsSet("SOI_TOWN_ENEMY_BEARING")) {
+      return std::nullopt;
+    }
+    bool ok = false;
+    const float bearing = qEnvironmentVariable("SOI_TOWN_ENEMY_BEARING").toFloat(&ok);
+    return ok ? std::optional<float>(bearing) : std::nullopt;
+  }
+
+  static void run_minutes(SessionContext& session, double minutes) {
+    const bool timeline = qEnvironmentVariableIsSet("SOI_TOWN_MAP");
+    for (int minute = 1; minute <= static_cast<int>(std::ceil(minutes)); ++minute) {
+      run_for(session, std::min(60.0, minutes * 60.0 - (minute - 1) * 60.0));
+      if (!timeline) {
+        continue;
+      }
+      const auto census = census_of(standing_town(session));
+      auto& economy = session.economy();
+      std::printf("   t=%2dmin walls %3d gates %d towers %d homes %2d farms %d "
+                  "barracks %d | wood %4d stone %3d\n",
+                  minute,
+                  census.walls - census.gates,
+                  census.gates,
+                  census.towers,
+                  census.homes,
+                  census.farms,
+                  census.barracks,
+                  economy.get(k_owner, Game::Systems::ResourceType::Wood),
+                  economy.get(k_owner, Game::Systems::ResourceType::Stone));
+      std::fflush(stdout);
+    }
+  }
+
+  static auto castle_is_selected(const char* name) -> bool {
+    if (!qEnvironmentVariableIsSet("SOI_TOWN_ONLY")) {
+      return true;
+    }
+    return qEnvironmentVariable("SOI_TOWN_ONLY") == QString::fromLatin1(name);
+  }
+
+  struct Enclosure {
+    bool has_ring = false;
+    bool closed = false;
+    int interior_cells = 0;
+    float breach_x = 0.0F;
+    float breach_z = 0.0F;
+  };
+
+  static auto gate_blocks(const Standing& gate, float x, float z) -> bool {
+    constexpr float k_along = Engine::Core::GateComponent::k_structure_half_span;
+    constexpr float k_across = Engine::Core::GateComponent::k_cross_half_extent;
+    const float dx = x - gate.x;
+    const float dz = z - gate.z;
+    return Engine::Core::GateComponent::spans_x_axis(gate.rotation_y)
+               ? std::abs(dx) <= k_along && std::abs(dz) <= k_across
+               : std::abs(dz) <= k_along && std::abs(dx) <= k_across;
+  }
+
+  static auto wall_reach_of(const Game::Systems::AI::TownPlan* plan) -> float {
+    float reach = 0.0F;
+    if (plan == nullptr) {
+      return reach;
+    }
+    for (const auto& step : plan->steps) {
+      if (step.building == "wall_segment" || step.building == "wall_gate") {
+        reach = std::max(reach, std::hypot(step.x, step.z));
+      }
+    }
+    return reach;
+  }
+
+  static auto enclosure_of(const std::vector<Standing>& town,
+                           float anchor_x,
+                           float anchor_z,
+                           const Game::Systems::AI::TownPlan* plan) -> Enclosure {
+    Enclosure result;
+    const float reach = wall_reach_of(plan);
+    if (reach <= 0.0F) {
+      return result;
+    }
+    result.has_ring = true;
+    std::vector<const Standing*> gates;
+    for (const auto& building : town) {
+      if (building.type == "wall_gate") {
+        gates.push_back(&building);
+      }
+    }
+    const auto blocked = [&](const Game::Systems::Point& cell) {
+      if (!Game::Systems::NavGrid::is_grid_walkable(cell)) {
+        return true;
+      }
+      const QVector3D at = Game::Systems::NavGrid::grid_to_world(cell);
+      return std::any_of(gates.begin(), gates.end(), [&](const Standing* gate) {
+        return gate_blocks(*gate, at.x(), at.z());
+      });
+    };
+    constexpr float k_escape_margin = 5.0F;
+    const float escape = reach + k_escape_margin;
+    const auto anchor = Game::Systems::NavGrid::world_to_grid(anchor_x, anchor_z);
+    auto start = anchor;
+    bool found = false;
+    constexpr int k_anchor_search = 8;
+    for (int radius = 0; radius <= k_anchor_search && !found; ++radius) {
+      for (int dx = -radius; dx <= radius && !found; ++dx) {
+        for (int dz = -radius; dz <= radius && !found; ++dz) {
+          if (std::max(std::abs(dx), std::abs(dz)) != radius) {
+            continue;
+          }
+          const Game::Systems::Point cell{anchor.x + dx, anchor.y + dz};
+          if (cell.x >= 0 && cell.y >= 0 && cell.x < k_map_size &&
+              cell.y < k_map_size && !blocked(cell)) {
+            start = cell;
+            found = true;
+          }
+        }
+      }
+    }
+    if (!found) {
+      return result;
+    }
+    std::set<std::pair<int, int>> seen{{start.x, start.y}};
+    std::deque<Game::Systems::Point> frontier{start};
+    result.closed = true;
+    while (!frontier.empty()) {
+      const auto cell = frontier.front();
+      frontier.pop_front();
+      const QVector3D at = Game::Systems::NavGrid::grid_to_world(cell);
+      if (std::hypot(at.x() - anchor_x, at.z() - anchor_z) > escape) {
+        result.closed = false;
+        result.breach_x = at.x();
+        result.breach_z = at.z();
+        break;
+      }
+      ++result.interior_cells;
+      for (const auto [dx, dz] :
+           {std::pair{1, 0}, std::pair{-1, 0}, std::pair{0, 1}, std::pair{0, -1}}) {
+        const Game::Systems::Point next{cell.x + dx, cell.y + dz};
+        if (next.x < 0 || next.y < 0 || next.x >= k_map_size || next.y >= k_map_size) {
+          continue;
+        }
+        if (!seen.insert({next.x, next.y}).second || blocked(next)) {
+          continue;
+        }
+        frontier.push_back(next);
+      }
+    }
+    return result;
+  }
+
+  static void
+  draw_nav_map(const std::vector<Standing>& town, float anchor_x, float anchor_z) {
+    if (!qEnvironmentVariableIsSet("SOI_TOWN_MAP")) {
+      return;
+    }
+    constexpr int k_half = 34;
+    const auto origin = Game::Systems::NavGrid::world_to_grid(anchor_x, anchor_z);
+    std::printf("   nav map, 1 m per cell, %d m each way of the anchor; # blocked "
+                ". open\n",
+                k_half);
+    for (int dz = -k_half; dz <= k_half; ++dz) {
+      std::string row;
+      for (int dx = -k_half; dx <= k_half; ++dx) {
+        const Game::Systems::Point cell{origin.x + dx, origin.y + dz};
+        char glyph = ' ';
+        if (cell.x >= 0 && cell.y >= 0 && cell.x < k_map_size && cell.y < k_map_size) {
+          glyph = Game::Systems::NavGrid::is_grid_walkable(cell) ? '.' : '#';
+        }
+        const QVector3D at = Game::Systems::NavGrid::grid_to_world(cell);
+        for (const auto& building : town) {
+          if (std::abs(building.x - at.x()) > 0.5F ||
+              std::abs(building.z - at.z()) > 0.5F) {
+            continue;
+          }
+          if (building.type == "wall_gate") {
+            glyph = 'G';
+          } else if (building.type == "defense_tower") {
+            glyph = 'T';
+          } else if (building.type == "barracks") {
+            glyph = 'B';
+          } else if (building.type == "home") {
+            glyph = 'h';
+          } else if (building.type == "farm") {
+            glyph = 'f';
+          } else if (building.type == "marketplace") {
+            glyph = 'M';
+          }
+        }
+        row.push_back(glyph);
+      }
+      std::printf("   |%s|\n", row.c_str());
+    }
   }
 
   static void run_for(SessionContext& session, double seconds) {
@@ -230,7 +451,8 @@ protected:
       }
       town.push_back(Standing{.type = Game::Units::spawn_typeToString(unit.spawn_type),
                               .x = transform->position.x,
-                              .z = transform->position.z});
+                              .z = transform->position.z,
+                              .rotation_y = transform->rotation.y});
     }
     return town;
   }
@@ -357,6 +579,8 @@ protected:
   struct Settlement {
     TownCensus census;
     ArmyCensus army;
+    Enclosure enclosure;
+    int wall_runs = 0;
 
     float fortification_coverage = 0.0F;
     Game::Systems::AI::AIContext::StationReport stations;
@@ -380,6 +604,86 @@ protected:
           .type = "soldier", .x = transform->position.x, .z = transform->position.z});
     }
     return soldiers;
+  }
+
+  static auto wall_runs(const std::vector<Standing>& town) -> int {
+    std::vector<Standing> line;
+    for (const auto& building : town) {
+      if (building.type == "wall_segment" || building.type == "wall_gate") {
+        line.push_back(building);
+      }
+    }
+
+    constexpr float k_in_the_line = 3.0F;
+    for (const auto& prop : Game::Map::TerrainService::instance().world_props()) {
+      if (!Game::Map::is_solid_world_prop_type(prop.type)) {
+        continue;
+      }
+      const QVector3D at =
+          Game::Map::TerrainService::instance().world_prop_world_position(prop);
+      const bool in_the_line =
+          std::any_of(line.begin(), line.end(), [&](const Standing& piece) {
+            return piece.type != "prop" &&
+                   std::hypot(piece.x - at.x(), piece.z - at.z()) <= k_in_the_line;
+          });
+      if (in_the_line) {
+        line.push_back(Standing{
+            .type = "prop",
+            .x = at.x(),
+            .z = at.z(),
+            .span = Game::Map::world_prop_ground_radius(prop.type, prop.scale)});
+      }
+    }
+    std::vector<const Standing*> pieces;
+    pieces.reserve(line.size());
+    for (const auto& piece : line) {
+      pieces.push_back(&piece);
+    }
+    std::vector<int> parent(pieces.size());
+    for (std::size_t i = 0; i < parent.size(); ++i) {
+      parent[i] = static_cast<int>(i);
+    }
+    const auto find = [&](int i) {
+      while (parent[static_cast<std::size_t>(i)] != i) {
+        i = parent[static_cast<std::size_t>(i)];
+      }
+      return i;
+    };
+    const auto half_span = [](const Standing& piece) {
+      if (piece.type == "wall_gate") {
+        return Engine::Core::GateComponent::k_structure_half_span;
+      }
+      return piece.type == "prop" ? piece.span : 1.0F;
+    };
+    constexpr float k_touch_slack = 0.4F;
+    for (std::size_t i = 0; i < pieces.size(); ++i) {
+      for (std::size_t j = i + 1; j < pieces.size(); ++j) {
+        const float reach =
+            half_span(*pieces[i]) + half_span(*pieces[j]) + k_touch_slack;
+        if (std::hypot(pieces[i]->x - pieces[j]->x, pieces[i]->z - pieces[j]->z) <=
+            reach) {
+          parent[static_cast<std::size_t>(find(static_cast<int>(i)))] =
+              find(static_cast<int>(j));
+        }
+      }
+    }
+    std::map<int, std::vector<const Standing*>> members;
+    for (std::size_t i = 0; i < pieces.size(); ++i) {
+      members[find(static_cast<int>(i))].push_back(pieces[i]);
+    }
+    if (qEnvironmentVariableIsSet("SOI_TOWN_MAP")) {
+      for (const auto& [root, run] : members) {
+        std::printf("   run of %zu: first %s at %.1f,%.1f last %s at %.1f,%.1f\n",
+                    run.size(),
+                    run.front()->type.c_str(),
+                    static_cast<double>(run.front()->x),
+                    static_cast<double>(run.front()->z),
+                    run.back()->type.c_str(),
+                    static_cast<double>(run.back()->x),
+                    static_cast<double>(run.back()->z));
+      }
+    }
+    return static_cast<int>(members.size());
   }
 
   static auto fortification_coverage(const std::vector<Standing>& town) -> float {
@@ -423,15 +727,41 @@ protected:
                   Game::Systems::NationID nation,
                   double minutes) -> Settlement {
     auto& session = settle(commander, nation);
-    run_for(session, minutes * 60.0);
+    run_minutes(session, minutes);
     const auto town = standing_town(session);
     const auto census = census_of(town);
     const auto army = army_of(session);
     Settlement settlement{.census = census, .army = army};
     settlement.fortification_coverage = fortification_coverage(town);
+    settlement.wall_runs = wall_runs(town);
     if (auto* ai = session.world().get_system<Game::Systems::AISystem>()) {
       if (const auto* plan = ai->plan_for(k_owner); plan != nullptr) {
         settlement.stations = plan->station_report;
+        const auto* town_plan = plan->strategy_config.doctrine != nullptr
+                                    ? plan->strategy_config.doctrine->town_plan
+                                    : nullptr;
+        settlement.enclosure =
+            enclosure_of(town, plan->base_pos_x, plan->base_pos_z, town_plan);
+        if (qEnvironmentVariableIsSet("SOI_TOWN_MAP")) {
+          std::printf("   wall runs: %d\n", settlement.wall_runs);
+          std::printf(
+              "   enclosure: %s (%d interior cells%s) facing %.2f,%.2f%s\n",
+              !settlement.enclosure.has_ring ? "no ring planned"
+              : settlement.enclosure.closed  ? "CLOSED"
+                                             : "OPEN",
+              settlement.enclosure.interior_cells,
+              settlement.enclosure.closed
+                  ? ""
+                  : (" breach near " +
+                     std::to_string(static_cast<int>(settlement.enclosure.breach_x)) +
+                     "," +
+                     std::to_string(static_cast<int>(settlement.enclosure.breach_z)))
+                        .c_str(),
+              static_cast<double>(plan->settlement_facing_x),
+              static_cast<double>(plan->settlement_facing_z),
+              plan->settlement_facing_locked ? " (locked)" : "");
+          draw_nav_map(town, plan->base_pos_x, plan->base_pos_z);
+        }
       }
     }
     if (qEnvironmentVariableIsSet("SOI_TOWN_MAP")) {
@@ -487,6 +817,7 @@ protected:
                   barracks_manpower(session));
     }
     draw_town(name, town, census, army, soldiers_of(session));
+    std::fflush(stdout);
     return settlement;
   }
 
@@ -555,13 +886,13 @@ TEST_F(AiTownPlanTest, EveryCommanderRaisesItsOwnTownFromAnEmptyField) {
   for (const char* castle : {"fabius", "scipio", "hanno", "hannibal"}) {
     const auto& census = towns.at(castle).census;
     const int fortifications = census.walls + census.towers;
-    const float sectors = towns.at(castle).fortification_coverage * 24.0F;
     EXPECT_GE(fortifications, 8) << castle << " raised almost no fortification";
-    EXPECT_GE(sectors + 0.01F, 0.5F * static_cast<float>(std::min(fortifications, 24)))
-        << castle << " spread " << fortifications << " walls and towers over only "
-        << sectors
-        << " of 24 compass sectors; a part-built ring or castrum must "
-           "still draw its outline";
+
+    EXPECT_LE(towns.at(castle).wall_runs, std::max(3, census.walls / 8))
+        << castle << " stands as " << towns.at(castle).wall_runs << " separate runs of "
+        << census.walls
+        << " wall pieces; a half-built ring is one wall growing out from its "
+           "gate, not posts with gaps between them";
   }
 
   for (const auto& [name, settlement] : towns) {
@@ -609,23 +940,28 @@ TEST_F(AiTownPlanTest, AWalledCommanderClosesItsCircuitGivenTime) {
        "roman_assault_camp"},
   };
   for (const auto& castle : castles) {
+    if (!castle_is_selected(castle.name)) {
+      continue;
+    }
     const auto* plan = Game::Systems::AI::authored_town_plan(castle.plan);
     ASSERT_NE(plan, nullptr) << castle.plan;
     const int planned = plan->step_count("wall_segment");
     const auto settlement =
         raise_town(castle.name, castle.commander, castle.nation, 50.0);
-    EXPECT_GE(settlement.census.walls * 100, planned * 15)
+    EXPECT_GE(settlement.census.walls * 100, planned * 50)
         << castle.name << " raised " << settlement.census.walls << " of the " << planned
         << " wall links in its blueprint after fifty minutes; a castle "
            "the economy cannot afford is a wish, not a plan";
-    EXPECT_GE(settlement.census.towers, 3)
+    EXPECT_GE(settlement.census.towers, 2)
         << castle.name << " has no towers to speak of";
     EXPECT_GE(settlement.census.gates, 1)
         << castle.name << " closed its ring without a gate to march out of";
-    EXPECT_GE(settlement.fortification_coverage, 0.60F)
-        << castle.name << " fortified only "
-        << settlement.fortification_coverage * 100.0F
-        << "% of the compass after fifty minutes; its outline should be closed by now";
+    EXPECT_TRUE(settlement.enclosure.has_ring && settlement.enclosure.closed)
+        << castle.name << " has not closed its ring after fifty minutes: ground "
+        << "inside the walls still connects to the field without passing a gate, "
+        << "near " << settlement.enclosure.breach_x << ","
+        << settlement.enclosure.breach_z
+        << "; a ring with a hole in it is a fence, not a castle";
     TearDown();
     SetUp();
   }

--- a/tests/systems/ai_doctrine_catalog_test.cpp
+++ b/tests/systems/ai_doctrine_catalog_test.cpp
@@ -301,13 +301,94 @@ TEST_F(AIDoctrineCatalogTest, ASilhouetteAlreadyDrawsTheOutline) {
       continue;
     }
     const auto silhouette = fortification_offsets(*plan, plan->silhouette_steps);
-    EXPECT_GE(TownPlan::compass_coverage(silhouette), 0.70F)
-        << plan->id << "'s silhouette leaves most of the compass open";
+    EXPECT_GE(TownPlan::compass_coverage(silhouette), 0.25F)
+        << plan->id << "'s silhouette shows almost nothing of its front";
+    for (const auto& offset : silhouette) {
+      EXPECT_LE(offset.z, 0.0F)
+          << plan->id << " puts a rear fortification at " << offset.x << "," << offset.z
+          << " in its silhouette; the front goes up first";
+    }
     const auto* gate = plan->front_gate();
     ASSERT_NE(gate, nullptr) << plan->id;
     const auto gate_slot = static_cast<int>(gate - plan->steps.data());
     EXPECT_TRUE(plan->is_silhouette_step(gate_slot))
         << plan->id << " leaves its front gate for later";
+  }
+}
+
+namespace {
+
+using WallCell = std::pair<int, int>;
+
+auto wall_cells_of(const TownPlan& plan, int first_steps) -> std::vector<WallCell> {
+  std::vector<WallCell> cells;
+  const int limit = std::min(first_steps, static_cast<int>(plan.steps.size()));
+  for (int slot = 0; slot < limit; ++slot) {
+    const auto& step = plan.steps[static_cast<std::size_t>(slot)];
+    const int x = static_cast<int>(std::lround(step.x));
+    const int z = static_cast<int>(std::lround(step.z));
+    if (step.building == "wall_segment") {
+      cells.emplace_back(x, z);
+    } else if (step.building == "wall_gate") {
+
+      const bool along_x = std::fmod(std::abs(step.rotation), 180.0F) < 45.0F;
+      for (int span = -2; span <= 2; span += 2) {
+        cells.emplace_back(along_x ? x + span : x, along_x ? z : z + span);
+      }
+    }
+  }
+  return cells;
+}
+
+auto connected_runs(const std::vector<WallCell>& cells) -> int {
+  const std::set<WallCell> standing(cells.begin(), cells.end());
+  std::set<WallCell> seen;
+  int runs = 0;
+  for (const auto& cell : standing) {
+    if (seen.contains(cell)) {
+      continue;
+    }
+    ++runs;
+    std::vector<WallCell> frontier{cell};
+    seen.insert(cell);
+    while (!frontier.empty()) {
+      const auto [x, z] = frontier.back();
+      frontier.pop_back();
+      for (int dx = -2; dx <= 2; dx += 2) {
+        for (int dz = -2; dz <= 2; dz += 2) {
+          const WallCell next{x + dx, z + dz};
+          if (standing.contains(next) && seen.insert(next).second) {
+            frontier.push_back(next);
+          }
+        }
+      }
+    }
+  }
+  return runs;
+}
+
+} // namespace
+
+TEST_F(AIDoctrineCatalogTest, AWallGoesUpAsOneGrowingRunNotAsPosts) {
+  reset_ai_doctrine_catalog();
+  ASSERT_TRUE(load_default_ai_doctrine_catalog());
+
+  for (const auto& definition : Game::Units::all_commander_definitions()) {
+    const auto* plan = authored_doctrine(definition.id)->town_plan;
+    ASSERT_NE(plan, nullptr);
+    const int circuits = plan->id == "roman_bulwark" ? 2 : 1;
+    int worst = 0;
+    for (int built = 1; built <= static_cast<int>(plan->steps.size()); ++built) {
+      const auto cells = wall_cells_of(*plan, built);
+      if (cells.empty()) {
+        continue;
+      }
+      worst = std::max(worst, connected_runs(cells));
+    }
+    EXPECT_LE(worst, circuits)
+        << plan->id << " has a moment where its wall stands as " << worst
+        << " separate runs; a half-built ring must be one wall with two ends, "
+           "not posts with gaps between them";
   }
 }
 

--- a/tests/tools/arena_scenarios_test.cpp
+++ b/tests/tools/arena_scenarios_test.cpp
@@ -1043,6 +1043,57 @@ TEST(ArenaScenariosTest, TheKingdomEstateKeepsItsWorkOutsideTheTown) {
   }
 }
 
+TEST(ArenaScenariosTest, TheKingdomEstateRoadsRunFromEdgeToEdge) {
+  const auto* scene = Arena::Scenarios::find_definition(
+      QString::fromLatin1(Arena::Scenarios::k_ai_kingdom_rise_id));
+  ASSERT_NE(scene, nullptr);
+  ASSERT_FALSE(scene->roads.empty());
+
+  const float map_reach = static_cast<float>(scene->terrain_grid_extent) * 0.5F;
+  constexpr float k_join = 0.01F;
+
+  const auto shares_endpoint = [&](const QVector3D& point) {
+    int touches = 0;
+    for (const auto& road : scene->roads) {
+      touches += static_cast<int>((road.start - point).length() <= k_join);
+      touches += static_cast<int>((road.end - point).length() <= k_join);
+    }
+    return touches > 1;
+  };
+  const auto lands_on_a_bridge = [&](const QVector3D& point) {
+    return std::any_of(scene->bridges.begin(),
+                       scene->bridges.end(),
+                       [&](const Game::Map::Bridge& bridge) {
+                         return (bridge.start - point).length() <= k_join ||
+                                (bridge.end - point).length() <= k_join;
+                       });
+  };
+  const auto leaves_the_map = [&](const QVector3D& point) {
+    return std::abs(point.x()) >= map_reach || std::abs(point.z()) >= map_reach;
+  };
+
+  for (const auto& road : scene->roads) {
+    for (const QVector3D& end : {road.start, road.end}) {
+      EXPECT_TRUE(shares_endpoint(end) || lands_on_a_bridge(end) || leaves_the_map(end))
+          << "a road ends at " << end.x() << ", " << end.z()
+          << ", which is neither a junction, a bridge, nor off the map";
+    }
+  }
+
+  for (const auto& bridge : scene->bridges) {
+    for (const QVector3D& landing : {bridge.start, bridge.end}) {
+      EXPECT_TRUE(std::any_of(scene->roads.begin(),
+                              scene->roads.end(),
+                              [&](const Game::Map::RoadSegment& road) {
+                                return (road.start - landing).length() <= k_join ||
+                                       (road.end - landing).length() <= k_join;
+                              }))
+          << "the bridge landing at " << landing.x() << ", " << landing.z()
+          << " has no road on it";
+    }
+  }
+}
+
 TEST(ArenaScenariosTest, ListsEverySettlementAndEconomyScenario) {
   for (auto const* settlement_id : {Arena::Scenarios::k_village_harvest_cycle_id,
                                     Arena::Scenarios::k_village_day_life_id,

--- a/tools/arena/README.md
+++ b/tools/arena/README.md
@@ -203,6 +203,55 @@ both default to on. Three things about that:
   does not want damage pills over a duel. A shot that wants the world alone
   says `"gameplay_ui": false`.
 
+**A reel is mixed as the game ships, not as this machine is configured.** The
+first half hour of `kingdom_rise` went out at a mean of -54 dB, effectively
+silent, and the cause was not the wiring: `AudioSystem` loads the persisted
+volume sliders in its constructor, and the box it was rendered on had
+`master_volume=0.18` from a playtest. `AudioRecorder::start` now calls
+`AudioSystem::apply_offline_reference_mix()`, which puts the five volumes back
+to the shipped first-run values in memory and _does not_ write them back --
+the `set_*_volume` setters all persist, so a recorder must never use them.
+
+**And then it is lifted once, per pass.** At the reference mix the game sits
+near -25 to -30 LUFS, which is correct for a game and far too quiet for a video
+file. `Spec::reel_loudness_lufs` (default -16, `0` to leave the recording
+alone) makes `PromoRunner` hold every clip of a pass until the pass ends,
+measure the clips played back to back with `ebur128`, and mux them all with the
+same gain and a -1.5 dBFS limiter. Measuring per clip would be more accurate
+and would be wrong: twelve contiguous clips that each hit -16 exactly have a
+level step at every join, and this reel concatenates.
+
+Two things about the measuring pass, both learned the expensive way. **ffmpeg's
+concat demuxer resolves a relative entry against the list file's own directory,
+not the working directory**, so with `--promo-out artifacts/kingdom-rise` --
+relative, the way the README itself spells it -- every path in the list pointed
+at nothing and the pass exited 254. It passed in testing only because that run
+used an absolute `--promo-out`. The list now holds absolute paths. And a
+measuring pass that fails now **fails the run**: it used to warn and mux at the
+game's own level, which is how a whole half hour came out 10 dB under a second
+time without anything looking wrong until the file was measured.
+
+**`alimiter` auto-levels by default, and that makes `limit` look inert.** Its
+`level` option is on unless you say `level=disabled`, and it normalises the
+output back up to 0 dB -- so the ceiling was doing nothing, the delivered master
+peaked at +0.6 dBFS, and dropping the cap from -1.5 to -3 dBFS changed the peak
+by 0.2 dB. With `level=disabled` a -2 dBFS cap delivers about -1.2 after the
+AAC encode overshoots it by ~0.8 dB. `PromoRunner` now measures the _delivered_
+clip -- the only thing worth measuring, since the limiter runs before the
+encoder -- and fails the run above -1 dBFS. Expect a clip's own integrated
+loudness to vary a few LU across a long reel once the auto-level is off; that
+spread is the content, and the pass as a whole is what lands on -16.
+
+**Music comes from the ambient state, so a scenario with no enemy needs to say
+so.** The recorder used to open every pass in `TENSE` and toggle
+`TENSE <-> COMBAT`, so a half-hour of a town being built was scored out of the
+tense set. `AudioRecorder::resting_state` now answers `PEACEFUL` when the world
+holds no two hostile owners, which is the whole of `ai_kingdom_rise`. The base
+tracks are 60 s loops, so the recorder also calls
+`AudioEventHandler::rotate_ambient_music` every two minutes; without it a
+thirty minute reel repeats one minute of music thirty times. An explicit
+`music_track` bed switches the rotation off -- that spec owns the score.
+
 **Author a road as a network, not as tracks.** Two rules, and both fail
 silently if you break them: every segment must share an endpoint with its
 neighbour _exactly_ (a one metre gap draws as a break in the middle of the
@@ -212,6 +261,18 @@ scatter prop within its half width plus the prop's radius plus 0.25 m, without
 a word -- the first routing of `ai_kingdom_rise`'s network would have quietly
 eaten three pines, four plants and a palm. Check a layout arithmetically before
 rendering it; the numbers are cheaper than a capture.
+
+The first shipped routing broke the second rule twice, and neither showed up
+in a shot at battle zoom -- it takes a top-down pass over the whole map to see
+a road network. The town approach left the northern trunk at the bridge and
+stopped dead in open grass at `(-4, -20)`, and the bridge itself had no road on
+its northern bank, so it crossed the river to nothing. The lane through the
+estate now runs the length of the map: off the northern edge at `(-8, -96)`,
+over the bridge, past the seat on its western side, and into the southern trunk
+at `(-4, 53.4)` -- which is why that trunk is split there rather than running
+`(-30, 52)` straight to `(24, 55)`. `ArenaScenariosTest.TheKingdomEstateRoadsRunFromEdgeToEdge`
+holds both rules: every free end is off the map, at a junction or on a bridge,
+and every bridge landing has a road on it.
 
 **Do not put `UnitsClearOfBuildings` on a builder group here.** A build crew's
 `construction_site` is the future building's own centre -- the gang encircles

--- a/tools/arena/arena_audio_recorder.cpp
+++ b/tools/arena/arena_audio_recorder.cpp
@@ -6,6 +6,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QProcess>
+#include <QRegularExpression>
 #include <QStandardPaths>
 #include <QStringList>
 
@@ -29,6 +30,12 @@ constexpr float k_ambient_check_seconds = 2.0F;
 constexpr float k_combat_radius = 15.0F;
 constexpr int k_wav_channels = 2;
 
+constexpr float k_score_rotation_seconds = 120.0F;
+
+constexpr float k_reel_true_peak_ceiling = 0.794F;
+
+constexpr float k_reel_delivered_peak_dbfs = -1.0F;
+
 } // namespace
 
 AudioRecorder::AudioRecorder() = default;
@@ -48,6 +55,8 @@ auto AudioRecorder::start(Engine::Core::World* world,
     qWarning() << "AudioRecorder: the audio system refused to start offline";
     return false;
   }
+
+  audio.apply_offline_reference_mix();
   m_world = world;
   m_handler = std::make_unique<Game::Audio::AudioEventHandler>(world);
   if (!m_handler->initialize()) {
@@ -63,10 +72,11 @@ auto AudioRecorder::start(Engine::Core::World* world,
   m_coordinator->configure_audio_manifest_mappings(0);
   m_coordinator->apply_mission_ambience(nullptr, QString{}, 0);
 
-  m_ambient_state = Engine::Core::AmbientState::TENSE;
+  m_ambient_state = resting_state();
   Engine::Core::EventManager::instance().publish(Engine::Core::AmbientStateChangedEvent(
       m_ambient_state, Engine::Core::AmbientState::PEACEFUL));
   m_ambient_timer = 0.0F;
+  m_score_timer = 0.0F;
   m_sample_carry = 0.0;
   m_running = true;
   qInfo() << "AudioRecorder: game audio running offline at" << k_sample_rate << "Hz";
@@ -77,6 +87,7 @@ void AudioRecorder::play_music_bed(const QString& track_id, float volume) {
   if (!m_running || track_id.isEmpty() || volume <= 0.0F) {
     return;
   }
+  m_scored_bed = true;
   AudioResourceLoader::ensure_audio_resource_loaded(track_id);
 
   AudioSystem::get_instance().play_sound(
@@ -101,6 +112,7 @@ void AudioRecorder::advance(float seconds, bool record) {
     return;
   }
   update_ambient_state(seconds);
+  rotate_score(seconds);
 
   m_sample_carry += static_cast<double>(seconds) * k_sample_rate;
   const auto frames = static_cast<unsigned>(std::floor(m_sample_carry));
@@ -170,10 +182,153 @@ void AudioRecorder::stop() {
   AudioSystem::get_instance().shutdown();
   m_world = nullptr;
   m_running = false;
+  m_scored_bed = false;
+}
+
+auto AudioRecorder::measure_loudness(const QStringList& wav_paths,
+                                     QString* error) -> std::optional<float> {
+  if (wav_paths.isEmpty()) {
+    return std::nullopt;
+  }
+  const QString ffmpeg = QStandardPaths::findExecutable(QStringLiteral("ffmpeg"));
+  if (ffmpeg.isEmpty()) {
+    if (error != nullptr) {
+      *error = QStringLiteral("ffmpeg was not found on PATH");
+    }
+    return std::nullopt;
+  }
+
+  const QString list_path = wav_paths.front() + QStringLiteral(".concat.txt");
+  QFile list(list_path);
+  if (!list.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    if (error != nullptr) {
+      *error = QStringLiteral("cannot write %1").arg(list_path);
+    }
+    return std::nullopt;
+  }
+  for (const QString& wav_path : wav_paths) {
+
+    const QString absolute = QFileInfo(wav_path).absoluteFilePath();
+    const QString quoted =
+        QString(absolute).replace(QLatin1Char('\''), QStringLiteral("'\\''"));
+    list.write(QStringLiteral("file '%1'\n").arg(quoted).toUtf8());
+  }
+  list.close();
+
+  QProcess probe;
+  probe.start(ffmpeg,
+              {QStringLiteral("-hide_banner"),
+               QStringLiteral("-nostats"),
+               QStringLiteral("-f"),
+               QStringLiteral("concat"),
+               QStringLiteral("-safe"),
+               QStringLiteral("0"),
+               QStringLiteral("-i"),
+               list_path,
+               QStringLiteral("-map"),
+               QStringLiteral("0:a:0"),
+               QStringLiteral("-af"),
+               QStringLiteral("ebur128=framelog=quiet"),
+               QStringLiteral("-f"),
+               QStringLiteral("null"),
+               QStringLiteral("-")});
+  probe.waitForFinished(-1);
+  const QString report = QString::fromUtf8(probe.readAllStandardError());
+  QFile::remove(list_path);
+
+  if (probe.exitStatus() != QProcess::NormalExit || probe.exitCode() != 0) {
+    if (error != nullptr) {
+      const QString tail = report.trimmed().section(QLatin1Char('\n'), -3);
+      *error = QStringLiteral("ffmpeg loudness pass exited with status %1: %2")
+                   .arg(QString::number(probe.exitCode()), tail);
+    }
+    return std::nullopt;
+  }
+
+  const int summary_at = report.lastIndexOf(QStringLiteral("Summary:"));
+  static const QRegularExpression integrated(
+      QStringLiteral("\\bI:\\s*(-?\\d+(?:\\.\\d+)?)\\s*LUFS"));
+  const QRegularExpressionMatch match =
+      integrated.match(report, summary_at < 0 ? 0 : summary_at);
+  if (!match.hasMatch()) {
+    if (error != nullptr) {
+      *error = QStringLiteral("ffmpeg reported no integrated loudness");
+    }
+    return std::nullopt;
+  }
+  bool ok = false;
+  const float lufs = match.captured(1).toFloat(&ok);
+  if (!ok || !std::isfinite(lufs)) {
+    if (error != nullptr) {
+      *error =
+          QStringLiteral("unreadable integrated loudness '%1'").arg(match.captured(1));
+    }
+    return std::nullopt;
+  }
+  return lufs;
+}
+
+auto AudioRecorder::measure_true_peak(const QString& media_path,
+                                      QString* error) -> std::optional<float> {
+  const QString ffmpeg = QStandardPaths::findExecutable(QStringLiteral("ffmpeg"));
+  if (ffmpeg.isEmpty()) {
+    if (error != nullptr) {
+      *error = QStringLiteral("ffmpeg was not found on PATH");
+    }
+    return std::nullopt;
+  }
+
+  QProcess probe;
+  probe.start(ffmpeg,
+              {QStringLiteral("-hide_banner"),
+               QStringLiteral("-nostats"),
+               QStringLiteral("-i"),
+               media_path,
+               QStringLiteral("-map"),
+               QStringLiteral("0:a:0"),
+               QStringLiteral("-af"),
+               QStringLiteral("ebur128=peak=true:framelog=quiet"),
+               QStringLiteral("-f"),
+               QStringLiteral("null"),
+               QStringLiteral("-")});
+  probe.waitForFinished(-1);
+  const QString report = QString::fromUtf8(probe.readAllStandardError());
+  if (probe.exitStatus() != QProcess::NormalExit || probe.exitCode() != 0) {
+    if (error != nullptr) {
+      *error = QStringLiteral("ffmpeg peak pass exited with status %1")
+                   .arg(probe.exitCode());
+    }
+    return std::nullopt;
+  }
+
+  const int peak_at = report.lastIndexOf(QStringLiteral("True peak:"));
+  static const QRegularExpression peak(
+      QStringLiteral("\\bPeak:\\s*(-?\\d+(?:\\.\\d+)?)\\s*dBFS"));
+  const QRegularExpressionMatch match = peak.match(report, peak_at < 0 ? 0 : peak_at);
+  if (!match.hasMatch()) {
+    if (error != nullptr) {
+      *error = QStringLiteral("ffmpeg reported no true peak");
+    }
+    return std::nullopt;
+  }
+  bool ok = false;
+  const float dbfs = match.captured(1).toFloat(&ok);
+  if (!ok || !std::isfinite(dbfs)) {
+    if (error != nullptr) {
+      *error = QStringLiteral("unreadable true peak '%1'").arg(match.captured(1));
+    }
+    return std::nullopt;
+  }
+  return dbfs;
+}
+
+auto AudioRecorder::delivered_peak_ceiling_dbfs() -> float {
+  return k_reel_delivered_peak_dbfs;
 }
 
 auto AudioRecorder::mux(const QString& clip_path,
                         const QString& wav_path,
+                        float gain_db,
                         QString* error) -> bool {
   const QString ffmpeg = QStandardPaths::findExecutable(QStringLiteral("ffmpeg"));
   if (ffmpeg.isEmpty()) {
@@ -183,18 +338,29 @@ auto AudioRecorder::mux(const QString& clip_path,
     return false;
   }
   const QString muxed = clip_path + QStringLiteral(".muxed.mp4");
-  const QStringList arguments{
-      QStringLiteral("-hide_banner"), QStringLiteral("-loglevel"),
-      QStringLiteral("error"),        QStringLiteral("-y"),
-      QStringLiteral("-i"),           clip_path,
-      QStringLiteral("-i"),           wav_path,
-      QStringLiteral("-map"),         QStringLiteral("0:v:0"),
-      QStringLiteral("-map"),         QStringLiteral("1:a:0"),
-      QStringLiteral("-c:v"),         QStringLiteral("copy"),
-      QStringLiteral("-c:a"),         QStringLiteral("aac"),
-      QStringLiteral("-b:a"),         QStringLiteral("256k"),
-      QStringLiteral("-shortest"),    QStringLiteral("-movflags"),
-      QStringLiteral("+faststart"),   muxed};
+  QStringList arguments{QStringLiteral("-hide_banner"),
+                        QStringLiteral("-loglevel"),
+                        QStringLiteral("error"),
+                        QStringLiteral("-y"),
+                        QStringLiteral("-i"),
+                        clip_path,
+                        QStringLiteral("-i"),
+                        wav_path,
+                        QStringLiteral("-map"),
+                        QStringLiteral("0:v:0"),
+                        QStringLiteral("-map"),
+                        QStringLiteral("1:a:0"),
+                        QStringLiteral("-c:v"),
+                        QStringLiteral("copy")};
+  if (gain_db > 0.0F) {
+    arguments << QStringLiteral("-filter:a")
+              << QStringLiteral("volume=%1dB,alimiter=limit=%2:level=disabled")
+                     .arg(QString::number(gain_db, 'f', 2),
+                          QString::number(k_reel_true_peak_ceiling, 'f', 3));
+  }
+  arguments << QStringLiteral("-c:a") << QStringLiteral("aac") << QStringLiteral("-b:a")
+            << QStringLiteral("256k") << QStringLiteral("-shortest")
+            << QStringLiteral("-movflags") << QStringLiteral("+faststart") << muxed;
   const int status = QProcess::execute(ffmpeg, arguments);
   if (status != 0) {
     if (error != nullptr) {
@@ -220,18 +386,56 @@ void AudioRecorder::update_ambient_state(float seconds) {
     return;
   }
   m_ambient_timer = 0.0F;
-  const auto next = any_side_in_combat() ? Engine::Core::AmbientState::COMBAT
-                                         : Engine::Core::AmbientState::TENSE;
+  const auto next =
+      any_side_in_combat() ? Engine::Core::AmbientState::COMBAT : resting_state();
   if (next == m_ambient_state) {
     return;
   }
   const auto previous = m_ambient_state;
   m_ambient_state = next;
+  m_score_timer = 0.0F;
   qInfo().noquote() << QStringLiteral("AudioRecorder: ambient state %1 -> %2")
                            .arg(static_cast<int>(previous))
                            .arg(static_cast<int>(next));
   Engine::Core::EventManager::instance().publish(
       Engine::Core::AmbientStateChangedEvent(next, previous));
+}
+
+void AudioRecorder::rotate_score(float seconds) {
+  if (m_scored_bed || m_handler == nullptr) {
+    return;
+  }
+  m_score_timer += seconds;
+  if (m_score_timer < k_score_rotation_seconds) {
+    return;
+  }
+  m_score_timer = 0.0F;
+  if (m_handler->rotate_ambient_music(m_ambient_state)) {
+    qInfo().noquote() << QStringLiteral("AudioRecorder: score rotated");
+  }
+}
+
+auto AudioRecorder::resting_state() const -> Engine::Core::AmbientState {
+  return has_opposing_forces() ? Engine::Core::AmbientState::TENSE
+                               : Engine::Core::AmbientState::PEACEFUL;
+}
+
+auto AudioRecorder::has_opposing_forces() const -> bool {
+  if (m_world == nullptr) {
+    return false;
+  }
+  int first_owner = 0;
+  for (auto [entity_id, unit] : m_world->view<const Engine::Core::UnitComponent>()) {
+    if (unit.health <= 0 || unit.owner_id <= 0) {
+      continue;
+    }
+    if (first_owner == 0) {
+      first_owner = unit.owner_id;
+    } else if (unit.owner_id != first_owner) {
+      return true;
+    }
+  }
+  return false;
 }
 
 auto AudioRecorder::any_side_in_combat() const -> bool {

--- a/tools/arena/arena_audio_recorder.h
+++ b/tools/arena/arena_audio_recorder.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <QString>
+#include <QStringList>
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "game/core/event_manager.h"
@@ -46,18 +48,32 @@ public:
 
   void stop();
 
-  [[nodiscard]] static auto
-  mux(const QString& clip_path, const QString& wav_path, QString* error) -> bool;
+  [[nodiscard]] static auto mux(const QString& clip_path,
+                                const QString& wav_path,
+                                float gain_db,
+                                QString* error) -> bool;
+
+  [[nodiscard]] static auto measure_loudness(const QStringList& wav_paths,
+                                             QString* error) -> std::optional<float>;
+
+  [[nodiscard]] static auto measure_true_peak(const QString& media_path,
+                                              QString* error) -> std::optional<float>;
+  [[nodiscard]] static auto delivered_peak_ceiling_dbfs() -> float;
 
 private:
   void update_ambient_state(float seconds);
+  void rotate_score(float seconds);
   [[nodiscard]] auto any_side_in_combat() const -> bool;
+  [[nodiscard]] auto has_opposing_forces() const -> bool;
+  [[nodiscard]] auto resting_state() const -> Engine::Core::AmbientState;
 
   Engine::Core::World* m_world{nullptr};
   std::unique_ptr<Game::Audio::AudioEventHandler> m_handler;
   std::unique_ptr<AudioCoordinator> m_coordinator;
   Engine::Core::AmbientState m_ambient_state{Engine::Core::AmbientState::PEACEFUL};
   float m_ambient_timer{0.0F};
+  float m_score_timer{0.0F};
+  bool m_scored_bed{false};
   double m_sample_carry{0.0};
   std::vector<float> m_scratch;
   std::vector<float> m_clip;

--- a/tools/arena/arena_economy_scenarios.cpp
+++ b/tools/arena/arena_economy_scenarios.cpp
@@ -111,7 +111,8 @@ void add_the_land(ArenaScenarioDefinition& scenario) {
   lane({34.0F, 0.0F, -45.0F}, {96.0F, 0.0F, -42.0F}, k_lane);
 
   lane({-96.0F, 0.0F, 54.0F}, {-30.0F, 0.0F, 52.0F}, k_lane);
-  lane({-30.0F, 0.0F, 52.0F}, {24.0F, 0.0F, 55.0F}, k_lane);
+  lane({-30.0F, 0.0F, 52.0F}, {-4.0F, 0.0F, 53.4F}, k_lane);
+  lane({-4.0F, 0.0F, 53.4F}, {24.0F, 0.0F, 55.0F}, k_lane);
   lane({24.0F, 0.0F, 55.0F}, {70.0F, 0.0F, 53.5F}, k_lane);
   lane({70.0F, 0.0F, 53.5F}, {96.0F, 0.0F, 53.0F}, k_lane);
 
@@ -119,7 +120,12 @@ void add_the_land(ArenaScenarioDefinition& scenario) {
   lane({62.0F, 0.0F, -20.0F}, {68.0F, 0.0F, 18.0F}, k_lane);
   lane({68.0F, 0.0F, 18.0F}, {70.0F, 0.0F, 53.5F}, k_lane);
 
-  lane({-8.0F, 0.0F, -43.0F}, {-4.0F, 0.0F, -20.0F}, 3.2F);
+  constexpr float k_town_lane = 3.2F;
+  lane({-8.0F, 0.0F, -96.0F}, {-8.0F, 0.0F, -57.0F}, k_town_lane);
+  lane({-8.0F, 0.0F, -43.0F}, {-4.0F, 0.0F, -20.0F}, k_town_lane);
+  lane({-4.0F, 0.0F, -20.0F}, {-6.0F, 0.0F, 4.0F}, k_town_lane);
+  lane({-6.0F, 0.0F, 4.0F}, {-5.0F, 0.0F, 30.0F}, k_town_lane);
+  lane({-5.0F, 0.0F, 30.0F}, {-4.0F, 0.0F, 53.4F}, k_town_lane);
 
   const auto grove = [&scenario](const char* type,
                                  QVector3D at,
@@ -168,7 +174,7 @@ void add_the_land(ArenaScenarioDefinition& scenario) {
   grove("iron_ore", {30.0F, 0.0F, -20.0F}, 1.0F, {{0.0F, 3.0F, 0.0F}});
 
   scenario.resource_patches.push_back(
-      patch("plant", 9, {-30.0F, 0.0F, 26.0F}, {3.0F, 0.0F, 1.2F}, 0.9F));
+      patch("plant", 9, {-34.0F, 0.0F, 26.0F}, {3.0F, 0.0F, 1.2F}, 0.9F));
   scenario.resource_patches.push_back(
       patch("plant", 8, {20.0F, 0.0F, -26.0F}, {2.8F, 0.0F, -0.8F}, 0.9F));
   scenario.resource_patches.push_back(

--- a/tools/arena/promo_runner.cpp
+++ b/tools/arena/promo_runner.cpp
@@ -1430,19 +1430,15 @@ private:
     m_encoder.reset();
 
     if (m_audio != nullptr && m_frames_written > 0) {
+
       const QString wav_path = m_clip_path + QStringLiteral(".wav");
-      QString audio_error;
       if (!m_audio->write_clip(wav_path)) {
         qWarning().noquote() << QStringLiteral(
                                     "Promo shot '%1': audio track not written")
                                     .arg(shot.name);
-      } else if (!AudioRecorder::mux(m_clip_path, wav_path, &audio_error)) {
-        qWarning().noquote()
-            << QStringLiteral("Promo shot '%1': %2").arg(shot.name, audio_error);
       } else {
-        qInfo().noquote() << QStringLiteral("  muxed %1 s of game audio into %2")
-                                 .arg(QString::number(m_audio->clip_seconds(), 'f', 2))
-                                 .arg(QFileInfo(m_clip_path).fileName());
+        m_pending_audio.push_back(
+            PendingAudio{m_clip_path, wav_path, shot.name, m_audio->clip_seconds()});
       }
       m_audio->begin_clip();
     }
@@ -1499,11 +1495,77 @@ private:
     begin_shot();
   }
 
+  void mux_pass_audio() {
+    if (m_pending_audio.empty()) {
+      return;
+    }
+
+    float gain_db = 0.0F;
+    if (m_spec.reel_loudness_lufs < 0.0F) {
+      QStringList wav_paths;
+      wav_paths.reserve(static_cast<int>(m_pending_audio.size()));
+      for (const PendingAudio& pending : m_pending_audio) {
+        wav_paths << pending.wav_path;
+      }
+      QString measure_error;
+      const std::optional<float> measured =
+          AudioRecorder::measure_loudness(wav_paths, &measure_error);
+      if (!measured.has_value()) {
+
+        qCritical().noquote() << QStringLiteral(
+                                     "Promo pass audio could not be measured, so it "
+                                     "stays at the game's own level: %1")
+                                     .arg(measure_error);
+        m_failed = true;
+      } else {
+        gain_db = std::clamp(m_spec.reel_loudness_lufs - *measured, 0.0F, 30.0F);
+        qInfo().noquote()
+            << QStringLiteral("  pass audio measured %1 LUFS, lifting %2 dB to %3 LUFS")
+                   .arg(QString::number(*measured, 'f', 1),
+                        QString::number(gain_db, 'f', 1),
+                        QString::number(m_spec.reel_loudness_lufs, 'f', 1));
+      }
+    }
+
+    for (const PendingAudio& pending : m_pending_audio) {
+      QString audio_error;
+      if (!AudioRecorder::mux(
+              pending.clip_path, pending.wav_path, gain_db, &audio_error)) {
+        qWarning().noquote() << QStringLiteral("Promo shot '%1': %2")
+                                    .arg(pending.shot_name, audio_error);
+      } else {
+        qInfo().noquote() << QStringLiteral("  muxed %1 s of game audio into %2")
+                                 .arg(QString::number(pending.seconds, 'f', 2),
+                                      QFileInfo(pending.clip_path).fileName());
+
+        QString peak_error;
+        const std::optional<float> peak =
+            AudioRecorder::measure_true_peak(pending.clip_path, &peak_error);
+        const float ceiling = AudioRecorder::delivered_peak_ceiling_dbfs();
+        if (!peak.has_value()) {
+          qWarning().noquote()
+              << QStringLiteral("Promo shot '%1': true peak not measured: %2")
+                     .arg(pending.shot_name, peak_error);
+        } else if (*peak > ceiling) {
+          qCritical().noquote()
+              << QStringLiteral("Promo shot '%1' is delivered at %2 dBFS, over the "
+                                "%3 dBFS ceiling; it will clip")
+                     .arg(pending.shot_name,
+                          QString::number(*peak, 'f', 1),
+                          QString::number(ceiling, 'f', 1));
+          m_failed = true;
+        }
+      }
+    }
+    m_pending_audio.clear();
+  }
+
   void end_pass() {
     if (!m_pass_active) {
       return;
     }
     m_pass_active = false;
+    mux_pass_audio();
     m_audio.reset();
     ++m_pass_index;
     QTimer::singleShot(0, [this]() { begin_next_pass(); });
@@ -1592,6 +1654,14 @@ private:
   bool m_shot_armed{false};
   bool m_focus_valid{false};
   bool m_logged_framing{false};
+  struct PendingAudio {
+    QString clip_path;
+    QString wav_path;
+    QString shot_name;
+    float seconds{0.0F};
+  };
+
+  std::vector<PendingAudio> m_pending_audio;
   std::unique_ptr<AudioRecorder> m_audio;
   int m_logged_bucket{-1};
   bool m_failed{false};

--- a/tools/arena/promo_spec.cpp
+++ b/tools/arena/promo_spec.cpp
@@ -284,6 +284,11 @@ auto load(const QString& path, QString* error) -> std::optional<Spec> {
                                         .toDouble(spec.report_sound_volume)),
                  0.0F,
                  1.0F);
+  spec.reel_loudness_lufs =
+      std::clamp(static_cast<float>(root.value(QStringLiteral("reel_loudness_lufs"))
+                                        .toDouble(spec.reel_loudness_lufs)),
+                 -70.0F,
+                 0.0F);
   spec.music_volume = std::clamp(
       static_cast<float>(
           root.value(QStringLiteral("music_volume")).toDouble(spec.music_volume)),

--- a/tools/arena/promo_spec.h
+++ b/tools/arena/promo_spec.h
@@ -124,6 +124,8 @@ struct Spec {
   QString music_track;
   float music_volume{0.18F};
 
+  float reel_loudness_lufs{-16.0F};
+
   QString report_sound_decided;
   QString report_sound_undecided;
   float report_sound_volume{0.45F};


### PR DESCRIPTION
Rework generated town plans so each wall circuit is emitted as an ordered walk from its front gate. Partial construction now keeps the visible front and the available wall pieces connected, while the updated plans, architecture notes, and catalog coverage describe the resulting build order and enclosure behavior.

Carry resource-prop scale and explicit construction keep-out discs through AI snapshots and commands so builders reserve future walls, gates, and towers before placing ordinary structures. Wall links use exact placement, wall crews accept a wider arrival tolerance, and failed placements report the nearest terrain prop to make remaining construction refusals diagnosable.

Extend the headless and arena diagnostics with wall-run, enclosure, town-map, and road-to-edge checks. Add offline reference audio mixing, ambient music rotation reporting, score-bed rotation, and reel loudness handling to make arena recordings repeatable and easier to inspect.