### PR TITLE
feat: make fogged landscape readable and enrich render feedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,6 +894,7 @@ if(QT_VERSION_MAJOR EQUAL 6)
         assets/shaders/include/directional_shadows.glsl
         assets/shaders/include/visibility_mask.glsl
         assets/shaders/include/noise.glsl
+        assets/shaders/include/foliage_bump.glsl
         assets/shaders/include/terrain_noise.glsl
         assets/shaders/directional_shadow_depth.vert
         assets/shaders/directional_shadow_depth_instanced.vert

--- a/assets.qrc
+++ b/assets.qrc
@@ -17,6 +17,7 @@
         <file>assets/shaders/include/visibility_mask.glsl</file>
         <file>assets/shaders/include/fog_reveal.glsl</file>
         <file>assets/shaders/include/noise.glsl</file>
+        <file>assets/shaders/include/foliage_bump.glsl</file>
         <file>assets/shaders/include/material_detail.glsl</file>
         <file>assets/shaders/include/ground_readability.glsl</file>
         <file>assets/shaders/include/character_wear.glsl</file>

--- a/assets/shaders/dead_tree_instanced.frag
+++ b/assets/shaders/dead_tree_instanced.frag
@@ -119,6 +119,6 @@ void main() {
   color += soi_rim_light(normal, view_dir);
   color = apply_directional_shadow(color, v_world_pos, v_normal);
   color += material_color * ao * local_lighting(v_world_pos, normalize(v_normal));
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_world_shading(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/fog_instanced.frag
+++ b/assets/shaders/fog_instanced.frag
@@ -57,15 +57,12 @@ void main() {
     discard;
   }
 
-  float alpha = v_alpha * body * mix(0.97, 1.0, large);
+  float mottle = large * 0.55 + erosion * 0.30 + detail * 0.15;
+  float alpha = v_alpha * body * mix(0.45, 1.0, mottle);
 
   if (alpha <= 0.004) {
     discard;
   }
 
-  vec3 lit = v_color * mix(0.86, 1.14, detail);
-  lit *= 0.94 + 0.10 * large;
-  lit = mix(lit * 0.82, lit, smoothstep(0.30, 0.90, fog));
-
-  frag_color = vec4(lit, clamp(alpha, 0.0, 1.0));
+  frag_color = vec4(v_color, clamp(alpha, 0.0, 1.0));
 }

--- a/assets/shaders/grass_instanced.frag
+++ b/assets/shaders/grass_instanced.frag
@@ -37,6 +37,6 @@ void main() {
   color += v_color * sun * backlit * 0.45 * fold * detail_weight;
 #endif
 
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_world_shading(color, v_world_pos.xz);
   frag_color = vec4(color, alpha);
 }

--- a/assets/shaders/include/character_shading.glsl
+++ b/assets/shaders/include/character_shading.glsl
@@ -64,8 +64,6 @@ vec3 shade_readable_character(vec3 base,
   vec3 sun_color = environment_primary_color();
   vec3 sky_color = environment_sky_color();
 
-  // Warm sunlight should not turn every armor/cloth surface the same gold as
-  // masonry. Preserve light intensity and authored team hues at tactical zoom.
   if (material_id == 0) {
     float sun_luma = dot(sun_color, vec3(0.299, 0.587, 0.114));
     sun_color = mix(sun_color, vec3(sun_luma), 0.30 * zoom);
@@ -231,8 +229,7 @@ vec3 soi_finish_character(vec3 color,
   }
 #endif
   if (material_id == 0) {
-    // Keep cloth identifiable without saturating skin, leather and armor into
-    // competing orange/yellow flecks. Leave other creature materials unchanged.
+
     bool cloth =
         color_role == k_humanoid_role_cloth || color_role == k_humanoid_role_cloth_dark;
     float luma = dot(color, vec3(0.299, 0.587, 0.114));
@@ -248,9 +245,7 @@ vec3 soi_finish_character(vec3 color,
     color = mix(vec3(hide_luma), color, k_elephant_hide_saturation);
   }
 #endif
-  // Preserve wool's light/dark modeling while removing the warm cast introduced
-  // by sunlight, ground bounce and the generic wildlife finish. The material
-  // mask excludes brown coats, dirty wool, faces and hooves.
+
 #if SOI_CHARACTER_WANTS(SOI_CHARACTER_WILDLIFE)
   if (material_id == k_wildlife_material) {
     float white_coat = wildlife_white_coat_weight(base);

--- a/assets/shaders/include/character_wear.glsl
+++ b/assets/shaders/include/character_wear.glsl
@@ -54,8 +54,7 @@ vec4 soi_wear_fetch(vec3 lattice, vec4 salts) {
 }
 
 #if SOI_CHARACTER_WANTS(SOI_CHARACTER_WILDLIFE)
-// Select pale neutral coats by authored color, not by shared wildlife role IDs
-// (wolves and sheep use the same material). Brown fur and dirt remain colored.
+
 float wildlife_white_coat_weight(vec3 base) {
   float luma = dot(base, vec3(0.299, 0.587, 0.114));
   float chroma = max(max(base.r, base.g), base.b) - min(min(base.r, base.g), base.b);

--- a/assets/shaders/include/environment_lighting.glsl
+++ b/assets/shaders/include/environment_lighting.glsl
@@ -51,9 +51,7 @@ float environment_cloud_cover() {
 }
 
 vec3 environment_shadow_tint() {
-  // Shadow receivers multiply their complete lighting result by this tint.
-  // Retain some indirect-light value instead of crushing it a second time.
-  // Preserve the authored night palette and the tint's relative channel balance.
+
   vec3 primary = environment_primary_color();
   float daylight = 1.0 - smoothstep(0.05, 0.40, primary.b - primary.r);
   return mix(u_env_shadow_tint_strength.rgb, vec3(1.0), 0.20 * daylight);

--- a/assets/shaders/include/fog_reveal.glsl
+++ b/assets/shaders/include/fog_reveal.glsl
@@ -3,9 +3,9 @@ uniform vec2 u_fog_mask_size;
 uniform float u_fog_mask_tile_size;
 uniform int u_has_fog_mask;
 
-const vec3 k_fog_reveal_shade = vec3(0.50, 0.50, 0.51);
-const vec3 k_fog_reveal_lift = vec3(0.012, 0.012, 0.013);
-const float k_fog_reveal_chroma = 0.55;
+const vec3 k_fog_reveal_shade = vec3(0.56, 0.56, 0.58);
+const vec3 k_fog_reveal_lift = vec3(0.010, 0.010, 0.012);
+const float k_fog_reveal_chroma = 0.80;
 
 bool fog_reveal_active() {
   return u_has_fog_mask == 1 && u_fog_mask_size.x > 0.0 && u_fog_mask_size.y > 0.0;

--- a/assets/shaders/include/foliage_bump.glsl
+++ b/assets/shaders/include/foliage_bump.glsl
@@ -1,0 +1,35 @@
+vec3 perturb_normal(vec3 n, vec3 world_pos, float height, float strength) {
+  vec3 dpdx = dFdx(world_pos);
+  vec3 dpdy = dFdy(world_pos);
+  vec3 r1 = cross(dpdy, n);
+  vec3 r2 = cross(n, dpdx);
+  float det = dot(dpdx, r1);
+  vec3 gradient = sign(det) * (dFdx(height) * r1 + dFdy(height) * r2);
+  return normalize(abs(det) * n - strength * gradient);
+}
+
+vec3 lobe_normal(vec3 n,
+                 vec3 local_pos,
+                 float frequency,
+                 float strength,
+                 vec3 seed,
+                 out float height) {
+  const vec3 k0 = vec3(0.86, 0.32, 0.40);
+  const vec3 k1 = vec3(-0.44, 0.78, 0.44);
+  const vec3 k2 = vec3(0.30, -0.52, 0.80);
+  const vec3 k3 = vec3(-0.70, -0.60, -0.38);
+  const vec3 k4 = vec3(0.55, 0.62, -0.56);
+  vec3 p = local_pos * frequency;
+  float a0 = dot(p, k0) + seed.x;
+  float a1 = dot(p, k1) * 1.31 + seed.y;
+  float a2 = dot(p, k2) * 1.73 + seed.z;
+  float a3 = dot(p, k3) * 2.21 + seed.x * 1.7;
+  float a4 = dot(p, k4) * 2.87 + seed.y * 2.3;
+  height = (sin(a0) * 1.00 + sin(a1) * 0.85 + sin(a2) * 0.70 + sin(a3) * 0.55 +
+            sin(a4) * 0.45) /
+           3.55;
+  vec3 gradient = k0 * cos(a0) * 1.00 + k1 * cos(a1) * 0.85 + k2 * cos(a2) * 0.70 +
+                  k3 * cos(a3) * 0.55 + k4 * cos(a4) * 0.45;
+  vec3 tangent_gradient = gradient - n * dot(gradient, n);
+  return normalize(n - tangent_gradient * strength);
+}

--- a/assets/shaders/include/ground_readability.glsl
+++ b/assets/shaders/include/ground_readability.glsl
@@ -1,5 +1,5 @@
-// Keep small ground features subordinate to units at normal gameplay distances.
-// Shared by terrain and scatter so their detail transitions stay in step.
+
+
 float ground_tactical_distance(float view_distance) {
   return smoothstep(32.0, 85.0, view_distance);
 }

--- a/assets/shaders/include/material_detail.glsl
+++ b/assets/shaders/include/material_detail.glsl
@@ -102,8 +102,7 @@ vec3 soi_material_variation(vec3 base_color,
                             vec3 normal,
                             int material_id) {
   float tactical = ground_tactical_distance(length(u_camera_pos - world_pos));
-  // Mineral and wood surfaces should support, rather than compete with, troop
-  // cloth colors. Apply this even when material-detail textures are disabled.
+
   if (material_id == k_material_mineral || material_id == k_material_wood) {
     float luma = dot(base_color, vec3(0.299, 0.587, 0.114));
     float saturation = material_id == k_material_mineral ? 0.86 : 0.92;
@@ -126,7 +125,7 @@ vec3 soi_material_variation(vec3 base_color,
   } else if (material_id == k_material_leather) {
     variation = soi_leather_variation(base_color, uv);
   }
-  // Retain close-up texture while reducing grain and sheen at army-view scale.
+
   variation = mix(base_color, variation, mix(1.0, 0.55, tactical));
   return clamp(variation, 0.0, 1.0);
 }

--- a/assets/shaders/include/tonemap.glsl
+++ b/assets/shaders/include/tonemap.glsl
@@ -42,8 +42,7 @@ vec3 soi_split_tone(vec3 color, float strength) {
 }
 
 vec3 soi_grade(vec3 mapped_color) {
-  // Keep contrast in the midtones without clipping shaded equipment and faces
-  // to black before the shadow lift. Scene lighting already supplies the mood.
+
   float mapped_luma = max(dot(mapped_color, k_soi_grade_luma), 0.0);
   float contrast_weight =
       smoothstep(0.04, 0.24, mapped_luma) * (1.0 - smoothstep(0.72, 1.0, mapped_luma));
@@ -51,15 +50,14 @@ vec3 soi_grade(vec3 mapped_color) {
   vec3 contrasted = (mapped_color - k_soi_grade_pivot) * contrast + k_soi_grade_pivot;
   contrasted = max(contrasted, vec3(0.0));
   float luma = dot(contrasted, k_soi_grade_luma);
-  // Avoid turning bright cloth and metal into clipped patches of primary color.
+
   float saturation = mix(k_soi_grade_saturation, 1.0, smoothstep(0.55, 0.95, luma));
   vec3 saturated = mix(vec3(luma), contrasted, saturation);
   saturated = max(saturated, vec3(0.0));
   vec3 tinted =
       mix(saturated, saturated * k_soi_grade_highlight_tint, clamp(luma, 0.0, 1.0));
   tinted = soi_split_tone(tinted, k_soi_grade_split_strength);
-  // Neutral materials (notably white wool) must survive the artistic warm
-  // grade as neutral. Retain the grade's luminance and leave colored cloth alone.
+
   float chroma = max(max(mapped_color.r, mapped_color.g), mapped_color.b) -
                  min(min(mapped_color.r, mapped_color.g), mapped_color.b);
   float neutral = 1.0 - smoothstep(0.015, 0.06, chroma);

--- a/assets/shaders/include/visibility_mask.glsl
+++ b/assets/shaders/include/visibility_mask.glsl
@@ -11,9 +11,9 @@ const float k_visibility_unseen_cutoff = 0.06;
 
 const float k_visibility_unseen_blend_end = 0.52;
 
-const vec3 k_visibility_unseen_shade = vec3(0.50, 0.50, 0.51);
-const vec3 k_visibility_unseen_lift = vec3(0.012, 0.012, 0.013);
-const float k_visibility_unseen_chroma = 0.55;
+const vec3 k_visibility_unseen_shade = vec3(0.56, 0.56, 0.58);
+const vec3 k_visibility_unseen_lift = vec3(0.010, 0.010, 0.012);
+const float k_visibility_unseen_chroma = 0.80;
 
 struct VisibilityMask {
   float seen_now;
@@ -122,7 +122,7 @@ vec3 apply_visibility_world_shading(vec3 lit_color, vec2 world_xz) {
   return apply_visibility_world_shading(lit_color, visibility_mask_fetch(world_xz));
 }
 
-vec3 apply_visibility_memory(vec3 lit_color, vec2 world_xz) {
+vec3 apply_visibility_revealed(vec3 lit_color, vec2 world_xz) {
   if (!visibility_mask_active()) {
     return lit_color;
   }

--- a/assets/shaders/iron_ore_instanced.frag
+++ b/assets/shaders/iron_ore_instanced.frag
@@ -82,7 +82,8 @@ void main() {
   rock_color = mix(rock_color, warm_mineral, mineral_noise * 0.12);
 
   float magic_strength = max(u_magic_strength, 0.0);
-  float magic_mix = clamp(magic_strength, 0.0, 1.0);
+
+  float magic_mix = clamp(magic_strength * 0.74, 0.0, 1.0);
 
   vec3 hematite_core = vec3(0.055, 0.055, 0.070);
   vec3 limonite_rim = vec3(0.30, 0.26, 0.24);
@@ -91,9 +92,11 @@ void main() {
   vec3 natural_ore = mix(rock_color, seam, vein_wide * 0.85);
   natural_ore = mix(natural_ore, rust_bloom, mineral_noise * 0.14 * (1.0 - vein_wide));
 
-  vec3 magic_a = vec3(0.14, 0.85, 1.35);
-  vec3 magic_b = vec3(0.82, 0.24, 1.45);
+  vec3 magic_a = vec3(0.70, 0.06, 1.28);
+  vec3 magic_b = vec3(0.06, 0.52, 1.20);
+  vec3 sanctum_gold = vec3(1.02, 0.54, 0.18);
   vec3 magic_color = mix(magic_a, magic_b, fbm(q * 1.7 + vec3(v_seed)));
+  vec3 sanctum_color = mix(magic_color, sanctum_gold, 0.30);
 
   vec3 stained_ore = mix(rock_color, magic_color * 0.55, vein_wide * 0.45);
   vec3 albedo = mix(natural_ore, stained_ore, magic_mix);
@@ -130,20 +133,24 @@ void main() {
 
   float fresnel = pow(1.0 - max(dot(N, V), 0.0), 3.0);
 
-  float pulse = 0.78 + 0.22 * sin(u_time * 2.1 + v_seed * 12.0 + fbm(q * 2.0) * 5.0);
+  float pulse = 0.74 + 0.26 * sin(u_time * 1.9 + v_seed * 6.28318 +
+                                  fbm(q * 1.7 + vec3(u_time * 0.28)) * 4.8);
 
   vec3 glow = magic_color * magic_strength * pulse *
               (vein_core * 1.75 + vein_wide * 0.22 + fresnel * vein_wide * 0.45 +
                crystal * 1.35);
+  vec3 aura = mix(magic_color, sanctum_color, 0.45) * magic_strength * fresnel *
+              (0.20 + 0.16 * pulse) * (0.45 + 0.55 * vein_wide);
 
   vec3 color = albedo * illumination * ao;
   color += sun_color * vec3(0.82, 0.86, 1.00) * ore_spec * ao;
-  vec3 glint_color = mix(sun_color * vec3(0.78, 0.83, 0.96), magic_color, magic_mix);
+  vec3 glint_color = mix(sun_color * vec3(0.78, 0.83, 0.96), sanctum_color, magic_mix);
   color += glint_color * crystal_spec;
   color += glow;
+  color += aura;
 
   color = apply_directional_shadow(color, v_world_pos, v_normal);
   color += albedo * ao * local_lighting(v_world_pos, normalize(v_normal));
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_world_shading(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/olive_instanced.frag
+++ b/assets/shaders/olive_instanced.frag
@@ -1,6 +1,7 @@
 #version 330 core
 #include "directional_shadows.glsl"
 #include "environment_lighting.glsl"
+#include "foliage_bump.glsl"
 #include "local_lighting.glsl"
 #include "noise.glsl"
 #include "visibility_mask.glsl"
@@ -12,7 +13,7 @@ in vec2 v_tex_coord;
 in float v_foliage_mask;
 in float v_leaf_seed;
 in float v_bark_seed;
-in float v_branch_id;
+flat in float v_branch_id;
 in vec2 v_local_pos_xz;
 in vec3 v_local_pos;
 
@@ -43,25 +44,30 @@ void main() {
   vec3 leaf_seed_offset =
       vec3(v_leaf_seed * 37.0, v_branch_id * 11.0, v_leaf_seed * 59.0);
   float footprint = max(fwidth(v_local_pos.x), fwidth(v_local_pos.z));
-  float fine_detail = 1.0 - smoothstep(0.003, 0.013, footprint);
-  float mid_detail = 1.0 - smoothstep(0.008, 0.030, footprint);
+  float fine_detail = 1.0 - smoothstep(0.006, 0.026, footprint);
+  float mid_detail = 1.0 - smoothstep(0.016, 0.055, footprint);
 
-  float leaf_fine = soi_noise3(v_local_pos * vec3(26.0, 21.0, 26.0) + leaf_seed_offset);
-  float leaf_clump = soi_noise3(v_local_pos * 9.5 + leaf_seed_offset.zxy);
+  float leaf_fine_raw =
+      soi_noise3(v_local_pos * vec3(26.0, 21.0, 26.0) + leaf_seed_offset);
+  float leaf_clump_raw = soi_noise3(v_local_pos * 9.5 + leaf_seed_offset.zxy);
   float leaf_mass = soi_noise3(v_local_pos * 4.5 + leaf_seed_offset.yzx);
-  leaf_fine = mix(0.5, leaf_fine, fine_detail);
-  leaf_clump = mix(0.5, leaf_clump, mid_detail);
+  float leaf_sprig = soi_noise3(v_local_pos * 15.0 + leaf_seed_offset.xzy * 1.7);
+  float leaf_fine = mix(0.5, leaf_fine_raw, fine_detail);
+  float leaf_clump = mix(0.5, leaf_clump_raw, mid_detail);
+  leaf_sprig = mix(0.5, leaf_sprig, mid_detail);
 
   float canopy_height = clamp((v_tex_coord.y - 0.52) / 0.58, 0.0, 1.0);
   float canopy_radius = length(v_local_pos_xz);
   float canopy_edge = smoothstep(0.10, 0.32, canopy_radius);
   float canopy_core = 1.0 - smoothstep(0.14, 0.40, canopy_radius);
 
-  vec3 leaf_dark_green = vec3(0.090, 0.132, 0.096);
-  vec3 leaf_mid_green = vec3(0.236, 0.296, 0.196);
-  vec3 leaf_light_green = vec3(0.400, 0.470, 0.290);
-  vec3 leaf_silver = vec3(0.640, 0.672, 0.590);
-  vec3 leaf_sun = vec3(0.560, 0.610, 0.350);
+  float silhouette = 1.0 - abs(dot(geometric_normal, view_dir));
+
+  vec3 leaf_dark_green = vec3(0.078, 0.110, 0.084);
+  vec3 leaf_mid_green = vec3(0.196, 0.246, 0.172);
+  vec3 leaf_light_green = vec3(0.340, 0.392, 0.270);
+  vec3 leaf_silver = vec3(0.600, 0.640, 0.590);
+  vec3 leaf_sun = vec3(0.470, 0.530, 0.362);
 
   float color_choice =
       clamp(leaf_clump * 0.90 + (leaf_fine - 0.5) * 0.26 + 0.10, 0.0, 1.0);
@@ -69,9 +75,17 @@ void main() {
   leaf_color =
       mix(leaf_color, leaf_light_green, smoothstep(0.40, 0.90, leaf_mass) * 0.62);
 
-  leaf_color = mix(leaf_color, v_color, 0.28);
+  leaf_color = mix(leaf_color, v_color, 0.24);
 
-  vec3 n = geometric_normal;
+  float lobe_height = 0.0;
+  float sprig_height = 0.0;
+  vec3 lobed = lobe_normal(
+      geometric_normal, v_local_pos, 10.0, 0.42, leaf_seed_offset, lobe_height);
+  lobed = lobe_normal(
+      lobed, v_local_pos, 24.0, 0.22 * mid_detail, leaf_seed_offset.zyx, sprig_height);
+  vec3 n = normalize(mix(geometric_normal, lobed, v_foliage_mask));
+  float crevice =
+      smoothstep(-0.55, 0.35, lobe_height + sprig_height * 0.5 * mid_detail);
   vec3 shading_normal =
       normalize(mix(n, n + vec3(0.0, 1.2, 0.0), v_foliage_mask * 0.50));
 
@@ -93,21 +107,25 @@ void main() {
   silver_show = max(silver_show, smoothstep(0.58, 0.95, leaf_fine) * 0.70);
   silver_show = max(silver_show, underside * smoothstep(0.35, 0.75, leaf_clump) * 0.80);
   silver_show += canopy_edge * smoothstep(0.45, 0.85, leaf_fine) * 0.35;
+  float turned_leaves =
+      smoothstep(0.56, 0.86, leaf_sprig) * (0.40 + 0.60 * silhouette) * mid_detail;
+  silver_show = max(silver_show, turned_leaves);
   leaf_color = mix(leaf_color,
                    leaf_silver,
-                   clamp(silver_show, 0.0, 1.0) * mix(0.22, 0.42, canopy_height));
+                   clamp(silver_show, 0.0, 1.0) * mix(0.26, 0.48, canopy_height));
 
   float sun_catch = smoothstep(0.43, 1.00, wrap) * mix(0.20, 0.62, leaf_clump);
   leaf_color = mix(leaf_color, leaf_sun, sun_catch * v_foliage_mask);
 
   float hemi = clamp(geometric_normal.y * 0.5 + 0.5, 0.0, 1.0);
-  float clump_shadow = 1.0 - smoothstep(0.30, 0.70, leaf_mass) * 0.22;
+  float clump_shadow = 1.0 - smoothstep(0.30, 0.70, leaf_mass) * 0.30;
   float canopy_shape = mix(0.82, 1.08, canopy_edge) * mix(0.90, 1.10, canopy_height);
   float canopy_occlusion = clamp(canopy_shape * mix(1.0, 0.72, canopy_core) *
                                      mix(1.0, 0.84, underside) * clump_shadow,
                                  0.38,
                                  1.14);
   float ao = mix(1.0, canopy_occlusion, v_foliage_mask) * mix(0.72, 1.0, hemi);
+  ao *= mix(1.0, mix(0.70, 1.04, crevice), v_foliage_mask);
 
   float bark_u = v_tex_coord.x * TWO_PI;
   float bark_v = v_tex_coord.y;
@@ -158,6 +176,6 @@ void main() {
 
   color = apply_directional_shadow(color, v_world_pos, geometric_normal);
   color += base_color * ao * local_lighting(v_world_pos, n);
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_world_shading(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/olive_instanced.vert
+++ b/assets/shaders/olive_instanced.vert
@@ -1,4 +1,5 @@
 #version 330 core
+#include "noise.glsl"
 
 layout(location = 0) in vec3 a_pos;
 layout(location = 1) in vec2 a_tex_coord;
@@ -21,7 +22,7 @@ out vec2 v_tex_coord;
 out float v_foliage_mask;
 out float v_leaf_seed;
 out float v_bark_seed;
-out float v_branch_id;
+flat out float v_branch_id;
 out vec2 v_local_pos_xz;
 out vec3 v_local_pos;
 
@@ -63,12 +64,12 @@ void main() {
 
   if (foliage_mask > 0.1) {
     float ang = atan(model_pos.z, model_pos.x);
-    float lump_base = sin(ang * 2.6 + silhouette_seed * TWO_PI) * 0.085;
-    float lump_fine = sin(ang * 5.4 + leaf_seed * TWO_PI * 1.9) * 0.042;
+    float lump_base = sin(ang * 2.6 + silhouette_seed * TWO_PI) * 0.100;
+    float lump_fine = sin(ang * 5.4 + leaf_seed * TWO_PI * 1.9) * 0.050;
     float lump_ragged =
-        sin(ang * 5.0 + a_pos.y * 16.0 + leaf_seed * TWO_PI * 3.1) * 0.040;
+        sin(ang * 5.0 + a_pos.y * 16.0 + leaf_seed * TWO_PI * 3.1) * 0.056;
     float lump_tuft =
-        sin(ang * 3.0 - a_pos.y * 23.0 + silhouette_seed * TWO_PI * 2.3) * 0.030;
+        sin(ang * 3.0 - a_pos.y * 23.0 + silhouette_seed * TWO_PI * 2.3) * 0.042;
     float lump_mag = (lump_base + lump_fine + lump_ragged + lump_tuft) * foliage_mask;
     model_pos.xz *= (1.0 + lump_mag);
     model_pos.y += (lump_ragged + lump_tuft) * 0.55 * foliage_mask;
@@ -89,6 +90,12 @@ void main() {
 
     float spread = mix(0.96, 1.14, fract(silhouette_seed * 7.31 + leaf_seed * 3.17));
     model_pos.xz *= mix(1.0, spread, foliage_mask);
+
+    vec3 lobe_seed = vec3(leaf_seed * 23.0, silhouette_seed * 17.0, leaf_seed * 41.0);
+    float lobe = soi_noise3(model_pos * 6.5 + lobe_seed) - 0.5;
+    float tuft = soi_noise3(model_pos * 14.0 + lobe_seed.zxy) - 0.5;
+    float billow = (lobe * 0.05 + tuft * 0.02) * foliage_mask;
+    model_pos += a_normal * billow;
   }
 
   vec3 local_pos = model_pos * scale;

--- a/assets/shaders/pine_instanced.frag
+++ b/assets/shaders/pine_instanced.frag
@@ -1,6 +1,7 @@
 #version 330 core
 #include "directional_shadows.glsl"
 #include "environment_lighting.glsl"
+#include "foliage_bump.glsl"
 #include "local_lighting.glsl"
 #include "noise.glsl"
 #include "visibility_mask.glsl"
@@ -21,16 +22,6 @@ out vec4 frag_color;
 
 const float PI = 3.14159265359;
 const float TWO_PI = 6.28318530718;
-
-vec3 perturb_normal(vec3 n, vec3 world_pos, float height, float strength) {
-  vec3 dpdx = dFdx(world_pos);
-  vec3 dpdy = dFdy(world_pos);
-  vec3 r1 = cross(dpdy, n);
-  vec3 r2 = cross(n, dpdx);
-  float det = dot(dpdx, r1);
-  vec3 gradient = sign(det) * (dFdx(height) * r1 + dFdy(height) * r2);
-  return normalize(abs(det) * n - strength * gradient);
-}
 
 void main() {
 
@@ -143,6 +134,6 @@ void main() {
 
   color = apply_directional_shadow(color, v_world_pos, geometric_normal);
   color += base_color * ao * local_lighting(v_world_pos, n);
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_world_shading(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/plant_instanced.frag
+++ b/assets/shaders/plant_instanced.frag
@@ -193,6 +193,6 @@ void main() {
 
   color = apply_directional_shadow(color, v_world_pos, v_normal);
   color += albedo * local_lighting(v_world_pos, normalize(v_normal));
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_world_shading(color, v_world_pos.xz);
   frag_color = vec4(color, coverage);
 }

--- a/assets/shaders/post_composite.frag
+++ b/assets/shaders/post_composite.frag
@@ -39,8 +39,7 @@ const int k_ao_ring_count = 3;
 const float k_ao_ring_spread[3] = float[3](2.5, 6.0, 12.0);
 const float k_ao_ring_weight[3] = float[3](1.0, 0.65, 0.24);
 const float k_ao_ring_reach = 1.7;
-// Depth-separated buildings must not cast broad screen-space occlusion halos.
-// Directional shadows handle their cast shadow; AO supplies local grounding.
+
 const float k_ao_far_cutoff = 4.0;
 const vec3 k_ao_tint = vec3(0.80, 0.83, 0.89);
 

--- a/assets/shaders/road.frag
+++ b/assets/shaders/road.frag
@@ -185,8 +185,6 @@ void main() {
     material_roughness = 0.94;
   }
 
-  // Derivative filtering handles subpixel edges; distance attenuation also
-  // prevents resolved paving/gravel contrast from competing with small troops.
   float ground_detail =
       mix(1.0, 0.40, ground_tactical_distance(length(u_camera_pos - v_world_pos)));
   base_color = mix(u_color * 0.92, base_color, ground_detail);

--- a/assets/shaders/stone_instanced.frag
+++ b/assets/shaders/stone_instanced.frag
@@ -113,12 +113,12 @@ void main() {
   float rim = pow(1.0 - max(dot(N, V), 0.0), 4.0) * 0.055;
 
   vec3 color = stone * illumination * crevice_ao;
-  // Tiny scatter should not retain full-strength bright rims and specular dots.
+
   color += soi_rim_light(N_face, V) * (1.0 - skirt * 0.6) * detail_weight;
   color += sun * (dry_spec + wet_spec) * detail_weight;
   color += sky * rim * detail_weight;
   color = apply_directional_shadow(color, v_world_pos, v_normal);
   color += stone * crevice_ao * local_lighting(v_world_pos, N);
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_world_shading(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/supply_cart_instanced.frag
+++ b/assets/shaders/supply_cart_instanced.frag
@@ -99,6 +99,6 @@ void main() {
   color += sky * rim;
   color = apply_directional_shadow(color, v_world_pos, v_normal);
   color += albedo * cavity * local_lighting(v_world_pos, normalize(v_normal));
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_revealed(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/tent_instanced.frag
+++ b/assets/shaders/tent_instanced.frag
@@ -216,6 +216,6 @@ void main() {
              k_lantern_gain;
   }
 
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_revealed(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/assets/shaders/terrain_chunk.frag
+++ b/assets/shaders/terrain_chunk.frag
@@ -256,7 +256,22 @@ vec3 unseen_terrain_color() {
   ground = mix(ground,
                u_snow_color,
                clamp(u_snow_coverage, 0.0, 1.0) * smoothstep(0.42, 0.86, normal.y));
-  ground *= u_tint;
+
+  vec3 hue_shift = mix(k_soi_terrain_hue_cool,
+                       k_soi_terrain_hue_warm,
+                       smoothstep(0.35, 0.65, detail_field.b));
+  ground *= mix(vec3(1.0), hue_shift, k_soi_terrain_hue_amount);
+  float worn_ground = smoothstep(0.16, 0.52, detail_field.a) * (1.0 - slope * 1.5) *
+                      (1.0 - u_snow_coverage);
+  vec3 worn_color = mix(u_grass_dry, u_soil_color, 0.42) * 0.92;
+  ground = mix(ground, worn_color, worn_ground * k_soi_terrain_earth_amount);
+  ground *= 0.94 + 0.12 * detail_field.r;
+
+  vec3 gray_level = vec3(dot(ground, vec3(0.299, 0.587, 0.114)));
+  float grounded_saturation =
+      clamp(u_grass_saturation * k_soi_terrain_saturation, 0.0, 1.16);
+  ground = mix(gray_level, ground, grounded_saturation);
+  ground *= vec3(1.012, 0.992, 0.965) * u_tint;
 
   return unseen_surface_color(ground * soi_surface_lighting(normal) *
                               (u_ambient_boost * cavity));

--- a/assets/shaders/weapon_rack_instanced.frag
+++ b/assets/shaders/weapon_rack_instanced.frag
@@ -134,6 +134,6 @@ void main() {
   color += sky * rim;
   color = apply_directional_shadow(color, v_world_pos, v_normal);
   color += albedo * ao * local_lighting(v_world_pos, normalize(v_normal));
-  color = apply_visibility_memory(color, v_world_pos.xz);
+  color = apply_visibility_revealed(color, v_world_pos.xz);
   frag_color = vec4(color, 1.0);
 }

--- a/docs/RENDERING_ARCHITECTURE.md
+++ b/docs/RENDERING_ARCHITECTURE.md
@@ -920,30 +920,49 @@ some point". Both channels pass through a 3x3 tent kernel and the texture is
 sampled with linear filtering, which is what turns the tile grid into a
 feathered edge instead of a staircase.
 
-Everything that belongs to the permanent map -- terrain chunks, roads, rivers,
-riverbanks, and the scattered props -- includes
+Unexplored ground is the map in shadow, not a hole in it. Everything that is
+the landscape -- terrain chunks, roads, rivers, riverbanks, bridges, and the
+natural scatter (boulders, trees, plants, grass, ore) plus authored landmarks
+(ruins, statues, shrines) -- is drawn under the fog and darkened per fragment.
+Those shaders include
 [`visibility_mask.glsl`](https://github.com/djeada/Standard-of-Iron/blob/main/assets/shaders/include/visibility_mask.glsl)
-and calls `apply_visibility_memory()`. That one call discards fragments the
-player has never seen and, on ground that is explored but not currently
-watched, replaces the lit colour with a drained, cooled, dimmed version of
-itself. Remembered terrain is therefore the real terrain rendered from memory,
-props included -- not a grey sheet laid over it.
+and call `apply_visibility_world_shading()`, which blends three looks by the
+mask: `unseen_surface_color()` on never-seen tiles (a neutral dim with most of
+the chroma kept, so a meadow is still a meadow), the drained memory colour on
+explored-but-unwatched tiles, and the lit colour under live sight. The three
+shading constants are duplicated in `fog_reveal.glsl` (bridges) and
+`render/entity/unseen_submitter.h` (CPU-shaded landmark meshes) and a shader
+source test keeps the copies equal. `terrain_chunk.frag` takes an early-out on
+never-seen tiles and shades a cheap albedo (base ground colours, the baked
+noise atlas, hue/wear/saturation passes, no shadows or micro-detail), so the
+whole unexplored map costs less per pixel than one lit tile. Landscape scatter
+renderers override `fog_culls_instances()` to `false`, so the CPU never
+repacks their instance buffers as sight moves; the fog is entirely a fragment
+term for them.
+
+Encampment dressing (tents, supply carts, weapon racks, campfires) is
+activity, not landscape. It is CPU-culled to explored ground
+(`ScatterMemoryMode::Remembered`) and its shaders call
+`apply_visibility_revealed()`, which discards on never-seen tiles as a backstop
+at the mask's feathered edge. Campfires stay `ScatterMemoryMode::VisibleOnly`
+so nothing keeps playing where nobody is looking.
 
 Only never-seen ground gets a fog layer. `FogRenderer` submits one instanced
 batch of chunk-sized quads covering the unexplored regions and hands the
 shader its own mask, so cost scales with the unexplored area in chunks rather
-than with map size or unit count. Newly revealed tiles dissolve rather than
-pop, and the layer subtracts live sight from its own opacity: soldiers stand
-above the fog plane, so fog creeping past the sight edge would show them
-apparently standing in it.
+than with map size or unit count. The quads are a dark, near-neutral colour at
+a low alpha whose opacity drifts with noise: a mottled shadow that darkens the
+shaded terrain a little more without lowering its contrast the way a grey haze
+did. Newly revealed tiles dissolve rather than pop, and the layer subtracts
+live sight from its own opacity: soldiers stand above the fog plane, so fog
+creeping past the sight edge would show them apparently standing in it.
 
 Two rules keep hidden activity hidden. Enemy units, enemy construction
 previews and combat effects are gated with `FogExtent::Anchor`, which asks
 about the tile the thing stands on rather than its whole bounding sphere -- the
 footprint rule would render an entire formation whose flank merely clipped the
-sight edge. Animated scatter (campfires) stays `ScatterMemoryMode::VisibleOnly`
-so nothing keeps playing where nobody is looking, while static props use
-`Remembered`.
+sight edge. Enemy buildings are drawn only on revealed ground, and units only
+under live sight.
 
 Per-update cost stays small because the mask is uploaded by dirty rectangle:
 the helper compares against the previous grid, grows a box by the blur's reach,

--- a/render/entity/production_completion_renderer.cpp
+++ b/render/entity/production_completion_renderer.cpp
@@ -7,9 +7,74 @@
 #include "game/core/component_presentation.h"
 #include "game/core/ownership_constants.h"
 #include "game/core/world.h"
+#include "render/draw_commands.h"
+#include "render/local_lighting.h"
 #include "render/scene_renderer.h"
 
 namespace Render::GL {
+
+namespace {
+
+constexpr float k_fade_in_seconds = 0.12F;
+constexpr float k_flare_seconds = 0.45F;
+constexpr float k_ring_seconds = 0.85F;
+constexpr float k_ring_delay_seconds = 0.26F;
+constexpr int k_ring_count = 2;
+
+constexpr float k_spark_cycle_seconds = 0.28F;
+constexpr int k_glint_count = 12;
+constexpr QVector3D k_gold{1.0F, 0.78F, 0.30F};
+constexpr QVector3D k_pale_gold{1.0F, 0.94F, 0.72F};
+
+void submit_ground_disc(Renderer* renderer,
+                        const QVector3D& ground,
+                        float radius,
+                        float alpha) {
+  if (alpha <= 0.01F) {
+    return;
+  }
+  GroundMarkerCmd disc;
+  disc.center = QVector3D(ground.x(), ground.y() + 0.05F, ground.z());
+  disc.outer_radius = radius * 0.95F;
+  disc.thickness = disc.outer_radius;
+  disc.color = k_pale_gold;
+  disc.alpha = alpha;
+  renderer->ground_marker(disc);
+}
+
+void submit_ground_ring(Renderer* renderer,
+                        const QVector3D& ground,
+                        float radius,
+                        float ring_age,
+                        float alpha_scale) {
+  if (ring_age < 0.0F || ring_age >= k_ring_seconds || alpha_scale <= 0.01F) {
+    return;
+  }
+  const float travel = ring_age / k_ring_seconds;
+  const float fade = (1.0F - travel) * (1.0F - travel);
+  GroundMarkerCmd ring;
+  ring.center = QVector3D(ground.x(), ground.y() + 0.07F, ground.z());
+  ring.outer_radius = radius * (0.55F + 1.10F * travel);
+  ring.thickness = std::max(0.08F, radius * 0.16F * (1.0F - 0.5F * travel));
+  ring.color = k_gold;
+  ring.alpha = alpha_scale * fade;
+  renderer->ground_marker(ring);
+}
+
+void submit_glow_light(Renderer* renderer,
+                       const QVector3D& position,
+                       float radius,
+                       float intensity,
+                       float flare) {
+  Render::LocalLight glow;
+  glow.position = position + QVector3D(0.0F, radius * 0.75F, 0.0F);
+  glow.color = k_gold;
+  glow.radius = std::clamp(radius * 2.6F, 4.0F, 9.0F);
+  glow.intensity = std::min(1.05F, 0.5F * intensity + 0.7F * flare);
+  renderer->local_light(glow);
+}
+
+} // namespace
 
 void render_production_completions(Renderer* renderer,
                                    Engine::Core::World* world,
@@ -34,42 +99,59 @@ void render_production_completions(Renderer* renderer,
         Engine::Core::ProductionCompletionComponent::k_duration - effect.remaining;
     const float progress = std::clamp(
         age / Engine::Core::ProductionCompletionComponent::k_duration, 0.0F, 1.0F);
-    const float fade_in = std::clamp(age / 0.18F, 0.0F, 1.0F);
+    const float fade_in = std::clamp(age / k_fade_in_seconds, 0.0F, 1.0F);
     const float fade_out = 1.0F - progress * progress * (3.0F - 2.0F * progress);
     const float intensity = fade_in * fade_out;
-    const QVector3D position(
-        transform.position.x, transform.position.y + 0.08F, transform.position.z);
-    const QVector3D gold(1.0F, 0.76F, 0.28F);
+    const float flare = fade_in * std::clamp(1.0F - age / k_flare_seconds, 0.0F, 1.0F);
+    const QVector3D ground(
+        transform.position.x, transform.position.y, transform.position.z);
+    const QVector3D position(ground.x(), ground.y() + 0.08F, ground.z());
     const float time = reduced_motion ? 0.0F : age;
     const float radius =
         effect.radius * (reduced_motion ? 1.0F : 1.0F + 0.18F * progress);
 
-    renderer->healer_aura(position, gold, radius, intensity, time);
-    renderer->healer_aura(position,
-                          QVector3D(1.0F, 0.94F, 0.70F),
-                          radius * 0.78F,
-                          intensity * 0.65F,
-                          time);
+    submit_ground_disc(
+        renderer, ground, effect.radius, 0.16F * intensity * intensity + 0.22F * flare);
+    submit_glow_light(renderer, ground, effect.radius, intensity, flare);
+
+    renderer->healer_aura(position, k_gold, radius, intensity, time);
+    renderer->healer_aura(
+        position, k_pale_gold, radius * 0.78F, intensity * 0.9F, time);
+    renderer->healer_aura(
+        position, k_pale_gold, radius * 0.52F, intensity * 0.8F, time);
     if (reduced_motion) {
+      submit_ground_ring(
+          renderer, ground, effect.radius, k_ring_seconds * 0.35F, 0.55F * intensity);
       continue;
     }
 
-    constexpr int k_glint_count = 10;
+    for (int ring = 0; ring < k_ring_count; ++ring) {
+      submit_ground_ring(renderer,
+                         ground,
+                         effect.radius,
+                         age - static_cast<float>(ring) * k_ring_delay_seconds,
+                         0.60F - 0.18F * static_cast<float>(ring));
+    }
+
     for (int i = 0; i < k_glint_count; ++i) {
       const float phase = static_cast<float>(i) / k_glint_count;
       const float angle = phase * 2.0F * std::numbers::pi_v<float> + age * 0.65F;
-      const float orbit = radius * (0.65F + 0.12F * std::sin(phase * 19.0F));
-      const float height = effect.radius * (0.15F + progress * 1.5F + phase * 0.35F);
+      const float orbit = radius * (0.70F + 0.18F * std::sin(phase * 19.0F));
+      const float height = effect.radius * (0.12F + progress * 0.85F + phase * 0.30F);
+      const QVector3D outward(std::cos(angle), 0.0F, std::sin(angle));
       const QVector3D glint =
-          position +
-          QVector3D(std::cos(angle) * orbit, height, std::sin(angle) * orbit);
-      const float shimmer = 0.65F + 0.35F * std::sin(age * 7.0F + phase * 23.0F);
-      renderer->metal_spark(glint,
-                            gold,
-                            0.12F,
-                            intensity * shimmer * 0.7F,
-                            0.0F,
-                            QVector3D(0.0F, 1.0F, 0.0F));
+          position + outward * orbit + QVector3D(0.0F, height, 0.0F);
+
+      const float spark_age =
+          std::fmod(age + phase * k_spark_cycle_seconds, k_spark_cycle_seconds);
+      const float shimmer = 0.75F + 0.25F * std::sin(age * 7.0F + phase * 23.0F);
+      renderer->metal_spark(
+          glint,
+          i % 3 == 0 ? k_pale_gold : k_gold,
+          0.09F + 0.035F * effect.radius,
+          (intensity + flare) * shimmer * 1.3F,
+          spark_age,
+          (outward * 0.5F + QVector3D(0.0F, 1.0F, 0.0F)).normalized());
     }
   }
 }

--- a/render/entity/unseen_submitter.h
+++ b/render/entity/unseen_submitter.h
@@ -6,9 +6,9 @@
 
 namespace Render::GL {
 
-inline constexpr float k_unseen_chroma = 0.55F;
-inline constexpr QVector3D k_unseen_shade{0.50F, 0.50F, 0.51F};
-inline constexpr QVector3D k_unseen_lift{0.012F, 0.012F, 0.013F};
+inline constexpr float k_unseen_chroma = 0.80F;
+inline constexpr QVector3D k_unseen_shade{0.56F, 0.56F, 0.58F};
+inline constexpr QVector3D k_unseen_lift{0.010F, 0.010F, 0.012F};
 
 [[nodiscard]] inline auto unseen_surface_color(const QVector3D& color) -> QVector3D {
   const float luminance =

--- a/render/ground/biome_renderer.cpp
+++ b/render/ground/biome_renderer.cpp
@@ -110,9 +110,7 @@ void BiomeRenderer::submit(Renderer& renderer, ResourceManager* resources) {
       [](const GrassInstanceGpu& instance) -> const QVector4D& {
         return instance.pos_height;
       },
-      renderer.static_world_visibility_filter_enabled()
-          ? renderer.submission_visibility().snapshot()
-          : nullptr,
+      nullptr,
       Scatter::ScatterMemoryMode::Remembered);
   if (visible_count == 0) {
     return;

--- a/render/ground/boulder_renderer.h
+++ b/render/ground/boulder_renderer.h
@@ -30,6 +30,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto fog_culls_instances() const -> bool override { return false; }
+
 private:
   void rebuild_boulder_instances();
   void append_world_prop_boulders();

--- a/render/ground/dead_tree_renderer.h
+++ b/render/ground/dead_tree_renderer.h
@@ -30,6 +30,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto fog_culls_instances() const -> bool override { return false; }
+
 private:
   void rebuild_dead_tree_instances();
   void append_world_prop_dead_trees();

--- a/render/ground/fog_renderer.cpp
+++ b/render/ground/fog_renderer.cpp
@@ -22,13 +22,13 @@ namespace {
 
 constexpr int k_chunk_cells = 14;
 constexpr float k_fog_y = 0.62F;
-constexpr float k_fog_alpha = 0.14F;
+constexpr float k_fog_alpha = 0.18F;
 constexpr float k_reveal_seconds = 0.22F;
 constexpr float k_soft_reveal_seconds = 0.55F;
 
 constexpr float k_fog_epsilon = 0.004F;
 
-const QVector3D k_fog_color{0.48F, 0.49F, 0.50F};
+const QVector3D k_fog_color{0.09F, 0.10F, 0.12F};
 
 auto chunk_count(int cells) -> int {
   return (std::max(0, cells) + k_chunk_cells - 1) / k_chunk_cells;

--- a/render/ground/iron_ore_renderer.cpp
+++ b/render/ground/iron_ore_renderer.cpp
@@ -21,6 +21,9 @@ namespace {
 using std::uint32_t;
 using namespace Render::Ground;
 
+constexpr float k_arcane_ore_glow = 1.05F;
+constexpr float k_haunted_ore_bonus = 0.30F;
+
 } // namespace
 
 namespace Render::GL {
@@ -32,11 +35,12 @@ void IronOreRenderer::configure(const Game::Map::TerrainHeightMap& height_map,
                                 const Game::Map::BiomeSettings& biome_settings,
                                 const std::vector<Game::Map::WorldProp>& world_props) {
   configure_biome_common(biome_settings);
+  m_state.track_visible_instances = true;
   m_state.params.light_direction = m_light_direction;
 
-  constexpr float k_haunted_ore_glow = 1.15F;
   m_state.params.magic_strength =
-      k_haunted_ore_glow * world().terrain_or_empty().supernatural_presence();
+      k_arcane_ore_glow +
+      k_haunted_ore_bonus * world().terrain_or_empty().supernatural_presence();
   generate_instances(world_props, height_map);
 }
 
@@ -45,7 +49,24 @@ void IronOreRenderer::set_light_direction(const QVector3D& dir) {
 }
 
 void IronOreRenderer::submit(Renderer& renderer, ResourceManager* resources) {
-  submit_prop_common(renderer, resources, TerrainScatterCmd::Species::IronOre);
+  if (submit_prop_common(renderer, resources, TerrainScatterCmd::Species::IronOre) ==
+      0) {
+    return;
+  }
+
+  for (const auto& inst : m_state.visible_instances) {
+    const QVector3D ore_pos = inst.pos_scale.toVector3D();
+    const float scale = std::max(inst.pos_scale.w(), 0.1F);
+    const float phase = inst.color_rot.w();
+    const float time = m_state.params.time;
+    const float pulse = 0.84F + 0.16F * std::sin((time * 1.9F) + phase);
+    Render::LocalLight votive;
+    votive.position = ore_pos + QVector3D(0.0F, scale * 0.6F, 0.0F);
+    votive.color = QVector3D(0.48F, 0.54F, 0.92F);
+    votive.radius = std::clamp(scale * 2.8F, 3.0F, 8.0F);
+    votive.intensity = 0.52F * pulse;
+    renderer.local_light(votive);
+  }
 }
 
 void IronOreRenderer::generate_instances(

--- a/render/ground/iron_ore_renderer.h
+++ b/render/ground/iron_ore_renderer.h
@@ -24,6 +24,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto fog_culls_instances() const -> bool override { return false; }
+
 private:
   void generate_instances(const std::vector<Game::Map::WorldProp>& world_props,
                           const Game::Map::TerrainHeightMap& height_map);

--- a/render/ground/plant_renderer.h
+++ b/render/ground/plant_renderer.h
@@ -28,6 +28,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto fog_culls_instances() const -> bool override { return false; }
+
 private:
   void generate_plant_instances();
 };

--- a/render/ground/scatter_renderer_base.h
+++ b/render/ground/scatter_renderer_base.h
@@ -123,9 +123,9 @@ public:
     return m_procedural_generations;
   }
 
-protected:
   [[nodiscard]] virtual auto fog_culls_instances() const -> bool { return true; }
 
+protected:
   void set_light_direction_common(const QVector3D& dir,
                                   const QVector3D& default_direction) {
     m_light_direction = dir.isNull() ? default_direction : dir.normalized();

--- a/render/ground/stone_renderer.h
+++ b/render/ground/stone_renderer.h
@@ -28,6 +28,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto fog_culls_instances() const -> bool override { return false; }
+
 private:
   void generate_stone_instances();
 };

--- a/render/ground/tree_renderer.h
+++ b/render/ground/tree_renderer.h
@@ -34,6 +34,8 @@ public:
 
   void submit(Renderer& renderer, ResourceManager* resources) override;
 
+  [[nodiscard]] auto fog_culls_instances() const -> bool override { return false; }
+
   [[nodiscard]] auto species() const -> Game::Map::TreeSpecies { return m_species; }
 
   [[nodiscard]] auto instances_for_test() const -> const std::vector<TreeInstanceGpu>& {

--- a/tests/render/fog_renderer_test.cpp
+++ b/tests/render/fog_renderer_test.cpp
@@ -107,7 +107,7 @@ TEST(FogRenderer, EmptyGridClearsEverything) {
   EXPECT_EQ(fog.patch_count(), 0U);
 }
 
-TEST(FogRenderer, UnexploredPatchesAreNeutralHazeNotABlueSlab) {
+TEST(FogRenderer, UnexploredPatchesAreADarkNeutralShadowNotAHaze) {
   FogRenderer fog;
   fog.update_mask(28, 28, 1.0F, filled_grid(28, 28, VisibilityState::Unseen));
   ASSERT_GT(fog.patch_count(), 0U);
@@ -124,6 +124,9 @@ TEST(FogRenderer, UnexploredPatchesAreNeutralHazeNotABlueSlab) {
   EXPECT_LE(blue - red, 0.06F)
       << "a blue-dominant haze is the dark-blue floor players reported instead of "
          "the real ground seen through fog";
+  EXPECT_LE(std::max({red, green, blue}), 0.25F)
+      << "the veil darkens the ground like a shadow; a bright grey at any alpha "
+         "lowers contrast and blurs the terrain underneath into a featureless smudge";
   EXPECT_LE(patch.alpha, 0.30F)
-      << "the haze is a veil over readable terrain, not a cover that replaces it";
+      << "the veil is a shadow over readable terrain, not a cover that replaces it";
 }

--- a/tests/render/renderer_visibility_policy_test.cpp
+++ b/tests/render/renderer_visibility_policy_test.cpp
@@ -1,8 +1,34 @@
 #include <gtest/gtest.h>
 
 #include "game/map/visibility_service.h"
+#include "render/ground/boulder_renderer.h"
+#include "render/ground/dead_tree_renderer.h"
+#include "render/ground/iron_ore_renderer.h"
+#include "render/ground/plant_renderer.h"
+#include "render/ground/stone_renderer.h"
+#include "render/ground/supply_cart_renderer.h"
+#include "render/ground/tree_renderer.h"
+#include "render/ground/weapon_rack_renderer.h"
 #include "render/scene_renderer.h"
 #include "scene/camera.h"
+
+TEST(RendererVisibilityPolicyTest, LandscapeScatterIsNeverCulledByFog) {
+  EXPECT_FALSE(Render::GL::StoneRenderer{}.fog_culls_instances())
+      << "boulders, trees, plants and ore are the map itself: they stay on screen "
+         "under the fog, shaded by the visibility mask, so unexplored ground is "
+         "recognisable terrain rather than an empty plain";
+  EXPECT_FALSE(Render::GL::BoulderRenderer{}.fog_culls_instances());
+  EXPECT_FALSE(
+      Render::GL::TreeRenderer{Game::Map::TreeSpecies::Pine}.fog_culls_instances());
+  EXPECT_FALSE(Render::GL::DeadTreeRenderer{}.fog_culls_instances());
+  EXPECT_FALSE(Render::GL::PlantRenderer{}.fog_culls_instances());
+  EXPECT_FALSE(Render::GL::IronOreRenderer{}.fog_culls_instances());
+
+  EXPECT_TRUE(Render::GL::SupplyCartRenderer{}.fog_culls_instances())
+      << "encampment dressing is activity, not landscape; it only appears once the "
+         "ground under it has been explored";
+  EXPECT_TRUE(Render::GL::WeaponRackRenderer{}.fog_culls_instances());
+}
 
 TEST(RendererVisibilityPolicyTest, ModeConfigUsesTotalVisibilityRules) {
   Render::GL::Renderer renderer;

--- a/tests/render/shader_source_test.cpp
+++ b/tests/render/shader_source_test.cpp
@@ -964,9 +964,56 @@ TEST(ShaderSource, UnexploredGroundShadesTheMapInsteadOfPaintingItBlue) {
   EXPECT_LE(*std::max_element(lift.begin(), lift.end()), 0.05F)
       << "a large lift washes the terrain out into flat haze";
 
-  EXPECT_GE(chroma, 0.40F)
-      << "fogged ground stays recognisably the same terrain, so it keeps a good part "
-         "of its colour rather than going fully grey";
+  EXPECT_GE(chroma, 0.70F)
+      << "fogged ground stays recognisably the same terrain, so it keeps most of its "
+         "colour; draining it further turned green meadows into grey-brown mud that "
+         "made the explored area read as an island";
+}
+
+TEST(ShaderSource, LandscapeScatterIsShadedUnderFogNotDeleted) {
+  const auto root = find_repo_root();
+  const auto mask =
+      read_text(root / "assets" / "shaders" / "include" / "visibility_mask.glsl");
+  ASSERT_FALSE(mask.empty());
+  const auto flat_mask = collapse_whitespace(mask);
+  const auto shading_begin = flat_mask.find("vec3 apply_visibility_world_shading(");
+  ASSERT_NE(shading_begin, std::string::npos);
+  const auto revealed_begin = flat_mask.find("vec3 apply_visibility_revealed(");
+  ASSERT_NE(revealed_begin, std::string::npos);
+  EXPECT_EQ(flat_mask.find("discard", shading_begin, revealed_begin - shading_begin),
+            std::string::npos)
+      << "world shading darkens what the player has not explored; a discard there "
+         "deletes the landscape and leaves the explored area floating on nothing";
+
+  const std::array<const char*, 7> landscape = {
+      "stone", "pine", "olive", "plant", "grass", "dead_tree", "iron_ore"};
+  for (const auto* name : landscape) {
+    const auto frag = read_text(root / "assets" / "shaders" /
+                                (std::string(name) + "_instanced.frag"));
+    ASSERT_FALSE(frag.empty()) << name;
+    const auto flat = collapse_whitespace(frag);
+    EXPECT_NE(flat.find("apply_visibility_world_shading(color, v_world_pos.xz)"),
+              std::string::npos)
+        << name
+        << " is part of the map itself: boulders, trees, plants and ore stay visible "
+           "in shadow under the fog so the terrain is recognisable before it is "
+           "explored";
+    EXPECT_EQ(flat.find("apply_visibility_revealed("), std::string::npos) << name;
+  }
+
+  const std::array<const char*, 3> camp_dressing = {
+      "tent", "supply_cart", "weapon_rack"};
+  for (const auto* name : camp_dressing) {
+    const auto frag = read_text(root / "assets" / "shaders" /
+                                (std::string(name) + "_instanced.frag"));
+    ASSERT_FALSE(frag.empty()) << name;
+    const auto flat = collapse_whitespace(frag);
+    EXPECT_NE(flat.find("apply_visibility_revealed(color, v_world_pos.xz)"),
+              std::string::npos)
+        << name
+        << " is encampment dressing, which is activity: it stays hidden until the "
+           "ground it stands on has been explored";
+  }
 }
 
 TEST(ShaderSource, EveryUnexploredSurfaceUsesTheSameShading) {

--- a/tools/arena/arena_viewport.cpp
+++ b/tools/arena/arena_viewport.cpp
@@ -41,6 +41,7 @@
 #include "arena_casting.h"
 #include "arena_scenario.h"
 #include "arena_scenarios.h"
+#include "game/accessibility/motion_settings.h"
 #include "game/core/component.h"
 #include "game/core/ownership_constants.h"
 #include "game/core/world.h"
@@ -90,6 +91,7 @@
 #include "render/entity/healer_aura_renderer.h"
 #include "render/entity/healing_beam_renderer.h"
 #include "render/entity/healing_waves_renderer.h"
+#include "render/entity/production_completion_renderer.h"
 #include "render/geom/arrow.h"
 #include "render/geom/projectile_renderer.h"
 #include "render/geom/range_rings.h"
@@ -684,6 +686,11 @@ void ArenaViewport::paintGL() {
       Render::GL::render_healing_beams(m_renderer.get(), res, *healing_beam_system);
       Render::GL::render_healing_waves(m_renderer.get(), res, *healing_beam_system);
     }
+    Render::GL::render_production_completions(
+        m_renderer.get(),
+        m_world.get(),
+        k_local_owner_id,
+        Game::Accessibility::MotionSettings::reduced_motion());
     Render::GL::render_healer_auras(m_renderer.get(), res, m_world.get());
     Render::GL::render_commander_auras(m_renderer.get(), res, m_world.get());
 


### PR DESCRIPTION
Keep map-defining terrain and natural scatter present beneath unexplored fog so the battlefield remains recognizable instead of collapsing into an empty or flat veil. Route landscape shaders through shared world visibility shading, reserve revealed-only handling for encampment dressing, and disable unnecessary CPU instance repacking as sight changes. Align the fog, reveal, and CPU unseen palettes and document the visibility policy.

Add a shared foliage bump include and use it to give pine and olive canopies more convincing lobes, sprigs, silhouettes, and crevice shading. Refine olive vertex breakup and interpolation, tune iron ore magic coloration and pulse behavior, and add restrained local ore illumination while registering the new shader asset.

Expand production completion feedback with layered gold auras, ground discs, expanding rings, local glow, animated directional glints, and reduced-motion support, then expose the effect in the arena viewport. Extend renderer-policy, shader-source, and fog-renderer coverage so the landscape/activity split and neutral shadow treatment remain explicit.

Keep shader sources in the repository formatter-compliant after synchronizing the branch with the latest mainline changes.