### PR TITLE
fix: stabilize troop movement through tight spaces

### DIFF
--- a/assets/shaders/ground_marker.frag
+++ b/assets/shaders/ground_marker.frag
@@ -20,6 +20,12 @@ float soft_band(float value, float low, float high, float feather) {
          (1.0 - smoothstep(high - feather, high + feather, value));
 }
 
+float band_coverage(float value, float low, float high, float pixel_span) {
+  float feather = max(pixel_span * 0.75, 0.02);
+  float fill = clamp((high - low) / max(pixel_span, 1e-4), 0.0, 1.0);
+  return soft_band(value, low, high, feather) * fill;
+}
+
 float dash_gate(float angle, float dash_count, float duty, float feather) {
   if (dash_count <= 1.0 && duty >= 0.999) {
     return 1.0;
@@ -43,29 +49,32 @@ void main() {
   float angle = v_shape_coord.x;
   float radial = v_shape_coord.y;
 
-  float radial_feather = max(fwidth(radial) * 0.75, 0.02);
+  float radial_span = fwidth(radial);
   float angular_feather = max(fwidth(angle) * dash_count, 0.004);
 
-  float main_band = soft_band(radial, k_band_inner, k_band_outer, radial_feather);
+  float main_band = band_coverage(radial, k_band_inner, k_band_outer, radial_span);
   main_band *= dash_gate(angle, dash_count, dash_duty, angular_feather);
 
   float coverage = main_band;
 
   if (second_end > second_start) {
     coverage =
-        max(coverage, soft_band(radial, second_start, second_end, radial_feather));
+        max(coverage, band_coverage(radial, second_start, second_end, radial_span));
   }
 
   if (tick_count > 0.0) {
     float tick_slot = abs(fract(angle * tick_count + 0.5) - 0.5) * 2.0;
     float tick_gate = 1.0 - smoothstep(0.12, 0.2, tick_slot);
     float tick_band =
-        soft_band(radial, k_band_inner, k_band_outer + tick_length, radial_feather);
+        band_coverage(radial, k_band_inner, k_band_outer + tick_length, radial_span);
     coverage = max(coverage, tick_band * tick_gate);
   }
 
   float glow_center = (k_band_inner + k_band_outer) * 0.5;
-  float glow = exp(-pow(abs(radial - glow_center) / 1.5, 2.0)) * 0.32;
+
+  float glow = exp(-pow(abs(radial - glow_center) / 1.05, 2.0)) * 0.28;
+
+  glow *= clamp(2.5 / max(radial_span, 1e-4), 0.0, 1.0);
 
   bool focused = v_flags >= 0.5;
   float pulse = focused ? 0.86 + 0.14 * sin(u_time * 3.6 + v_phase) : 1.0;

--- a/assets/shaders/ground_marker.vert
+++ b/assets/shaders/ground_marker.vert
@@ -19,6 +19,18 @@ uniform vec2 u_height_uv_offset;
 uniform float u_height_to_world;
 uniform float u_ground_offset;
 
+uniform float u_angular_step;
+
+uniform vec2 u_height_world_per_texel;
+
+uniform float u_slope_clearance;
+
+uniform float u_max_slope_lift;
+
+uniform vec2 u_half_viewport;
+uniform float u_min_marker_pixels;
+uniform float u_max_thickness_gain;
+
 out vec2 v_shape_coord;
 out vec3 v_color;
 out float v_alpha;
@@ -26,15 +38,26 @@ out float v_pattern;
 out float v_flags;
 out float v_phase;
 
+const float k_two_pi = 6.28318530718;
+
 float sample_terrain_height(vec2 world_xz, float fallback) {
   if (u_has_height_tex != 1) {
     return fallback;
   }
-  vec2 uv = world_xz * u_height_uv_scale + u_height_uv_offset;
-  if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
-    return fallback;
-  }
+
+  vec2 uv = clamp(world_xz * u_height_uv_scale + u_height_uv_offset, 0.0, 1.0);
   return texture(u_height_tex, uv).r * u_height_to_world;
+}
+
+float pixels_per_world(vec3 anchor, vec2 dir) {
+  vec4 near_clip = u_view_proj * vec4(anchor, 1.0);
+  vec4 far_clip = u_view_proj * vec4(anchor + vec3(dir.x, 0.0, dir.y), 1.0);
+  if (near_clip.w <= 0.0001 || far_clip.w <= 0.0001) {
+    return 0.0;
+  }
+  vec2 near_px = (near_clip.xy / near_clip.w) * u_half_viewport;
+  vec2 far_px = (far_clip.xy / far_clip.w) * u_half_viewport;
+  return length(far_px - near_px);
 }
 
 void main() {
@@ -45,11 +68,50 @@ void main() {
   float radial = a_tex_coord.y;
   float angle = a_tex_coord.x;
 
-  float world_radius = max(outer_radius + (radial - 1.0) * thickness, 0.0);
   vec2 dir = vec2(a_position.x, a_position.z);
+
+  float band_thickness = thickness;
+  if (u_min_marker_pixels > 0.0 && u_half_viewport.y > 0.0) {
+    vec2 anchor_xz = center.xz + dir * outer_radius;
+    vec3 anchor =
+        vec3(anchor_xz.x, sample_terrain_height(anchor_xz, center.y), anchor_xz.y);
+    float scale = pixels_per_world(anchor, dir);
+    if (scale > 0.0001) {
+      band_thickness = clamp(u_min_marker_pixels / scale,
+                             thickness,
+                             thickness * max(u_max_thickness_gain, 1.0));
+    }
+  }
+
+  float world_radius = max(outer_radius + (radial - 1.0) * band_thickness, 0.0);
   vec2 world_xz = center.xz + dir * world_radius;
 
   float height = sample_terrain_height(world_xz, center.y);
+  float lift = u_ground_offset;
+
+  if (u_has_height_tex == 1) {
+
+    float half_step = u_angular_step * 0.5;
+    float theta = angle * k_two_pi;
+    vec2 behind = vec2(cos(theta - half_step), sin(theta - half_step));
+    vec2 ahead = vec2(cos(theta + half_step), sin(theta + half_step));
+    height =
+        max(height, sample_terrain_height(center.xz + behind * world_radius, center.y));
+    height =
+        max(height, sample_terrain_height(center.xz + ahead * world_radius, center.y));
+
+    vec2 step_world = max(u_height_world_per_texel, vec2(0.0001));
+    float dh_x = sample_terrain_height(world_xz + vec2(step_world.x, 0.0), center.y) -
+                 sample_terrain_height(world_xz - vec2(step_world.x, 0.0), center.y);
+    float dh_z = sample_terrain_height(world_xz + vec2(0.0, step_world.y), center.y) -
+                 sample_terrain_height(world_xz - vec2(0.0, step_world.y), center.y);
+    vec2 gradient = vec2(dh_x / (2.0 * step_world.x), dh_z / (2.0 * step_world.y));
+
+    float secant = sqrt(1.0 + dot(gradient, gradient));
+    float sine_slope = clamp(length(gradient) / secant, 0.0, 1.0);
+    lift = u_ground_offset * min(secant, max(u_max_slope_lift, 1.0)) +
+           u_slope_clearance * smoothstep(0.04, 0.40, sine_slope);
+  }
 
   v_shape_coord = vec2(angle, radial);
   v_color = i_color_alpha.rgb;
@@ -58,6 +120,5 @@ void main() {
   v_flags = i_shape.z;
   v_phase = i_shape.w;
 
-  gl_Position =
-      u_view_proj * vec4(world_xz.x, height + u_ground_offset, world_xz.y, 1.0);
+  gl_Position = u_view_proj * vec4(world_xz.x, height + lift, world_xz.y, 1.0);
 }

--- a/docs/TROOP_MOVEMENT_REVIEW.md
+++ b/docs/TROOP_MOVEMENT_REVIEW.md
@@ -1,0 +1,772 @@
+# Troop movement review — 2026-09-10
+
+Evidence pass for the complaint that large, multi-unit moves through towns and
+other tight ground are glitchy: the warning marker pops up, troops do not react
+at once, units spin, direction changes look fake, soldiers get left behind, and
+the recovery machinery runs all the time. Everything below was measured on
+`main` at `dfcbb886` with binaries built from that tree the same evening, in
+three ways:
+
+- **The real game**, an all-AI skirmish watched through `--observe` on
+  Sunbaked Terraces (four AIs, 11 simulated minutes) with the movement trace on
+  (`SOI_MOVEMENT_TRACE_DIR`, stride 6).
+- **The Arena**, the existing tight-space scenarios plus three new manoeuvre
+  scenarios written for this review (`maneuver_town_relay`,
+  `maneuver_obstacle_slalom`, `maneuver_countermarch_streets`), on the RTX at
+  30 Hz with `--animation-diagnostics` so every soldier's root is in the trace.
+- **The headless gate**, `battlefield_gameplay_verifier --all --seconds 60`
+  with the trace on, read back through `movement_trace_report`.
+
+The new scenarios exist because the old ones were too kind: one straight
+corridor, four units, one order. A player drives fourteen units of four troop
+types through a staggered town and changes their mind every ten seconds. That
+is what the manoeuvre scenarios do, and they fail on `main`.
+
+## 1. What was observed
+
+### 1.1 The real game (observed skirmish)
+
+Army units only (swords, spears, archers, knights), 26 725 samples of units
+under an active order:
+
+| Measurement                                                       | Value                  |
+| ----------------------------------------------------------------- | ---------------------- |
+| Samples in `LocallyBlocked` / `Repathing` / `Recovering`          | 33 % of active samples |
+| Samples where the player-facing **Blocked** marker would be shown | 3.1 %                  |
+| Orders that ended `Unreachable` (abandoned by the ladder)         | 29 of 1 953            |
+| Longest single order held without arriving                        | 83 s                   |
+| One unit's repath count inside one order                          | 37                     |
+
+Two units account for most of the blocked time, and both show the same
+mechanism. Entity 100, a swordsman unit, stands **exactly on its resolved goal**
+(`remaining = 0`, no waypoints, no neighbours, no contact, no rejected motor
+step) and is declared `LocallyBlocked` for 28 s at a stretch, escalates to
+`RelaxFormation`, is abandoned as `Unreachable`, is re-ordered by the AI to the
+same spot, and repeats for the rest of the match. A builder (entity 65) does
+the same 0.8 m from a goal it can never reach because the requested point is
+inside a footprint 6.5 m away. Neither ever moved a body while "blocked"; the
+motor was asked for nothing (`des_v = 0`).
+
+Root yaw rate while under orders, by body type: formation blocks stay under
+160 °/s; single bodies (civilians, healers, commanders, builder crews) reach
+the raw 720 °/s cap; sheep and wolves exceed 200 °/s on 20–31 % of their frames.
+
+### 1.2 Arena, existing tight-space scenarios
+
+Every scenario was run with frame captures and per-soldier diagnostics. Stalls
+are the arena's own `movement:` summary (seconds a group made no progress while
+holding an order); soldier numbers are computed from `trace.jsonl` over living,
+unculled soldiers.
+
+| Scenario                         | Verdict on main             | Longest unit stall                  | Soldier frames > 200 °/s | Soldier pops (> 4 m/s) | Max soldier speed |
+| -------------------------------- | --------------------------- | ----------------------------------- | ------------------------ | ---------------------- | ----------------- |
+| `stuck_town_streets`             | **FAIL** permanent stall    | 25.3 s (Following), 21.6 s Yielding | 3.3–4.8 %                | 1 293 frames           | 15.0 m/s          |
+| `nav_town_crossing`              | stall                       | 18.1 s (Following)                  | 3.3 %                    | yes                    | 15.2 m/s          |
+| `stuck_interrupted_march`        | stall                       | 20.1 s (Following)                  | 2.5 %                    | yes                    | 15.2 m/s          |
+| `path_building_alley`            | **FAIL** missed destination | 17.4 s (Following)                  | 3.8 %                    | no                     | 4.2 m/s           |
+| `army_formation_obstacle_course` | **FAIL** missed destination | 4.9 s (LocallyBlocked), 1 wedged    | 6.1–6.5 %                | yes                    | 15.0 m/s          |
+| `army_formation_narrow_gate`     | **FAIL** missed destination | 4.0 s                               | 1.1 %                    | yes                    | 14.5 m/s          |
+| `traversal_city_alley`           | pass (movement)             | 3.4 s                               | —                        | —                      | —                 |
+| `crossing_formations`            | pass                        | 1.4 s                               | 3.0–7.0 %                | no                     | 4.7 m/s           |
+| `stuck_crossing_congestion`      | pass                        | 0.7 s                               | 0.1 %                    | no                     | 5.1 m/s           |
+
+Two things repeat in every row:
+
+- **Long stalls in `Following`.** A group sits still for 17–25 s while its
+  order state says it is following its route. The recovery ladder does not
+  see it because the ladder's clock only starts once the route follower stops
+  publishing progress, and a unit that is being slowed to a crawl by traffic
+  ("Yielding") or that is inching forward keeps resetting it.
+- **Soldier pops at 14–15 m/s.** In every scenario with a building or a prop
+  near the route, soldiers jump 0.45–0.5 m in one 30 Hz frame. 14 m/s is
+  `k_ground_clamp_speed` in `unit_traversal_layout_system.cpp`: when a
+  formation slot lands inside a footprint (typically because the root turned
+  and the rigid slot offsets swept through a wall), the slot's _current_
+  position is yanked inward at that speed. `stuck_town_streets` alone has
+  1 293 such frames in 80 s. This is the "soldier gets lost / teleports"
+  complaint.
+
+### 1.3 Arena, the new manoeuvre scenarios
+
+`maneuver_town_relay` — 14 units, ~150 soldiers, seven orders in 112 s through
+a staggered town (three of them reversing a march in progress, one a full
+deploy):
+
+- **FAIL**: two swordsman units ended the run 15.9 s and 16.3 s into a stall
+  _in `Following`_; the spear group missed its final destination.
+- Three of the four spear units never left the west edge on the last order:
+  they finished 42 m from their goal after 10–16 s standing still, five
+  repaths and three "recoveries". Units left behind is exactly what a player
+  sees when they re-order an army and part of it does not come.
+- Per soldier: spears 9.3 % of frames turning faster than 200 °/s, swords
+  4.9 %, archers 5.8 %; 15–17 m/s position pops in all three infantry groups
+  and 12.7 m/s in the knights; 1 356 spear frames of a soldier sliding along
+  in an idle pose.
+- Per unit: knights' roots turn at up to 189 °/s and every unit reversed its
+  heading by more than 120° between two consecutive samples four to seven times
+  — the "fake" direction change. A reversal is instantaneous re-aiming of the
+  route at the new goal; nothing wheels.
+- Visually, the army walked _around_ the town every time it could. A closed
+  variant with palisades on both flanks (forcing a route through the streets)
+  is in the file and is what the gate should run.
+
+The palisaded variant is reported in §1.6.
+
+### 1.4 Headless verifier
+
+`battlefield_gameplay_verifier --all --seconds 60` passes all eight scenarios
+and the movement trace reports 14 findings: ten `AngularSpeedExceeded` /
+`AngularAccelerationExceeded` at 960–1 440 °/s and two `HeadingOscillation`.
+Half of those angular numbers are an instrumentation bug: the trace manifest
+written from the environment hard-codes `fixed_step_seconds = 1/60` while the
+verifier steps at 1/30, so every yaw rate in that run is doubled. Corrected,
+they are 480–720 °/s, which is still the single-body cap and still twice what
+any RTS body should do. The headless scenarios are otherwise clean, which is
+the point: the defects live in crowded, built-up ground, and the headless
+gate has no scenario there.
+
+### 1.5 The other two manoeuvre scenarios
+
+`maneuver_obstacle_slalom` — the same army zigzagging between boulder fields,
+ruins, pine clusters and farmsteads, seven orders with two reversals:
+
+- **FAIL**: an archer's rendered root jumped **14.02 m in one frame** (the
+  render-side snap, 7 m doubled while wheeling); the spear group finished
+  10–20 m short of its last destination after 95 s.
+- Longest unit stall 11.0 s (`Following`); soldier frames > 200 °/s: 4.2–4.6 %;
+  15 m/s pops in every infantry group and 14.8 m/s in the knights.
+
+`maneuver_countermarch_streets` — two six-unit friendly armies through one
+street grid from opposite ends, reversed before contact, sent through each
+other twice, then crossed at the junction where an enemy block stands:
+
+- **FAIL**: two western swordsman units ended the run 21.3 s into `Repathing`
+  and 17.1 s into `Following` without progress; the group missed its
+  destination.
+- The western army stalled for **34 s**, repathed ten times and abandoned one
+  order; two of its units finished at the far south-east edge of the field
+  (their goals had been moved there by `assign_local_recovery_move`, which
+  substitutes a "recovery cell" up to 64 cells away for the order) — a unit
+  wandering off on its own is this mechanism.
+- Soldier frames > 200 °/s: **11.8 % and 12.5 %** in the two western groups
+  (the ones in head-on traffic); 2 125 frames of spearmen sliding in an idle
+  pose; 15–16 m/s pops in all four groups.
+
+### 1.6 The palisaded relay
+
+With palisades on both flanks of the town (the version now in the file), the
+same seven orders give: **FAIL** — a swordsman unit 18.0 s into a `Following`
+stall at the end, the archers missing their destination, and an archer unit
+20.5 s in `Yielding`. Soldier frames > 200 °/s rise to **7.8–8.9 %** for all
+three infantry groups, idle-while-translating frames to 1 514 (swords), and the
+knights' roots still turn at 189 °/s. The army also found the one open strip
+along the inside of the palisade and marched down it as a blob rather than
+threading the gaps, which is why the committed layout hugs the palisades to the
+outer rows and opens a plaza in the middle.
+
+Head-on friendly traffic is the worst case in the whole review: the avoidance
+stage slows both sides to a crawl inside a lane the width of two body cores,
+neither side has room to lean in a 5 m street, the `Yielding` budget (8 s)
+expires into `LocallyBlocked`, both repath into the same street and the
+recovery ladder scatters the goals.
+
+## 2. The bar: what a clean RTS does
+
+Measured against StarCraft II, Company of Heroes and Total War style unit
+handling, the contract a player expects is:
+
+1. **Acknowledge instantly.** Within one or two simulation ticks of a click,
+   every unit in the selection has a new heading target and its front rank is
+   moving. There is no "thinking" pause and nothing visible about routing.
+2. **One path per group, one lane per unit.** A boxed selection gets one
+   corridor and every unit its own lane in it, in the order the units already
+   stand. Units flow through a gap like water: the shape narrows, files fold
+   into the gap in their existing order and unfold on the far side, and nobody
+   is left behind — a unit that cannot reach the exact point walks to the
+   nearest point it can reach and stands down there, silently.
+3. **Bodies never overlap and never freeze.** Two friendly units meeting
+   head-on slide past each other; one gives way for a bounded time, never both,
+   and neither stands still. Enemy bodies cannot be walked through.
+4. **Turning is a body, not a value.** A block wheels around a pivot at a
+   bounded rate (infantry ~90–150 °/s at the root, faster for a single man,
+   slower for horse and elephant); soldiers walk the arc; a reversal is an
+   about-face with the rear rank becoming the front, or a wheel — never all
+   twelve bodies spinning on the spot at 300 °/s and then sliding into place.
+5. **Soldiers are continuous.** A soldier's presented position moves at most a
+   little faster than the unit (catch-up ≈ 1.3× unit speed), never pops, never
+   plays idle while translating, and never stands inside a wall for a frame.
+6. **Recovery is silent and rare.** Repathing is invisible. A player-facing
+   "cannot get there" signal appears once, for a truly unreachable order, not
+   after 1.2 s of traffic.
+
+## 3. Where each symptom comes from
+
+The stack is `RouteFollowSystem` (desired velocity) → `LocalAvoidanceSystem`
+(traffic) → `MovementSystem` (motor, root yaw) → `UnitTraversalLayoutSystem`
+(soldier slots, corridor squeeze) → combat presentation → renderer smoothing
+(`soldier_turn_smoothing.cpp`). What produces each complaint:
+
+**The warning marker.** `ActivityKind::Blocked` is raised from
+`MovementComponent::stuck_timer ≥ 1.2 s`, a mirror of
+`progress.no_progress_seconds` written by the route follower. It is a fourth
+stall clock next to `progress.state` (0.35 s to `LocallyBlocked`), the recovery
+ladder in `track_objective_stall` (2.5 s rungs, 9 s no-closer rungs) and the
+presentation stall gate in `world.cpp` (0.4 s). Each decides "stuck" on its own
+definition; the marker fires on the one nobody else uses.
+
+**Units that never arrive and loop through recovery.** In
+`RouteFollowSystem::follow`, arrival is refused when the _requested_ goal is
+further than `arrive_radius + 0.75 m` from where the route ends
+(`route_stops_short_of_the_order`). A goal inside a footprint is resolved to
+the nearest walkable cell — deliberately — and then arriving at that cell is
+treated as being blocked: state `LocallyBlocked`, desired velocity not
+published, repath to the same cell, `Recovering`, `Unreachable`; the AI
+re-issues the order and it starts again. The same rule turns the last unit of
+a formation order into a permanent "blocked" body when its slot was fitted a
+metre away from where it can stand. This is a state machine bug, not a
+pathfinding one: reaching the nearest reachable point _is_ the terminal outcome.
+
+**Two stall ladders.** `update_progress` runs its own
+`LocallyBlocked → Repathing → Recovering` escalation with
+`retarget_unit`/`assign_local_recovery_move`, and `track_objective_stall` runs
+a second ladder (`Replan → Sidestep → RelaxFormation → Abandoned`) calling the
+same two functions on different clocks. They interleave, which is why a stuck
+unit shows repath counts of 16–37 inside one order and why stall fixes have
+kept regressing.
+
+**No body separation in the shipped game.** `BodyContactSystem` — the only
+stage that pulls overlapping unit bodies apart — is composed into
+`MovementPipeline`, which is used by `balance_sim` and tests. The game, the
+arena and the verifier build their systems through `register_runtime_systems`,
+which never adds it. Traffic avoidance only slows and leans bodies of the same
+owner within a lane of two 0.5 m cores; a 3 m wide block is a 0.5 m disc to
+it. So friendly blocks walk through each other, enemy blocks are not kept apart
+except by melee rules, and the gate test that asserts `BodyOverlap == 0` is
+vacuous because nothing writes the metric.
+
+**Rotating on the spot / spinning soldiers.** The root heading target for a
+formation is the direction of the _desired_ (pre-avoidance) velocity, which is
+the direction to an aim point 0.45–2 m ahead along the route
+(`heading_reference`). At a route vertex the aim point jumps to the next leg
+and the heading target jumps with it; the motor then throttles translation by
+heading error (`heading_translation_scale`, 20°→100°), so the block stops and
+turns in place, while the body actually moves along the _steered_ velocity —
+the root faces where it wanted to go, not where it goes. Soldier facing is a
+separate render-side smoothing at 300 °/s × 0.78–1.18 per man with a
+0.015–0.15 s per-rank delay, so twelve men spin at up to 350 °/s about their
+own axes (5–9 % of frames in the manoeuvre scenario) whenever the root heading
+target moves. Single bodies turn at 720 °/s in the simulation and the verifier
+records 1 440 °/s because of the manifest bug above.
+
+**Fake direction changes.** A new order re-aims the route immediately; there
+is no about-face, no wheel and no pivot at the simulation level. The render
+"wheel path" in `soldier_turn_smoothing.cpp` only bends each soldier's
+catch-up path when the root is already turning fast, and is disabled in combat
+and hold mode.
+
+**The collapse into a corridor looks bad.** Four independent narrowings are
+multiplied in `update_slot_states`: the traversal `lateral_scale`, a second
+`corridor_half_width / widest` correction, `onto_walkable_ground` bisection of
+the _target_, and the same bisection applied to the _current_ position at
+14 m/s. Only the first is reported in `TraversalLayoutFacts`, so the trace
+under-reports the squeeze, and the last one is the visible pop. Corridor width
+is measured three ways (`measure_width`, `center_constrained_waypoints`,
+`fit_lane`) with three probe steps and caps.
+
+**Lost soldiers.** A slot that ends inside a footprint after the root turns is
+clamped inward at 14 m/s; if the whole block is pinned against cover the
+render side can still snap a body 7 m (14 m while wheeling). Combined with the
+missing contact pass, a soldier can be drawn well outside the block it belongs
+to and then jump back.
+
+### 3.1 Two sources of truth to remove
+
+| Rule                       | Implementations today                                                                                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Movement pipeline order    | `MovementPipeline` (tests, balance_sim) vs `register_runtime_systems` (game); the latter lacks `BodyContactSystem`                                                          |
+| "Is it stuck"              | `no_progress_seconds`, `stall.stalled_seconds`/`no_closer_seconds`, `stuck_timer` (marker), `MotionPresentation::stalled_seconds`, trace thresholds, `AI::is_going_nowhere` |
+| Stall recovery             | `update_progress` ladder and `track_objective_stall` ladder, both calling `retarget_unit` / `assign_local_recovery_move`                                                    |
+| Yaw integration            | nine `fmod(diff+540,360)-180` clamps with ceilings 720/360/300/260/240/180/120/900 across motor, combat, RPG, builder bypass, renderer                                      |
+| Standability radius        | `is_movement_point_allowed` (radius 0), `Walkability::can_stand` (full clearance), `MotorCollision::allowed_here` (either), avoidance probe                                 |
+| Corridor width             | `measure_width`, `center_constrained_waypoints::probe_side`, `fit_lane` scale steps                                                                                         |
+| Lateral squeeze            | `lateral_scale`, `corridor_half_width/widest`, target bisection, current bisection at 14 m/s                                                                                |
+| Soldier separation floor   | `TraversalPolicy` 0.55, `UnitLayoutStyle::min_separation_scale`, `update_slot_states` 2r·1.04, `resolve_group_slots`, `SlotTerrainFitter`, avoidance 0.15, contact radii    |
+| Group pace                 | `declared_group_pace` (min speed at order time), `ArmyFormation::cohesion_pace`, `ArmyFormationRuntime::move_speed_multiplier`                                              |
+| Arrival radius / "in slot" | route follower radius, cohesion 1.35×spacing, staging 2.5 m, corridor waypoint tolerance, arena defaults                                                                    |
+| Slot layout                | `FormationCombat::resolve_layout` (sim) and `resolve_formation_instances` (render, then overwritten)                                                                        |
+| Stable slot order          | `rebuild_stable_mapping` (unused) vs `narrow_file_slots_into`                                                                                                               |
+| Trace time base            | `configure_from_environment` writes 1/60 whatever the world steps at                                                                                                        |
+
+## 4. Tests first
+
+Headless, deterministic, fast — these are the loop's inner gate:
+
+- `tests/headless/movement_quality_gate_test.cpp`: two new capture scenarios,
+  `army_town_relay` (the palisaded staggered town, fourteen mixed units, the
+  seven-order script) and `army_countermarch` (two six-unit armies through
+  one street grid with an enemy block in the junction), with budgets on
+  findings, `ProgressStall`, `SoldierAnchorJump`, `AngularSpeedExceeded`,
+  `IndefiniteActiveOrder` and a new `UnitLeftBehind` finding (a unit whose
+  final position is further from its last goal than the group tolerance while
+  siblings arrived).
+- Route follower: arriving at the resolved goal of an unreachable request is
+  terminal (`Arrived`, or a single `Unreachable` with no retarget), never
+  `LocallyBlocked`; a unit standing on its goal never enters the ladder.
+- One stall authority: a test that walks a blocked unit through the ladder and
+  asserts each retarget/recovery is issued exactly once per rung, from one
+  place, and that `stuck_timer`, the presentation stall and the marker all read
+  the same clock.
+- Motor: the root heading follows the accepted velocity when steering deviates
+  from the desired one; a 180° reversal wheels at the formation turn rate and
+  the block's translation ramps rather than stopping; one yaw integrator, with
+  the existing per-type ceilings, used by every writer (architecture test:
+  grep for `fmod(` … `540` outside it fails).
+- Traversal: slot recovery onto ground moves a soldier no faster than the
+  relocation limit; the squeeze is reported once and applied once; the
+  corridor width is measured by one function shared with the corridor planner.
+- Registry: `BodyContactSystem` is present and ordered after the motor in
+  `register_runtime_systems` (`movement_stage_ownership_test`).
+- Trace: the manifest's `fixed_step_seconds` equals the world's step.
+
+Arena, rendered, the outer gate: the three `maneuver_*` scenarios pass their
+expectations (response ≤ 1 s per order, no permanent stall over 8 s, no root
+teleport, soldiers on walkable ground, every group within tolerance of its
+last destination, frame budget).
+
+## 5. Improvement loop (ordered by player impact)
+
+1. Arrival semantics and one stall ladder (kills the marker spam, the
+   `Unreachable` re-order loop and units left behind).
+2. Register the contact pass; make avoidance lanes formation-aware (bodies
+   stop walking through each other; head-on traffic resolves).
+3. One yaw authority; root heading from accepted velocity; a wheel/about-face
+   rule for reversals at the simulation level, with the renderer only
+   smoothing (kills the spin and the fake turn).
+4. One squeeze, one ground recovery at body speed, one corridor measurement
+   (kills the pops and the collapsed-column look).
+5. Delete the duplicated rules in §3.1 as each authority lands; the
+   architecture tests above keep them from coming back.
+
+Then the visual recheck: the three manoeuvre scenarios and the observed
+skirmish again, same seeds, same cameras, side by side with the captures from
+this pass (kept under `artifacts/movement-review-2026-09-10/`).
+
+## 6. First fix slice (Sep 10–11)
+
+Landed in the tree with tests first; every suite below is green unless noted.
+
+- **Arrival is terminal.** `RouteFollowSystem::follow`: a route that ends short
+  of a requested point that is not ground (a click inside a footprint) is
+  `Arrived` with `arrived_short`, silently. A requested point that is ground but
+  has no route gets one confirming replan and is then given up once
+  (`Unreachable`), without twelve seconds on the ladder. Orders whose issuer
+  re-targets them (`AttackChase`, `ScriptedMove`, `GuardReturn`,
+  `RecoveryMove`, any structure approach) are never ended by the follower
+  (`MovementComponent::issuer_retargets`). A unit pressed against standing
+  friends within 1.5 m of its goal has arrived.
+- **One recovery ladder.** `update_progress` only classifies
+  (`Following`/`Turning`/`Yielding`/`LocallyBlocked`); every retarget and
+  recovery move is issued by `track_objective_stall` (Replan 1.5 s, Sidestep
+  4 s, RelaxFormation 7 s, Abandoned 12 s of standstill; no-closer clock
+  9/18/27/36 s). Time queued behind friendly traffic does not count as a stall.
+- **The marker reads the ladder.** `ActivityKind::Blocked` appears when the
+  ladder has reached Sidestep on a live order; `stuck_timer`/`stuck_ref_*` are
+  gone from `MovementComponent`.
+- **The contact pass ships.** `BodyContactSystem` is registered after the
+  motor. Animals are not pushed; idle combat units are nudged (35 % share) by a
+  body under way so a column can pass a huddle; on a bridge, hill entrance or
+  gate passage bodies never spread sideways, the one behind backs off.
+  `BuildingCollisionRegistry::point_in_navigation_passage` is the one passage
+  predicate (steering and contact both use it).
+- **Blocks wheel and go.** Formation turn rate floor 180 °/s (outer file
+  4.5 m/s or 2× pace), translation stays at full pace within 45° of heading
+  error and tapers to zero at 150° (single bodies keep 20°/100°); the root
+  faces the _steered_ velocity.
+- **Soldiers walk out of walls.** Slot recovery onto ground runs at the
+  4.5 m/s recovery pace, never 14 m/s; a slot whose recovery point is already
+  held by another slot takes the nearest open ground in sight of the root
+  instead of stacking on it.
+- **Trace time base.** `MovementTrace::set_fixed_step_seconds` is fed by the
+  world every tick; the manifest reports the real step.
+
+New tests: `StuckRecoveryTest.{AnObjectiveInsideASealedPenEndsAtTheWallWithoutShuffling,
+StandingOnTheResolvedGoalIsArrivedNotBlocked, ANoRouteOrderIsGivenUpAtOnceWithoutTheLadder,
+RecoveryIsIssuedByOneLadder}`, `TightGapNavigationTest.{ASoldierSweptIntoCoverWalksOutInsteadOfPopping,
+AReversedBlockWheelsFastAndStepsOffAtOnce}`, `UnitActivityTest.ArrivingShortOfAnUnreachablePointIsNotBlocked`,
+`MovementStageOwnershipTest.TheRegistryOrdersFollowThenSteerThenMotor` (now requires the contact pass),
+`MovementTraceTest.TheManifestTakesTheStepTheWorldActuallyRuns`, and the three `maneuver_*` arena scenarios.
+
+**Not this work:** `WallSiegeTest.FrontRankVisuallyReachesTheFacadeFromWalkableGround`
+fails on `origin/main` since #1449 ("settle the melee stance",
+`formation_contact_processor.cpp`); bisected by swapping that one file back to
+`dfcbb886`, which makes it pass with every change above in place.
+
+## 7. Second fix loop (Sep 11)
+
+The first slice, re-measured on the tightened town relay, removed the soldier
+pops (worst soldier speed 16 m/s down to 6.7 m/s) and every unanswered order.
+It also introduced two defects, both found in the trace and both fixed:
+
+- **Treading water in wall gaps.** `WallNetworkService` registers every gap in
+  a wall run as a navigation passage, so the spaced palisade was a row of
+  "gates". The one-lane contact rule pushed the rear body back along its own
+  travel; the motor walked it straight back in. Unit roots oscillated
+  ±0.05 m every frame with the walk animation on. In a lane, contact now only
+  eases the body ahead forward; the body behind is not pushed. Avoidance may
+  bring a body to a full stop, but only when it is touching a neighbour ahead
+  and has no room to lean -- everywhere else traffic still never stops a body.
+- **Heading jitter.** Facing the steered velocity swung the root ±6° per frame
+  whenever a lean or a contact nudge touched it, and soldier frames above
+  200 °/s rose from 10 % to 15 %. The root faces the route again.
+
+Also in this loop:
+
+- **One yaw integrator.** `Game::Systems::turn_yaw_toward`,
+  `signed_yaw_delta` and `yaw_degrees_from_direction` in
+  `game/util/planar_math.h` replace eleven private copies across the motor,
+  duel footwork, builder bypass, melee lock facing, commander target assist,
+  RPG engagement, formation contact soldier yaw, defensive layout, unit layout,
+  wildlife bite facing and trace analysis. The builder bypass now honours the
+  formation turn rate. `MovementStageOwnershipTest.EverySimulationYawTurnsThroughOneHelper`
+  fails on any new copy under `game/`.
+- **Gate test.** `GateTraversalTest.GroupMembersIndividuallyUseTheGateCenterline`
+  (24 bodies through one gate) went red with the treadmill and is green again.
+- **Scenario.** The relay's palisades are continuous and the army spawns in
+  columns; the previous layout overlapped groups at spawn and let the army
+  leave the town through the gaps.
+
+### Open decision for Adam
+
+A move order given to a unit locked in melee with a living enemy is dropped
+without a word (`prepare_move` in `movement_orders.cpp` returns nothing). That
+is the one remaining silent refusal on the player's move path. Letting the
+order disengage the unit is a combat rule change -- it interacts with the melee
+lock, `rear_rank_bypass` and the commander duels -- so it is not changed here.
+
+## 8. Third fix loop (Sep 11)
+
+Measured on the relay after loop 2: soldier spin down to 9 % (swords), 4.7 %
+(spears) and 2.7 % (archers) of frames above 200 °/s, worst soldier speed
+7.9 m/s. The movement trace still reported 293 `DirectionReversal` and 16
+`HeadingOscillation` findings, and the counter-march had one order go
+unanswered for over a second. Three causes, all in the trace:
+
+- **The aim point was pinned to the next corner.** Corridor routes through a
+  town are staircases of cell corners, a vertex every metre (a 116 m route had
+  29 waypoints, another 109). The follower aimed at `min(s + lookahead,
+next vertex)`, so approaching each corner the aim sat 0.2 m ahead and a 4 cm
+  nudge swung the desired velocity by up to 60°. 652 of 686 velocity reversals
+  were in plain `Following` with no contact at all.
+  `MovementRoute::steering_aim_s` now moves an aim that is closer than 75 % of
+  the look-ahead on down the route, but only as far as a straight line from
+  the body is walkable, so it still never cuts a building corner.
+- **The root faced the direction to that aim point.** Replaced by a look-ahead
+  heading fact (`DesiredMotionFacts::heading_x/z`, the route tangent at the aim
+  point) that depends only on progress along the route, plus a 2° deadband for
+  formations. New test `BlocksMarchingShoulderToShoulderHoldTheirHeading`.
+- **The traversal root hold parked the block.** When the front rank was wider
+  than a pinch ahead, the motor zeroed the block's velocity and reported
+  `Yielding` for up to 3 s. That is the order that "did not respond within
+  1 s". The block now keeps 35 % of its pace while it folds; the narrow-layout
+  test asserts the hold still happens and that the block never stands still.
+- **Render soldier turn rate** 300 → 200 °/s (mounted stays 150), so a change
+  of block heading reads as men turning rather than spinning.
+
+Tried and reverted: removing the instantaneous corridor correction and the
+sideways drive in `update_slot_states`. They are not redundant with
+`lateral_scale`: the correction squeezes below the files-one-body-apart floor
+at once, which the slew-limited scale cannot, and without it a soldier stood
+inside the wall of a one-cell gap.
+
+### Open findings
+
+- **Deploy slots on the wrong side of a wall.** A 14-unit `Line` deploy next
+  to a palisade placed five sword slots south of the palisade's end
+  (`SlotTerrainFitter` searches outward for free ground without asking whether
+  it is reachable from the anchor side). The units walk round the wall for
+  16 s. The planner should reject slots not connected to the anchor.
+- **Blocks detour round a town instead of using an 8 m street.** The clearance
+  cost (`k_clearance_avoid_weight` × block clearance per penalised cell) makes
+  a 12-man block's route through a street costlier than a long walk round the
+  outside. Visible in the counter-march; not changed here.
+- **Melee lock refuses move orders** (see section 7).
+
+## 9. Fourth loop (Sep 11): refusals and freezes
+
+Found by driving the manoeuvre scenarios with the movement trace and an
+env-gated diagnostic (`SOI_DEBUG_IDLE_ORDER=1` prints every unit that holds a
+live order with ground to cover and no desired motion).
+
+- **Units frozen with a live order.** `ArmyFormationRuntime::move_speed_multiplier`
+  ended in `std::clamp`, which passes NaN straight through. A NaN pace gave a NaN
+  look-ahead, `std::max(0, NaN)` returned 0, the aim point sat on the unit's own
+  feet, and the desired velocity was zero for 12 s until the ladder abandoned the
+  order. Guarded at the multiplier, at `formation_navigation_speed` and inside
+  `MovementRoute::steering_aim_s`; test `ANonFiniteLookaheadStillAimsDownTheRoute`.
+- **Orders into a building walked round it.** An order on a point that is not
+  standable resolved to the nearest standable cell by search order, which could be
+  the far face. `resolve_walkable_target_toward` now takes the first standable point
+  walking back from the click toward the unit (unless it is much further than the
+  nearest). Test `AClickInsideABuildingStopsOnTheSideTheUnitCameFrom`; this also
+  restored `CommanderSharedTraversalTest` parity.
+- **Unreachable orders wait instead of dying or dithering.** A point that is ground
+  but has no route: the unit stands at the end of the best route, keeps the order,
+  asks the planner again once a second, and goes on the moment a breach or an opened
+  gate makes a route. No ladder, no recovery moves; the Blocked marker shows; the
+  order is given up once after 12 s. Tests
+  `ANoRouteOrderWaitsWithoutShufflingThenEndsOnce`,
+  `AnObjectiveInsideASealedPenWaitsAtTheWallWithoutShuffling`.
+- **Queues.** A unit whose steering says it is queued behind traffic no longer
+  sidesteps (a shove) or abandons; those rungs become a silent replan and a restart,
+  while the relaxed-clearance replan still runs (it is what fits a block through a
+  one-cell breach). `BuildingObstructionLifecycleTest` depends on it.
+- **Treading water against a standing friend.** Avoidance kept a body pressing at a
+  third of its pace into a friend that was not moving; the contact pass pushed it
+  back every tick. A body touching a standing body now stops pushing and only leans
+  round it (or waits, if there is no room).
+- **Sideways sliding restored to the original band.** Loop 1 widened the
+  translate-while-turning band to 45°/150° to kill the reversal freeze; that let a
+  block strafe through a right-angle turn at 57 % pace. The 20°/100° band is back;
+  the 180 °/s wheel floor keeps an about-face under a second.
+- **Combat presses are not movement overlaps.** The contact pass records body
+  overlap only outside a melee press (both bodies engaged, or opposing bodies with
+  either engaged), so the quality gate measures traffic, not the fight.
+- **A locked noncombatant fights only its captor.** Faster movement let a raider
+  lock a builder in melee, and the lock hands the captor to the builder as its
+  target (`sync_melee_lock_target`). Gating that path on combat role was tried and
+  reverted: `BareHandedMeleeTest` requires a caught builder to fight back.
+  `AutoEngagementResponseTest.ANoncombatantNeverPicksItsOwnFight` now separates the
+  two: auto-engagement must record `NoCombatRole` for the builder, and a locked
+  builder's only allowed target is its captor.
+- `AutoEngagementResponseTest.SwordsmenGoToTheAidOfAnAllyBittenByWolves` samples every
+  tick: the escort now answers and kills the wolf inside the second, and a dead
+  target is cleared.
+
+## 10. Fifth loop (Sep 11): churn, stale facts and every suite green
+
+Measured on loop 4: the headless verifier passed all eight scenarios but its trace
+held 144 `RepathChurn` findings (1 026 repaths, 996 of them issued while the unit
+was `Yielding`), the quality gate's bot skirmish reported two idle bodies "inside
+one another" for 6-8 s, the breach test and `AiTownPlanTest` were red, and
+`WallSiegeTest` had been red on origin/main since #1449.
+
+- **Queues replanned every few seconds.** A unit waiting behind friends who were
+  moving climbed the ladder like a stalled one: a replan at 1.5 s, a "sidestep"
+  replan at 4 s, a relaxed-clearance replan at 7 s, then a restart. The planner
+  does not see bodies, so each replan returned the same route -- or one pointing
+  back the way the unit came. Every spontaneous unit-root reversal found in the
+  relay and countermarch traces (1 and 4, against 50/31 order-driven ones)
+  followed exactly such a `Blocked` replan. Two rules now: a queue that creeps
+  (at least 0.1 m in the one-second window) is flowing, not stalled; and the
+  ladder does not act on a queued unit until it has stood for
+  `k_queue_patience_seconds` (6 s). The clocks keep counting, so a queue that
+  never moves still escalates. Test
+  `TightGapNavigationTest.AQueueAtAGapWaitsItsTurnInsteadOfReplanning` (twenty
+  units through one cell, at most one replan each).
+- **Idle bodies reported overlaps they no longer had.** Local avoidance resets
+  steering facts only for a body under way, and the contact pass only ever raised
+  `body_overlap`. An idle unit brushed once kept that overlap for the rest of the
+  game, which is what the quality gate's bot skirmish measured (constant 0.483 m
+  and 0.600 m). The contact pass owns the fact now and clears it every tick. Test
+  `TightGapNavigationTest.AnIdleBodyDoesNotKeepAnOverlapItNoLongerHas`.
+- **A full stop that never ended.** Loop 2 let avoidance bring a body to a
+  complete stop when it touched a body ahead with no room to lean (and loop 4
+  when it touched a standing one). Nothing ever lifted that stop. Three soldiers
+  reaching a fresh breach side by side each waited for the others until the
+  ladder gave their orders up (`UnitsRerouteThroughNewlyOpenedBreach`), and AI
+  builder crews stood behind crews working on the neighbouring links, so the last
+  links of a ring went unbuilt (`AiTownPlanTest`: scipio's ring left open in every
+  run). Bisected with switches in one build, two to three runs each: removing the
+  stop fixed both but let a body press 0.45 m into another for 0.72 s in the
+  quality gate; keeping either half of it kept both failures. The stop now lasts
+  only while the ladder has seen the body stand still for at most
+  `k_stop_patience_seconds` (1 s); after that it presses on at the floor pace and
+  the contact pass slides it past. Breach, quality gate, the gap and recovery
+  suites and three walled-town runs all pass with it.
+- **The front rank stopped short of the wall it attacked** (red since #1449). Two
+  things held it back. #1449 clamped a soldier's step toward the opponent it is
+  paired with to `spacing * 0.20` so a line fight does not skate, and a wall
+  attacked in melee arrives through that pairing too: every soldier's contact
+  offset read exactly that clamp. And the rank that faces a structure was measured
+  from the combat layout's anchors, while a traversal layout had moved the soldiers
+  a rank behind them, so no soldier counted as facing the wall. The facade rank is
+  now measured where the soldiers stand, steps up to the facade (to the
+  structure's contact clearance, at most `spacing * 1.6`, as the unpaired
+  structure branch already allowed) and strikes it. Line fights keep the short
+  pull.
+- **An order held for eleven minutes.** In the observed skirmish one mounted unit
+  accounted for 98 % of all `LocallyBlocked` samples: it stood on its own cell for
+  674 s while every order it was given resolved to that cell. A route of no length
+  is invalid, and the follower treated "invalid" as "a new route" on every tick,
+  which restarted the wait at the obstruction every tick -- the 12 s give-up never
+  fired and the Blocked marker never went away. A wait now restarts only when the
+  route revision changes, and it ends with the order: giving the order up, or
+  losing it, clears it (it used to survive the give-up in the unit's facts). Test
+  `StuckRecoveryTest.AnOrderFromACellWithNoWayOutIsGivenUpNotHeldForever` (it held
+  the order with a 0.017 s wait after 20 s before the fix).
+- **The relay's palisades were off the wall lattice.** `ArenaScenariosTest.WallGroupsSitOnTheWallNetworkLattice`
+  requires every wall piece on the two-metre lattice; the palisades sat at
+  z = ±18.5. They are at ±18 now (36 m apart); the relay still passes.
+- **A flaky audio test.** `AudioGameplayScenarioTest.ADistantBattleIsCarriedAsOneMassNotAsSilence`
+  deals its blows once, and a cue whose only sound is still decoding is dropped,
+  not deferred. In the full run the audio loader was still mastering music and
+  ambience when the test fired. The test now waits for that sound to be ready.
+- **`AiTownPlanTest` depended on machine load.** `AISystem::process_results` waits
+  at most 4 ms (`k_default_decision_wait_budget`) for a decision; one that is not
+  back from the worker by then is applied on a later update. Over fifty simulated
+  minutes that makes a different town on a loaded machine.
+  `EveryCommanderRaisesItsOwnTownFromAnEmptyField` passed five isolated reruns but
+  failed inside the full `ai_tests` binary on this tree (scipio left soldiers by its
+  barracks) and on its parent commit alike (hanno's wall in six runs, hasdrubal's
+  soldiers adrift). The test now sets `set_decision_wait_budget` so every decision
+  is waited for; the plan is judged, not the machine. (The speed-floor bisect
+  above therefore used two to three runs per switch, never one.)
+
+Tried and dropped: letting the one-lane contact rule keep the sideways part of a
+push (for side-by-side bodies at a breach). It breaks
+`AnArmyClimbsAHillThroughItsEntrance` and `AnArmyCrossesARiverOnTheBridgeDeck`.
+
+### Measured on the final build
+
+- **Every test.** `scripts/run-tests.sh` in the full profile (extended tests, and
+  the verifier with two determinism runs per scenario), the QML design-system test
+  and the two model harnesses.
+- **Arena, against the baseline captures.** `maneuver_town_relay` passes (it had
+  three unanswered orders, a unit inside a building and a missed destination);
+  `stuck_town_streets` passes (permanent stall before). Worst soldier speed is
+  5–9 m/s everywhere (up to 16 m/s and a 420 m/s teleport before); soldier frames
+  turning faster than 200 °/s dropped in every scenario (relay 9.1 % → 5.3 %,
+  countermarch 7.6 % → 2.1 %). Spontaneous unit-root reversals -- the root turning
+  back with no new order in the last 3 s -- are 0–3 per scenario, each after a
+  replan; the rest follow orders. Still failing as on the baseline:
+  `path_building_alley`, `army_formation_narrow_gate` and
+  `army_formation_obstacle_course` miss their destinations, the countermarch's
+  west groups miss theirs, and the slalom's archers trip the arena's "went nowhere"
+  rule. In the traces those units move at full pace the whole time; the arena
+  rule measures progress toward the scenario destination while the unit follows a
+  later order or a long detour.
+- **Headless verifier trace.** `RepathChurn` 144 → 0. Up: `ObstructionNotEscalated`
+  7 → 51 (queued units now wait instead of replanning), `BodyOverlap` 26 → 46 and
+  `DirectionReversal` 12 → 27. The quality gate's budgets still hold.
+- **Observed skirmish.** Samples with no progress for 1.2 s or more: 11.5 % → 0.2 %
+  of active army samples. Most replans in one order: 7 → 2. No order ended
+  unreachable. The blocked share was the frozen unit above.
+
+### Open findings
+
+- What enclosed the unit at (2.5, 83.5) on Sunbaked Terraces. Two runs put a unit
+  there; its orders now end after the 12 s wait, but it still cannot move.
+- The no-closer clock measures straight-line distance to the objective, so a unit
+  walking a long detour at full pace climbs to a replan and a sidestep (15 such
+  replans in the countermarch, 0–8 in the other scenarios).
+- The `BodyOverlap` and `DirectionReversal` increases in the verifier trace are
+  the cost of pressing on after a one-second stop; they are within the gate but
+  should be driven down.
+- The movement trace keeps the last order state of a unit whose movement gate is
+  not route following, so a gated unit can read as `LocallyBlocked` in the trace
+  without any recovery running.
+
+## 11. Sixth loop (Sep 11): builders that do not set off
+
+Adam started The Timber Levy, selected the builders and sent them somewhere: "they
+do not start immediately they need time... they break layout... this should never
+happen". Every suite was green. The real mission was driven with an action
+fixture (`select_all`, `select_by_type builder`, three `move_to` orders) and the
+movement trace, and each order was read for the time until the unit had moved
+0.3 m, its root yaw per tick and its order state.
+
+- **A reversal stood the gang still while the block swung round.** Sent the way
+  its back was turned, a formation wheeled its rigid block round its centre at
+  180 °/s and could not take a step until its heading error fell below 100 °.
+  A twelve-man gang stood for 0.85 s, and its outer men were carried round the
+  block at 7.2 m/s (walking pace 2.3 m/s) -- that is the "breaks layout". A
+  formation now **faces about in place**: past the no-translation error the
+  root turns through 180 ° at once and every root-local soldier position (the
+  traversal slots, the presentation soldiers, fallen bodies) is negated with it,
+  so no soldier moves in the world; the rear rank leads off. The turned frame
+  lives in `UnitTraversalLayoutStateComponent::about_faced` and is applied where
+  the canonical layout becomes soldier positions: slot targets, the presentation
+  fallback, the anchor fallback and the renderer's fallback. Only a half turn is
+  used: footprints, clearance and lateral extents all take the layout's x as the
+  frontage, and a point reflection keeps them true where a quarter turn would
+  not. Tests `TightGapNavigationTest.AGangOrderedBehindItselfFacesAboutAndSetsOffAtOnce`
+  (0.85 s and 7.2 m/s before) and `AGangOrderedWellRoundItsShoulderSetsOffAtOnce`
+  (125 °: 0.55 s before, threshold first set at 135 °).
+- **Arrived and Recovering alternated every frame.** The mission set its gangs
+  down on ground `is_movement_point_allowed` rejects. The recovery move walked
+  them out, but a formation counts itself arrived within 0.9 m of its target, so
+  over the last 0.9 m it arrived, stopped on the rejected ground, and was sent
+  again the next tick. A unit no longer arrives where it cannot stand. Test
+  `StuckRecoveryTest.AUnitSetDownOnAFootprintStepsOffOnceAndStandsThere` (five
+  recovery orders in four seconds before). A start 0.55 m inside a footprint did
+  not reproduce it; the start must be further than the arrival radius from open
+  ground.
+- **The mission put the gangs inside each other.** Starting units were laid on a
+  fixed 1.2 m grid whatever their size: the four builder gangs overlapped by
+  2.1-3.0 m and stood on unstandable ground, and the swordsmen stood 2.5-3.6 m
+  inside the commander. Each starting unit is now set down on the nearest ring
+  round its authored point where its footprint stands on open ground clear of
+  every unit already on the field. Test
+  `MissionStartupTest.StartingUnitsStandApartOnOpenGround`.
+- **Every march ran at three quarters of its pace.** The motor pulled the body
+  toward the steered velocity and applied drag against that same pull, so a
+  body settled at `a / (a + 3)` of what its route asked: 1.52 m/s of 2.1 m/s for
+  a builder gang in the trace, 2.37 m/s of 3 m/s in a test, and a correspondingly
+  slow set-off. An order the route follower owns (player, formation, planner,
+  attack-move) now closes on its velocity with no drag. Removing the drag for
+  every body broke `WildlifeFightMotionTest.ASingleWolfClosesOnFleeingSheepAndFinishesTheHunt`
+  (three bites for four) and `MeleeExchangeDuelTest.ASwordDuelKeepsItsDamageRateAndShowsEveryReaction`
+  (1379 damage against a floor of 1448); an A/B switch in one build showed both
+  pass with the old drag and fail without it. Orders whose issuer re-aims them
+  every tick -- chases, scripted wildlife walks, guard returns, recovery --
+  keep the damped drive they were tuned against. Test
+  `CommandServiceTest.AnOrderedUnitMarchesAtItsOwnPace`.
+- **The quality gate read an about-face as a body spinning.** The first full
+  profile after the about-face failed `MovementQualityGateTest` in three capture
+  scenarios (26, 39 and 51 findings against a budget of 20): every about-face
+  was a 10 440 °/s body yaw rate and two angular-acceleration findings. The root
+  frame flips; no body turns with it. The trace sample now carries
+  `about_faced`, and the analysis measures the yaw step beyond a half turn on the
+  tick the flag changes, so a real one-tick spin is still reported. Tests
+  `MovementAnalysisTest.AnAboutFaceIsNotABodySpinningOnTheSpot` and
+  `AHalfTurnInOneTickWithoutAnAboutFaceIsStillASpin`.
+- **Two builder crews on one site could never start work.** With the about-face,
+  `AiTownPlanTest.AWalledCommanderClosesItsCircuitGivenTime` failed for Scipio
+  (one tower, ring open near -3.5,-34.5) in every run, and passed with the
+  about-face switched off. The about-face was not wrong: it changed the timeline,
+  and in the new one the AI assigned the second tower 30 times instead of 11. Its
+  build trace showed crews giving up "0.20 m out" of the tower site, and the
+  movement trace showed two crews frozen 0.26 m apart on the site centre for
+  thousands of ticks. A site counted as reached only within 15 cm (walls had
+  been widened to 1 m in an earlier fix), and the contact pass holds two crews
+  further apart than that, so neither ever arrived. Every product now arrives
+  within the same metre. Test
+  `ProductionSystemTest.TwoCrewsHeldApartOnOneSiteBothStartWork`.
+- **A quicker body walked into the back of a friend in a crowd.** Once player
+  orders drove at their full pace, `MovementQualityGateTest` still failed in
+  archers_vs_infantry (a body 0.91 m inside a friend for 3.5 s) and, under other
+  timings, in bot_skirmish (0.66-0.90 m). Logging every contact push for the pair
+  showed no rejected pushes and no exhausted budget on the body itself: the body
+  behind kept its floor pace (0.35 of its speed) into a friend walking the same
+  way, every push it got was against its own travel and was turned sideways by
+  `slide_along_travel`, and the friend's own budget was spent on its crowd. A
+  larger separation budget moved the failure to the other scenario. Avoidance
+  now keeps a body pressed against a friend walking the same way (faster than
+  0.2 m/s, within 60 degrees) to that friend's pace; it may still lean past, and
+  a friend standing still keeps the wait-then-press rule. A hand-built test of
+  two units on open ground did not reproduce it (the quicker one leans past), so
+  the capture scenarios of the gate are the regression tests.
+
+### Open findings
+
+- **An order undone the tick after it was given, once.** In the run before these
+  fixes, three of the four gangs received the player's second and third orders
+  and, one tick later, fresh orders back to the slots of the order before
+  (same tick for all three, a new route each, no repath recorded). The command
+  queue dispatches each command once, a right click submits one `Move`, and
+  army-formation groups are only committed by `DeployFormation`, so the issuer
+  was not found by reading. With every order and dispatched command logged
+  (`MovementSystem::issue_move*`, `CommandQueue::drain`), three further runs of
+  the same fixture on the fixed build showed only the player's orders reaching
+  the gangs. The difference between the runs is that the gangs no longer start
+  overlapping on unstandable ground, but that is not proven to be the cause.

--- a/game/core/component_core.h
+++ b/game/core/component_core.h
@@ -238,9 +238,9 @@ public:
     return structure_approach_target_id;
   }
 
-  [[nodiscard]] auto get_stuck_time() const -> float { return stuck_timer; }
-
   [[nodiscard]] auto get_precise_arrival() const -> bool { return precise_arrival; }
+
+  [[nodiscard]] auto get_issuer_retargets() const -> bool { return issuer_retargets; }
 
   [[nodiscard]] auto get_order_sequence() const -> std::uint64_t {
     return order_sequence;
@@ -268,6 +268,7 @@ public:
 
   void begin_order() {
     ++order_sequence;
+    issuer_retargets = false;
     route_id = 0U;
     route_lane_offset = 0.0F;
     route_lane_min_scale = 1.0F;
@@ -311,11 +312,8 @@ private:
 
   float navigation_clearance{0.5F};
 
-  bool stuck_ref_valid{false};
-  float stuck_ref_x{0.0F}, stuck_ref_z{0.0F};
-  float stuck_timer{0.0F};
-
   bool precise_arrival{false};
+  bool issuer_retargets{false};
   EntityID structure_approach_target_id{0};
   bool can_enter_forest{true};
 

--- a/game/core/component_gameplay.h
+++ b/game/core/component_gameplay.h
@@ -553,6 +553,8 @@ public:
   std::vector<UnitTraversalSlotState> slot_states;
   std::uint32_t slot_states_revision{0U};
 
+  bool about_faced{false};
+
   float entry_progress{0.0F};
   float exit_progress{1.0F};
   float transition_progress{1.0F};

--- a/game/core/movement_facts.h
+++ b/game/core/movement_facts.h
@@ -100,6 +100,9 @@ struct DesiredMotionFacts {
   float velocity_z{0.0F};
   float tangent_x{0.0F};
   float tangent_z{1.0F};
+
+  float heading_x{0.0F};
+  float heading_z{0.0F};
   float lookahead_x{0.0F};
   float lookahead_z{0.0F};
   float speed_limit{0.0F};
@@ -126,6 +129,8 @@ struct SteeringFacts {
   float contact_push_x{0.0F};
   float contact_push_z{0.0F};
   SteeringResult result{SteeringResult::Unconstrained};
+
+  bool blocked_by_standing_body{false};
 };
 
 struct MotorFacts {
@@ -169,6 +174,8 @@ struct MovementStallFacts {
   float closest_approach{0.0F};
   float no_closer_seconds{0.0F};
 
+  float queued_seconds{0.0F};
+
   MovementRecoveryRung rung{MovementRecoveryRung::None};
   std::uint32_t recovery_attempts{0};
   float clearance_relief{1.0F};
@@ -198,6 +205,13 @@ struct MovementProgressFacts {
   std::uint32_t repath_attempts{0};
   MovementRepathReason repath_reason{MovementRepathReason::None};
 
+  bool arrived_short{false};
+  std::uint32_t short_route_replans{0};
+
+  bool holding_at_obstruction{false};
+  float holding_seconds{0.0F};
+  float holding_recheck_seconds{0.0F};
+
   MovementStallFacts stall;
 };
 
@@ -215,6 +229,7 @@ struct TraversalLayoutFacts {
   float lateral_scale{1.0F};
   float transition_progress{1.0F};
   float mode_dwell_seconds{0.0F};
+  bool about_faced{false};
 };
 
 } // namespace Engine::Core

--- a/game/core/movement_trace.cpp
+++ b/game/core/movement_trace.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <charconv>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -254,6 +255,7 @@ auto to_json(const MovementTroopSample& s) -> std::string {
   w.field("formation_hw", s.formation_half_width);
   w.field("file_spacing", s.file_spacing);
   w.field("lateral_scale", s.lateral_scale);
+  w.field("about_faced", s.about_faced);
   w.field("portal", s.portal_id);
   w.field("mode", static_cast<std::uint32_t>(s.traversal_mode));
   w.field("normal_files", s.normal_files);
@@ -414,6 +416,7 @@ auto parse_troop_sample(const std::string& line, MovementTroopSample& out) -> bo
   read_float(line, "formation_hw", out.formation_half_width);
   read_float(line, "file_spacing", out.file_spacing);
   read_float(line, "lateral_scale", out.lateral_scale);
+  read_bool(line, "about_faced", out.about_faced);
   read_small(line, "normal_files", out.normal_files);
   read_small(line, "portal", out.portal_id);
   read_small(line, "mode", out.traversal_mode);
@@ -487,6 +490,7 @@ struct MovementTrace::Session {
   std::size_t troop_limit{k_default_troop_limit};
   std::size_t soldier_limit{k_default_soldier_limit};
 
+  std::string directory;
   std::uint64_t tick_stride{1};
   std::uint64_t byte_budget{k_default_file_byte_budget};
   std::uint64_t bytes_written{0};
@@ -539,6 +543,33 @@ void MovementTrace::configure_from_environment() {
   m_session->byte_budget = byte_budget;
 }
 
+namespace {
+
+void write_manifest_file(const std::string& directory,
+                         const MovementTraceManifest& manifest) {
+  std::ofstream manifest_stream(directory + "/manifest.json", std::ios::trunc);
+  if (manifest_stream.is_open()) {
+    manifest_stream << to_json(manifest) << '\n';
+  }
+}
+
+} // namespace
+
+void MovementTrace::set_fixed_step_seconds(float seconds) {
+  if (!(seconds > 0.0F)) {
+    return;
+  }
+  std::lock_guard<std::mutex> const lock(m_mutex);
+  if (!m_session ||
+      std::abs(m_session->manifest.fixed_step_seconds - seconds) < 1.0e-6F) {
+    return;
+  }
+  m_session->manifest.fixed_step_seconds = seconds;
+  if (m_session->to_file && !m_session->directory.empty()) {
+    write_manifest_file(m_session->directory, m_session->manifest);
+  }
+}
+
 auto MovementTrace::begin_file_session(const std::string& directory,
                                        const MovementTraceManifest& manifest) -> bool {
   end_session();
@@ -550,6 +581,7 @@ auto MovementTrace::begin_file_session(const std::string& directory,
 
   auto session = std::make_unique<Session>();
   session->manifest = manifest;
+  session->directory = directory;
   session->to_file = true;
   session->troop_stream.open(directory + "/troops.jsonl", std::ios::trunc);
   session->soldier_stream.open(directory + "/soldiers.jsonl", std::ios::trunc);

--- a/game/core/movement_trace.h
+++ b/game/core/movement_trace.h
@@ -90,6 +90,8 @@ struct MovementTroopSample {
   float formation_half_width{0.0F};
   float file_spacing{0.0F};
   float lateral_scale{1.0F};
+
+  bool about_faced{false};
   std::uint32_t portal_id{0};
   TraversalLayoutMode traversal_mode{TraversalLayoutMode::Normal};
   std::uint32_t normal_files{0};
@@ -178,6 +180,8 @@ public:
                           const MovementTraceManifest& manifest) -> bool;
 
   void begin_memory_session(const MovementTraceManifest& manifest);
+
+  void set_fixed_step_seconds(float seconds);
 
   void end_session();
 

--- a/game/core/movement_trace_analysis.cpp
+++ b/game/core/movement_trace_analysis.cpp
@@ -10,6 +10,8 @@
 #include <sstream>
 #include <unordered_map>
 
+#include "../util/planar_math.h"
+
 namespace Engine::Core {
 
 namespace {
@@ -26,7 +28,7 @@ state_claims_stillness(std::uint8_t presentation_state) -> bool {
 }
 
 auto shortest_angle(float from_degrees, float to_degrees) -> float {
-  return std::fmod((to_degrees - from_degrees + 540.0F), 360.0F) - 180.0F;
+  return Game::Systems::signed_yaw_delta(from_degrees, to_degrees);
 }
 
 auto is_active_state(MovementOrderState state) -> bool {
@@ -141,6 +143,7 @@ struct EntityWalkState {
   float previous_heading_delta{0.0F};
   bool has_previous_yaw{false};
   float previous_yaw{0.0F};
+  bool previous_about_faced{false};
   float previous_angular_speed{0.0F};
   bool has_previous_angular_speed{false};
   bool has_previous_direction{false};
@@ -528,7 +531,11 @@ void analyze_troops(const std::vector<MovementTroopSample>& troops,
       }
 
       if (walk.has_previous_yaw) {
-        float const delta = shortest_angle(walk.previous_yaw, sample.root_yaw);
+
+        float const frame_flip =
+            sample.about_faced != walk.previous_about_faced ? 180.0F : 0.0F;
+        float const delta =
+            shortest_angle(walk.previous_yaw + frame_flip, sample.root_yaw);
         float const angular_speed = std::fabs(delta) / dt;
         if (angular_speed > thresholds.max_angular_speed_degrees) {
           sink.add(
@@ -582,6 +589,7 @@ void analyze_troops(const std::vector<MovementTroopSample>& troops,
         }
       }
       walk.previous_yaw = sample.root_yaw;
+      walk.previous_about_faced = sample.about_faced;
       walk.has_previous_yaw = true;
 
       float const speed = accepted_speed(sample);

--- a/game/core/world.cpp
+++ b/game/core/world.cpp
@@ -173,12 +173,13 @@ void begin_motion_presentation_frame(World& world, float delta_time) {
   }
 }
 
-void publish_movement_trace_frame(World& world) {
+void publish_movement_trace_frame(World& world, float delta_time) {
   auto& trace = MovementTrace::instance();
   trace.configure_from_environment();
   if (!trace.enabled()) {
     return;
   }
+  trace.set_fixed_step_seconds(delta_time);
 
   world.each<MovementFactsComponent, TransformComponent, UnitComponent>(
       [&world, &trace](EntityID id,
@@ -285,6 +286,7 @@ void publish_movement_trace_frame(World& world) {
         sample.formation_half_width = facts.traversal.desired_half_width;
         sample.file_spacing = facts.traversal.file_spacing;
         sample.lateral_scale = facts.traversal.lateral_scale;
+        sample.about_faced = facts.traversal.about_faced;
         sample.normal_files = facts.traversal.normal_files;
         sample.direction_source = facts.direction_source;
         trace.record(sample);
@@ -1492,7 +1494,7 @@ void World::update(float delta_time) {
     finalize_motion_presentation_frame(*this, delta_time);
     publish_creature_presentation_frame(*this);
   }
-  publish_movement_trace_frame(*this);
+  publish_movement_trace_frame(*this, delta_time);
   const auto presentation_ended = std::chrono::steady_clock::now();
   if (!m_is_render_snapshot &&
       m_render_snapshots_requested.load(std::memory_order_acquire)) {

--- a/game/formation/army_formation_registry.cpp
+++ b/game/formation/army_formation_registry.cpp
@@ -549,6 +549,10 @@ auto ArmyFormationRuntime::move_speed_multiplier(const Engine::Core::Entity& ent
       error < 0.0F ? 0.0F
                    : std::clamp((error - in_slot_radius) / recovery_span, 0.0F, 0.25F);
   float const target_speed = pace * (1.0F + recovery);
+
+  if (!std::isfinite(target_speed)) {
+    return k_maintain_speed_multiplier;
+  }
   return std::clamp(target_speed / unit->speed, 0.1F, 1.0F);
 }
 

--- a/game/formation/unit_layout.cpp
+++ b/game/formation/unit_layout.cpp
@@ -6,6 +6,8 @@
 #include <numbers>
 #include <utility>
 
+#include "../util/planar_math.h"
+
 namespace Game::Formation {
 
 namespace {
@@ -1012,8 +1014,7 @@ auto UnitLayoutSystem::rows_for(int count, int max_per_row) -> int {
 namespace {
 
 [[nodiscard]] auto shortest_yaw_delta(float from, float to) -> float {
-  float delta = std::fmod(to - from + 540.0F, 360.0F) - 180.0F;
-  return delta;
+  return Game::Systems::signed_yaw_delta(from, to);
 }
 
 } // namespace

--- a/game/map/terrain_service.cpp
+++ b/game/map/terrain_service.cpp
@@ -384,6 +384,9 @@ void TerrainService::initialize(const MapDefinition& map_def) {
   m_road_segments = map_def.roads;
   m_forests = map_def.forests;
   rebuild_road_spatial_index();
+
+  m_reserved_world_prop_ids.clear();
+  m_next_world_prop_id = 1;
   m_authored_world_props = map_def.world_props;
   normalize_world_props(m_authored_world_props);
   register_authored_building_obstacles(map_def);

--- a/game/mission/mission_setup_coordinator.cpp
+++ b/game/mission/mission_setup_coordinator.cpp
@@ -36,6 +36,7 @@
 #include "game/systems/nation_registry.h"
 #include "game/systems/nav_grid.h"
 #include "game/systems/owner_registry.h"
+#include "game/systems/walkability.h"
 #include "game/systems/world_restore.h"
 #include "game/units/factory.h"
 #include "game/units/spawn_type.h"
@@ -255,22 +256,85 @@ auto MissionSetupCoordinator::apply_mission_setup(
       }
 
       const int count = std::max(1, unit_setup.count);
-      const int grid =
-          static_cast<int>(std::ceil(std::sqrt(static_cast<float>(count))));
       const QVector3D base_pos = position_to_world(unit_setup.position);
-      float base_tile_size = ctx.level.tile_size;
-      if (map_loaded && map_def.coordSystem == Game::Map::CoordSystem::Grid) {
-        base_tile_size = map_def.grid.tile_size;
-      }
-      const float spacing = std::max(0.5F, base_tile_size * 1.2F);
+
+      auto place_clear_of_units = [&ctx, &base_pos](Engine::Core::Entity& placed) {
+        constexpr float k_gap = 0.3F;
+        constexpr int k_max_rings = 48;
+        constexpr int k_footprint_probes = 8;
+        constexpr float k_two_pi = 6.2831853F;
+        const float radius =
+            Game::Systems::CommandService::get_unit_radius(ctx.world, placed.get_id());
+        Game::Systems::BodyProfile ground;
+        if (const auto* movement =
+                placed.get_component<Engine::Core::MovementComponent>()) {
+          ground.passability = movement->get_can_enter_forest()
+                                   ? Game::Systems::Pathfinding::Passability::Light
+                                   : Game::Systems::Pathfinding::Passability::Heavy;
+        }
+        struct Occupied {
+          QVector3D centre;
+          float radius;
+        };
+        std::vector<Occupied> occupied;
+        for (auto* other :
+             ctx.world.collect_entities_with<Engine::Core::MovementComponent>()) {
+          const auto* other_transform =
+              other->get_component<Engine::Core::TransformComponent>();
+          if (other == &placed || other_transform == nullptr ||
+              other->has_component<Engine::Core::BuildingComponent>()) {
+            continue;
+          }
+          occupied.push_back(
+              {QVector3D(
+                   other_transform->position.x, 0.0F, other_transform->position.z),
+               Game::Systems::CommandService::get_unit_radius(ctx.world,
+                                                              other->get_id())});
+        }
+        const auto fits = [&](const QVector3D& centre) {
+          if (!Game::Systems::Walkability::can_stand(centre, ground)) {
+            return false;
+          }
+          for (int probe = 0; probe < k_footprint_probes; ++probe) {
+            const float angle = static_cast<float>(probe) * k_two_pi /
+                                static_cast<float>(k_footprint_probes);
+            const QVector3D edge(centre.x() + std::sin(angle) * radius * 0.6F,
+                                 0.0F,
+                                 centre.z() + std::cos(angle) * radius * 0.6F);
+            if (!Game::Systems::Walkability::can_stand(edge, ground)) {
+              return false;
+            }
+          }
+          return std::none_of(
+              occupied.begin(), occupied.end(), [&](const Occupied& other) {
+                return (other.centre - centre).length() < other.radius + radius + k_gap;
+              });
+        };
+        const QVector3D origin(base_pos.x(), 0.0F, base_pos.z());
+        const float step = std::max(0.5F, radius * 0.5F);
+        for (int ring = 0; ring <= k_max_rings; ++ring) {
+          const float distance = step * static_cast<float>(ring);
+          const int samples =
+              ring == 0
+                  ? 1
+                  : std::max(6,
+                             static_cast<int>(std::ceil(k_two_pi * distance / step)));
+          for (int sample = 0; sample < samples; ++sample) {
+            const float angle =
+                static_cast<float>(sample) * k_two_pi / static_cast<float>(samples);
+            const QVector3D candidate(origin.x() + std::sin(angle) * distance,
+                                      0.0F,
+                                      origin.z() + std::cos(angle) * distance);
+            if (fits(candidate)) {
+              return std::optional<QVector3D>(candidate);
+            }
+          }
+        }
+        return std::optional<QVector3D>();
+      };
 
       for (int i = 0; i < count; ++i) {
-        const int row = i / grid;
-        const int col = i % grid;
-        const float offset_x = (float(col) - (grid - 1) * 0.5F) * spacing;
-        const float offset_z = (float(row) - (grid - 1) * 0.5F) * spacing;
-        const QVector3D pos =
-            QVector3D(base_pos.x() + offset_x, base_pos.y(), base_pos.z() + offset_z);
+        QVector3D pos = base_pos;
 
         Game::Units::SpawnParams sp;
         sp.position = pos;
@@ -289,6 +353,15 @@ auto MissionSetupCoordinator::apply_mission_setup(
         auto* entity = ctx.world.get_entity(unit->id());
         if (entity == nullptr) {
           continue;
+        }
+        if (auto* transform =
+                entity->get_component<Engine::Core::TransformComponent>()) {
+          if (const auto placed = place_clear_of_units(*entity)) {
+            transform->position.x = placed->x();
+            transform->position.z = placed->z();
+            pos.setX(placed->x());
+            pos.setZ(placed->z());
+          }
         }
 
         if (unit_setup.behavior == Game::Mission::UnitBehavior::Guard) {

--- a/game/systems/ai_system/ai_settlement_frame.cpp
+++ b/game/systems/ai_system/ai_settlement_frame.cpp
@@ -389,7 +389,9 @@ void resolve_station(const AISnapshot& snapshot, AIContext& context) {
 }
 
 auto station_radius(const AIContext& context) -> float {
-  return std::max(8.0F, context.macro_targets.assembly_radius);
+
+  return std::max(
+      {8.0F, context.macro_targets.assembly_radius, context.station.required_radius});
 }
 
 auto station_standing(const EntitySnapshot& entity,

--- a/game/systems/body_contact_system.cpp
+++ b/game/systems/body_contact_system.cpp
@@ -6,14 +6,18 @@
 #include <cmath>
 #include <vector>
 
+#include "../core/ambient_session.h"
 #include "../core/component_economy.h"
 #include "../core/component_gameplay.h"
 #include "../core/entity.h"
 #include "../core/system_context.h"
 #include "../core/world.h"
+#include "../map/terrain_service.h"
 #include "../wildlife/wildlife_config.h"
 #include "body_profile.h"
+#include "building_collision_registry.h"
 #include "command_service.h"
+#include "nav_grid.h"
 #include "walkability.h"
 
 namespace Game::Systems {
@@ -26,12 +30,17 @@ struct ContactBody {
   float radius{0.0F};
   BodyProfile profile;
   bool movable{false};
+  bool locked_in_melee{false};
+
+  bool yields_when_idle{false};
   float separation_remaining{0.0F};
   Engine::Core::EntityID melee_intent{0};
 
   bool has_travel{false};
   float travel_x{0.0F};
   float travel_z{0.0F};
+
+  bool in_one_lane_passage{false};
 };
 
 auto melee_intent_of(const Engine::Core::Entity& entity) -> Engine::Core::EntityID {
@@ -51,12 +60,34 @@ auto melee_intent_of(const Engine::Core::Entity& entity) -> Engine::Core::Entity
   return target != nullptr ? target->target_id : 0;
 }
 
+auto body_yields_when_idle(const Engine::Core::Entity& entity) -> bool {
+  if (entity.has_component<Engine::Core::BuildingComponent>() ||
+      entity.has_component<Engine::Core::WildlifeComponent>() ||
+      entity.has_component<Engine::Core::BuilderProductionComponent>()) {
+    return false;
+  }
+  if (const auto* attack = entity.get_component<Engine::Core::AttackComponent>();
+      attack != nullptr && attack->in_melee_lock) {
+    return false;
+  }
+  if (const auto* hold = entity.get_component<Engine::Core::HoldModeComponent>();
+      hold != nullptr && hold->active) {
+    return false;
+  }
+  const auto* movement = entity.get_component<Engine::Core::MovementComponent>();
+  return movement != nullptr && !movement->get_has_target();
+}
+
 auto body_is_movable(const Engine::Core::Entity& entity,
                      const Engine::Core::MovementFactsComponent* facts) -> bool {
   if (facts == nullptr || !facts->desired.valid) {
     return false;
   }
   if (entity.has_component<Engine::Core::BuildingComponent>()) {
+    return false;
+  }
+
+  if (entity.has_component<Engine::Core::WildlifeComponent>()) {
     return false;
   }
   if (const auto* attack = entity.get_component<Engine::Core::AttackComponent>();
@@ -75,6 +106,13 @@ void slide_along_travel(const ContactBody& body, float& dx, float& dz) {
     return;
   }
   float const along = (dx * body.travel_x) + (dz * body.travel_z);
+  if (body.in_one_lane_passage) {
+
+    float const forward = std::max(along, 0.0F);
+    dx = body.travel_x * forward;
+    dz = body.travel_z * forward;
+    return;
+  }
   if (along >= 0.0F) {
     return;
   }
@@ -130,6 +168,9 @@ void BodyContactSystem::run(Engine::Core::SystemContext& context) {
   if (entries.size() < 2U) {
     return;
   }
+  const auto& services = Game::Session::services_for(world);
+  const auto& terrain = *services.terrain;
+  const auto& buildings = *services.building_collision;
 
   std::vector<ContactBody> bodies(entries.size());
   float widest_radius = 0.0F;
@@ -153,12 +194,18 @@ void BodyContactSystem::run(Engine::Core::SystemContext& context) {
     body.transform = transform;
     body.facts = world.try_get<Engine::Core::MovementFactsComponent>(entity->get_id());
     if (body.facts != nullptr) {
+
       body.facts->steering.contact_push_x = 0.0F;
       body.facts->steering.contact_push_z = 0.0F;
+      body.facts->steering.body_overlap = 0.0F;
     }
     body.radius = CommandService::get_unit_radii(world, entry.id).core;
     body.profile = body_profile_for(*entity);
     body.movable = body_is_movable(*entity, body.facts);
+    if (const auto* attack = entity->get_component<Engine::Core::AttackComponent>()) {
+      body.locked_in_melee = attack->in_melee_lock;
+    }
+    body.yields_when_idle = !body.movable && body_yields_when_idle(*entity);
     if (body.facts != nullptr && body.facts->desired.valid) {
       float const speed =
           std::hypot(body.facts->desired.velocity_x, body.facts->desired.velocity_z);
@@ -170,6 +217,15 @@ void BodyContactSystem::run(Engine::Core::SystemContext& context) {
     }
     body.separation_remaining =
         std::min(k_separation_speed * delta_time, k_max_separation_step);
+    {
+      auto const cell =
+          NavGrid::world_to_grid(transform->position.x, transform->position.z);
+      body.in_one_lane_passage =
+          terrain.is_on_bridge(transform->position.x, transform->position.z) ||
+          terrain.is_hill_entrance(cell.x, cell.y) ||
+          buildings.point_in_navigation_passage(transform->position.x,
+                                                transform->position.z);
+    }
     body.melee_intent = melee_intent_of(*entity);
     widest_radius = std::max(widest_radius, body.radius);
   }
@@ -203,6 +259,10 @@ void BodyContactSystem::run(Engine::Core::SystemContext& context) {
             return;
           }
 
+          bool const me_pushable = me.movable || (them.movable && me.yields_when_idle);
+          bool const them_pushable =
+              them.movable || (me.movable && them.yields_when_idle);
+
           const float combined = me.radius + them.radius;
           if (combined <= 1.0e-4F) {
             return;
@@ -230,20 +290,48 @@ void BodyContactSystem::run(Engine::Core::SystemContext& context) {
           }
 
           const float overlap = combined - distance;
+
+          bool const combat_press = me.locked_in_melee || them.locked_in_melee ||
+                                    (me.melee_intent != 0 && them.melee_intent != 0) ||
+                                    (other.owner_id != entries[slot].owner_id &&
+                                     (me.melee_intent != 0 || them.melee_intent != 0));
           m_diagnostics.deepest_overlap =
               std::max(m_diagnostics.deepest_overlap, overlap);
           ++m_diagnostics.pairs_resolved;
-          if (me.facts != nullptr) {
+          if (me.facts != nullptr && !combat_press) {
             me.facts->steering.body_overlap =
                 std::max(me.facts->steering.body_overlap, overlap);
           }
-          if (them.facts != nullptr) {
+          if (them.facts != nullptr && !combat_press) {
             them.facts->steering.body_overlap =
                 std::max(them.facts->steering.body_overlap, overlap);
           }
 
-          const float my_share = me.movable ? (them.movable ? 0.5F : 1.0F) : 0.0F;
-          const float their_share = them.movable ? (me.movable ? 0.5F : 1.0F) : 0.0F;
+          constexpr float k_idle_share = 0.35F;
+          float my_share = 0.0F;
+          float their_share = 0.0F;
+          if (me.movable && them.movable) {
+            my_share = 0.5F;
+            their_share = 0.5F;
+          } else if (me.movable) {
+            their_share = them_pushable ? k_idle_share : 0.0F;
+            my_share = 1.0F - their_share;
+          } else if (them.movable) {
+            my_share = me_pushable ? k_idle_share : 0.0F;
+            their_share = 1.0F - my_share;
+          }
+          if (me.in_one_lane_passage || them.in_one_lane_passage) {
+
+            float const me_ahead_of_them =
+                me.has_travel ? (px * me.travel_x) + (pz * me.travel_z) : 0.0F;
+            if (me_ahead_of_them > 0.0F) {
+              my_share = 0.0F;
+              their_share = them.movable ? 1.0F : 0.0F;
+            } else if (me_ahead_of_them < 0.0F) {
+              their_share = 0.0F;
+              my_share = me.movable ? 1.0F : 0.0F;
+            }
+          }
 
           if (my_share > 0.0F &&
               !try_push(me, nx * overlap * my_share, nz * overlap * my_share)) {

--- a/game/systems/building_collision_registry.cpp
+++ b/game/systems/building_collision_registry.cpp
@@ -653,6 +653,17 @@ auto BuildingCollisionRegistry::is_circle_overlapping_building(
   return false;
 }
 
+auto BuildingCollisionRegistry::point_in_navigation_passage(float x,
+                                                            float z) const -> bool {
+  for (const auto& passage : m_navigation_passages) {
+    if (std::abs(x - passage.center_x) <= passage.width * 0.5F + 0.5F &&
+        std::abs(z - passage.center_z) <= passage.depth * 0.5F + 0.5F) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void BuildingCollisionRegistry::set_navigation_passages(
     std::vector<NavigationPassage> passages) {
   auto same_rect = [](const NavigationPassage& lhs, const NavigationPassage& rhs) {

--- a/game/systems/building_collision_registry.h
+++ b/game/systems/building_collision_registry.h
@@ -237,6 +237,8 @@ public:
 
   void set_navigation_passages(std::vector<NavigationPassage> passages);
 
+  [[nodiscard]] auto point_in_navigation_passage(float x, float z) const -> bool;
+
   [[nodiscard]] auto
   navigation_passages() const -> const std::vector<NavigationPassage>& {
     return m_navigation_passages;

--- a/game/systems/combat_system/attack_processor.cpp
+++ b/game/systems/combat_system/attack_processor.cpp
@@ -14,6 +14,7 @@
 #include "../../units/spawn_type.h"
 #include "../../units/squad.h"
 #include "../../units/troop_config.h"
+#include "../../util/planar_math.h"
 #include "../../visuals/team_colors.h"
 #include "../attack_range.h"
 #include "../combat_actions/combat_action_definition.h"
@@ -371,11 +372,10 @@ void lock_facing(Engine::Core::TransformComponent* actor_transform,
   float const dx = target_transform->position.x - actor_transform->position.x;
   float const dz = target_transform->position.z - actor_transform->position.z;
   if (dx * dx + dz * dz > 0.000001F) {
-    float const target_yaw = std::atan2(dx, dz) * 180.0F / std::numbers::pi_v<float>;
-    float const diff =
-        std::fmod(target_yaw - actor_transform->rotation.y + 540.0F, 360.0F) - 180.0F;
-    float const max_step = turn_rate_degrees * std::max(0.0F, delta_time);
-    actor_transform->rotation.y += std::clamp(diff, -max_step, max_step);
+    actor_transform->rotation.y = Game::Systems::turn_yaw_toward(
+        actor_transform->rotation.y,
+        Game::Systems::yaw_degrees_from_direction(dx, dz),
+        turn_rate_degrees * std::max(0.0F, delta_time));
   }
   actor_transform->desired_yaw = actor_transform->rotation.y;
   actor_transform->has_desired_yaw = false;

--- a/game/systems/combat_system/combat_action_processor.cpp
+++ b/game/systems/combat_system/combat_action_processor.cpp
@@ -10,6 +10,7 @@
 #include "../../core/entity.h"
 #include "../../core/event_manager.h"
 #include "../../core/world.h"
+#include "../../util/planar_math.h"
 #include "../combat_actions/body_impact.h"
 #include "../combat_actions/combat_action_definition.h"
 #include "../combat_actions/combat_action_events.h"
@@ -1045,13 +1046,11 @@ void apply_rts_commander_root_motion(
                                   std::numbers::pi_v<float> / 180.0F);
       if (facing >= cone) {
 
-        float const target_yaw =
-            std::atan2(to_x, to_z) * 180.0F / std::numbers::pi_v<float>;
-        float const diff =
-            std::fmod(target_yaw - transform->rotation.y + 540.0F, 360.0F) - 180.0F;
-        float const max_step =
-            k_rts_commander_assist_turn_degrees_per_second * std::max(0.0F, delta_time);
-        transform->rotation.y += std::clamp(diff, -max_step, max_step);
+        transform->rotation.y = Game::Systems::turn_yaw_toward(
+            transform->rotation.y,
+            Game::Systems::yaw_degrees_from_direction(to_x, to_z),
+            k_rts_commander_assist_turn_degrees_per_second *
+                std::max(0.0F, delta_time));
         transform->desired_yaw = transform->rotation.y;
         float const yaw_rad =
             transform->rotation.y * std::numbers::pi_v<float> / 180.0F;

--- a/game/systems/combat_system/formation_contact_processor.cpp
+++ b/game/systems/combat_system/formation_contact_processor.cpp
@@ -13,6 +13,7 @@
 
 #include "../../core/component.h"
 #include "../../core/world.h"
+#include "../../util/planar_math.h"
 #include "../formation_combat_geometry.h"
 #include "combat_utils.h"
 #include "structure_combat.h"
@@ -643,6 +644,26 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
         structure_shift_local_z = sin_yaw * world_shift.x() + cos_yaw * world_shift.z();
       }
     }
+
+    float nearest_facade_anchor = std::numeric_limits<float>::infinity();
+    if (display_opponent != nullptr && actor_transform != nullptr &&
+        is_building(display_opponent)) {
+      for (auto const& slot : layout.live_slots) {
+        float anchor_x = slot.local_x;
+        float anchor_z = slot.local_z;
+        if (traversal != nullptr) {
+          if (auto const* moved = traversal->slot_for(slot.index); moved != nullptr) {
+            anchor_x = moved->current_local_x;
+            anchor_z = moved->current_local_z;
+          }
+        }
+        nearest_facade_anchor = std::min(
+            nearest_facade_anchor,
+            closest_structure_surface(
+                *display_opponent, local_to_world(*actor_transform, anchor_x, anchor_z))
+                .distance);
+      }
+    }
     struct DamageCarrier {
       const Engine::Core::FormationContactFront* front{nullptr};
       std::optional<std::uint16_t> attacker_slot;
@@ -667,6 +688,8 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
     std::size_t const previous_directive_count = directives.size();
     bool soldiers_changed = previous_directive_count != layout.all_slots.size();
     directives.resize(layout.all_slots.size());
+    float const frame_sign =
+        traversal != nullptr && traversal->about_faced ? -1.0F : 1.0F;
     for (auto const& original_slot : layout.all_slots) {
       auto const* live_slot = find_live_slot(layout, original_slot.index);
       std::optional<Engine::Core::FormationSoldierPresentation> previous_value;
@@ -679,10 +702,10 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
       directive.slot_index = original_slot.index;
       directive.row = live_slot != nullptr ? live_slot->row : original_slot.row;
       directive.col = live_slot != nullptr ? live_slot->col : original_slot.col;
-      directive.local_x =
-          live_slot != nullptr ? live_slot->local_x : original_slot.local_x;
-      directive.local_z =
-          live_slot != nullptr ? live_slot->local_z : original_slot.local_z;
+      directive.local_x = frame_sign * (live_slot != nullptr ? live_slot->local_x
+                                                             : original_slot.local_x);
+      directive.local_z = frame_sign * (live_slot != nullptr ? live_slot->local_z
+                                                             : original_slot.local_z);
       auto const* traversal_slot =
           traversal != nullptr ? traversal->slot_for(original_slot.index) : nullptr;
       if (live_slot != nullptr && traversal != nullptr) {
@@ -740,8 +763,24 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
             assignment.pair->surface_gap +
             (retained.root_distance - assignment.pair->root_distance);
 
+        bool const opponent_is_structure = opponent != nullptr && is_building(opponent);
+        StructureSurfaceContact facade_surface{};
+        bool structure_facade_rank = false;
+        if (opponent_is_structure && actor_transform != nullptr) {
+          facade_surface = closest_structure_surface(
+              *opponent,
+              local_to_world(*actor_transform, directive.local_x, directive.local_z));
+          structure_facade_rank = opponent != display_opponent ||
+                                  !std::isfinite(nearest_facade_anchor) ||
+                                  facade_surface.distance <=
+                                      nearest_facade_anchor + structure_render_shift +
+                                          layout.spacing * 0.55F;
+        }
+
         bool const opponent_within_reach =
-            directive.engagement_surface_gap <= layout.spacing * 0.65F;
+            opponent_is_structure
+                ? structure_facade_rank
+                : directive.engagement_surface_gap <= layout.spacing * 0.65F;
         directive.combat_role =
             opponent_within_reach
                 ? combat_role_for(layout.seed, original_slot.index, true)
@@ -754,10 +793,12 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
                 ? world.try_get<Engine::Core::TransformComponent>(opponent->get_id())
                 : nullptr;
         if (actor_transform != nullptr && opponent_transform != nullptr) {
-          float const target_x = target_slot != nullptr
+          float const target_x = structure_facade_rank ? facade_surface.point.x()
+                                 : target_slot != nullptr
                                      ? target_slot->world_x
                                      : opponent_transform->position.x;
-          float const target_z = target_slot != nullptr
+          float const target_z = structure_facade_rank ? facade_surface.point.z()
+                                 : target_slot != nullptr
                                      ? target_slot->world_z
                                      : opponent_transform->position.z;
           auto const contact_vector = local_contact_vector(*actor_transform,
@@ -768,15 +809,21 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
           float const desired_yaw = contact_vector.yaw;
           float const prior_yaw =
               previous != nullptr ? previous->local_yaw : directive.local_yaw;
-          float const yaw_delta = std::remainder(desired_yaw - prior_yaw, 360.0F);
-          float const max_turn = k_contact_turn_degrees * std::max(0.0F, delta_time);
-          directive.local_yaw = prior_yaw + std::clamp(yaw_delta, -max_turn, max_turn);
+          directive.local_yaw = Game::Systems::turn_yaw_toward(
+              prior_yaw,
+              desired_yaw,
+              k_contact_turn_degrees * std::max(0.0F, delta_time));
 
           constexpr float k_weapon_contact_distance = 0.72F;
           float const pull_distance =
-              std::clamp(contact_vector.distance - k_weapon_contact_distance,
-                         0.0F,
-                         layout.spacing * 0.20F);
+              structure_facade_rank
+                  ? std::clamp(facade_surface.distance -
+                                   structure_attack_profile(entity).contact_clearance,
+                               0.0F,
+                               layout.spacing * 1.6F)
+                  : std::clamp(contact_vector.distance - k_weapon_contact_distance,
+                               0.0F,
+                               layout.spacing * 0.20F);
           if (contact_vector.distance > 0.0001F) {
             directive.local_x +=
                 contact_vector.x / contact_vector.distance * pull_distance;
@@ -834,11 +881,10 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
                                                              surface.point.z());
             float const prior_yaw =
                 previous != nullptr ? previous->local_yaw : directive.local_yaw;
-            float const yaw_delta =
-                std::remainder(contact_vector.yaw - prior_yaw, 360.0F);
-            float const max_turn = k_contact_turn_degrees * std::max(0.0F, delta_time);
-            directive.local_yaw =
-                prior_yaw + std::clamp(yaw_delta, -max_turn, max_turn);
+            directive.local_yaw = Game::Systems::turn_yaw_toward(
+                prior_yaw,
+                contact_vector.yaw,
+                k_contact_turn_degrees * std::max(0.0F, delta_time));
 
             float const desired_gap =
                 structure_attack_profile(entity).contact_clearance;
@@ -873,11 +919,10 @@ void publish_formation_presentation(Engine::Core::World& world, float delta_time
         if (directive.unassigned_seconds < k_contact_yaw_hold_seconds) {
           directive.local_yaw = previous->local_yaw;
         } else {
-          float const yaw_delta =
-              std::remainder(directive.local_yaw - previous->local_yaw, 360.0F);
-          float const max_turn = k_disengage_turn_degrees * std::max(0.0F, delta_time);
-          directive.local_yaw =
-              previous->local_yaw + std::clamp(yaw_delta, -max_turn, max_turn);
+          directive.local_yaw = Game::Systems::turn_yaw_toward(
+              previous->local_yaw,
+              directive.local_yaw,
+              k_disengage_turn_degrees * std::max(0.0F, delta_time));
         }
       }
 

--- a/game/systems/defensive_unit_layout_service.cpp
+++ b/game/systems/defensive_unit_layout_service.cpp
@@ -8,6 +8,7 @@
 #include "../core/entity.h"
 #include "../formation/unit_layout.h"
 #include "../units/spawn_type.h"
+#include "../util/planar_math.h"
 
 namespace Game::Systems {
 
@@ -18,7 +19,7 @@ namespace {
 }
 
 [[nodiscard]] auto signed_angle_delta(float from_degrees, float to_degrees) -> float {
-  return std::fmod((to_degrees - from_degrees + 540.0F), 360.0F) - 180.0F;
+  return Game::Systems::signed_yaw_delta(from_degrees, to_degrees);
 }
 
 [[nodiscard]] auto troop_type_of(const Engine::Core::Entity& entity)

--- a/game/systems/formation_combat_geometry.cpp
+++ b/game/systems/formation_combat_geometry.cpp
@@ -667,13 +667,15 @@ void soldier_spatial_anchors_into(const Engine::Core::Entity& entity,
                                                  : nullptr;
   };
 
+  float const frame_sign =
+      traversal != nullptr && traversal->about_faced ? -1.0F : 1.0F;
   for (auto const& base : base_layout.live_slots) {
     SoldierSpatialAnchor anchor{
         .slot_index = base.index,
         .row = base.row,
         .col = base.col,
-        .local_x = base.local_x,
-        .local_z = base.local_z,
+        .local_x = frame_sign * base.local_x,
+        .local_z = frame_sign * base.local_z,
         .local_yaw = base.local_yaw,
         .source = SoldierAnchorSource::BaseLayout,
     };
@@ -716,6 +718,59 @@ auto soldier_spatial_anchors(const Engine::Core::Entity& entity,
 auto soldier_spatial_anchors(const Engine::Core::Entity& entity)
     -> std::vector<SoldierSpatialAnchor> {
   return soldier_spatial_anchors(entity, resolve_layout(entity));
+}
+
+auto face_about_in_place(Engine::Core::Entity& entity) -> bool {
+  auto* traversal =
+      entity.get_component<Engine::Core::UnitTraversalLayoutStateComponent>();
+  auto* transform = entity.get_component<Engine::Core::TransformComponent>();
+  if (traversal == nullptr || transform == nullptr) {
+    return false;
+  }
+
+  transform->rotation.y += transform->rotation.y > 0.0F ? -180.0F : 180.0F;
+  traversal->about_faced = !traversal->about_faced;
+  for (auto& slot : traversal->slot_states) {
+    slot.start_local_x = -slot.start_local_x;
+    slot.start_local_z = -slot.start_local_z;
+    slot.previous_local_x = -slot.previous_local_x;
+    slot.previous_local_z = -slot.previous_local_z;
+    slot.current_local_x = -slot.current_local_x;
+    slot.current_local_z = -slot.current_local_z;
+    slot.target_local_x = -slot.target_local_x;
+    slot.target_local_z = -slot.target_local_z;
+    slot.velocity_x = -slot.velocity_x;
+    slot.velocity_z = -slot.velocity_z;
+  }
+  ++traversal->slot_states_revision;
+
+  if (auto* presentation =
+          entity.get_component<Engine::Core::FormationPresentationComponent>()) {
+    for (auto& soldier : presentation->soldiers) {
+      soldier.local_x = -soldier.local_x;
+      soldier.local_z = -soldier.local_z;
+      soldier.previous_local_x = -soldier.previous_local_x;
+      soldier.previous_local_z = -soldier.previous_local_z;
+      soldier.relocation_velocity_x = -soldier.relocation_velocity_x;
+      soldier.relocation_velocity_z = -soldier.relocation_velocity_z;
+      soldier.contact_offset_x = -soldier.contact_offset_x;
+      soldier.contact_offset_z = -soldier.contact_offset_z;
+    }
+    ++presentation->revision;
+  }
+
+  if (auto* casualties =
+          entity.get_component<Engine::Core::SoldierCasualtyAnimationComponent>()) {
+
+    for (auto& entry : casualties->entries) {
+      entry.local_x = -entry.local_x;
+      entry.local_z = -entry.local_z;
+      entry.local_yaw += 180.0F;
+      entry.launch_velocity_x = -entry.launch_velocity_x;
+      entry.launch_velocity_z = -entry.launch_velocity_z;
+    }
+  }
+  return true;
 }
 
 auto formation_turn_radius(const Engine::Core::Entity& entity) -> float {

--- a/game/systems/formation_combat_geometry.h
+++ b/game/systems/formation_combat_geometry.h
@@ -113,6 +113,8 @@ void soldier_spatial_anchors_into(const Engine::Core::Entity& entity,
                                   const FormationLayout& base_layout,
                                   std::vector<SoldierSpatialAnchor>& result);
 
+auto face_about_in_place(Engine::Core::Entity& entity) -> bool;
+
 [[nodiscard]] auto living_slot_indices(const Engine::Core::Entity& entity,
                                        int total_count) -> std::vector<std::uint16_t>;
 

--- a/game/systems/local_avoidance_system.cpp
+++ b/game/systems/local_avoidance_system.cpp
@@ -9,6 +9,7 @@
 
 #include "../core/ambient_session.h"
 #include "../core/component.h"
+#include "../core/component_economy.h"
 #include "../core/entity.h"
 #include "../core/system_context.h"
 #include "../core/world.h"
@@ -23,6 +24,13 @@ namespace Game::Systems {
 
 namespace {
 
+constexpr float k_press_patience_seconds = 0.5F;
+
+constexpr float k_stop_patience_seconds = 1.0F;
+
+constexpr float k_leader_min_pace = 0.2F;
+constexpr float k_leader_heading_agreement = 0.5F;
+
 struct Body {
   float core_radius{0.5F};
   float navigation_clearance{0.0F};
@@ -33,6 +41,13 @@ struct Body {
   bool is_moving{false};
   bool can_enter_forest{true};
   bool considered{false};
+  bool has_travel{false};
+  float travel_x{0.0F};
+  float travel_z{0.0F};
+
+  float pace{0.0F};
+
+  bool gives_way_when_standing{false};
 };
 
 auto compute_avoidance_priority(Engine::Core::SystemContext& context,
@@ -54,18 +69,6 @@ auto compute_avoidance_priority(Engine::Core::SystemContext& context,
     return 1;
   }
   return 2;
-}
-
-auto point_is_in_navigation_passage(const BuildingCollisionRegistry& buildings,
-                                    float x,
-                                    float z) -> bool {
-  for (const auto& passage : buildings.navigation_passages()) {
-    if (std::abs(x - passage.center_x) <= passage.width * 0.5F + 0.5F &&
-        std::abs(z - passage.center_z) <= passage.depth * 0.5F + 0.5F) {
-      return true;
-    }
-  }
-  return false;
 }
 
 auto response_share(const Body& me, const Body& them) -> float {
@@ -128,6 +131,14 @@ void LocalAvoidanceSystem::run(Engine::Core::SystemContext& context) {
     if (const auto* facts =
             context.try_get<Engine::Core::MovementFactsComponent>(entry.id)) {
       body.avoids = facts->desired.valid;
+      body.pace = facts->last_accepted_speed;
+      float const speed = Game::Systems::planar_length(facts->desired.velocity_x,
+                                                       facts->desired.velocity_z);
+      if (facts->desired.valid && speed > 1.0e-4F) {
+        body.has_travel = true;
+        body.travel_x = facts->desired.velocity_x / speed;
+        body.travel_z = facts->desired.velocity_z / speed;
+      }
     }
     if (const auto* formation =
             context.try_get<Engine::Core::FormationModeComponent>(entry.id)) {
@@ -146,6 +157,14 @@ void LocalAvoidanceSystem::run(Engine::Core::SystemContext& context) {
 
       body.engaged_target = wildlife->focus_id;
     }
+    body.gives_way_when_standing =
+        !body.is_moving && body.engaged_target == 0 &&
+        !context.has<Engine::Core::WildlifeComponent>(entry.id) &&
+        !context.has<Engine::Core::BuilderProductionComponent>(entry.id) &&
+        [&context, &entry] {
+          const auto* hold = context.try_get<Engine::Core::HoldModeComponent>(entry.id);
+          return hold == nullptr || !hold->active;
+        }();
   }
 
   const Engine::Core::WorldSpatialIndex::Entry* const first = entries.data();
@@ -196,6 +215,9 @@ void LocalAvoidanceSystem::run(Engine::Core::SystemContext& context) {
     float lean_z = 0.0F;
     std::uint32_t neighbor_count = 0;
     bool rank_ahead = false;
+    bool touching_ahead = false;
+    bool touching_a_standing_body = false;
+    float leader_pace = 1.0e9F;
 
     index.for_each_in_radius(entry.x, entry.z, query_radius, [&](const auto& other) {
       ++neighbors_examined;
@@ -239,6 +261,27 @@ void LocalAvoidanceSystem::run(Engine::Core::SystemContext& context) {
         return;
       }
       ++neighbor_count;
+      if (along <= lane) {
+
+        bool const they_see_me_ahead =
+            them.has_travel && ((-px * them.travel_x) + (-pz * them.travel_z)) > 0.0F;
+        bool const i_go_first = they_see_me_ahead && entry.id < other.id;
+        if (!i_go_first) {
+          touching_ahead = true;
+          float const heading_agreement =
+              them.has_travel ? (them.travel_x * tx) + (them.travel_z * tz) : 0.0F;
+          if (them.avoids && them.pace > k_leader_min_pace &&
+              heading_agreement > k_leader_heading_agreement) {
+            leader_pace = std::min(leader_pace, them.pace * heading_agreement);
+          }
+
+          bool const pressed_in_vain =
+              facts->progress.no_progress_seconds > k_press_patience_seconds;
+          if (!them.avoids && (!them.gives_way_when_standing || pressed_in_vain)) {
+            touching_a_standing_body = true;
+          }
+        }
+      }
       if (me.formation_id != 0U && them.formation_id == me.formation_id) {
 
         rank_ahead = true;
@@ -267,11 +310,10 @@ void LocalAvoidanceSystem::run(Engine::Core::SystemContext& context) {
     });
 
     facts->steering.neighbor_count = neighbor_count;
+    facts->steering.blocked_by_standing_body = touching_a_standing_body;
     if (neighbor_count == 0U) {
       continue;
     }
-
-    speed_scale = std::clamp(speed_scale, k_min_speed_fraction, 1.0F);
 
     if (const float leaned = Game::Systems::planar_length(lean_x, lean_z);
         leaned > k_lean_gain) {
@@ -283,7 +325,7 @@ void LocalAvoidanceSystem::run(Engine::Core::SystemContext& context) {
     Point const own_cell = NavGrid::world_to_grid(entry.x, entry.z);
     bool has_room = !rank_ahead && !terrain.is_on_bridge(entry.x, entry.z) &&
                     !terrain.is_hill_entrance(own_cell.x, own_cell.y) &&
-                    !point_is_in_navigation_passage(buildings, entry.x, entry.z);
+                    !buildings.point_in_navigation_passage(entry.x, entry.z);
 
     float lean_magnitude = Game::Systems::planar_length(lean_x, lean_z);
     if (has_room && lean_magnitude > 1.0e-4F) {
@@ -304,6 +346,16 @@ void LocalAvoidanceSystem::run(Engine::Core::SystemContext& context) {
       lean_x = 0.0F;
       lean_z = 0.0F;
       lean_magnitude = 0.0F;
+    }
+
+    bool const waits_its_turn =
+        ((!has_room && touching_ahead) || touching_a_standing_body) &&
+        facts->progress.stall.stalled_seconds <= k_stop_patience_seconds;
+    float const speed_floor = waits_its_turn ? 0.0F : k_min_speed_fraction;
+    speed_scale = std::clamp(speed_scale, speed_floor, 1.0F);
+
+    if (leader_pace < desired_speed * speed_scale) {
+      speed_scale = leader_pace / desired_speed;
     }
 
     float steered_vx = (desired_vx * speed_scale) + (lean_x * desired_speed);
@@ -350,6 +402,8 @@ auto LocalAvoidanceSystem::access() const -> Engine::Core::SystemAccess {
                                      MovementIntentComponent,
                                      MovementComponent,
                                      FormationModeComponent,
+                                     HoldModeComponent,
+                                     BuilderProductionComponent,
                                      BuildingComponent,
                                      PendingRemovalComponent>{},
                                Writes<MovementFactsComponent>{});

--- a/game/systems/movement_orders.cpp
+++ b/game/systems/movement_orders.cpp
@@ -11,6 +11,7 @@
 #include "../core/component_gameplay.h"
 #include "../core/world.h"
 #include "../map/terrain_service.h"
+#include "body_profile.h"
 #include "combat_rules.h"
 #include "command_service.h"
 #include "formation_combat_geometry.h"
@@ -78,6 +79,36 @@ auto resolve_walkable_direct_target(const QVector3D& target,
   constexpr float k_target_search_radius = 64.0F;
   return nearest_standable_world(target, passability, k_target_search_radius)
       .value_or(target);
+}
+
+auto resolve_walkable_target_toward(const QVector3D& target,
+                                    const QVector3D& from,
+                                    Pathfinding::Passability passability) -> QVector3D {
+  BodyProfile profile;
+  profile.radius = 0.0F;
+  profile.passability = passability;
+  if (Walkability::can_stand(target, profile)) {
+    return target;
+  }
+  QVector3D const nearest = resolve_walkable_direct_target(target, passability);
+  QVector3D toward = from - target;
+  toward.setY(0.0F);
+  float const span = toward.length();
+  if (span <= 1.0e-3F) {
+    return nearest;
+  }
+  toward /= span;
+  constexpr float k_step = 0.25F;
+  constexpr float k_side_slack = 1.5F;
+  float const nearest_gap = (nearest - target).length();
+  for (float travelled = k_step; travelled <= span; travelled += k_step) {
+    QVector3D const probe = target + toward * travelled;
+    if (!Walkability::can_stand(probe, profile)) {
+      continue;
+    }
+    return travelled <= nearest_gap + k_side_slack ? probe : nearest;
+  }
+  return nearest;
 }
 
 auto segment_traverses_navigation_portal(const QVector3D& from,
@@ -203,6 +234,11 @@ struct PreparedMove {
   float previous_vz{0.0F};
   bool preserve_velocity{false};
 };
+
+[[nodiscard]] auto issuer_retargets(MoveOrderKind kind) -> bool {
+  return kind == MoveOrderKind::AttackChase || kind == MoveOrderKind::ScriptedMove ||
+         kind == MoveOrderKind::GuardReturn || kind == MoveOrderKind::RecoveryMove;
+}
 
 auto prepare_move(Engine::Core::World& world,
                   Engine::Core::EntityID unit_id,
@@ -470,28 +506,31 @@ void MovementSystem::assign_navigation_target(
     return;
   }
 
+  QVector3D const current_pos(transform.position.x, 0.0F, transform.position.z);
+  QVector3D const planned_target = resolve_walkable_target_toward(
+      requested_target, current_pos, passability_for(movement));
+
   Point const start =
       NavGrid::world_to_grid(transform.position.x, transform.position.z);
-  Point const end = NavGrid::world_to_grid(requested_target.x(), requested_target.z());
-  QVector3D const current_pos(transform.position.x, 0.0F, transform.position.z);
+  Point const end = NavGrid::world_to_grid(planned_target.x(), planned_target.z());
 
   bool const portal_route =
-      segment_traverses_navigation_portal(current_pos, requested_target);
+      segment_traverses_navigation_portal(current_pos, planned_target);
   bool const direct_clear =
       is_direct_path_walkable(current_pos,
-                              requested_target,
+                              planned_target,
                               passability_for(movement),
                               movement.get_navigation_clearance());
   if ((start == end && direct_clear) || (direct_clear && !portal_route)) {
     assign_direct_target(
         movement,
-        resolve_walkable_direct_target(requested_target, passability_for(movement)));
+        resolve_walkable_direct_target(planned_target, passability_for(movement)));
     return;
   }
 
   auto const corridor = RouteCorridorPlanner::plan(*pathfinder,
                                                    current_pos,
-                                                   requested_target,
+                                                   planned_target,
                                                    passability_for(movement),
                                                    movement.get_navigation_clearance());
   if (!corridor.reachable() || !assign_waypoints_to_movement(*pathfinder,
@@ -499,10 +538,10 @@ void MovementSystem::assign_navigation_target(
                                                              corridor.centerline.back(),
                                                              transform,
                                                              movement)) {
-    QVector3D const fallback = corridor.centerline.empty()
-                                   ? resolve_walkable_direct_target(
-                                         requested_target, passability_for(movement))
-                                   : corridor.centerline.back();
+    QVector3D const fallback =
+        corridor.centerline.empty()
+            ? resolve_walkable_direct_target(planned_target, passability_for(movement))
+            : corridor.centerline.back();
     assign_direct_target(movement, fallback);
   }
 
@@ -603,6 +642,7 @@ auto MovementSystem::retarget_unit(Engine::Core::World& world,
     return false;
   }
 
+  movement->has_requested_goal = false;
   assign_navigation_target(NavGrid::get_pathfinder(), *transform, *movement, goal);
   return true;
 }
@@ -625,6 +665,7 @@ void MovementSystem::issue_move(Engine::Core::World& world,
     return;
   }
   prepared.movement->precise_arrival = options.kind == MoveOrderKind::AttackChase;
+  prepared.movement->issuer_retargets = issuer_retargets(options.kind);
   assign_navigation_target(
       NavGrid::get_pathfinder(), *prepared.transform, *prepared.movement, target);
   if (prepared.preserve_velocity && prepared.movement->get_has_target()) {
@@ -661,6 +702,7 @@ void MovementSystem::issue_move_units(Engine::Core::World& world,
     if (prepared.back().movement != nullptr) {
       prepared.back().movement->precise_arrival =
           options.kind == MoveOrderKind::AttackChase;
+      prepared.back().movement->issuer_retargets = issuer_retargets(options.kind);
     }
   }
 

--- a/game/systems/movement_route.h
+++ b/game/systems/movement_route.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <utility>
@@ -55,6 +57,52 @@ public:
   [[nodiscard]] auto tangent_at(float s) const -> std::pair<float, float>;
 
   [[nodiscard]] auto next_vertex_s(float s) const -> float;
+
+  template <typename SegmentClear>
+  [[nodiscard]] auto steering_aim_s(float from_x,
+                                    float from_z,
+                                    float lookahead,
+                                    float min_aim_distance,
+                                    const SegmentClear& segment_clear) const -> float {
+
+    constexpr float k_fallback_lookahead = 0.45F;
+    float const reach =
+        std::isfinite(lookahead) && lookahead > 0.0F ? lookahead : k_fallback_lookahead;
+    if (!std::isfinite(min_aim_distance)) {
+      min_aim_distance = reach * 0.75F;
+    }
+    float const target = std::min(m_length, m_travelled + reach);
+    float aim_s = std::min(target, next_vertex_s(m_travelled));
+    constexpr int k_max_extensions = 16;
+    constexpr int k_clear_bisections = 6;
+    for (int extension = 0; extension < k_max_extensions && aim_s < target;
+         ++extension) {
+      auto const aim = point_at(aim_s);
+      if (std::hypot(aim.first - from_x, aim.second - from_z) >= min_aim_distance) {
+        break;
+      }
+      float const next = std::min(target, next_vertex_s(aim_s));
+      auto const beyond = point_at(next);
+      if (segment_clear(from_x, from_z, beyond.first, beyond.second)) {
+        aim_s = next;
+        continue;
+      }
+      float clear_s = aim_s;
+      float blocked_s = next;
+      for (int bisection = 0; bisection < k_clear_bisections; ++bisection) {
+        float const middle = (clear_s + blocked_s) * 0.5F;
+        auto const point = point_at(middle);
+        if (segment_clear(from_x, from_z, point.first, point.second)) {
+          clear_s = middle;
+        } else {
+          blocked_s = middle;
+        }
+      }
+      aim_s = clear_s;
+      break;
+    }
+    return aim_s;
+  }
 
   [[nodiscard]] auto final_point() const -> std::pair<float, float>;
 

--- a/game/systems/movement_system.cpp
+++ b/game/systems/movement_system.cpp
@@ -13,6 +13,7 @@
 #include "../map/terrain_service.h"
 #include "../units/spawn_type.h"
 #include "../units/troop_config.h"
+#include "../util/planar_math.h"
 #include "body_profile.h"
 #include "combat_rules.h"
 #include "combat_system/structure_combat.h"
@@ -52,8 +53,19 @@ constexpr float desired_yaw_turn_speed_degrees = 720.0F;
 constexpr float k_formation_heading_min_speed = 0.4F;
 constexpr float k_formation_heading_speed_fraction = 0.25F;
 constexpr float k_formation_intent_min_distance = 1.0F;
+
 constexpr float full_translation_heading_error_degrees = 20.0F;
 constexpr float stopped_translation_heading_error_degrees = 100.0F;
+
+constexpr float k_formation_turn_speed_floor_degrees = 180.0F;
+constexpr float k_formation_heading_deadband_degrees = 2.0F;
+
+constexpr float k_formation_about_face_degrees =
+    stopped_translation_heading_error_degrees;
+
+constexpr float k_root_hold_pace = 0.35F;
+constexpr float k_formation_outer_file_speed_floor = 4.5F;
+constexpr float k_formation_outer_file_speed_scale = 2.0F;
 
 constexpr float k_motor_substep_cells = 0.45F;
 constexpr int k_max_motor_substeps = 8;
@@ -68,10 +80,15 @@ auto formation_turn_speed_degrees(const Engine::Core::Entity& entity,
     return single_body_turn_speed;
   }
 
-  float const max_outer_speed = std::max(2.0F, unit.speed * 1.5F);
+  float const max_outer_speed =
+      std::max(k_formation_outer_file_speed_floor,
+               unit.speed * k_formation_outer_file_speed_scale);
   float const derived =
       max_outer_speed / turn_radius * 180.0F / std::numbers::pi_v<float>;
-  return std::clamp(derived, 30.0F, single_body_turn_speed);
+  return std::clamp(
+      derived,
+      std::min(k_formation_turn_speed_floor_degrees, single_body_turn_speed),
+      single_body_turn_speed);
 }
 
 struct HeadingReference {
@@ -89,10 +106,15 @@ auto heading_reference(const Engine::Core::Entity& entity,
 
     auto const* facts = entity.get_component<Engine::Core::MovementFactsComponent>();
     if (facts != nullptr && facts->desired.valid) {
+      float const hx = facts->desired.heading_x;
+      float const hz = facts->desired.heading_z;
+      if (hx * hx + hz * hz > 1.0e-5F) {
+        return {true, Game::Systems::yaw_degrees_from_direction(hx, hz)};
+      }
       float const dx = facts->desired.velocity_x;
       float const dz = facts->desired.velocity_z;
       if (dx * dx + dz * dz > 1.0e-5F) {
-        return {true, std::atan2(dx, dz) * 180.0F / std::numbers::pi_v<float>};
+        return {true, Game::Systems::yaw_degrees_from_direction(dx, dz)};
       }
     }
     float const intent_x = movement.get_target_x() - transform.position.x;
@@ -121,7 +143,7 @@ auto heading_translation_scale(float yaw_degrees, HeadingReference reference) ->
     return 1.0F;
   }
   float const error =
-      std::fabs(std::fmod((reference.yaw - yaw_degrees + 540.0F), 360.0F) - 180.0F);
+      std::fabs(Game::Systems::signed_yaw_delta(yaw_degrees, reference.yaw));
   return 1.0F - std::clamp((error - full_translation_heading_error_degrees) /
                                (stopped_translation_heading_error_degrees -
                                 full_translation_heading_error_degrees),
@@ -136,15 +158,12 @@ void apply_desired_yaw(Engine::Core::TransformComponent* transform,
     return;
   }
 
-  float const current = transform->rotation.y;
   float const target_yaw = transform->desired_yaw;
-  float const diff = std::fmod((target_yaw - current + 540.0F), 360.0F) - 180.0F;
-  float const step = std::clamp(
-      diff, -turn_speed_degrees * delta_time, turn_speed_degrees * delta_time);
-  transform->rotation.y = current + step;
+  transform->rotation.y = Game::Systems::turn_yaw_toward(
+      transform->rotation.y, target_yaw, turn_speed_degrees * delta_time);
 
   float const remaining_diff =
-      std::fmod((target_yaw - transform->rotation.y + 540.0F), 360.0F) - 180.0F;
+      Game::Systems::signed_yaw_delta(transform->rotation.y, target_yaw);
   if (std::fabs(remaining_diff) < 0.5F) {
     transform->rotation.y = target_yaw;
     transform->has_desired_yaw = false;
@@ -240,21 +259,32 @@ void finalize_orientation(Engine::Core::Entity* entity,
 
   bool const shell_holds_its_face =
       DefensiveUnitLayoutService::holds_position(*entity) && transform->has_desired_yaw;
+  bool const formation =
+      unit != nullptr && FormationCombat::has_formation_slots(*entity);
+
+  auto const face_about_toward = [&](float yaw) {
+    return formation && !shell_holds_its_face &&
+           std::fabs(Game::Systems::signed_yaw_delta(transform->rotation.y, yaw)) >
+               k_formation_about_face_degrees &&
+           FormationCombat::face_about_in_place(*entity);
+  };
   auto const reference = heading_reference(*entity, *transform, *movement, unit);
   if (reference.valid && !shell_holds_its_face) {
-    float const target_yaw = reference.yaw;
-    float const current = transform->rotation.y;
-    float const diff = std::fmod((target_yaw - current + 540.0F), 360.0F) - 180.0F;
-    float const step =
-        std::clamp(diff, -turn_speed * delta_time, turn_speed * delta_time);
-    transform->rotation.y = current + step;
+    (void)face_about_toward(reference.yaw);
+
+    float const deadband = formation ? k_formation_heading_deadband_degrees : 0.0F;
+    if (std::fabs(Game::Systems::signed_yaw_delta(transform->rotation.y,
+                                                  reference.yaw)) > deadband) {
+      transform->rotation.y = Game::Systems::turn_yaw_toward(
+          transform->rotation.y, reference.yaw, turn_speed * delta_time);
+    }
   } else if (transform->has_desired_yaw) {
-    float const current = transform->rotation.y;
     float const target_yaw = transform->desired_yaw;
-    float const diff = std::fmod((target_yaw - current + 540.0F), 360.0F) - 180.0F;
-    float const step =
-        std::clamp(diff, -turn_speed * delta_time, turn_speed * delta_time);
-    transform->rotation.y = current + step;
+    (void)face_about_toward(target_yaw);
+    float const diff =
+        Game::Systems::signed_yaw_delta(transform->rotation.y, target_yaw);
+    transform->rotation.y = Game::Systems::turn_yaw_toward(
+        transform->rotation.y, target_yaw, turn_speed * delta_time);
     if (std::fabs(diff) < 0.5F && !shell_holds_its_face) {
       transform->has_desired_yaw = false;
     }
@@ -435,9 +465,6 @@ void MovementSystem::repath_after_obstruction_release(
                                              movement->get_order_sequence())) {
       continue;
     }
-
-    movement->stuck_ref_valid = false;
-    movement->stuck_timer = 0.0F;
   }
 }
 
@@ -816,19 +843,15 @@ auto MovementSystem::apply_duel_footwork(Engine::Core::Entity* entity,
 
   float const face_x = opponent_transform->position.x - transform.position.x;
   float const face_z = opponent_transform->position.z - transform.position.z;
-  float const target_yaw =
-      std::atan2(face_x, face_z) * 180.0F / std::numbers::pi_v<float>;
-  float const current = transform.rotation.y;
-  float const diff = std::fmod((target_yaw - current + 540.0F), 360.0F) - 180.0F;
+  float const target_yaw = Game::Systems::yaw_degrees_from_direction(face_x, face_z);
   auto const* footwork_unit = entity->get_component<Engine::Core::UnitComponent>();
   float const footwork_turn_speed =
       footwork_unit != nullptr
           ? std::min(k_duel_footwork_turn_degrees_per_second,
                      Game::Units::body_turn_speed_degrees(footwork_unit->spawn_type))
           : k_duel_footwork_turn_degrees_per_second;
-  transform.rotation.y = current + std::clamp(diff,
-                                              -footwork_turn_speed * delta_time,
-                                              footwork_turn_speed * delta_time);
+  transform.rotation.y = Game::Systems::turn_yaw_toward(
+      transform.rotation.y, target_yaw, footwork_turn_speed * delta_time);
   transform.desired_yaw = transform.rotation.y;
   transform.has_desired_yaw = false;
   return true;
@@ -983,13 +1006,11 @@ void MovementSystem::move_unit(Engine::Core::Entity* entity,
       transform->position.z += movement->vz * delta_time;
 
       float const target_yaw =
-          std::atan2(movement->vx, movement->vz) * 180.0F / std::numbers::pi_v<float>;
-      float const current = transform->rotation.y;
-      float const diff = std::fmod((target_yaw - current + 540.0F), 360.0F) - 180.0F;
-      float const turn_speed = Game::Units::body_turn_speed_degrees(unit->spawn_type);
-      float const step =
-          std::clamp(diff, -turn_speed * delta_time, turn_speed * delta_time);
-      transform->rotation.y = current + step;
+          Game::Systems::yaw_degrees_from_direction(movement->vx, movement->vz);
+      float const turn_speed = formation_turn_speed_degrees(
+          *entity, *unit, Game::Units::body_turn_speed_degrees(unit->spawn_type));
+      transform->rotation.y = Game::Systems::turn_yaw_toward(
+          transform->rotation.y, target_yaw, turn_speed * delta_time);
       facts->progress.state = Engine::Core::MovementOrderState::Following;
     }
 
@@ -1021,12 +1042,18 @@ void MovementSystem::move_unit(Engine::Core::Entity* entity,
     movement->vx *= std::max(0.0F, 1.0F - limits.damping * delta_time);
     movement->vz *= std::max(0.0F, 1.0F - limits.damping * delta_time);
   } else {
-    float const ax = (target_vx - movement->vx) * limits.acceleration;
-    float const az = (target_vz - movement->vz) * limits.acceleration;
-    movement->vx += ax * delta_time;
-    movement->vz += az * delta_time;
-    movement->vx *= std::max(0.0F, 1.0F - 0.5F * limits.damping * delta_time);
-    movement->vz *= std::max(0.0F, 1.0F - 0.5F * limits.damping * delta_time);
+    if (movement->get_issuer_retargets()) {
+
+      movement->vx += (target_vx - movement->vx) * limits.acceleration * delta_time;
+      movement->vz += (target_vz - movement->vz) * limits.acceleration * delta_time;
+      movement->vx *= std::max(0.0F, 1.0F - 0.5F * limits.damping * delta_time);
+      movement->vz *= std::max(0.0F, 1.0F - 0.5F * limits.damping * delta_time);
+    } else {
+
+      float const gain = std::min(1.0F, limits.acceleration * delta_time);
+      movement->vx += (target_vx - movement->vx) * gain;
+      movement->vz += (target_vz - movement->vz) * gain;
+    }
   }
 
   QVector3D const current_pos_3d(transform->position.x, 0.0F, transform->position.z);
@@ -1064,11 +1091,9 @@ void MovementSystem::move_unit(Engine::Core::Entity* entity,
       traversal != nullptr && traversal->root_motion_blocked && world != nullptr &&
       world->presentation_enabled() &&
       entity->has_component<Engine::Core::RenderableComponent>()) {
-    translated_vx = 0.0F;
-    translated_vz = 0.0F;
-    movement->vx = 0.0F;
-    movement->vz = 0.0F;
-    facts->progress.state = Engine::Core::MovementOrderState::Yielding;
+
+    translated_vx *= k_root_hold_pace;
+    translated_vz *= k_root_hold_pace;
   }
 
   MotorCollision const collision(*entity, old_x, old_z);
@@ -1149,7 +1174,6 @@ auto MovementSystem::access() const -> Engine::Core::SystemAccess {
                                      ElephantComponent,
                                      RpgCommanderActionComponent,
                                      BuilderProductionComponent,
-                                     UnitTraversalLayoutStateComponent,
                                      RenderableComponent,
                                      PendingRemovalComponent>{},
                                Writes<MovementComponent,
@@ -1157,7 +1181,10 @@ auto MovementSystem::access() const -> Engine::Core::SystemAccess {
                                       TransformComponent,
                                       AttackComponent,
                                       StaminaComponent,
-                                      TerrainContextComponent>{});
+                                      TerrainContextComponent,
+                                      UnitTraversalLayoutStateComponent,
+                                      FormationPresentationComponent,
+                                      SoldierCasualtyAnimationComponent>{});
 }
 
 } // namespace Game::Systems

--- a/game/systems/production_system.cpp
+++ b/game/systems/production_system.cpp
@@ -689,9 +689,7 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
     }
   }
 
-  constexpr float CONSTRUCTION_ARRIVAL_DISTANCE_SQ = 0.0225F;
-
-  constexpr float k_wall_site_arrival_distance_sq = 1.0F * 1.0F;
+  constexpr float k_site_arrival_distance_sq = 1.0F * 1.0F;
 
   constexpr float k_site_approach_limit_seconds = 30.0F;
 
@@ -790,9 +788,7 @@ void ProductionSystem::update(Engine::Core::World* world, float delta_time) {
         float const dz = builder_prod->construction_site_z - transform->position.z;
         float const dist_sq = dx * dx + dz * dz;
 
-        const float arrival_sq = is_wall_network_product(builder_prod->product_type)
-                                     ? k_wall_site_arrival_distance_sq
-                                     : CONSTRUCTION_ARRIVAL_DISTANCE_SQ;
+        const float arrival_sq = k_site_arrival_distance_sq;
         if (dist_sq < arrival_sq) {
 
           builder_prod->at_construction_site = true;

--- a/game/systems/route_follow_system.cpp
+++ b/game/systems/route_follow_system.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 
 #include "../core/entity.h"
 #include "../formation/army_formation_registry.h"
@@ -30,25 +32,23 @@ constexpr float k_progress_window_metres = 0.03F;
 
 constexpr float k_launch_grace_seconds = 0.60F;
 
-constexpr float k_yield_budget_seconds = 8.0F;
 constexpr float k_block_declare_seconds = 0.35F;
-
-constexpr float k_block_escalate_seconds = 0.40F;
 constexpr float k_repath_settle_seconds = 0.60F;
-constexpr float k_recovery_budget_seconds = 1.50F;
-constexpr std::uint32_t k_max_repath_attempts = 3U;
-
-constexpr std::uint32_t k_max_order_repaths = 24U;
 
 constexpr float k_stall_window_seconds = 1.0F;
 constexpr float k_stall_progress_fraction = 0.20F;
 constexpr float k_stall_progress_floor_metres = 0.10F;
 constexpr float k_stall_progress_ceiling_metres = 0.60F;
-constexpr float k_stall_rung_seconds = 2.5F;
+constexpr float k_stall_replan_seconds = 1.5F;
+constexpr float k_stall_sidestep_seconds = 4.0F;
+constexpr float k_stall_relax_seconds = 7.0F;
+constexpr float k_stall_abandon_seconds = 12.0F;
 constexpr float k_stall_objective_change_metres = 1.5F;
 constexpr float k_stall_relaxed_clearance = 0.35F;
 
 constexpr float k_no_closer_rung_seconds = 9.0F;
+
+constexpr float k_queue_patience_seconds = 6.0F;
 constexpr float k_no_closer_progress_metres = 0.5F;
 
 constexpr float k_lookahead_speed_seconds = 0.35F;
@@ -57,23 +57,17 @@ constexpr float k_lookahead_max = 2.0F;
 constexpr float k_projection_window_min = 1.5F;
 constexpr float k_degenerate_aim_distance = 0.15F;
 
+constexpr float k_minimum_aim_fraction = 0.75F;
+
 constexpr std::uint64_t k_route_prune_interval_ticks = 600U;
 
 constexpr float k_short_route_slack = 0.75F;
 
-[[nodiscard]] auto is_escalating_state(Engine::Core::MovementOrderState state) -> bool {
+constexpr float k_hold_at_obstruction_seconds = 12.0F;
+constexpr float k_hold_recheck_seconds = 1.0F;
 
-  switch (state) {
-  case Engine::Core::MovementOrderState::LocallyBlocked:
-  case Engine::Core::MovementOrderState::Yielding:
-  case Engine::Core::MovementOrderState::Repathing:
-  case Engine::Core::MovementOrderState::Recovering:
-  case Engine::Core::MovementOrderState::Unreachable:
-    return true;
-  default:
-    return false;
-  }
-}
+constexpr float k_occupied_goal_slack = 1.5F;
+constexpr float k_occupied_goal_press_seconds = 0.5F;
 
 [[nodiscard]] auto
 route_stops_short_of_the_order(const Engine::Core::MovementComponent& movement,
@@ -88,6 +82,24 @@ route_stops_short_of_the_order(const Engine::Core::MovementComponent& movement,
       movement.get_requested_goal_x() - transform.position.x,
       movement.get_requested_goal_z() - transform.position.z);
   return to_requested > arrive_radius + k_short_route_slack;
+}
+
+[[nodiscard]] auto route_now_reaches(const Engine::Core::MovementComponent& movement,
+                                     const QVector3D& from,
+                                     const QVector3D& goal) -> bool {
+  auto* pathfinder = NavGrid::get_pathfinder();
+  if (pathfinder == nullptr) {
+    return false;
+  }
+  pathfinder->update_navigation_grid();
+  Point const start = NavGrid::world_to_grid(from.x(), from.z());
+  Point const end = NavGrid::world_to_grid(goal.x(), goal.z());
+  auto const passability = movement.get_can_enter_forest()
+                               ? Pathfinding::Passability::Light
+                               : Pathfinding::Passability::Heavy;
+  auto const path = pathfinder->find_path(
+      start, end, passability, movement.get_navigation_clearance());
+  return !path.empty() && path.back() == end;
 }
 
 void publish_direct_control_intent(const Engine::Core::Entity& entity,
@@ -107,6 +119,8 @@ void publish_direct_control_intent(const Engine::Core::Entity& entity,
   facts.desired.velocity_z = commander->fpv_motion_vz;
   facts.desired.tangent_x = commander->fpv_motion_vx / speed;
   facts.desired.tangent_z = commander->fpv_motion_vz / speed;
+  facts.desired.heading_x = facts.desired.tangent_x;
+  facts.desired.heading_z = facts.desired.tangent_z;
   facts.desired.lookahead_x = transform.position.x + commander->fpv_motion_vx;
   facts.desired.lookahead_z = transform.position.z + commander->fpv_motion_vz;
   facts.desired.speed_limit = speed;
@@ -129,24 +143,28 @@ void forget_stall_window(Engine::Core::MovementStallFacts& stall) {
 void restart_stall_ladder(Engine::Core::MovementStallFacts& stall) {
   stall.stalled_seconds = 0.0F;
   stall.no_closer_seconds = 0.0F;
+  stall.queued_seconds = 0.0F;
   stall.rung = Engine::Core::MovementRecoveryRung::None;
   stall.clearance_relief = 1.0F;
   forget_stall_window(stall);
 }
 
 [[nodiscard]] auto ladder_rung(float seconds,
-                               float per_rung) -> Engine::Core::MovementRecoveryRung {
+                               float replan_at,
+                               float sidestep_at,
+                               float relax_at,
+                               float abandon_at) -> Engine::Core::MovementRecoveryRung {
   using Rung = Engine::Core::MovementRecoveryRung;
-  if (seconds >= 4.0F * per_rung) {
+  if (seconds >= abandon_at) {
     return Rung::Abandoned;
   }
-  if (seconds >= 3.0F * per_rung) {
+  if (seconds >= relax_at) {
     return Rung::RelaxFormation;
   }
-  if (seconds >= 2.0F * per_rung) {
+  if (seconds >= sidestep_at) {
     return Rung::Sidestep;
   }
-  if (seconds >= per_rung) {
+  if (seconds >= replan_at) {
     return Rung::Replan;
   }
   return Rung::None;
@@ -154,8 +172,16 @@ void restart_stall_ladder(Engine::Core::MovementStallFacts& stall) {
 
 [[nodiscard]] auto rung_for(const Engine::Core::MovementStallFacts& stall)
     -> Engine::Core::MovementRecoveryRung {
-  return std::max(ladder_rung(stall.stalled_seconds, k_stall_rung_seconds),
-                  ladder_rung(stall.no_closer_seconds, k_no_closer_rung_seconds));
+  return std::max(ladder_rung(stall.stalled_seconds,
+                              k_stall_replan_seconds,
+                              k_stall_sidestep_seconds,
+                              k_stall_relax_seconds,
+                              k_stall_abandon_seconds),
+                  ladder_rung(stall.no_closer_seconds,
+                              k_no_closer_rung_seconds,
+                              2.0F * k_no_closer_rung_seconds,
+                              3.0F * k_no_closer_rung_seconds,
+                              4.0F * k_no_closer_rung_seconds));
 }
 
 } // namespace
@@ -198,32 +224,6 @@ auto is_movement_point_allowed(const QVector3D& pos,
   return Walkability::can_stand(pos, profile);
 }
 
-auto goal_is_reachable_from(const Engine::Core::MovementComponent& movement,
-                            const QVector3D& current,
-                            const QVector3D& goal,
-                            float clearance = -1.0F) -> bool {
-  auto* pathfinder = NavGrid::get_pathfinder();
-  if (pathfinder == nullptr) {
-    return false;
-  }
-  pathfinder->update_navigation_grid();
-  Point const start_cell = NavGrid::world_to_grid(current.x(), current.z());
-  Point const goal_cell = NavGrid::world_to_grid(goal.x(), goal.z());
-  auto const passability = movement.get_can_enter_forest()
-                               ? Pathfinding::Passability::Light
-                               : Pathfinding::Passability::Heavy;
-  auto const route = pathfinder->find_path(
-      start_cell,
-      goal_cell,
-      passability,
-      clearance >= 0.0F ? clearance : movement.get_navigation_clearance());
-  if (route.empty()) {
-    return false;
-  }
-
-  return route.back() == goal_cell;
-}
-
 auto max_navigation_speed(const Engine::Core::UnitComponent& unit,
                           const Engine::Core::StaminaComponent* stamina) -> float {
   float speed = std::max(0.1F, unit.speed);
@@ -243,6 +243,9 @@ auto formation_navigation_speed(const Engine::Core::Entity& entity,
   const auto* movement = entity.get_component<Engine::Core::MovementComponent>();
   if (movement != nullptr && movement->get_declared_group_pace() > 0.0F) {
     speed = std::min(speed, movement->get_declared_group_pace());
+  }
+  if (!std::isfinite(speed) || speed <= 0.0F) {
+    speed = max_navigation_speed(unit, stamina);
   }
   return speed;
 }
@@ -312,6 +315,7 @@ void RouteFollowSystem::update(Engine::Core::World* world, float delta_time) {
         auto* entity = world->get_entity(id);
         if (entity != nullptr) {
           follow(*entity, *world, delta_time);
+          report_idle_order(*entity, *world);
         }
       });
 
@@ -450,13 +454,22 @@ void RouteFollowSystem::follow(Engine::Core::Entity& entity,
     if (Engine::Core::is_active_movement_state(facts->progress.state)) {
       facts->progress.state = Engine::Core::MovementOrderState::Cancelled;
     }
+    facts->progress.holding_at_obstruction = false;
+    facts->progress.holding_seconds = 0.0F;
     return;
   }
 
   auto& route = m_routes[entity.get_id()];
   bool route_changed = false;
-  if (!route.valid() || route.route_revision() != movement->get_route_revision()) {
+  bool const new_route_revision =
+      route.route_revision() != movement->get_route_revision();
+  if (!route.valid() || new_route_revision) {
     route_changed = true;
+    if (new_route_revision) {
+
+      facts->progress.holding_at_obstruction = false;
+      facts->progress.holding_seconds = 0.0F;
+    }
 
     route.build(movement->get_route_revision(),
                 movement->get_topology_revision(),
@@ -493,6 +506,8 @@ void RouteFollowSystem::follow(Engine::Core::Entity& entity,
   float endpoint_z = movement->get_target_y();
   float remaining = 0.0F;
   float tangent_x = 0.0F;
+  float heading_x = 0.0F;
+  float heading_z = 0.0F;
   float tangent_z = 0.0F;
 
   if (route.valid()) {
@@ -524,7 +539,23 @@ void RouteFollowSystem::follow(Engine::Core::Entity& entity,
 
     float const lookahead = std::clamp(
         max_speed * k_lookahead_speed_seconds, k_lookahead_min, k_lookahead_max);
-    float aim_s = std::min(s + lookahead, route.next_vertex_s(s));
+    auto const* pathfinder = NavGrid::get_pathfinder();
+    auto const aim_passability = movement->get_can_enter_forest()
+                                     ? Pathfinding::Passability::Light
+                                     : Pathfinding::Passability::Heavy;
+    float aim_s = route.steering_aim_s(
+        transform->position.x,
+        transform->position.z,
+        lookahead,
+        lookahead * k_minimum_aim_fraction,
+        [pathfinder,
+         aim_passability](float from_x, float from_z, float to_x, float to_z) {
+          return pathfinder == nullptr ||
+                 pathfinder->is_world_segment_walkable(QVector3D(from_x, 0.0F, from_z),
+                                                       QVector3D(to_x, 0.0F, to_z),
+                                                       aim_passability,
+                                                       0.0F);
+        });
     auto aim = route.point_at(aim_s);
     if (Game::Systems::planar_length(aim.first - transform->position.x,
                                      aim.second - transform->position.z) <
@@ -535,6 +566,9 @@ void RouteFollowSystem::follow(Engine::Core::Entity& entity,
     aim_x = aim.first;
     aim_z = aim.second;
 
+    auto const lead = route.tangent_at(aim_s);
+    heading_x = lead.first;
+    heading_z = lead.second;
     auto const tangent = route.tangent_at(s);
     tangent_x = tangent.first;
     tangent_z = tangent.second;
@@ -558,18 +592,93 @@ void RouteFollowSystem::follow(Engine::Core::Entity& entity,
 
   float const endpoint_distance = Game::Systems::planar_length(
       endpoint_x - transform->position.x, endpoint_z - transform->position.z);
-  if (remaining <= arrive_radius && endpoint_distance <= arrive_radius) {
+  bool const pressed_against_a_standing_friend =
+      facts->steering.valid && facts->steering.body_overlap > 0.0F &&
+      facts->progress.no_progress_seconds > k_occupied_goal_press_seconds;
+  bool const goal_is_held_by_friends =
+      current_position_allowed && pressed_against_a_standing_friend &&
+      !movement->get_issuer_retargets() &&
+      movement->get_structure_approach_target() == 0 &&
+      remaining <= arrive_radius + k_occupied_goal_slack &&
+      endpoint_distance <= arrive_radius + k_occupied_goal_slack;
+  if (goal_is_held_by_friends) {
+    movement->stop();
+    OrderService::clear_player_order_intent(&entity);
+    facts->progress.state = Engine::Core::MovementOrderState::Arrived;
+    facts->progress.arrived_short = true;
+    facts->progress.no_progress_seconds = 0.0F;
+    facts->progress.no_progress_advance = 0.0F;
+    facts->progress.remaining_arclength = 0.0F;
+    route.clear();
+    return;
+  }
 
-    if (route_stops_short_of_the_order(*movement, *transform, arrive_radius)) {
+  if (current_position_allowed && remaining <= arrive_radius &&
+      endpoint_distance <= arrive_radius) {
 
-      if (!is_escalating_state(facts->progress.state)) {
-        facts->progress.state = Engine::Core::MovementOrderState::LocallyBlocked;
+    bool const stopped_short =
+        route_stops_short_of_the_order(*movement, *transform, arrive_radius);
+    if (stopped_short && (movement->get_issuer_retargets() ||
+                          movement->get_structure_approach_target() != 0)) {
+
+      facts->progress.state = Engine::Core::MovementOrderState::LocallyBlocked;
+      return;
+    }
+    if (stopped_short) {
+      QVector3D const requested = order_goal_of(*movement);
+      bool const requested_point_is_ground =
+          is_movement_point_allowed(requested, entity);
+      if (!requested_point_is_ground) {
+
+        movement->stop();
+        OrderService::clear_player_order_intent(&entity);
+        facts->progress.state = Engine::Core::MovementOrderState::Arrived;
+        facts->progress.arrived_short = true;
+        facts->progress.no_progress_seconds = 0.0F;
+        facts->progress.no_progress_advance = 0.0F;
+        facts->progress.remaining_arclength = 0.0F;
+        route.clear();
+        return;
+      }
+      if (facts->progress.short_route_replans == 0U) {
+
+        ++facts->progress.short_route_replans;
+        MovementSystem::retarget_unit(world, entity.get_id(), requested);
+        ++facts->progress.repath_count;
+        facts->progress.repath_reason =
+            Engine::Core::MovementRepathReason::RouteInvalid;
+        facts->progress.state = Engine::Core::MovementOrderState::Repathing;
+        return;
+      }
+
+      facts->progress.holding_at_obstruction = true;
+      facts->progress.holding_seconds += delta_time;
+      facts->progress.holding_recheck_seconds += delta_time;
+      if (facts->progress.holding_recheck_seconds >= k_hold_recheck_seconds) {
+        facts->progress.holding_recheck_seconds = 0.0F;
+        QVector3D const here(transform->position.x, 0.0F, transform->position.z);
+        if (route_now_reaches(*movement, here, requested)) {
+          facts->progress.holding_at_obstruction = false;
+          facts->progress.holding_seconds = 0.0F;
+          facts->progress.short_route_replans = 0;
+          MovementSystem::retarget_unit(world, entity.get_id(), requested);
+          ++facts->progress.repath_count;
+          facts->progress.repath_reason =
+              Engine::Core::MovementRepathReason::ObstructionReleased;
+          facts->progress.state = Engine::Core::MovementOrderState::Repathing;
+          return;
+        }
+      }
+      facts->progress.state = Engine::Core::MovementOrderState::LocallyBlocked;
+      if (facts->progress.holding_seconds > k_hold_at_obstruction_seconds) {
+        abandon_objective(entity, *movement, *facts, requested);
       }
       return;
     }
     movement->stop();
     OrderService::clear_player_order_intent(&entity);
     facts->progress.state = Engine::Core::MovementOrderState::Arrived;
+    facts->progress.arrived_short = false;
     facts->progress.no_progress_seconds = 0.0F;
     facts->progress.no_progress_advance = 0.0F;
     facts->progress.remaining_arclength = 0.0F;
@@ -609,6 +718,12 @@ void RouteFollowSystem::follow(Engine::Core::Entity& entity,
   facts->desired.velocity_z = nz * desired_speed;
   facts->desired.tangent_x = tangent_x;
   facts->desired.tangent_z = tangent_z;
+  if (heading_x == 0.0F && heading_z == 0.0F) {
+    heading_x = tangent_x;
+    heading_z = tangent_z;
+  }
+  facts->desired.heading_x = heading_x;
+  facts->desired.heading_z = heading_z;
   facts->desired.lookahead_x = aim_x;
   facts->desired.lookahead_z = aim_z;
   facts->desired.speed_limit = max_speed;
@@ -623,6 +738,9 @@ void RouteFollowSystem::abandon_objective(Engine::Core::Entity& entity,
 
   auto& progress = facts.progress;
   progress.state = Engine::Core::MovementOrderState::Unreachable;
+
+  progress.holding_at_obstruction = false;
+  progress.holding_seconds = 0.0F;
   progress.no_progress_seconds = 0.0F;
   progress.no_progress_advance = 0.0F;
   progress.remaining_arclength = 0.0F;
@@ -655,6 +773,11 @@ auto RouteFollowSystem::track_objective_stall(
 
   auto& stall = facts.progress.stall;
 
+  if (movement.get_has_target() && facts.progress.holding_at_obstruction) {
+
+    restart_stall_ladder(stall);
+    return false;
+  }
   if (!movement.get_has_target()) {
 
     stall.objective_valid = false;
@@ -715,15 +838,29 @@ auto RouteFollowSystem::track_objective_stall(
     stall.window_reference_z = here.z();
   }
 
+  bool const queued_behind_traffic =
+      facts.steering.valid &&
+      facts.steering.result == Engine::Core::SteeringResult::Yielded &&
+      !facts.steering.blocked_by_standing_body;
+
+  if (queued_behind_traffic) {
+    stall.queued_seconds += delta_time;
+  } else {
+    stall.queued_seconds = 0.0F;
+  }
+
   stall.window_seconds += delta_time;
   if (stall.window_seconds >= k_stall_window_seconds) {
 
     float const moved = Game::Systems::planar_length(
         here.x() - stall.window_reference_x, here.z() - stall.window_reference_z);
+
     float const expected =
-        std::clamp(max_speed * stall.window_seconds * k_stall_progress_fraction,
-                   k_stall_progress_floor_metres,
-                   k_stall_progress_ceiling_metres);
+        queued_behind_traffic
+            ? k_stall_progress_floor_metres
+            : std::clamp(max_speed * stall.window_seconds * k_stall_progress_fraction,
+                         k_stall_progress_floor_metres,
+                         k_stall_progress_ceiling_metres);
     float const window = stall.window_seconds;
     stall.window_seconds = 0.0F;
     stall.window_reference_x = here.x();
@@ -735,7 +872,13 @@ auto RouteFollowSystem::track_objective_stall(
     }
   }
 
+  if (queued_behind_traffic && stall.queued_seconds < k_queue_patience_seconds) {
+
+    return false;
+  }
+
   auto const wanted = rung_for(stall);
+
   if (wanted < stall.rung) {
 
     stall.rung = wanted;
@@ -759,6 +902,14 @@ auto RouteFollowSystem::track_objective_stall(
     break;
 
   case MovementRecoveryRung::Sidestep:
+
+    if (queued_behind_traffic) {
+
+      MovementSystem::retarget_unit(world, entity.get_id(), objective);
+      ++facts.progress.repath_count;
+      facts.progress.repath_reason = MovementRepathReason::Blocked;
+      break;
+    }
     if (MovementSystem::assign_local_recovery_move(
             here, QVector3D(objective.x(), 0.0F, objective.z()), &movement)) {
       facts.progress.state = MovementOrderState::Recovering;
@@ -782,11 +933,76 @@ auto RouteFollowSystem::track_objective_stall(
     break;
 
   case MovementRecoveryRung::Abandoned:
+
+    if (queued_behind_traffic) {
+
+      stall.stalled_seconds = 0.0F;
+      stall.rung = MovementRecoveryRung::None;
+      forget_stall_window(stall);
+      break;
+    }
     abandon_objective(entity, movement, facts, objective);
     return true;
   }
 
   return false;
+}
+
+void RouteFollowSystem::report_idle_order(const Engine::Core::Entity& entity,
+                                          const Engine::Core::World& world) {
+  static bool const enabled = std::getenv("SOI_DEBUG_IDLE_ORDER") != nullptr;
+  if (!enabled) {
+    return;
+  }
+  auto const* movement = entity.get_component<Engine::Core::MovementComponent>();
+  auto const* facts = entity.get_component<Engine::Core::MovementFactsComponent>();
+  auto const* transform = entity.get_component<Engine::Core::TransformComponent>();
+  if (movement == nullptr || facts == nullptr || transform == nullptr ||
+      !movement->get_has_target()) {
+    return;
+  }
+  float const speed = facts->desired.valid ? planar_length(facts->desired.velocity_x,
+                                                           facts->desired.velocity_z)
+                                           : 0.0F;
+  if (speed > 1.0e-3F || facts->progress.remaining_arclength < 1.0F ||
+      classify_movement_gate(entity) != MovementGate::RouteFollowing) {
+    return;
+  }
+  if (world.tick_id() % 15U != 0U) {
+    return;
+  }
+  auto const found = m_routes.find(entity.get_id());
+  bool const has_route = found != m_routes.end() && found->second.valid();
+  std::fprintf(
+      stderr,
+      "SOI_IDLE_ORDER tick=%llu entity=%llu state=%s rung=%d desired_valid=%d "
+      "pos=(%.2f,%.2f) target=(%.2f,%.2f) goal=(%.2f,%.2f) requested=(%.2f,%.2f) "
+      "aim=(%.2f,%.2f) remaining=%.2f route=%d length=%.2f travelled=%.2f "
+      "points=%zu path=%zu index=%zu allowed_here=%d\n",
+      static_cast<unsigned long long>(world.tick_id()),
+      static_cast<unsigned long long>(entity.get_id()),
+      Engine::Core::movement_state_name(facts->progress.state),
+      static_cast<int>(facts->progress.stall.rung),
+      static_cast<int>(facts->desired.valid),
+      transform->position.x,
+      transform->position.z,
+      movement->get_target_x(),
+      movement->get_target_y(),
+      movement->get_goal_x(),
+      movement->get_goal_y(),
+      movement->get_requested_goal_x(),
+      movement->get_requested_goal_z(),
+      facts->desired.lookahead_x,
+      facts->desired.lookahead_z,
+      facts->progress.remaining_arclength,
+      static_cast<int>(has_route),
+      has_route ? found->second.length() : 0.0F,
+      has_route ? found->second.travelled() : 0.0F,
+      has_route ? found->second.point_count() : 0U,
+      movement->get_path().size(),
+      movement->get_path_index(),
+      static_cast<int>(is_movement_point_allowed(
+          QVector3D(transform->position.x, 0.0F, transform->position.z), entity)));
 }
 
 auto RouteFollowSystem::route_for(Engine::Core::EntityID entity_id) const
@@ -822,6 +1038,10 @@ auto RouteFollowSystem::update_progress(Engine::Core::Entity& entity,
     progress.no_progress_advance = 0.0F;
     progress.repath_attempts = 0;
     progress.repath_count = 0;
+    progress.arrived_short = false;
+    progress.short_route_replans = 0;
+    progress.holding_at_obstruction = false;
+    progress.holding_seconds = 0.0F;
   }
   progress.order_seconds += delta_time;
 
@@ -863,86 +1083,23 @@ auto RouteFollowSystem::update_progress(Engine::Core::Entity& entity,
   case MovementOrderState::Yielding:
     if (!yielding_to_traffic) {
       progress.state = MovementOrderState::Following;
-    } else if (progress.state_seconds > k_yield_budget_seconds) {
-      progress.state = MovementOrderState::LocallyBlocked;
-    }
-    break;
-
-  case MovementOrderState::LocallyBlocked:
-    if (progress.state_seconds > k_block_escalate_seconds) {
-      if (progress.repath_attempts >= k_max_repath_attempts) {
-        progress.state = MovementOrderState::Recovering;
-        progress.repath_reason = MovementRepathReason::RecoveryEscalation;
-      } else {
-        QVector3D const goal =
-            movement.get_has_requested_goal()
-                ? QVector3D(movement.get_requested_goal_x(),
-                            0.0F,
-                            movement.get_requested_goal_z())
-                : QVector3D(movement.get_goal_x(), 0.0F, movement.get_goal_y());
-        MovementSystem::retarget_unit(world, entity.get_id(), goal);
-        ++progress.repath_count;
-        ++progress.repath_attempts;
-        progress.repath_reason = MovementRepathReason::Blocked;
-        progress.state = MovementOrderState::Repathing;
-      }
     }
     break;
 
   case MovementOrderState::Repathing:
+  case MovementOrderState::Recovering:
     if (progress.state_seconds > k_repath_settle_seconds) {
       progress.state = MovementOrderState::LocallyBlocked;
     }
     break;
 
-  case MovementOrderState::Recovering: {
-    QVector3D const current(transform.position.x, 0.0F, transform.position.z);
-    QVector3D const goal = order_goal_of(movement);
-    if (progress.state_seconds <= k_recovery_budget_seconds) {
-      MovementSystem::assign_local_recovery_move(current, goal, &movement);
-      break;
-    }
-
-    if (progress.repath_count < k_max_order_repaths) {
-      if (goal_is_reachable_from(movement, current, goal)) {
-        progress.state = MovementOrderState::LocallyBlocked;
-        progress.repath_attempts = 0;
-        progress.no_progress_seconds = 0.0F;
-        progress.no_progress_advance = 0.0F;
-        MovementSystem::retarget_unit(world, entity.get_id(), goal);
-        ++progress.repath_count;
-        progress.repath_reason = MovementRepathReason::Blocked;
-        break;
-      }
-
-      float const relaxed =
-          movement.get_navigation_clearance() * k_stall_relaxed_clearance;
-      if (progress.stall.clearance_relief >= 1.0F &&
-          goal_is_reachable_from(movement, current, goal, relaxed)) {
-        progress.stall.clearance_relief = k_stall_relaxed_clearance;
-        progress.stall.rung = Engine::Core::MovementRecoveryRung::RelaxFormation;
-        movement.set_navigation_clearance(relaxed);
-        progress.state = MovementOrderState::LocallyBlocked;
-        progress.repath_attempts = 0;
-        progress.no_progress_seconds = 0.0F;
-        progress.no_progress_advance = 0.0F;
-        MovementSystem::retarget_unit(world, entity.get_id(), goal);
-        ++progress.repath_count;
-        progress.repath_reason = MovementRepathReason::RecoveryEscalation;
-        break;
-      }
-    }
-    abandon_objective(entity, movement, facts, goal);
+  case MovementOrderState::LocallyBlocked:
     break;
-  }
 
   default:
     progress.state = MovementOrderState::Following;
     break;
   }
-
-  movement.stuck_timer = progress.no_progress_seconds;
-  movement.stuck_ref_valid = false;
 
   progress.previous_state = entry_state;
   progress.state_seconds =

--- a/game/systems/route_follow_system.h
+++ b/game/systems/route_follow_system.h
@@ -50,6 +50,9 @@ public:
   route_for(Engine::Core::EntityID entity_id) const -> const MovementRoute*;
 
 private:
+  void report_idle_order(const Engine::Core::Entity& entity,
+                         const Engine::Core::World& world);
+
   void
   follow(Engine::Core::Entity& entity, Engine::Core::World& world, float delta_time);
 

--- a/game/systems/rpg_combat_system/rpg_combat_processor.cpp
+++ b/game/systems/rpg_combat_system/rpg_combat_processor.cpp
@@ -11,6 +11,7 @@
 #include "../../core/ambient_session.h"
 #include "../../core/component_commander.h"
 #include "../../core/world.h"
+#include "../../util/planar_math.h"
 #include "../combat_system/combat_random.h"
 #include "../combat_system/combat_utils.h"
 #include "../combat_system/target_rules.h"
@@ -94,11 +95,8 @@ void turn_body_toward(Engine::Core::TransformComponent& transform,
                       float delta_time) {
   float const current =
       transform.has_desired_yaw ? transform.desired_yaw : transform.rotation.y;
-  float gap = std::fmod((target_yaw_degrees - current + 540.0F), 360.0F) - 180.0F;
-  float const step = std::clamp(gap,
-                                -k_engaged_turn_rate_degrees * delta_time,
-                                k_engaged_turn_rate_degrees * delta_time);
-  transform.desired_yaw = current + step;
+  transform.desired_yaw = Game::Systems::turn_yaw_toward(
+      current, target_yaw_degrees, k_engaged_turn_rate_degrees * delta_time);
   transform.has_desired_yaw = true;
 }
 
@@ -293,8 +291,8 @@ void refresh_commander_engagement(Engine::Core::World* world,
     }
     bool sector_taken = false;
     for (float const bearing : taken_bearings) {
-      float gap = std::fmod(slot.signed_angle_degrees - bearing + 540.0F, 360.0F);
-      gap -= 180.0F;
+      float const gap =
+          Game::Systems::signed_yaw_delta(bearing, slot.signed_angle_degrees);
       if (std::abs(gap) < k_press_sector_degrees) {
         sector_taken = true;
         break;

--- a/game/systems/runtime_system_registry.cpp
+++ b/game/systems/runtime_system_registry.cpp
@@ -11,6 +11,7 @@
 #include "../wildlife/wildlife_system.h"
 #include "ai_system.h"
 #include "arrow_system.h"
+#include "body_contact_system.h"
 #include "capture_system.h"
 #include "civilian_delivery_system.h"
 #include "cleanup_system.h"
@@ -64,6 +65,8 @@ void register_runtime_systems(Engine::Core::World& world) {
   world.add_system(std::make_unique<LocalAvoidanceSystem>(),
                    Engine::Core::SystemPhase::Movement);
   world.add_system(std::make_unique<MovementSystem>(),
+                   Engine::Core::SystemPhase::Movement);
+  world.add_system(std::make_unique<BodyContactSystem>(),
                    Engine::Core::SystemPhase::Movement);
   world.add_system(std::make_unique<UnitTraversalLayoutSystem>(),
                    Engine::Core::SystemPhase::Movement);

--- a/game/systems/unit_activity.cpp
+++ b/game/systems/unit_activity.cpp
@@ -7,13 +7,22 @@
 #include "builder_product_types.h"
 #include "game/core/component_economy.h"
 #include "game/core/entity.h"
+#include "game/core/movement_facts.h"
 #include "game/core/world.h"
 
 namespace Game::Systems {
 
 namespace {
 
-constexpr float k_blocked_after_seconds = 1.2F;
+[[nodiscard]] auto movement_is_wedged(const Engine::Core::Entity& entity) -> bool {
+  const auto* movement = entity.get_component<Engine::Core::MovementComponent>();
+  const auto* facts = entity.get_component<Engine::Core::MovementFactsComponent>();
+  if (movement == nullptr || facts == nullptr || !movement->get_has_target()) {
+    return false;
+  }
+  return facts->progress.holding_at_obstruction ||
+         facts->progress.stall.rung >= Engine::Core::MovementRecoveryRung::Sidestep;
+}
 
 struct KindName {
   ActivityKind kind;
@@ -108,8 +117,7 @@ auto builder_activity(const Engine::Core::Entity& entity,
   }
 
   if (has_job || !builder.queued_construction_site_ids.empty()) {
-    const auto* movement = entity.get_component<Engine::Core::MovementComponent>();
-    if (movement != nullptr && movement->get_stuck_time() >= k_blocked_after_seconds) {
+    if (movement_is_wedged(entity)) {
       activity.state = ActivityState::Unavailable;
       return activity;
     }
@@ -224,7 +232,7 @@ auto classify_unit_activity(const Engine::Core::Entity& entity) -> UnitActivity 
 
   if (const auto* movement = entity.get_component<Engine::Core::MovementComponent>()) {
     if (movement->get_has_target()) {
-      if (movement->get_stuck_time() >= k_blocked_after_seconds) {
+      if (movement_is_wedged(entity)) {
         return {ActivityKind::Blocked, ActivityState::Unavailable, 0};
       }
       return {ActivityKind::Move, ActivityState::Active, 0};

--- a/game/systems/unit_traversal_layout_system.cpp
+++ b/game/systems/unit_traversal_layout_system.cpp
@@ -299,6 +299,7 @@ void publish_facts(const Engine::Core::UnitTraversalLayoutStateComponent& state,
   facts.mode_dwell_seconds = state.mode_dwell_seconds;
   facts.normal_files = state.normal_files;
   facts.lateral_scale = state.lateral_scale;
+  facts.about_faced = state.about_faced;
   facts.file_spacing = state.authored_file_spacing * state.lateral_scale;
 }
 
@@ -319,9 +320,7 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
           ? *narrow_shape
           : layout.all_slots;
 
-  float const corridor_half_width = state.available_half_width -
-                                    (layout.body_radius * k_soldier_probe_reach) -
-                                    k_width_epsilon;
+  float const frame_sign = state.about_faced ? -1.0F : 1.0F;
   for (std::size_t index = 0; index < layout.all_slots.size(); ++index) {
     auto const& slot = layout.all_slots[index];
     auto const& placed = shape[index];
@@ -330,12 +329,12 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
       target = *previous;
     } else {
       target.slot_index = slot.index;
-      target.start_local_x = slot.local_x;
-      target.start_local_z = slot.local_z;
-      target.previous_local_x = slot.local_x;
-      target.previous_local_z = slot.local_z;
-      target.current_local_x = slot.local_x;
-      target.current_local_z = slot.local_z;
+      target.start_local_x = frame_sign * slot.local_x;
+      target.start_local_z = frame_sign * slot.local_z;
+      target.previous_local_x = target.start_local_x;
+      target.previous_local_z = target.start_local_z;
+      target.current_local_x = target.start_local_x;
+      target.current_local_z = target.start_local_z;
     }
     target.row = placed.row;
     target.col = placed.col;
@@ -343,8 +342,8 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
         layout.live_slots.begin(),
         layout.live_slots.end(),
         [&slot](auto const& candidate) { return candidate.index == slot.index; });
-    target.target_local_x = placed.local_x;
-    target.target_local_z = placed.local_z;
+    target.target_local_x = frame_sign * placed.local_x;
+    target.target_local_z = frame_sign * placed.local_z;
     if (state.active) {
 
       target.target_local_x *= state.lateral_scale;
@@ -396,6 +395,9 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
 
   auto const limits = relocation_limits(unit.spawn_type);
 
+  float const corridor_half_width = state.available_half_width -
+                                    (layout.body_radius * k_soldier_probe_reach) -
+                                    k_width_epsilon;
   if (state.active && corridor_half_width > 0.0F) {
     float widest = 0.0F;
     for (auto const& slot : next) {
@@ -403,9 +405,9 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
         widest = std::max(widest, std::abs(slot.target_local_x));
       }
     }
-    float const floor_correction = k_minimum_squeeze_scale;
     if (widest > corridor_half_width) {
-      float const correction = std::max(corridor_half_width / widest, floor_correction);
+      float const correction =
+          std::max(corridor_half_width / widest, k_minimum_squeeze_scale);
       for (auto& slot : next) {
         slot.target_local_x *= correction;
       }
@@ -424,6 +426,21 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
                                                   passability);
   };
 
+  auto slot_is_in_sight_of_root = [&](float local_x, float local_z) {
+    if (pathfinder == nullptr) {
+      return true;
+    }
+    float const world_x =
+        transform.position.x + (cos_yaw * local_x) + (sin_yaw * local_z);
+    float const world_z =
+        transform.position.z - (sin_yaw * local_x) + (cos_yaw * local_z);
+    return pathfinder->is_world_segment_walkable(
+        QVector3D(transform.position.x, 0.0F, transform.position.z),
+        QVector3D(world_x, 0.0F, world_z),
+        passability,
+        0.0F);
+  };
+
   auto slot_terrain_is_open = [&](float local_x, float local_z) {
     if (pathfinder == nullptr) {
       return true;
@@ -436,35 +453,110 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
     return pathfinder->is_terrain_walkable(cell.x, cell.y);
   };
 
-  auto onto_walkable_ground = [&](float& local_x, float& local_z) {
-    if (slot_ground_is_open(local_x, local_z)) {
-      return false;
-    }
-    float low = 0.0F;
-    float high = 1.0F;
-    for (int bisection = 0; bisection < k_slot_recovery_bisections; ++bisection) {
-      float const middle = (low + high) * 0.5F;
-      if (slot_ground_is_open(local_x * middle, local_z * middle)) {
-        low = middle;
-      } else {
-        high = middle;
-      }
-    }
-    float const corrected_x = local_x * low;
-    float const corrected_z = local_z * low;
-    float const correction =
-        Game::Systems::planar_length(corrected_x - local_x, corrected_z - local_z);
-    float const budget = k_ground_clamp_speed * step;
-    if (correction > budget && correction > 0.0001F) {
-      float const share = budget / correction;
-      local_x += (corrected_x - local_x) * share;
-      local_z += (corrected_z - local_z) * share;
-      return true;
-    }
-    local_x = corrected_x;
-    local_z = corrected_z;
-    return true;
-  };
+  float const minimum_separation =
+      std::max(Game::Formation::TraversalPolicy::k_minimum_soldier_separation,
+               layout.body_radius * 2.0F * 1.04F);
+
+  auto nearest_open_ground =
+      [&](std::size_t self, float local_x, float local_z, float& out_x, float& out_z) {
+        constexpr std::array<float, 4> k_rings{{0.5F, 1.0F, 1.5F, 2.25F}};
+        constexpr int k_ring_probes = 12;
+        float best_distance = std::numeric_limits<float>::infinity();
+        bool found = false;
+        for (float const ring : k_rings) {
+          for (int probe = 0; probe < k_ring_probes; ++probe) {
+            float const angle = static_cast<float>(probe) * 2.0F *
+                                std::numbers::pi_v<float> /
+                                static_cast<float>(k_ring_probes);
+            float const candidate_x = local_x + std::cos(angle) * ring;
+            float const candidate_z = local_z + std::sin(angle) * ring;
+            if (!slot_ground_is_open(candidate_x, candidate_z) ||
+                !slot_is_in_sight_of_root(candidate_x, candidate_z)) {
+              continue;
+            }
+            bool clear_of_others = true;
+            for (std::size_t other = 0; other < next.size(); ++other) {
+              if (other == self || !next[other].alive) {
+                continue;
+              }
+              if (Game::Systems::planar_length(
+                      candidate_x - next[other].target_local_x,
+                      candidate_z - next[other].target_local_z) < minimum_separation) {
+                clear_of_others = false;
+                break;
+              }
+            }
+            if (!clear_of_others) {
+              continue;
+            }
+            float const distance = Game::Systems::planar_length(candidate_x - local_x,
+                                                                candidate_z - local_z);
+            if (distance < best_distance) {
+              best_distance = distance;
+              out_x = candidate_x;
+              out_z = candidate_z;
+              found = true;
+            }
+          }
+          if (found) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+  auto onto_walkable_ground =
+      [&](std::size_t self, float& local_x, float& local_z, float speed_budget) {
+        if (slot_ground_is_open(local_x, local_z)) {
+          return false;
+        }
+
+        float low = 0.0F;
+        float high = 1.0F;
+        for (int bisection = 0; bisection < k_slot_recovery_bisections; ++bisection) {
+          float const middle = (low + high) * 0.5F;
+          if (slot_ground_is_open(local_x * middle, local_z * middle)) {
+            low = middle;
+          } else {
+            high = middle;
+          }
+        }
+        float corrected_x = local_x * low;
+        float corrected_z = local_z * low;
+        bool stacked = false;
+        for (std::size_t other = 0; other < next.size(); ++other) {
+          if (other == self || !next[other].alive) {
+            continue;
+          }
+          if (Game::Systems::planar_length(corrected_x - next[other].target_local_x,
+                                           corrected_z - next[other].target_local_z) <
+              minimum_separation * 0.5F) {
+            stacked = true;
+            break;
+          }
+        }
+        if (stacked) {
+
+          float ring_x = 0.0F;
+          float ring_z = 0.0F;
+          if (nearest_open_ground(self, local_x, local_z, ring_x, ring_z)) {
+            corrected_x = ring_x;
+            corrected_z = ring_z;
+          }
+        }
+        float const correction =
+            Game::Systems::planar_length(corrected_x - local_x, corrected_z - local_z);
+        float const budget = speed_budget * step;
+        if (correction > budget && correction > 0.0001F) {
+          float const share = budget / correction;
+          local_x += (corrected_x - local_x) * share;
+          local_z += (corrected_z - local_z) * share;
+          return true;
+        }
+        local_x = corrected_x;
+        local_z = corrected_z;
+        return true;
+      };
 
   std::vector<std::uint8_t> recovering_to_ground(next.size(), 0U);
   for (std::size_t index = 0; index < next.size(); ++index) {
@@ -472,13 +564,10 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
     if (!slot.alive) {
       continue;
     }
-    recovering_to_ground[index] = static_cast<std::uint8_t>(
-        onto_walkable_ground(slot.target_local_x, slot.target_local_z));
+    recovering_to_ground[index] = static_cast<std::uint8_t>(onto_walkable_ground(
+        index, slot.target_local_x, slot.target_local_z, k_ground_clamp_speed));
   }
 
-  float const minimum_separation =
-      std::max(Game::Formation::TraversalPolicy::k_minimum_soldier_separation,
-               layout.body_radius * 2.0F * 1.04F);
   state.blocked_slot_count = 0U;
   for (std::size_t slot_index = 0; slot_index < next.size(); ++slot_index) {
     auto& slot = next[slot_index];
@@ -616,8 +705,10 @@ void update_slot_states(const Engine::Core::TransformComponent& transform,
                                ? 0.0F
                                : slot.blocked_seconds + step;
 
-    if (slot.alive &&
-        onto_walkable_ground(slot.current_local_x, slot.current_local_z)) {
+    if (slot.alive && onto_walkable_ground(slot_index,
+                                           slot.current_local_x,
+                                           slot.current_local_z,
+                                           k_ground_recovery_speed)) {
       slot.velocity_x = 0.0F;
       slot.velocity_z = 0.0F;
       if (!slot.blocked) {

--- a/game/util/planar_math.h
+++ b/game/util/planar_math.h
@@ -1,11 +1,32 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
+#include <numbers>
 
 namespace Game::Systems {
 
 [[nodiscard]] inline auto planar_length(float x, float z) noexcept -> float {
   return std::sqrt((x * x) + (z * z));
+}
+
+[[nodiscard]] inline auto yaw_degrees_from_direction(float dx,
+                                                     float dz) noexcept -> float {
+  return std::atan2(dx, dz) * 180.0F / std::numbers::pi_v<float>;
+}
+
+[[nodiscard]] inline auto signed_yaw_delta(float from_degrees,
+                                           float to_degrees) noexcept -> float {
+
+  return std::remainder(to_degrees - from_degrees, 360.0F);
+}
+
+[[nodiscard]] inline auto turn_yaw_toward(float current_degrees,
+                                          float target_degrees,
+                                          float max_step_degrees) noexcept -> float {
+  float const delta = signed_yaw_delta(current_degrees, target_degrees);
+  float const step = std::max(0.0F, max_step_degrees);
+  return current_degrees + std::clamp(delta, -step, step);
 }
 
 } // namespace Game::Systems

--- a/game/wildlife/wildlife_system.cpp
+++ b/game/wildlife/wildlife_system.cpp
@@ -26,6 +26,7 @@
 #include "../systems/walkability.h"
 #include "../units/factory.h"
 #include "../units/spawn_type.h"
+#include "../util/planar_math.h"
 #include "bird_flock.h"
 #include "wildlife_terrain_probe.h"
 
@@ -581,7 +582,7 @@ auto WildlifeSystem::begin_bite(Engine::Core::Entity& entity,
   transform->has_desired_yaw = true;
   float const reach = k_wolf_bite_windup_range + prey.radius;
   if (dx * dx + dz * dz > reach * reach ||
-      std::abs(std::remainder(yaw - transform->rotation.y, 360.0F)) >
+      std::abs(Game::Systems::signed_yaw_delta(transform->rotation.y, yaw)) >
           k_wolf_bite_facing_degrees) {
     return false;
   }

--- a/render/draw_commands.h
+++ b/render/draw_commands.h
@@ -214,6 +214,9 @@ struct GroundMarkerCmd {
 
   Game::Accessibility::TeamPattern pattern{Game::Accessibility::TeamPattern::Solid};
   bool focused = false;
+
+  float occluded_alpha = 0.0F;
+
   TerrainSurfaceCmd::HeightResources height{};
   CommandPriority priority{CommandPriority::Critical};
 };

--- a/render/entity/formation_instance_layout.cpp
+++ b/render/entity/formation_instance_layout.cpp
@@ -158,13 +158,17 @@ void apply_authoritative_formation_slots(
   }
 
   auto const layout = Game::Systems::FormationCombat::resolve_layout(*entity);
+  auto const* traversal =
+      entity->get_component<Engine::Core::UnitTraversalLayoutStateComponent>();
+  float const frame_sign =
+      traversal != nullptr && traversal->about_faced ? -1.0F : 1.0F;
   for (auto const& slot : layout.occupied_slots) {
     if (slot.index >= instances.size()) {
       continue;
     }
     auto& instance = instances[slot.index];
-    instance.offset_x = slot.local_x;
-    instance.offset_z = slot.local_z;
+    instance.offset_x = frame_sign * slot.local_x;
+    instance.offset_z = frame_sign * slot.local_z;
     instance.yaw_offset = slot.local_yaw;
     instance.row_index = static_cast<std::uint8_t>(slot.row);
     instance.col_index = static_cast<std::uint8_t>(slot.col);

--- a/render/entity/production_completion_renderer.cpp
+++ b/render/entity/production_completion_renderer.cpp
@@ -1,5 +1,7 @@
 #include "production_completion_renderer.h"
 
+#include <QtGlobal>
+
 #include <algorithm>
 #include <cmath>
 #include <numbers>
@@ -7,9 +9,12 @@
 #include "game/core/component_presentation.h"
 #include "game/core/ownership_constants.h"
 #include "game/core/world.h"
+#include "game/map/render_visibility_rules.h"
+#include "game/map/visibility_service.h"
 #include "render/draw_commands.h"
 #include "render/local_lighting.h"
 #include "render/scene_renderer.h"
+#include "render/world_view.h"
 
 namespace Render::GL {
 
@@ -80,18 +85,32 @@ void render_production_completions(Renderer* renderer,
                                    Engine::Core::World* world,
                                    int local_owner_id,
                                    bool reduced_motion) {
-  if (renderer == nullptr || world == nullptr ||
-      Game::Core::is_neutral_owner(local_owner_id)) {
+  if (renderer == nullptr || world == nullptr) {
     return;
   }
+
+  static const bool trace = qEnvironmentVariableIsSet("SOI_FX_TRACE");
+
+  const auto& world_view = renderer->world_view();
+  const auto visibility = world_view.has_visibility()
+                              ? world_view.visibility()->snapshot_ptr()
+                              : Game::Map::VisibilityService::SnapshotPtr{};
+  const bool fog_applies = visibility != nullptr && visibility->initialized &&
+                           !Game::Core::is_neutral_owner(local_owner_id);
 
   for (auto [entity, effect, transform, unit] :
        world->entity_view<Engine::Core::ProductionCompletionComponent,
                           Engine::Core::TransformComponent,
                           Engine::Core::UnitComponent>()) {
-    if (unit.owner_id != local_owner_id || unit.health <= 0 ||
+    if (unit.health <= 0 ||
         entity.has_component<Engine::Core::PendingRemovalComponent>() ||
         effect.remaining <= 0.0F) {
+      continue;
+    }
+    if (fog_applies && unit.owner_id != local_owner_id &&
+        Game::Map::classify_world_visibility(
+            *visibility, transform.position.x, transform.position.z) !=
+            Game::Map::RenderVisibilityState::Visible) {
       continue;
     }
 
@@ -109,6 +128,14 @@ void render_production_completions(Renderer* renderer,
     const float time = reduced_motion ? 0.0F : age;
     const float radius =
         effect.radius * (reduced_motion ? 1.0F : 1.0F + 0.18F * progress);
+    if (trace) {
+      qWarning("FXTRACE completion p%d age %.2f radius %.2f at %.1f %.1f",
+               unit.owner_id,
+               static_cast<double>(age),
+               static_cast<double>(effect.radius),
+               static_cast<double>(ground.x()),
+               static_cast<double>(ground.z()));
+    }
 
     submit_ground_disc(
         renderer, ground, effect.radius, 0.16F * intensity * intensity + 0.22F * flare);

--- a/render/entity/wildlife/sheep_renderer.cpp
+++ b/render/entity/wildlife/sheep_renderer.cpp
@@ -60,6 +60,15 @@ auto resolve_variant(const DrawState& state) -> Render::GL::WildlifeVariant {
   variant.roles[Render::Wildlife::k_sheep_role_wool_shade - 1U] = shade;
   variant.roles[Render::Wildlife::k_sheep_role_wool_grubby - 1U] =
       mixed(shade, QVector3D(0.46F, 0.39F, 0.28F), 0.60F);
+
+  for (std::uint8_t role = Render::Wildlife::k_sheep_role_wool;
+       role <= Render::Wildlife::k_sheep_role_wool_grubby;
+       ++role) {
+    auto& color = variant.roles[role - 1U];
+    float const value = color.x() * 0.299F + color.y() * 0.587F + color.z() * 0.114F;
+    color = QVector3D(value, value, value);
+  }
+
   variant.roles[Render::Wildlife::k_sheep_role_face - 1U] = face;
   variant.roles[Render::Wildlife::k_sheep_role_hoof - 1U] =
       mixed(face, QVector3D(0.15F, 0.13F, 0.12F), 0.62F);

--- a/render/geom/ground_marker_tessellation.h
+++ b/render/geom/ground_marker_tessellation.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <numbers>
+
+namespace Render::Geom {
+
+inline constexpr std::array<int, 5> k_marker_segment_lods{24, 48, 96, 192, 384};
+
+inline constexpr float k_marker_samples_per_cell = 3.0F;
+inline constexpr float k_marker_min_arc_world = 0.12F;
+inline constexpr float k_marker_max_arc_world = 1.0F;
+
+[[nodiscard]] inline auto marker_segment_count(std::size_t lod) -> int {
+  return k_marker_segment_lods[std::min(lod, k_marker_segment_lods.size() - 1U)];
+}
+
+[[nodiscard]] inline auto marker_angular_step(std::size_t lod) -> float {
+  return 2.0F * std::numbers::pi_v<float> /
+         static_cast<float>(marker_segment_count(lod));
+}
+
+[[nodiscard]] inline auto marker_target_arc_world(float world_per_cell) -> float {
+  const float cell = world_per_cell > 0.0F ? world_per_cell : 1.0F;
+  return std::clamp(
+      cell / k_marker_samples_per_cell, k_marker_min_arc_world, k_marker_max_arc_world);
+}
+
+[[nodiscard]] inline auto marker_segment_lod(float outer_radius,
+                                             float world_per_cell) -> std::size_t {
+  const float radius = std::max(outer_radius, 0.0F);
+  const float wanted = 2.0F * std::numbers::pi_v<float> * radius /
+                       marker_target_arc_world(world_per_cell);
+  for (std::size_t lod = 0; lod + 1U < k_marker_segment_lods.size(); ++lod) {
+    if (static_cast<float>(k_marker_segment_lods[lod]) >= wanted) {
+      return lod;
+    }
+  }
+  return k_marker_segment_lods.size() - 1U;
+}
+
+[[nodiscard]] inline auto marker_chord_world(float outer_radius,
+                                             std::size_t lod) -> float {
+  return 2.0F * std::max(outer_radius, 0.0F) *
+         std::sin(marker_angular_step(lod) * 0.5F);
+}
+
+} // namespace Render::Geom

--- a/render/geom/range_rings.cpp
+++ b/render/geom/range_rings.cpp
@@ -15,6 +15,8 @@ constexpr float k_group_alpha = 0.5F;
 constexpr float k_minimum_alpha_scale = 0.9F;
 constexpr float k_minimum_phase = 1.6F;
 
+constexpr float k_occluded_alpha = 0.34F;
+
 const QVector3D k_max_range_color(0.90F, 0.82F, 0.46F);
 const QVector3D k_min_range_color(0.86F, 0.34F, 0.24F);
 
@@ -98,6 +100,7 @@ void render_range_rings(Renderer* renderer,
     marker.pattern = marker_pattern(ring.pattern);
     marker.focused = ring.focused;
     marker.phase = ring.minimum ? k_minimum_phase : 0.0F;
+    marker.occluded_alpha = k_occluded_alpha;
     renderer->ground_marker(marker);
   }
 }

--- a/render/gl/backend/effects_command_executor.cpp
+++ b/render/gl/backend/effects_command_executor.cpp
@@ -10,6 +10,20 @@ namespace {
 const QVector3D k_grid_line_color(0.22F, 0.25F, 0.22F);
 constexpr float k_ground_marker_offset = 0.06F;
 
+constexpr float k_ground_marker_slope_clearance = 0.14F;
+constexpr float k_ground_marker_max_slope_lift = 4.0F;
+
+constexpr float k_ground_marker_min_pixels = 1.6F;
+constexpr float k_ground_marker_max_thickness_gain = 6.0F;
+
+auto ground_marker_world_per_cell(const TerrainSurfaceCmd::HeightResources& height)
+    -> float {
+  if (height.uv_scale.x() <= 0.0F || height.texel_size.x() <= 0.0F) {
+    return 1.0F;
+  }
+  return height.texel_size.x() / height.uv_scale.x();
+}
+
 auto billboard_effect_type(EffectBatchCmd::Kind kind) -> BackendPipelines::EffectType {
   switch (kind) {
   case EffectBatchCmd::Kind::BuildingFlame:
@@ -128,10 +142,20 @@ void Backend::execute_effects_commands(const PreparedBatch& prepared,
     set_uniform_if_valid(*marker_shader, uniforms.time, m_animation_time);
     set_uniform_if_valid(
         *marker_shader, uniforms.ground_offset, k_ground_marker_offset);
+    set_uniform_if_valid(*marker_shader,
+                         uniforms.half_viewport,
+                         QVector2D(static_cast<float>(m_viewport_width) * 0.5F,
+                                   static_cast<float>(m_viewport_height) * 0.5F));
+    set_uniform_if_valid(
+        *marker_shader, uniforms.min_marker_pixels, k_ground_marker_min_pixels);
+    set_uniform_if_valid(*marker_shader,
+                         uniforms.max_thickness_gain,
+                         k_ground_marker_max_thickness_gain);
 
     const auto& height = std::get<GroundMarkerCmdIndex>(queue.get_sorted(i)).height;
     const bool has_height = height.enabled && height.texture != nullptr;
     set_uniform_if_valid(*marker_shader, uniforms.has_height_tex, has_height ? 1 : 0);
+    float world_per_cell = 1.0F;
     if (has_height) {
       height.texture->bind(TextureUnit::terrain_height);
       m_last_bound_texture = height.texture;
@@ -140,24 +164,54 @@ void Backend::execute_effects_commands(const PreparedBatch& prepared,
       set_uniform_if_valid(*marker_shader, uniforms.height_uv_scale, height.uv_scale);
       set_uniform_if_valid(*marker_shader, uniforms.height_uv_offset, height.uv_offset);
       set_uniform_if_valid(*marker_shader, uniforms.height_to_world, height.to_world);
+
+      world_per_cell = ground_marker_world_per_cell(height);
+      set_uniform_if_valid(*marker_shader,
+                           uniforms.height_world_per_texel,
+                           QVector2D(world_per_cell, world_per_cell));
+      set_uniform_if_valid(
+          *marker_shader, uniforms.slope_clearance, k_ground_marker_slope_clearance);
+      set_uniform_if_valid(
+          *marker_shader, uniforms.max_slope_lift, k_ground_marker_max_slope_lift);
     }
 
-    m_ground_marker_pipeline->m_scratch.clear();
+    const auto marker_instance =
+        [](const GroundMarkerCmd& marker,
+           float alpha) -> BackendPipelines::GroundMarkerPipeline::InstanceGpu {
+      return {.center_radius = QVector4D(marker.center, marker.outer_radius),
+              .color_alpha = QVector4D(marker.color, alpha),
+              .shape = QVector4D(marker.thickness,
+                                 static_cast<float>(marker.pattern),
+                                 marker.focused ? 1.0F : 0.0F,
+                                 marker.phase)};
+    };
+
+    m_ground_marker_pipeline->begin_batch();
+    bool any_occluded = false;
     for (std::size_t j = i; j < batch_end; ++j) {
       const auto& marker = std::get<GroundMarkerCmdIndex>(queue.get_sorted(j));
-      BackendPipelines::GroundMarkerPipeline::InstanceGpu gpu{};
-      gpu.center_radius = QVector4D(marker.center, marker.outer_radius);
-      gpu.color_alpha = QVector4D(marker.color, marker.alpha);
-      gpu.shape = QVector4D(marker.thickness,
-                            static_cast<float>(marker.pattern),
-                            marker.focused ? 1.0F : 0.0F,
-                            marker.phase);
-      m_ground_marker_pipeline->m_scratch.emplace_back(gpu);
+      any_occluded = any_occluded || marker.occluded_alpha > 0.0F;
+      m_ground_marker_pipeline->add_instance(
+          marker_instance(marker, marker.alpha), marker.outer_radius, world_per_cell);
     }
+    m_ground_marker_pipeline->flush_batch();
 
-    const std::size_t marker_count = m_ground_marker_pipeline->m_scratch.size();
-    m_ground_marker_pipeline->upload_instances(marker_count);
-    m_ground_marker_pipeline->draw(marker_count);
+    if (any_occluded) {
+
+      DepthFuncScope const depth_func(GL_GREATER);
+      m_ground_marker_pipeline->begin_batch();
+      for (std::size_t j = i; j < batch_end; ++j) {
+        const auto& marker = std::get<GroundMarkerCmdIndex>(queue.get_sorted(j));
+        if (marker.occluded_alpha <= 0.0F) {
+          continue;
+        }
+        m_ground_marker_pipeline->add_instance(
+            marker_instance(marker, marker.alpha * marker.occluded_alpha),
+            marker.outer_radius,
+            world_per_cell);
+      }
+      m_ground_marker_pipeline->flush_batch();
+    }
     break;
   }
   case SelectionSmokeCmdIndex: {

--- a/render/gl/backend/ground_marker_pipeline.cpp
+++ b/render/gl/backend/ground_marker_pipeline.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "render/geom/ground_marker_pattern.h"
+#include "render/geom/ground_marker_tessellation.h"
 #include "render/gl/gl_resource_tracking.h"
 #include "render/gl/mesh.h"
 #include "render/gl/render_constants.h"
@@ -20,7 +21,6 @@ using namespace Render::GL::ComponentCount;
 
 namespace {
 
-constexpr int k_angular_segments = 96;
 constexpr int k_radial_segments = 6;
 constexpr std::size_t k_default_instance_capacity = 256;
 constexpr std::size_t k_capacity_growth = 2;
@@ -46,20 +46,33 @@ auto GroundMarkerPipeline::initialize() -> bool {
     return false;
   }
 
-  build_mesh();
+  build_meshes();
   cache_uniforms();
-  m_initialized = m_mesh.drawable();
+  m_initialized =
+      std::all_of(m_meshes.begin(), m_meshes.end(), [](const StaticMeshBuffers& mesh) {
+        return mesh.drawable();
+      });
   return m_initialized;
 }
 
 void GroundMarkerPipeline::shutdown() {
   if (QOpenGLContext::currentContext() != nullptr) {
     initializeOpenGLFunctions();
-    release_mesh_buffers(*this, m_mesh);
+    for (StaticMeshBuffers& mesh : m_meshes) {
+      release_mesh_buffers(*this, mesh);
+    }
+    if (m_instance_buffer != 0U) {
+      glDeleteBuffers(1, &m_instance_buffer);
+    }
+  } else {
+    m_meshes = {};
   }
+  m_instance_buffer = 0;
   m_instance_capacity = 0;
   m_instances_resident = 0;
-  m_scratch.clear();
+  for (auto& bucket : m_scratch) {
+    bucket.clear();
+  }
   m_initialized = false;
 }
 
@@ -78,17 +91,56 @@ void GroundMarkerPipeline::cache_uniforms() {
   m_uniforms.height_uv_scale = m_shader->optional_uniform_handle("u_height_uv_scale");
   m_uniforms.height_uv_offset = m_shader->optional_uniform_handle("u_height_uv_offset");
   m_uniforms.height_to_world = m_shader->optional_uniform_handle("u_height_to_world");
+  m_uniforms.angular_step = m_shader->optional_uniform_handle("u_angular_step");
+  m_uniforms.height_world_per_texel =
+      m_shader->optional_uniform_handle("u_height_world_per_texel");
+  m_uniforms.slope_clearance = m_shader->optional_uniform_handle("u_slope_clearance");
+  m_uniforms.max_slope_lift = m_shader->optional_uniform_handle("u_max_slope_lift");
+  m_uniforms.half_viewport = m_shader->optional_uniform_handle("u_half_viewport");
+  m_uniforms.min_marker_pixels =
+      m_shader->optional_uniform_handle("u_min_marker_pixels");
+  m_uniforms.max_thickness_gain =
+      m_shader->optional_uniform_handle("u_max_thickness_gain");
 }
 
-void GroundMarkerPipeline::build_mesh() {
+void GroundMarkerPipeline::build_meshes() {
   initializeOpenGLFunctions();
-  release_mesh_buffers(*this, m_mesh);
 
+  for (StaticMeshBuffers& mesh : m_meshes) {
+    release_mesh_buffers(*this, mesh);
+  }
+  if (m_instance_buffer != 0U) {
+    glDeleteBuffers(1, &m_instance_buffer);
+    m_instance_buffer = 0;
+  }
+
+  glGenBuffers(1, &m_instance_buffer);
+  note_buffers_created(1);
+  glBindBuffer(GL_ARRAY_BUFFER, m_instance_buffer);
+  m_instance_capacity = k_default_instance_capacity;
+  glBufferData(GL_ARRAY_BUFFER,
+               static_cast<GLsizeiptr>(m_instance_capacity * sizeof(InstanceGpu)),
+               nullptr,
+               GL_DYNAMIC_DRAW);
+  note_buffer_storage(
+      static_cast<std::size_t>(m_instance_capacity * sizeof(InstanceGpu)), false);
+
+  for (std::size_t lod = 0; lod < k_lod_count; ++lod) {
+    build_mesh(m_meshes[lod], Render::Geom::marker_segment_count(lod));
+    m_scratch[lod].reserve(k_default_instance_capacity);
+  }
+
+  glBindVertexArray(0);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}
+
+void GroundMarkerPipeline::build_mesh(StaticMeshBuffers& mesh, int angular_segments) {
   std::vector<Vertex> vertices;
   std::vector<unsigned int> indices;
   vertices.reserve(
-      static_cast<std::size_t>((k_angular_segments + 1) * (k_radial_segments + 1)));
-  indices.reserve(static_cast<std::size_t>(k_angular_segments * k_radial_segments * 6));
+      static_cast<std::size_t>((angular_segments + 1) * (k_radial_segments + 1)));
+  indices.reserve(static_cast<std::size_t>(angular_segments * k_radial_segments * 6));
 
   constexpr float k_two_pi = 2.0F * std::numbers::pi_v<float>;
   const float radial_span =
@@ -97,18 +149,18 @@ void GroundMarkerPipeline::build_mesh() {
   for (int ring = 0; ring <= k_radial_segments; ++ring) {
     const float t = static_cast<float>(ring) / static_cast<float>(k_radial_segments);
     const float radial = Render::Geom::k_marker_geometry_inner + t * radial_span;
-    for (int segment = 0; segment <= k_angular_segments; ++segment) {
+    for (int segment = 0; segment <= angular_segments; ++segment) {
       const float u =
-          static_cast<float>(segment) / static_cast<float>(k_angular_segments);
+          static_cast<float>(segment) / static_cast<float>(angular_segments);
       const float angle = u * k_two_pi;
       vertices.push_back(
           {{std::cos(angle), 0.0F, std::sin(angle)}, {0.0F, 1.0F, 0.0F}, {u, radial}});
     }
   }
 
-  const auto row_stride = static_cast<unsigned int>(k_angular_segments + 1);
+  const auto row_stride = static_cast<unsigned int>(angular_segments + 1);
   for (int ring = 0; ring < k_radial_segments; ++ring) {
-    for (int segment = 0; segment < k_angular_segments; ++segment) {
+    for (int segment = 0; segment < angular_segments; ++segment) {
       const auto base = static_cast<unsigned int>(ring) * row_stride +
                         static_cast<unsigned int>(segment);
       const unsigned int next = base + 1U;
@@ -118,13 +170,13 @@ void GroundMarkerPipeline::build_mesh() {
     }
   }
 
-  glGenVertexArrays(1, &m_mesh.vao);
+  glGenVertexArrays(1, &mesh.vao);
   note_vertex_arrays_created(1);
-  glBindVertexArray(m_mesh.vao);
+  glBindVertexArray(mesh.vao);
 
-  glGenBuffers(1, &m_mesh.vertex_buffer);
+  glGenBuffers(1, &mesh.vertex_buffer);
   note_buffers_created(1);
-  glBindBuffer(GL_ARRAY_BUFFER, m_mesh.vertex_buffer);
+  glBindBuffer(GL_ARRAY_BUFFER, mesh.vertex_buffer);
   glBufferData(GL_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(vertices.size() * sizeof(Vertex)),
                vertices.data(),
@@ -132,17 +184,17 @@ void GroundMarkerPipeline::build_mesh() {
   note_buffer_storage(static_cast<std::size_t>(vertices.size() * sizeof(Vertex)),
                       vertices.data() != nullptr);
 
-  glGenBuffers(1, &m_mesh.index_buffer);
+  glGenBuffers(1, &mesh.index_buffer);
   note_buffers_created(1);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mesh.index_buffer);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.index_buffer);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
                static_cast<GLsizeiptr>(indices.size() * sizeof(unsigned int)),
                indices.data(),
                GL_STATIC_DRAW);
   note_buffer_storage(static_cast<std::size_t>(indices.size() * sizeof(unsigned int)),
                       indices.data() != nullptr);
-  m_mesh.index_count = static_cast<GLsizei>(indices.size());
-  m_mesh.vertex_count = static_cast<GLsizei>(vertices.size());
+  mesh.index_count = static_cast<GLsizei>(indices.size());
+  mesh.vertex_count = static_cast<GLsizei>(vertices.size());
 
   glEnableVertexAttribArray(VertexAttrib::position);
   glVertexAttribPointer(VertexAttrib::position,
@@ -166,17 +218,7 @@ void GroundMarkerPipeline::build_mesh() {
                         sizeof(Vertex),
                         reinterpret_cast<void*>(offsetof(Vertex, tex_coord)));
 
-  glGenBuffers(1, &m_mesh.instance_buffer);
-  note_buffers_created(1);
-  glBindBuffer(GL_ARRAY_BUFFER, m_mesh.instance_buffer);
-  m_instance_capacity = k_default_instance_capacity;
-  glBufferData(GL_ARRAY_BUFFER,
-               static_cast<GLsizeiptr>(m_instance_capacity * sizeof(InstanceGpu)),
-               nullptr,
-               GL_DYNAMIC_DRAW);
-  note_buffer_storage(
-      static_cast<std::size_t>(m_instance_capacity * sizeof(InstanceGpu)), false);
-
+  glBindBuffer(GL_ARRAY_BUFFER, m_instance_buffer);
   const auto stride = static_cast<GLsizei>(sizeof(InstanceGpu));
   glEnableVertexAttribArray(VertexAttrib::instance_position);
   glVertexAttribPointer(VertexAttrib::instance_position,
@@ -206,10 +248,6 @@ void GroundMarkerPipeline::build_mesh() {
   glVertexAttribDivisor(VertexAttrib::instance_color, 1);
 
   glBindVertexArray(0);
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-  m_scratch.reserve(m_instance_capacity);
 }
 
 void GroundMarkerPipeline::upload_pattern_table() {
@@ -238,15 +276,54 @@ void GroundMarkerPipeline::upload_pattern_table() {
   }
 }
 
-void GroundMarkerPipeline::upload_instances(std::size_t count) {
+void GroundMarkerPipeline::begin_batch() {
+  for (auto& bucket : m_scratch) {
+    bucket.clear();
+  }
+}
+
+void GroundMarkerPipeline::add_instance(const InstanceGpu& instance,
+                                        float outer_radius,
+                                        float world_per_cell) {
+  const std::size_t lod =
+      Render::Geom::marker_segment_lod(outer_radius, world_per_cell);
+  m_scratch[std::min(lod, k_lod_count - 1U)].push_back(instance);
+}
+
+auto GroundMarkerPipeline::batched_instance_count() const -> std::size_t {
+  std::size_t total = 0;
+  for (const auto& bucket : m_scratch) {
+    total += bucket.size();
+  }
+  return total;
+}
+
+void GroundMarkerPipeline::flush_batch() {
+  if (m_shader == nullptr) {
+    return;
+  }
+  for (std::size_t lod = 0; lod < k_lod_count; ++lod) {
+    if (m_scratch[lod].empty()) {
+      continue;
+    }
+    if (m_uniforms.angular_step != Shader::InvalidUniform) {
+      m_shader->set_uniform(m_uniforms.angular_step,
+                            Render::Geom::marker_angular_step(lod));
+    }
+    upload_instances(lod, m_scratch[lod].size());
+    draw(lod, m_scratch[lod].size());
+  }
+}
+
+void GroundMarkerPipeline::upload_instances(std::size_t lod, std::size_t count) {
   m_instances_resident = 0;
-  count = std::min(count, m_scratch.size());
-  if (count == 0 || m_mesh.instance_buffer == 0U) {
+  count = std::min(count, m_scratch[lod].size());
+  if (count == 0 || m_instance_buffer == 0U) {
     return;
   }
 
   initializeOpenGLFunctions();
-  glBindBuffer(GL_ARRAY_BUFFER, m_mesh.instance_buffer);
+  glBindBuffer(GL_ARRAY_BUFFER, m_instance_buffer);
   if (count > m_instance_capacity) {
     m_instance_capacity =
         std::max<std::size_t>(count, m_instance_capacity * k_capacity_growth);
@@ -256,27 +333,27 @@ void GroundMarkerPipeline::upload_instances(std::size_t count) {
                  GL_DYNAMIC_DRAW);
     note_buffer_storage(
         static_cast<std::size_t>(m_instance_capacity * sizeof(InstanceGpu)), false);
-    m_scratch.reserve(m_instance_capacity);
   }
   glBufferSubData(GL_ARRAY_BUFFER,
                   0,
                   static_cast<GLsizeiptr>(count * sizeof(InstanceGpu)),
-                  m_scratch.data());
+                  m_scratch[lod].data());
   note_buffer_transfer(static_cast<std::size_t>(count * sizeof(InstanceGpu)));
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   m_instances_resident = count;
 }
 
-void GroundMarkerPipeline::draw(std::size_t count) {
+void GroundMarkerPipeline::draw(std::size_t lod, std::size_t count) {
   count = m_draw_guard.clamp(count, m_instances_resident);
-  if (!m_mesh.drawable() || count == 0) {
+  const StaticMeshBuffers& mesh = m_meshes[lod];
+  if (!mesh.drawable() || count == 0) {
     return;
   }
 
   initializeOpenGLFunctions();
-  glBindVertexArray(m_mesh.vao);
+  glBindVertexArray(mesh.vao);
   glDrawElementsInstanced(GL_TRIANGLES,
-                          m_mesh.index_count,
+                          mesh.index_count,
                           GL_UNSIGNED_INT,
                           nullptr,
                           static_cast<GLsizei>(count));

--- a/render/gl/backend/ground_marker_pipeline.h
+++ b/render/gl/backend/ground_marker_pipeline.h
@@ -11,6 +11,7 @@
 #include "instance_draw_guard.h"
 #include "mesh_buffers.h"
 #include "pipeline_interface.h"
+#include "render/geom/ground_marker_tessellation.h"
 #include "render/gl/shader.h"
 #include "render/gl/shader_cache.h"
 
@@ -33,6 +34,7 @@ public:
   };
 
   static constexpr std::size_t k_pattern_slots = 12;
+  static constexpr std::size_t k_lod_count = Render::Geom::k_marker_segment_lods.size();
 
   struct Uniforms {
     GL::Shader::UniformHandle time{GL::Shader::InvalidUniform};
@@ -42,25 +44,39 @@ public:
     GL::Shader::UniformHandle height_uv_scale{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle height_uv_offset{GL::Shader::InvalidUniform};
     GL::Shader::UniformHandle height_to_world{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle angular_step{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle height_world_per_texel{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle slope_clearance{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle max_slope_lift{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle half_viewport{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle min_marker_pixels{GL::Shader::InvalidUniform};
+    GL::Shader::UniformHandle max_thickness_gain{GL::Shader::InvalidUniform};
   };
 
   [[nodiscard]] auto shader() const -> GL::Shader* { return m_shader; }
   [[nodiscard]] auto uniforms() const -> const Uniforms& { return m_uniforms; }
 
   void upload_pattern_table();
-  void upload_instances(std::size_t count);
-  void draw(std::size_t count);
 
-  std::vector<InstanceGpu> m_scratch;
+  void begin_batch();
+  void
+  add_instance(const InstanceGpu& instance, float outer_radius, float world_per_cell);
+  [[nodiscard]] auto batched_instance_count() const -> std::size_t;
+  void flush_batch();
 
 private:
-  void build_mesh();
+  void build_meshes();
+  void build_mesh(StaticMeshBuffers& mesh, int angular_segments);
+  void upload_instances(std::size_t lod, std::size_t count);
+  void draw(std::size_t lod, std::size_t count);
 
   GL::ShaderCache* m_shader_cache;
   GL::Shader* m_shader{nullptr};
   Uniforms m_uniforms;
   std::array<GL::Shader::UniformHandle, k_pattern_slots> m_pattern_handles{};
-  StaticMeshBuffers m_mesh;
+  std::array<StaticMeshBuffers, k_lod_count> m_meshes{};
+  std::array<std::vector<InstanceGpu>, k_lod_count> m_scratch{};
+  GLuint m_instance_buffer{0};
   std::size_t m_instance_capacity{0};
   std::size_t m_instances_resident{0};
   bool m_initialized{false};

--- a/render/gl/state_scopes.h
+++ b/render/gl/state_scopes.h
@@ -97,6 +97,15 @@ struct CullFaceScope {
   }
 };
 
+struct DepthFuncScope {
+  GLint prev{GL_LESS};
+  explicit DepthFuncScope(GLenum func) {
+    glGetIntegerv(GL_DEPTH_FUNC, &prev);
+    glDepthFunc(func);
+  }
+  ~DepthFuncScope() { glDepthFunc(static_cast<GLenum>(prev)); }
+};
+
 struct DepthTestScope {
   GLboolean prev_enable;
   explicit DepthTestScope(bool enable)

--- a/render/humanoid/runtime/instance_prepare.cpp
+++ b/render/humanoid/runtime/instance_prepare.cpp
@@ -967,7 +967,7 @@ void append_prepared_soldier(const HumanoidUnitSnapshot& s,
     smoothing_inputs.max_speed =
         turn_smoothing_cap * turn_variation.catch_up_speed_scale;
     smoothing_inputs.turn_rate_degrees =
-        (is_mounted_spawn ? 150.0F : 300.0F) * turn_variation.turn_rate_scale;
+        (is_mounted_spawn ? 150.0F : 200.0F) * turn_variation.turn_rate_scale;
     smoothing_inputs.response_delay_seconds =
         turn_smoothing_stagger ? turn_variation.response_delay_seconds : 0.0F;
     smoothing_inputs.allow_travel_yaw = turn_smoothing_travel_yaw;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -493,6 +493,7 @@ add_executable(
     render/creature/render_request_test.cpp
     render/selection_ring_layout_test.cpp
     render/ground_marker_pattern_test.cpp
+    render/ground_marker_tessellation_test.cpp
     render/arrow_cloud_render_test.cpp
     render/projectile_relation_test.cpp
     render/orientation_arrow_mesh_test.cpp

--- a/tests/core/audio_gameplay_scenarios_test.cpp
+++ b/tests/core/audio_gameplay_scenarios_test.cpp
@@ -660,6 +660,16 @@ TEST_F(AudioGameplayScenarioTest, ADistantBattleIsCarriedAsOneMassNotAsSilence) 
   auto* attacker = add_soldier(k_enemy_owner, Game::Units::SpawnType::Knight, 400.0F);
   auto* target = add_soldier(k_local_owner, Game::Units::SpawnType::Spearman, 402.0F);
 
+  constexpr const char* k_distant_mass = "sfx.combat.battlefield_distant_mass_01";
+  bool ready = false;
+  for (int attempt = 0; attempt < 2000 && !ready; ++attempt) {
+    ready = AudioSystem::get_instance().is_resource_ready(k_distant_mass);
+    if (!ready) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+  ASSERT_TRUE(ready) << k_distant_mass << " never finished loading";
+
   for (int blow = 0; blow < 8; ++blow) {
     Game::Systems::Combat::apply_unit_damage(&m_world, target, 1, attacker->get_id());
   }

--- a/tests/core/mission_startup_test.cpp
+++ b/tests/core/mission_startup_test.cpp
@@ -4,6 +4,7 @@
 
 #include "app/session/skirmish_loader.h"
 #include "core/world.h"
+#include "game/core/component.h"
 #include "game/map/map_context.h"
 #include "game/map/terrain_service.h"
 #include "game/map/visibility_service.h"
@@ -12,12 +13,14 @@
 #include "game/mission/mission_definition_view.h"
 #include "game/mission/mission_setup_coordinator.h"
 #include "game/systems/ai_system.h"
+#include "game/systems/command_service.h"
 #include "game/systems/default_content.h"
 #include "game/systems/global_stats_registry.h"
 #include "game/systems/match_snapshot.h"
 #include "game/systems/nation_registry.h"
 #include "game/systems/owner_registry.h"
 #include "game/systems/runtime_system_registry.h"
+#include "game/systems/walkability.h"
 #include "render/scene_renderer.h"
 #include "scene/camera.h"
 
@@ -49,13 +52,14 @@ protected:
     Game::Map::MapContextStore::reset_statistics();
   }
 
-  [[nodiscard]] auto prepare_mission() -> bool {
+  [[nodiscard]] auto
+  prepare_mission(const char* mission_file = k_mission_file) -> bool {
     m_world.set_presentation_enabled(false);
     Game::Systems::register_runtime_systems(m_world);
 
     int selected_player_id = k_local_owner;
     if (!m_campaign.start_mission_file(
-            QString::fromLatin1(k_mission_file), selected_player_id, &m_error)) {
+            QString::fromLatin1(mission_file), selected_player_id, &m_error)) {
       return false;
     }
     if (!m_campaign.current_mission_definition().has_value()) {
@@ -147,6 +151,47 @@ TEST_F(MissionStartupTest, InitialAiSnapshotsAreBuiltBeforeTheFirstPlayableFrame
          "phase had already produced";
   EXPECT_GT(ai_system->completed_decision_count(), 0U)
       << "the decisions prepared during loading were never applied";
+}
+
+TEST_F(MissionStartupTest, StartingUnitsStandApartOnOpenGround) {
+
+  ASSERT_TRUE(prepare_mission("assets/missions/the_timber_levy.json"))
+      << m_error.toStdString();
+
+  struct Placed {
+    Engine::Core::EntityID id;
+    QVector3D root;
+    float radius;
+  };
+  std::vector<Placed> units;
+  for (auto* entity : m_world.collect_entities_with<Engine::Core::UnitComponent>()) {
+    const auto* unit = entity->get_component<Engine::Core::UnitComponent>();
+    const auto* transform = entity->get_component<Engine::Core::TransformComponent>();
+    if (unit == nullptr || transform == nullptr || unit->owner_id != k_local_owner ||
+        entity->has_component<Engine::Core::BuildingComponent>() ||
+        !entity->has_component<Engine::Core::MovementComponent>()) {
+      continue;
+    }
+    units.push_back(
+        {entity->get_id(),
+         QVector3D(transform->position.x, 0.0F, transform->position.z),
+         Game::Systems::CommandService::get_unit_radius(m_world, entity->get_id())});
+  }
+  ASSERT_GE(units.size(), 9U);
+
+  const Game::Systems::BodyProfile point_body;
+  for (std::size_t first = 0; first < units.size(); ++first) {
+    EXPECT_TRUE(Game::Systems::Walkability::can_stand(units[first].root, point_body))
+        << "unit " << units[first].id << " starts on ground it cannot stand on at ("
+        << units[first].root.x() << ", " << units[first].root.z() << ")";
+    for (std::size_t second = first + 1; second < units.size(); ++second) {
+      const float gap = (units[first].root - units[second].root).length() -
+                        units[first].radius - units[second].radius;
+      EXPECT_GE(gap, -0.05F) << "units " << units[first].id << " and "
+                             << units[second].id << " start overlapping by " << -gap
+                             << " m";
+    }
+  }
 }
 
 } // namespace

--- a/tests/core/movement_trace_test.cpp
+++ b/tests/core/movement_trace_test.cpp
@@ -126,6 +126,16 @@ TEST(MovementTraceTest, MemorySessionCapturesBothStreams) {
   EXPECT_EQ(trace.manifest().seed, 1234U);
 }
 
+TEST(MovementTraceTest, TheManifestTakesTheStepTheWorldActuallyRuns) {
+
+  auto& trace = MovementTrace::instance();
+  trace.begin_memory_session(manifest());
+  EXPECT_FLOAT_EQ(trace.manifest().fixed_step_seconds, k_step);
+  trace.set_fixed_step_seconds(1.0F / 30.0F);
+  EXPECT_FLOAT_EQ(trace.manifest().fixed_step_seconds, 1.0F / 30.0F);
+  trace.end_session();
+}
+
 TEST(MovementTraceTest, AFileTraceKeepsOnlyEveryNthTick) {
   const auto directory =
       std::filesystem::temp_directory_path() / "soi_movement_trace_stride";
@@ -257,6 +267,12 @@ TEST(MovementTraceTest, TroopSampleSurvivesAJsonRoundTrip) {
   EXPECT_TRUE(parsed.has_contact);
   EXPECT_FLOAT_EQ(parsed.body_overlap, original.body_overlap);
   EXPECT_EQ(parsed.direction_source, original.direction_source);
+  EXPECT_FALSE(parsed.about_faced);
+
+  original.about_faced = true;
+  ASSERT_TRUE(
+      Engine::Core::parse_troop_sample(Engine::Core::to_json(original), parsed));
+  EXPECT_TRUE(parsed.about_faced);
 }
 
 TEST(MovementTraceTest, SoldierSampleSurvivesAJsonRoundTrip) {
@@ -359,6 +375,56 @@ TEST(MovementAnalysisTest, AlternatingHeadingIsRejected) {
   thresholds.fixed_step_seconds = k_step;
   auto const analysis = analyze_movement_trace(samples, {}, thresholds);
   EXPECT_GE(analysis.count(MovementFindingKind::HeadingOscillation), 1U);
+}
+
+namespace {
+
+auto half_turn_run(bool reports_about_face) -> std::vector<MovementTroopSample> {
+  std::vector<MovementTroopSample> samples;
+  float z = 0.0F;
+  for (std::uint32_t tick = 0; tick < 60U; ++tick) {
+    MovementTroopSample sample;
+    sample.tick = tick;
+    sample.entity_id = 6U;
+    sample.command_sequence = 1U;
+    sample.state = MovementOrderState::Following;
+    sample.previous_root_z = z;
+    z += (tick < 30U ? 2.0F : -2.0F) * k_step;
+    sample.root_z = z;
+    sample.route_advance = 2.0F * k_step;
+    sample.remaining_arclength = 20.0F;
+    sample.order_seconds = static_cast<float>(tick) * k_step;
+    sample.accepted_vz = tick < 30U ? 2.0F : -2.0F;
+    sample.presentation_valid = true;
+    sample.presentation_state = 1U;
+    sample.direction_source = MovementDirectionSource::AcceptedVelocity;
+    sample.root_yaw = tick < 30U ? 0.0F : 180.0F;
+    sample.about_faced = reports_about_face && tick >= 30U;
+    samples.push_back(sample);
+  }
+  return samples;
+}
+
+} // namespace
+
+TEST(MovementAnalysisTest, AnAboutFaceIsNotABodySpinningOnTheSpot) {
+
+  MovementGateThresholds thresholds;
+  thresholds.fixed_step_seconds = k_step;
+  auto const analysis = analyze_movement_trace(half_turn_run(true), {}, thresholds);
+  EXPECT_EQ(analysis.count(MovementFindingKind::AngularSpeedExceeded), 0U)
+      << Engine::Core::format_movement_findings(analysis);
+  EXPECT_EQ(analysis.count(MovementFindingKind::AngularAccelerationExceeded), 0U)
+      << Engine::Core::format_movement_findings(analysis);
+  EXPECT_EQ(analysis.count(MovementFindingKind::HeadingOscillation), 0U)
+      << Engine::Core::format_movement_findings(analysis);
+}
+
+TEST(MovementAnalysisTest, AHalfTurnInOneTickWithoutAnAboutFaceIsStillASpin) {
+  MovementGateThresholds thresholds;
+  thresholds.fixed_step_seconds = k_step;
+  auto const analysis = analyze_movement_trace(half_turn_run(false), {}, thresholds);
+  EXPECT_GE(analysis.count(MovementFindingKind::AngularSpeedExceeded), 1U);
 }
 
 TEST(MovementAnalysisTest, RingOffTheBodyAnchorIsRejectedAtTinyError) {

--- a/tests/headless/ai_town_plan_test.cpp
+++ b/tests/headless/ai_town_plan_test.cpp
@@ -1,6 +1,7 @@
 #include <QtGlobal>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <deque>
@@ -178,6 +179,8 @@ protected:
 
     if (auto* ai = session.world().get_system<Game::Systems::AISystem>()) {
       ai->reinitialize();
+
+      ai->set_decision_wait_budget(std::chrono::seconds(60));
       auto profile =
           Game::Systems::AI::doctrine_profile_for_owner(session.world(), k_owner);
       EXPECT_TRUE(profile.has_value()) << "the commander has no authored doctrine";

--- a/tests/headless/auto_engagement_response_test.cpp
+++ b/tests/headless/auto_engagement_response_test.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <gtest/gtest.h>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "game/core/component.h"
@@ -188,11 +189,23 @@ TEST_F(AutoEngagementResponseTest, SwordsmenGoToTheAidOfAnAllyBittenByWolves) {
   auto& world = m_session->world();
   Game::Systems::Combat::deal_damage(&world, world.get_entity(victim), 10, wolf);
 
-  run_for(1.0);
+  std::vector<bool> answered(escort.size(), false);
+  const double step = m_session->clock().tick_seconds();
+  for (double elapsed = 0.0; elapsed < 1.0; elapsed += step) {
+    run_for(step);
+    for (std::size_t index = 0; index < escort.size(); ++index) {
+      answered[index] = answered[index] || target_of(escort[index]) == wolf;
+    }
+  }
 
-  for (auto const swordsman : escort) {
-    EXPECT_EQ(target_of(swordsman), wolf)
-        << "swordsman " << swordsman << " watched a wolf maul the man beside him";
+  auto const* wolf_unit =
+      entity(wolf) != nullptr ? entity(wolf)->get_component<UnitComponent>() : nullptr;
+  bool const wolf_is_down = wolf_unit == nullptr || wolf_unit->health <= 0;
+  for (std::size_t index = 0; index < escort.size(); ++index) {
+    EXPECT_TRUE(answered[index] && (target_of(escort[index]) == wolf || wolf_is_down))
+        << "swordsman " << escort[index] << " watched a wolf maul the man beside him"
+        << "; wolf " << (wolf_is_down ? "down" : "alive") << ", his target "
+        << target_of(escort[index]);
   }
 }
 
@@ -394,7 +407,19 @@ TEST_F(AutoEngagementResponseTest, ANoncombatantNeverPicksItsOwnFight) {
 
   run_for(2.0);
 
-  EXPECT_EQ(target_of(builder), 0U) << "a builder went looking for a fight";
+  auto const* builder_attack = entity(builder)->get_component<AttackComponent>();
+  bool const locked_by_raider = builder_attack != nullptr &&
+                                builder_attack->in_melee_lock &&
+                                builder_attack->melee_lock_target_id == raider;
+  if (locked_by_raider) {
+    EXPECT_EQ(target_of(builder), raider) << "a locked builder fought someone else";
+  } else {
+    EXPECT_EQ(target_of(builder), 0U) << "a builder went looking for a fight";
+  }
+  auto const* record = EngagementTrace::instance().find(builder);
+  ASSERT_NE(record, nullptr);
+  EXPECT_EQ(record->outcome, Game::Systems::Combat::EngagementOutcome::NoCombatRole)
+      << "auto-engagement acquired a target for a builder";
 }
 
 } // namespace

--- a/tests/headless/gate_traversal_test.cpp
+++ b/tests/headless/gate_traversal_test.cpp
@@ -7,6 +7,7 @@
 #include "game/command/command.h"
 #include "game/command/command_queue.h"
 #include "game/core/component_gameplay.h"
+#include "game/core/movement_facts.h"
 #include "game/core/world.h"
 #include "game/session/session_context.h"
 #include "game/session/simulation_clock.h"
@@ -255,7 +256,28 @@ TEST_F(GateTraversalTest, GroupMembersIndividuallyUseTheGateCenterline) {
       used_centerline.begin(), used_centerline.end(), [](bool used) { return used; }))
       << "not every group member traversed the gate independently";
   for (const auto troop : troops) {
-    EXPECT_GT(position_z(*session, troop), gate_position.z() + 2.0F);
+    auto const* facts =
+        session->world().try_get<Engine::Core::MovementFactsComponent>(troop);
+    auto const* movement =
+        session->world().try_get<Engine::Core::MovementComponent>(troop);
+    const QVector3D where = entity_position(*session, troop);
+    EXPECT_GT(position_z(*session, troop), gate_position.z() + 2.0F)
+        << "unit " << troop << " at (" << where.x() << ", " << where.z() << ") state "
+        << (facts != nullptr ? Engine::Core::movement_state_name(facts->progress.state)
+                             : "?")
+        << " rung "
+        << (facts != nullptr ? static_cast<int>(facts->progress.stall.rung) : -1)
+        << " abandoned "
+        << (facts != nullptr && facts->progress.stall.objective_abandoned)
+        << " arrived_short " << (facts != nullptr && facts->progress.arrived_short)
+        << " steer "
+        << (facts != nullptr ? static_cast<int>(facts->steering.result) : -1)
+        << " overlap " << (facts != nullptr ? facts->steering.body_overlap : -1.0F)
+        << " no_closer "
+        << (facts != nullptr ? facts->progress.stall.no_closer_seconds : -1.0F)
+        << " target " << (movement != nullptr && movement->get_has_target())
+        << " goal (" << (movement != nullptr ? movement->get_goal_x() : 0.0F) << ", "
+        << (movement != nullptr ? movement->get_goal_y() : 0.0F) << ")";
   }
 }
 

--- a/tests/headless/stuck_recovery_test.cpp
+++ b/tests/headless/stuck_recovery_test.cpp
@@ -22,6 +22,7 @@
 #include "game/systems/owner_registry.h"
 #include "game/systems/pathfinding.h"
 #include "game/systems/runtime_system_registry.h"
+#include "game/systems/walkability.h"
 #include "game/units/factory.h"
 #include "game/units/spawn_type.h"
 
@@ -196,7 +197,8 @@ TEST_F(StuckRecoveryTest, AnOrderIntoASealedPenIsGivenUpOnWithinTheRecoveryBudge
       << "the objective was abandoned but the unit was left holding it";
 }
 
-TEST_F(StuckRecoveryTest, GivingUpClimbsTheLadderInsteadOfJumpingToTheEnd) {
+TEST_F(StuckRecoveryTest, ANoRouteOrderWaitsWithoutShufflingThenEndsOnce) {
+
   constexpr int k_pen_x = 12;
   constexpr int k_pen_z = 24;
   seal_a_pen(k_pen_x, k_pen_z, 3);
@@ -206,6 +208,7 @@ TEST_F(StuckRecoveryTest, GivingUpClimbsTheLadderInsteadOfJumpingToTheEnd) {
   CommandService::move_unit(m_session->world(), id, world_of(40, k_pen_z));
 
   std::vector<MovementRecoveryRung> seen;
+  bool held = false;
   const double step = m_session->clock().tick_seconds();
   for (double elapsed = 0.0; elapsed < k_recovery_budget_seconds; elapsed += step) {
     run_for(step);
@@ -213,18 +216,53 @@ TEST_F(StuckRecoveryTest, GivingUpClimbsTheLadderInsteadOfJumpingToTheEnd) {
     if (facts == nullptr) {
       continue;
     }
-    const auto rung = facts->progress.stall.rung;
-    if (seen.empty() || seen.back() != rung) {
-      seen.push_back(rung);
+    held = held || facts->progress.holding_at_obstruction;
+    if (seen.empty() || seen.back() != facts->progress.stall.rung) {
+      seen.push_back(facts->progress.stall.rung);
     }
   }
 
-  EXPECT_NE(std::find(seen.begin(), seen.end(), MovementRecoveryRung::Replan),
-            seen.end())
-      << "the unit was given up on without ever being replanned";
-  EXPECT_EQ(seen.back(), MovementRecoveryRung::Abandoned);
-  EXPECT_TRUE(std::is_sorted(seen.begin(), seen.end()))
-      << "the recovery ladder went backwards instead of escalating";
+  const auto* facts = facts_of(id);
+  ASSERT_NE(facts, nullptr);
+  EXPECT_TRUE(held) << "the unit never waited at the obstruction";
+  EXPECT_TRUE(facts->progress.stall.objective_abandoned)
+      << "the order was never given up";
+  EXPECT_EQ(facts->progress.stall.recovery_attempts, 0U)
+      << "the recovery ladder ran for a unit the planner had no route for";
+  EXPECT_LE(facts->progress.repath_count, 1U);
+  for (auto const rung : seen) {
+    EXPECT_TRUE(rung == MovementRecoveryRung::None ||
+                rung == MovementRecoveryRung::Abandoned)
+        << "a waiting unit climbed recovery rung " << static_cast<int>(rung);
+  }
+  EXPECT_LT((position_of(id) - world_of(k_pen_x, k_pen_z)).length(), 2.0F)
+      << "the unit shuffled about inside the pen";
+}
+
+TEST_F(StuckRecoveryTest, AnOrderFromACellWithNoWayOutIsGivenUpNotHeldForever) {
+
+  constexpr int k_pen_x = 12;
+  constexpr int k_pen_z = 24;
+  seal_a_pen(k_pen_x, k_pen_z, 1);
+
+  const EntityID id = spawn(world_of(k_pen_x, k_pen_z));
+  ASSERT_NE(id, 0U);
+  CommandService::move_unit(m_session->world(), id, world_of(40, k_pen_z));
+  ASSERT_NE(movement_of(id), nullptr);
+  ASSERT_TRUE(movement_of(id)->get_has_target())
+      << "the order was refused outright, so there is nothing to give up";
+
+  run_for(k_recovery_budget_seconds + 4.0);
+
+  const auto* facts = facts_of(id);
+  ASSERT_NE(facts, nullptr);
+  EXPECT_FALSE(movement_of(id)->get_has_target())
+      << "the unit was still holding an order it can never carry out; state "
+      << Engine::Core::movement_state_name(facts->progress.state) << " holding "
+      << facts->progress.holding_at_obstruction << " held for "
+      << facts->progress.holding_seconds << " s";
+  EXPECT_TRUE(facts->progress.stall.objective_abandoned);
+  EXPECT_FALSE(facts->progress.holding_at_obstruction);
 }
 
 TEST_F(StuckRecoveryTest, GivingUpDoesNotTurnIntoARepathLoop) {
@@ -247,27 +285,190 @@ TEST_F(StuckRecoveryTest, GivingUpDoesNotTurnIntoARepathLoop) {
       << "the same objective was abandoned over and over";
 }
 
-TEST_F(StuckRecoveryTest, AnObjectiveInsideASealedPenIsGivenUpOnFromOutside) {
+TEST_F(StuckRecoveryTest, AnObjectiveInsideASealedPenWaitsAtTheWallWithoutShuffling) {
+
   constexpr int k_pen_x = 30;
   constexpr int k_pen_z = 24;
-  seal_a_pen(k_pen_x, k_pen_z, 5);
+  constexpr int k_half = 5;
+  seal_a_pen(k_pen_x, k_pen_z, k_half);
 
   const EntityID id = spawn(world_of(8, k_pen_z));
   ASSERT_NE(id, 0U);
   CommandService::move_unit(m_session->world(), id, world_of(k_pen_x, k_pen_z));
-
   ASSERT_TRUE(movement_of(id)->get_has_target());
 
-  run_for(60.0);
+  const float wall_x = world_of(k_pen_x - k_half, k_pen_z).x();
+  double reached_wall_at = -1.0;
+  double waiting_at = -1.0;
+  float wait_position_x = 0.0F;
+  float drift_while_waiting = 0.0F;
+  const double step = m_session->clock().tick_seconds();
+  for (double elapsed = 0.0; elapsed < 30.0; elapsed += step) {
+    run_for(step);
+    const auto* facts = facts_of(id);
+    if (reached_wall_at < 0.0 && position_of(id).x() > wall_x - 2.5F) {
+      reached_wall_at = elapsed;
+    }
+    if (facts != nullptr && facts->progress.holding_at_obstruction) {
+      if (waiting_at < 0.0) {
+        waiting_at = elapsed;
+        wait_position_x = position_of(id).x();
+      }
+      drift_while_waiting = std::max(drift_while_waiting,
+                                     std::fabs(position_of(id).x() - wait_position_x));
+    }
+  }
 
   const auto* facts = facts_of(id);
   ASSERT_NE(facts, nullptr);
-  EXPECT_TRUE(facts->progress.stall.objective_abandoned)
-      << "the unit never gave up on a destination walled off from every side; "
-         "worst standstill "
-      << facts->progress.stall.stalled_seconds << " s, worst no-closer "
-      << facts->progress.stall.no_closer_seconds << " s";
+  ASSERT_GE(reached_wall_at, 0.0) << "the unit never walked up to the compound";
+  ASSERT_GE(waiting_at, 0.0) << "the unit never settled into waiting at the wall";
+  EXPECT_LT(waiting_at - reached_wall_at, 2.5)
+      << "the unit took " << waiting_at - reached_wall_at << " s to stop at the wall";
+  EXPECT_LT(drift_while_waiting, 0.6F) << "the unit shuffled while it waited";
+  EXPECT_EQ(facts->progress.stall.recovery_attempts, 0U)
+      << "the recovery ladder ran for a unit that had nowhere further to go";
+  EXPECT_LE(facts->progress.repath_count, 1U)
+      << "arriving at the wall turned into a repath loop";
+}
+
+TEST_F(StuckRecoveryTest, StandingOnTheResolvedGoalIsArrivedNotBlocked) {
+
+  constexpr int k_here_x = 12;
+  constexpr int k_z = 24;
+  for (int grid_x = k_here_x + 1; grid_x <= k_here_x + 4; ++grid_x) {
+    for (int grid_z = k_z - 2; grid_z <= k_z + 2; ++grid_z) {
+      block_cell(grid_x, grid_z);
+    }
+  }
+  refresh_grid();
+
+  const EntityID id = spawn(world_of(k_here_x, k_z));
+  ASSERT_NE(id, 0U);
+  CommandService::move_unit(m_session->world(), id, world_of(k_here_x + 2, k_z));
+
+  bool ever_blocked = false;
+  const double step = m_session->clock().tick_seconds();
+  for (double elapsed = 0.0; elapsed < 6.0; elapsed += step) {
+    run_for(step);
+    const auto* facts = facts_of(id);
+    if (facts != nullptr &&
+        (facts->progress.state == MovementOrderState::LocallyBlocked ||
+         facts->progress.state == MovementOrderState::Repathing ||
+         facts->progress.state == MovementOrderState::Recovering ||
+         facts->progress.state == MovementOrderState::Unreachable)) {
+      ever_blocked = true;
+    }
+  }
+
+  const auto* facts = facts_of(id);
+  ASSERT_NE(facts, nullptr);
   EXPECT_FALSE(movement_of(id)->get_has_target());
+  EXPECT_EQ(facts->progress.state, MovementOrderState::Arrived);
+  EXPECT_FALSE(ever_blocked) << "a unit standing on its goal was declared blocked";
+  EXPECT_EQ(facts->progress.stall.rung, MovementRecoveryRung::None);
+  EXPECT_LT((position_of(id) - world_of(k_here_x, k_z)).length(), 0.6F)
+      << "the unit wandered off a goal it was already standing on";
+}
+
+TEST_F(StuckRecoveryTest, AUnitSetDownOnAFootprintStepsOffOnceAndStandsThere) {
+
+  constexpr int k_x = 20;
+  constexpr int k_z = 24;
+  for (int grid_x = k_x - 2; grid_x <= k_x + 2; ++grid_x) {
+    for (int grid_z = k_z - 1; grid_z <= k_z + 1; ++grid_z) {
+      block_cell(grid_x, grid_z);
+    }
+  }
+  refresh_grid();
+
+  const EntityID id = spawn(world_of(k_x, k_z) + QVector3D(0.3F, 0.0F, 0.0F));
+  ASSERT_NE(id, 0U);
+
+  int recovery_orders = 0;
+  bool was_recovering = false;
+  const double step = m_session->clock().tick_seconds();
+  for (double elapsed = 0.0; elapsed < 4.0; elapsed += step) {
+    run_for(step);
+    const auto* facts = facts_of(id);
+    ASSERT_NE(facts, nullptr);
+    const bool recovering = facts->progress.state == MovementOrderState::Recovering;
+    if (recovering && !was_recovering) {
+      ++recovery_orders;
+    }
+    was_recovering = recovering;
+  }
+
+  const Game::Systems::BodyProfile point_body;
+  EXPECT_TRUE(Game::Systems::Walkability::can_stand(position_of(id), point_body))
+      << "the unit is still standing on the footprint at (" << position_of(id).x()
+      << ", " << position_of(id).z() << ")";
+  EXPECT_LE(recovery_orders, 1) << "the unit was sent off the footprint "
+                                << recovery_orders << " times in four seconds";
+  EXPECT_FALSE(movement_of(id)->get_has_target());
+}
+
+TEST_F(StuckRecoveryTest, RecoveryIsIssuedByOneLadder) {
+
+  constexpr int k_pen_x = 12;
+  constexpr int k_pen_z = 24;
+  seal_a_pen(k_pen_x, k_pen_z, 3);
+
+  const EntityID id = spawn(world_of(k_pen_x, k_pen_z));
+  ASSERT_NE(id, 0U);
+  CommandService::move_unit(m_session->world(), id, world_of(40, k_pen_z));
+
+  std::uint64_t last_revision = movement_of(id)->get_route_revision();
+  int reroutes = 0;
+  const double step = m_session->clock().tick_seconds();
+  for (double elapsed = 0.0; elapsed < k_recovery_budget_seconds; elapsed += step) {
+    run_for(step);
+    const auto* movement = movement_of(id);
+    if (movement == nullptr) {
+      continue;
+    }
+    if (movement->get_route_revision() != last_revision) {
+      last_revision = movement->get_route_revision();
+      ++reroutes;
+    }
+    if (!movement->get_has_target()) {
+      break;
+    }
+  }
+
+  const auto* facts = facts_of(id);
+  ASSERT_NE(facts, nullptr);
+  EXPECT_TRUE(facts->progress.stall.objective_abandoned);
+  EXPECT_LE(reroutes, 2)
+      << "more re-routes than the one confirming replan: a second ladder is running";
+  EXPECT_LE(facts->progress.repath_count, 1U);
+}
+
+TEST_F(StuckRecoveryTest, AClickInsideABuildingStopsOnTheSideTheUnitCameFrom) {
+
+  constexpr int k_block_x = 24;
+  constexpr int k_block_z = 26;
+  for (int grid_x = k_block_x - 3; grid_x <= k_block_x + 3; ++grid_x) {
+    for (int grid_z = k_block_z - 3; grid_z <= k_block_z + 3; ++grid_z) {
+      block_cell(grid_x, grid_z);
+    }
+  }
+  refresh_grid();
+
+  const EntityID id = spawn(world_of(k_block_x, 12));
+  ASSERT_NE(id, 0U);
+  CommandService::move_unit(m_session->world(), id, world_of(k_block_x, k_block_z));
+  run_for(20.0);
+
+  const QVector3D where = position_of(id);
+  const QVector3D south_face = world_of(k_block_x, k_block_z - 4);
+  EXPECT_LT(where.z(), world_of(k_block_x, k_block_z - 3).z())
+      << "the unit ended at (" << where.x() << ", " << where.z()
+      << "), not on the south face it approached";
+  EXPECT_LT(std::fabs(where.x() - south_face.x()), 1.5F)
+      << "the unit walked along the block instead of stopping in front of it";
+  EXPECT_GT(where.z(), south_face.z() - 2.5F)
+      << "the unit stopped well short of the block";
 }
 
 TEST_F(StuckRecoveryTest, ABlockTooWideForTheGateStillWalksThroughIt) {

--- a/tests/headless/tight_gap_navigation_test.cpp
+++ b/tests/headless/tight_gap_navigation_test.cpp
@@ -5,12 +5,15 @@
 #include <cmath>
 #include <cstdio>
 #include <gtest/gtest.h>
+#include <ios>
 #include <limits>
 #include <memory>
 #include <numbers>
 #include <utility>
 #include <vector>
 
+#include "game/command/command.h"
+#include "game/command/command_queue.h"
 #include "game/core/component.h"
 #include "game/core/world.h"
 #include "game/formation/traversal_layout_policy.h"
@@ -274,6 +277,107 @@ protected:
   std::shared_ptr<Game::Units::UnitFactoryRegistry> m_factory;
 };
 
+TEST_F(TightGapNavigationTest, AGangOrderedBehindItselfFacesAboutAndSetsOffAtOnce) {
+
+  open_field();
+  m_session->world().set_presentation_enabled(true);
+  const EntityID gang = spawn(Game::Units::SpawnType::Builder, world_of(20, 20), 0.0F);
+  ASSERT_NE(gang, 0U);
+  run_for(2.0);
+
+  auto* entity = m_session->world().get_entity(gang);
+  ASSERT_NE(entity, nullptr);
+  const float walk_speed = entity->get_component<UnitComponent>()->speed;
+  const auto soldiers = [&] {
+    std::vector<std::pair<std::uint16_t, QVector3D>> result;
+    for (const auto& anchor :
+         Game::Systems::FormationCombat::soldier_spatial_anchors(*entity)) {
+      result.emplace_back(anchor.slot_index,
+                          QVector3D(anchor.world_x, 0.0F, anchor.world_z));
+    }
+    return result;
+  };
+  ASSERT_GT(soldiers().size(), 4U);
+
+  const QVector3D start = position_of(gang);
+  const QVector3D behind = world_of(20, 8);
+  const auto plan =
+      CommandService::plan_ground_move(m_session->world(), {gang}, behind);
+  Game::Command::Move move;
+  move.units = {gang};
+  move.targets = plan.target_positions();
+  move.facing_angles = plan.facing_angles();
+  move.kind = Game::Systems::MoveOrderKind::PlayerMove;
+  move.preserve_formation_mode = plan.preserve_formation_mode;
+  Game::Command::submit(
+      m_session->world(), Game::Command::Source::LocalPlayer, k_owner, std::move(move));
+
+  const double step = m_session->clock().tick_seconds();
+  auto last = soldiers();
+  double set_off = -1.0;
+  float fastest_soldier = 0.0F;
+  for (double elapsed = step; elapsed <= 1.5 + 1e-6; elapsed += step) {
+    run_for(step);
+    if (set_off < 0.0 && (position_of(gang) - start).length() > 0.3F) {
+      set_off = elapsed;
+    }
+    const auto now = soldiers();
+    for (const auto& [slot, position] : now) {
+      for (const auto& [previous_slot, previous] : last) {
+        if (previous_slot == slot) {
+          fastest_soldier =
+              std::max(fastest_soldier,
+                       (position - previous).length() / static_cast<float>(step));
+        }
+      }
+    }
+    last = now;
+  }
+
+  EXPECT_GE(set_off, 0.0) << "the gang had not moved 0.3 m after 1.5 s";
+  EXPECT_LE(set_off, 0.4) << "the gang stood turning for " << set_off
+                          << " s before it walked away from its own back";
+  EXPECT_LE(fastest_soldier, walk_speed + 0.75F)
+      << "a builder was swept round the gang at " << fastest_soldier
+      << " m/s while it turned (walking pace " << walk_speed << " m/s)";
+}
+
+TEST_F(TightGapNavigationTest, AGangOrderedWellRoundItsShoulderSetsOffAtOnce) {
+
+  open_field();
+  m_session->world().set_presentation_enabled(true);
+  const EntityID gang = spawn(Game::Units::SpawnType::Builder, world_of(20, 20), 0.0F);
+  ASSERT_NE(gang, 0U);
+  run_for(2.0);
+
+  const QVector3D start = position_of(gang);
+  const float bearing = 125.0F * std::numbers::pi_v<float> / 180.0F;
+  const QVector3D destination =
+      start + QVector3D(std::sin(bearing), 0.0F, std::cos(bearing)) * 12.0F;
+  const auto plan =
+      CommandService::plan_ground_move(m_session->world(), {gang}, destination);
+  Game::Command::Move move;
+  move.units = {gang};
+  move.targets = plan.target_positions();
+  move.facing_angles = plan.facing_angles();
+  move.kind = Game::Systems::MoveOrderKind::PlayerMove;
+  move.preserve_formation_mode = plan.preserve_formation_mode;
+  Game::Command::submit(
+      m_session->world(), Game::Command::Source::LocalPlayer, k_owner, std::move(move));
+
+  const double step = m_session->clock().tick_seconds();
+  double set_off = -1.0;
+  for (double elapsed = step; elapsed <= 1.5 + 1e-6 && set_off < 0.0; elapsed += step) {
+    run_for(step);
+    if ((position_of(gang) - start).length() > 0.3F) {
+      set_off = elapsed;
+    }
+  }
+  EXPECT_GE(set_off, 0.0) << "the gang had not moved 0.3 m after 1.5 s";
+  EXPECT_LE(set_off, 0.4) << "the gang stood turning for " << set_off
+                          << " s before it walked off round its shoulder";
+}
+
 TEST_F(TightGapNavigationTest, RouteTakesTheMiddleOfAWideCorridor) {
   open_field(k_bare_field);
   constexpr int k_corridor_z = 15;
@@ -471,6 +575,172 @@ TEST_F(TightGapNavigationTest, EveryUnitFitsThroughTheSameOneCellGap) {
   }
 }
 
+TEST_F(TightGapNavigationTest, ASoldierSweptIntoCoverWalksOutInsteadOfPopping) {
+
+  open_field();
+  constexpr int k_gap_z = 24;
+  wall_off_column(24, k_gap_z);
+
+  const EntityID id = spawn(Game::Units::SpawnType::Spearman, world_of(14, k_gap_z));
+  ASSERT_NE(id, 0U);
+  auto* entity = m_session->world().get_entity(id);
+  ASSERT_NE(entity, nullptr);
+  CommandService::move_unit(m_session->world(), id, world_of(34, k_gap_z));
+
+  const double step = m_session->clock().tick_seconds();
+  constexpr float k_recovery_pace = 4.5F;
+  float worst_step = 0.0F;
+  float closest_pair = std::numeric_limits<float>::infinity();
+  int slot_samples = 0;
+  for (double elapsed = 0.0; elapsed < 30.0; elapsed += step) {
+    run_for(step);
+    auto const* traversal =
+        entity->get_component<Engine::Core::UnitTraversalLayoutStateComponent>();
+    if (traversal == nullptr) {
+      continue;
+    }
+    for (std::size_t left = 0; left < traversal->slot_states.size(); ++left) {
+      auto const& slot = traversal->slot_states[left];
+      if (!slot.alive) {
+        continue;
+      }
+      ++slot_samples;
+      worst_step = std::max(worst_step,
+                            std::hypot(slot.current_local_x - slot.previous_local_x,
+                                       slot.current_local_z - slot.previous_local_z));
+      for (std::size_t right = left + 1; right < traversal->slot_states.size();
+           ++right) {
+        auto const& other = traversal->slot_states[right];
+        if (!other.alive) {
+          continue;
+        }
+        closest_pair =
+            std::min(closest_pair,
+                     std::hypot(slot.current_local_x - other.current_local_x,
+                                slot.current_local_z - other.current_local_z));
+      }
+    }
+  }
+  ASSERT_GT(slot_samples, 0);
+  EXPECT_GT(closest_pair, 0.2F)
+      << "two soldiers were stacked " << closest_pair
+      << " m apart: slots swept into cover collapsed onto the root";
+  EXPECT_LE(worst_step, k_recovery_pace * static_cast<float>(step) + 0.01F)
+      << "a soldier's slot moved " << worst_step << " m in one tick";
+  EXPECT_GT(position_of(id).x(), world_of(30, k_gap_z).x())
+      << "the block never made it through the gap, so the bound proves little";
+}
+
+TEST_F(TightGapNavigationTest, TwoBodiesConvergingOnOneGapDoNotWaitForEachOther) {
+
+  open_field();
+  constexpr int k_gap_z = 24;
+  wall_off_column(24, k_gap_z);
+
+  const EntityID north =
+      spawn(Game::Units::SpawnType::Spearman, world_of(21, k_gap_z + 2));
+  const EntityID south =
+      spawn(Game::Units::SpawnType::Spearman, world_of(21, k_gap_z - 2));
+  ASSERT_NE(north, 0U);
+  ASSERT_NE(south, 0U);
+  std::vector<EntityID> const pair{north, south};
+  std::vector<QVector3D> const targets(2, world_of(34, k_gap_z));
+  CommandService::move_units(m_session->world(), pair, targets);
+  run_for(30.0);
+
+  for (auto const id : pair) {
+    EXPECT_GT(position_of(id).x(), world_of(28, k_gap_z).x())
+        << "unit " << id << " never got through the gap it shared";
+  }
+}
+
+TEST_F(TightGapNavigationTest, AQueueAtAGapWaitsItsTurnInsteadOfReplanning) {
+
+  open_field();
+  constexpr int k_gap_z = 24;
+  wall_off_column(24, k_gap_z);
+
+  std::vector<EntityID> army;
+  for (int i = 0; i < 20; ++i) {
+    const EntityID id = spawn(Game::Units::SpawnType::Spearman,
+                              world_of(10 + (i / 9), k_gap_z - 4 + (i % 9)));
+    ASSERT_NE(id, 0U);
+    army.push_back(id);
+  }
+  std::vector<QVector3D> const targets(army.size(), world_of(36, k_gap_z));
+  CommandService::move_units(m_session->world(), army, targets);
+
+  std::map<EntityID, std::uint32_t> most_repaths;
+  std::map<EntityID, double> queued_seconds;
+  const double step = m_session->clock().tick_seconds();
+  for (double elapsed = 0.0; elapsed < 90.0; elapsed += step) {
+    run_for(step);
+    for (auto const id : army) {
+      auto* entity = m_session->world().get_entity(id);
+      auto const* facts =
+          entity != nullptr
+              ? entity->get_component<Engine::Core::MovementFactsComponent>()
+              : nullptr;
+      if (facts == nullptr) {
+        continue;
+      }
+      most_repaths[id] = std::max(most_repaths[id], facts->progress.repath_count);
+      if (facts->progress.state == Engine::Core::MovementOrderState::Yielding) {
+        queued_seconds[id] += step;
+      }
+    }
+  }
+
+  double longest_queue = 0.0;
+  for (auto const id : army) {
+    longest_queue = std::max(longest_queue, queued_seconds[id]);
+    EXPECT_LE(most_repaths[id], 1U)
+        << "unit " << id << " replanned " << most_repaths[id] << " times after "
+        << queued_seconds[id] << " s queued at the gap";
+    EXPECT_GT(position_of(id).x(), world_of(28, k_gap_z).x())
+        << "unit " << id << " never got through the gap";
+  }
+  EXPECT_GT(longest_queue, 2.0) << "no queue formed; the test is not testing a queue";
+}
+
+TEST_F(TightGapNavigationTest, AnIdleBodyDoesNotKeepAnOverlapItNoLongerHas) {
+
+  open_field();
+  const EntityID standing = spawn(Game::Units::SpawnType::Spearman, world_of(20, 24));
+  const EntityID mover = spawn(Game::Units::SpawnType::Spearman, world_of(20, 24));
+  ASSERT_NE(standing, 0U);
+  ASSERT_NE(mover, 0U);
+  CommandService::move_unit(m_session->world(), mover, world_of(40, 24));
+
+  auto const* facts = m_session->world()
+                          .get_entity(standing)
+                          ->get_component<Engine::Core::MovementFactsComponent>();
+  float deepest = 0.0F;
+  const double step = m_session->clock().tick_seconds();
+  for (double elapsed = 0.0; elapsed < 1.0; elapsed += step) {
+    run_for(step);
+    facts = m_session->world()
+                .get_entity(standing)
+                ->get_component<Engine::Core::MovementFactsComponent>();
+    if (facts != nullptr) {
+      deepest = std::max(deepest, facts->steering.body_overlap);
+    }
+  }
+  ASSERT_GT(deepest, 0.0F)
+      << "the two units never touched; the test is not testing contact";
+
+  run_for(8.0);
+  ASSERT_GT(position_of(mover).x() - position_of(standing).x(), 6.0F)
+      << "the mover never left";
+  facts = m_session->world()
+              .get_entity(standing)
+              ->get_component<Engine::Core::MovementFactsComponent>();
+  ASSERT_NE(facts, nullptr);
+  EXPECT_EQ(facts->steering.body_overlap, 0.0F)
+      << "the standing unit still reports the overlap of a unit " << std::fixed
+      << position_of(mover).x() - position_of(standing).x() << " m away";
+}
+
 TEST_F(TightGapNavigationTest, AnArmyFunnelsThroughAOneCellGap) {
   open_field();
   constexpr int k_gap_z = 24;
@@ -510,6 +780,7 @@ TEST_F(TightGapNavigationTest, NarrowLayoutChangesPresentationButNotCombatLayout
   bool squeezed = false;
   bool traversal_was_active = false;
   bool observed_predictive_root_hold = false;
+  bool root_stood_still_while_holding = false;
   int traversal_enters = 0;
   int traversal_exits = 0;
   std::uint32_t active_portal = 0U;
@@ -568,10 +839,15 @@ TEST_F(TightGapNavigationTest, NarrowLayoutChangesPresentationButNotCombatLayout
         expected_progress = 1.0F;
       }
       EXPECT_NEAR(traversal->transition_progress, expected_progress, 0.0001F);
-      observed_predictive_root_hold =
-          observed_predictive_root_hold ||
-          (traversal->root_motion_blocked &&
-           std::hypot(facts->motor.accepted_vx, facts->motor.accepted_vz) < 0.001F);
+      if (traversal->root_motion_blocked &&
+          facts->progress.state != Engine::Core::MovementOrderState::Arrived) {
+        observed_predictive_root_hold = true;
+
+        if (std::hypot(facts->motor.accepted_vx, facts->motor.accepted_vz) < 0.001F &&
+            facts->motor.valid && !facts->motor.blocked) {
+          root_stood_still_while_holding = true;
+        }
+      }
     }
     if (traversal == nullptr || presentation == nullptr || !traversal->active) {
       continue;
@@ -725,6 +1001,8 @@ TEST_F(TightGapNavigationTest, NarrowLayoutChangesPresentationButNotCombatLayout
       << "soldiers scraped the gate jamb for longer than it takes to file through";
   EXPECT_TRUE(observed_predictive_root_hold)
       << "the block walked into the gate mouth instead of forming up first";
+  EXPECT_FALSE(root_stood_still_while_holding)
+      << "the block stood still in front of the gap while it folded";
   auto const* final_traversal =
       entity->get_component<Engine::Core::UnitTraversalLayoutStateComponent>();
   ASSERT_NE(final_traversal, nullptr);
@@ -1014,6 +1292,78 @@ TEST_F(TightGapNavigationTest, SiegeBodyTurnsAtABoundedRateBeforeFullSpeed) {
   EXPECT_GT(transform->position.x, start.x() + 0.5F);
 }
 
+TEST_F(TightGapNavigationTest, BlocksMarchingShoulderToShoulderHoldTheirHeading) {
+
+  open_field();
+  const EntityID north =
+      spawn(Game::Units::SpawnType::Spearman, world_of(8, 25), 90.0F);
+  const EntityID south =
+      spawn(Game::Units::SpawnType::Spearman, world_of(8, 24), 90.0F);
+  ASSERT_NE(north, 0U);
+  ASSERT_NE(south, 0U);
+  CommandService::move_unit(m_session->world(), north, world_of(40, 25));
+  CommandService::move_unit(m_session->world(), south, world_of(40, 24));
+
+  auto* north_transform =
+      m_session->world().get_entity(north)->get_component<TransformComponent>();
+  auto* south_transform =
+      m_session->world().get_entity(south)->get_component<TransformComponent>();
+  ASSERT_NE(north_transform, nullptr);
+  ASSERT_NE(south_transform, nullptr);
+
+  const double step = m_session->clock().tick_seconds();
+  run_for(1.5);
+  float north_previous = north_transform->rotation.y;
+  float south_previous = south_transform->rotation.y;
+  int flicker_ticks = 0;
+  int ticks = 0;
+  for (double elapsed = 0.0; elapsed < 6.0; elapsed += step) {
+    run_for(step);
+    for (auto [transform, previous] : {std::pair{north_transform, &north_previous},
+                                       std::pair{south_transform, &south_previous}}) {
+      float const turned = std::fabs(
+          std::fmod(transform->rotation.y - *previous + 540.0F, 360.0F) - 180.0F);
+      if (turned > 1.5F) {
+        ++flicker_ticks;
+      }
+      *previous = transform->rotation.y;
+      ++ticks;
+    }
+  }
+  EXPECT_LE(flicker_ticks, ticks / 50)
+      << flicker_ticks << " of " << ticks
+      << " ticks turned a marching block by more than 1.5 degrees on a straight road";
+  EXPECT_GT(position_of(north).x(), world_of(20, 25).x()) << "the blocks never marched";
+}
+
+TEST_F(TightGapNavigationTest, AReversedBlockWheelsFastAndStepsOffAtOnce) {
+
+  open_field();
+  const QVector3D start = world_of(24, 24);
+  const EntityID id = spawn(Game::Units::SpawnType::Spearman, start);
+  auto* entity = m_session->world().get_entity(id);
+  ASSERT_NE(entity, nullptr);
+  auto* transform = entity->get_component<TransformComponent>();
+  ASSERT_NE(transform, nullptr);
+  const float initial_yaw = transform->rotation.y;
+  ASSERT_NEAR(initial_yaw, 0.0F, 0.5F);
+
+  CommandService::move_unit(m_session->world(), id, world_of(24, 6));
+
+  run_for(1.0);
+  float const turned = std::fabs(
+      std::fmod(transform->rotation.y - initial_yaw + 540.0F, 360.0F) - 180.0F);
+  EXPECT_GE(turned, 150.0F) << "one second after a reversal the block had wheeled only "
+                            << turned << " degrees";
+  float const early_travel =
+      std::hypot(transform->position.x - start.x(), transform->position.z - start.z());
+  EXPECT_GT(early_travel, 0.1F) << "a second after a reversal the block had not moved";
+
+  run_for(3.0);
+  EXPECT_LT(transform->position.z, start.z() - 3.0F)
+      << "four seconds after a reversal the block was still not on its way back";
+}
+
 TEST_F(TightGapNavigationTest, AnArmyCrossesARiverOnTheBridgeDeck) {
   Game::Map::MapDefinition map;
   map.grid.width = k_map;
@@ -1154,8 +1504,22 @@ TEST_F(TightGapNavigationTest, AnArmyClimbsAHillThroughItsEntrance) {
                           [](bool used) { return used; }))
       << "not every unit traversed the hill entrance independently";
   for (std::size_t index = 0; index < army.size(); ++index) {
+    auto const* facts =
+        m_session->world().try_get<Engine::Core::MovementFactsComponent>(army[index]);
+    auto const* movement =
+        m_session->world().try_get<Engine::Core::MovementComponent>(army[index]);
     EXPECT_LE(closest_entrance_distance[index], 0.25F)
-        << "unit " << index << " never crossed the hill entrance throat";
+        << "unit " << index << " never crossed the hill entrance throat; ended at ("
+        << position_of(army[index]).x() << ", " << position_of(army[index]).z()
+        << ") state "
+        << (facts != nullptr ? Engine::Core::movement_state_name(facts->progress.state)
+                             : "?")
+        << " rung "
+        << (facts != nullptr ? static_cast<int>(facts->progress.stall.rung) : -1)
+        << " steer "
+        << (facts != nullptr ? static_cast<int>(facts->steering.result) : -1)
+        << " overlap " << (facts != nullptr ? facts->steering.body_overlap : -1.0F)
+        << " target " << (movement != nullptr && movement->get_has_target());
     EXPECT_LE(entrance_offset[index], 0.75F)
         << "unit " << index << " drifted off the hill entrance centerline";
   }

--- a/tests/headless/wall_siege_test.cpp
+++ b/tests/headless/wall_siege_test.cpp
@@ -322,8 +322,26 @@ TEST_F(WallSiegeTest, FrontRankVisuallyReachesTheFacadeFromWalkableGround) {
       << "the grid-controlled unit root stopped a formation-depth away from the wall";
   EXPECT_GE(minimum_visible_facade_gap, -0.05F)
       << "the rendered formation crossed through the attacked wall facade";
-  EXPECT_LE(closest_visible_gap, contact_clearance + 0.15F)
-      << "the front rank did not visually reach the wall it was attacking";
+  {
+    auto const* facts =
+        raider_entity->get_component<Engine::Core::MovementFactsComponent>();
+    auto const* movement =
+        raider_entity->get_component<Engine::Core::MovementComponent>();
+    auto const* attack = raider_entity->get_component<Engine::Core::AttackComponent>();
+    EXPECT_LE(closest_visible_gap, contact_clearance + 0.15F)
+        << "the front rank did not visually reach the wall it was attacking; root gap "
+        << root_surface.distance << " state "
+        << (facts != nullptr ? Engine::Core::movement_state_name(facts->progress.state)
+                             : "?")
+        << " rung "
+        << (facts != nullptr ? static_cast<int>(facts->progress.stall.rung) : -1)
+        << " arrived_short " << (facts != nullptr && facts->progress.arrived_short)
+        << " target " << (movement != nullptr && movement->get_has_target())
+        << " approach "
+        << (movement != nullptr ? movement->get_structure_approach_target() : 0)
+        << " lock " << (attack != nullptr && attack->in_melee_lock) << " contact "
+        << presentation->soldiers.size();
+  }
   EXPECT_LT(health_of(*session, wall), 4000);
 }
 

--- a/tests/map/map_crossing_traversal_test.cpp
+++ b/tests/map/map_crossing_traversal_test.cpp
@@ -122,6 +122,11 @@ protected:
     return Game::Systems::Walkability::nearest_standable(position, profile, 24.0F);
   }
 
+  static auto facts_no_progress(const Engine::Core::Entity& entity) -> float {
+    const auto* facts = entity.get_component<Engine::Core::MovementFactsComponent>();
+    return facts == nullptr ? 0.0F : facts->progress.no_progress_seconds;
+  }
+
   static auto
   worst_stuck_time(Engine::Core::World& world,
                    const std::vector<Engine::Core::EntityID>& ids) -> float {
@@ -131,9 +136,9 @@ protected:
       if (entity == nullptr) {
         continue;
       }
-      const auto* movement = entity->get_component<Engine::Core::MovementComponent>();
-      if (movement != nullptr) {
-        worst = std::max(worst, movement->get_stuck_time());
+      const auto* facts = entity->get_component<Engine::Core::MovementFactsComponent>();
+      if (facts != nullptr) {
+        worst = std::max(worst, facts->progress.no_progress_seconds);
       }
     }
     return worst;
@@ -241,7 +246,7 @@ TEST_F(MapCrossingTraversalTest, ASquadOrderedOverEveryShippedFordReachesTheFarB
                    m->get_goal_x(),
                    m->get_goal_y(),
                    static_cast<int>(m->get_has_target()),
-                   m->get_stuck_time(),
+                   facts_no_progress(*first),
                    m->get_path_index(),
                    m->get_path().size(),
                    m->get_vx(),

--- a/tests/map/terrain_service_test.cpp
+++ b/tests/map/terrain_service_test.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <gtest/gtest.h>
 #include <utility>
+#include <vector>
 
 #include "app/session/skirmish_loader.h"
 #include "game/core/world.h"
@@ -74,6 +76,45 @@ auto brute_point_near_road(const std::vector<Game::Map::RoadSegment>& roads,
     }
   }
   return false;
+}
+
+TEST_F(TerrainServiceTest, AMapNumbersItsPropsTheSameWhateverWasLoadedBefore) {
+
+  const auto map_with_props = [](int count) {
+    Game::Map::MapDefinition map_def;
+    map_def.grid.width = 24;
+    map_def.grid.height = 24;
+    map_def.grid.tile_size = 1.0F;
+    map_def.biome.procedural_boulders_enabled = false;
+    map_def.biome.procedural_iron_ore_enabled = false;
+    map_def.biome.procedural_trees_enabled = false;
+    for (int index = 0; index < count; ++index) {
+      Game::Map::WorldProp prop;
+      prop.type = Game::Map::WorldProp::Type::Boulder;
+      prop.x = 4.0F + (static_cast<float>(index) * 2.0F);
+      prop.z = 6.0F;
+      map_def.world_props.push_back(prop);
+    }
+    return map_def;
+  };
+  const auto authored_ids = [](const Game::Map::TerrainService& terrain) {
+    std::vector<std::uint64_t> ids;
+    for (const auto& prop : terrain.authored_world_props()) {
+      ids.push_back(prop.id);
+    }
+    return ids;
+  };
+
+  auto& terrain = Game::Map::TerrainService::instance();
+  terrain.initialize(map_with_props(3));
+  const auto first_load = authored_ids(terrain);
+  ASSERT_EQ(first_load.size(), 3U);
+
+  terrain.initialize(map_with_props(10));
+  terrain.initialize(map_with_props(3));
+  const auto second_load = authored_ids(terrain);
+  EXPECT_EQ(second_load, first_load)
+      << "the same map numbered its props differently after another map was loaded";
 }
 
 TEST_F(TerrainServiceTest, BuildsDerivedFieldForFlatTerrainWithIrregularity) {

--- a/tests/render/ground_marker_tessellation_test.cpp
+++ b/tests/render/ground_marker_tessellation_test.cpp
@@ -1,0 +1,84 @@
+#include <cstddef>
+#include <gtest/gtest.h>
+
+#include "render/geom/ground_marker_tessellation.h"
+
+namespace {
+
+using Render::Geom::k_marker_segment_lods;
+using Render::Geom::marker_angular_step;
+using Render::Geom::marker_chord_world;
+using Render::Geom::marker_segment_count;
+using Render::Geom::marker_segment_lod;
+using Render::Geom::marker_target_arc_world;
+
+constexpr float k_tile = 1.0F;
+
+constexpr float k_soldier_ring = 0.35F;
+constexpr float k_unit_ring = 0.95F;
+constexpr float k_bow_range = 9.0F;
+constexpr float k_siege_range = 22.0F;
+
+} // namespace
+
+TEST(GroundMarkerTessellation, ChordStaysUnderTheTargetArcAtEveryRadius) {
+  const float target = marker_target_arc_world(k_tile);
+
+  const float resolvable =
+      static_cast<float>(k_marker_segment_lods.back()) * target / (2.0F * 3.14159265F);
+
+  for (float radius = 0.05F; radius <= resolvable; radius += 0.05F) {
+    const std::size_t lod = marker_segment_lod(radius, k_tile);
+    EXPECT_LE(marker_chord_world(radius, lod), target * 1.001F)
+        << "radius " << radius << " samples the ground too coarsely to drape on it";
+  }
+}
+
+TEST(GroundMarkerTessellation, SelectionRingsAreCheaperThanTheOldFixedRing) {
+
+  EXPECT_LT(marker_segment_count(marker_segment_lod(k_soldier_ring, k_tile)), 96);
+  EXPECT_LT(marker_segment_count(marker_segment_lod(k_unit_ring, k_tile)), 96);
+}
+
+TEST(GroundMarkerTessellation, RangeRingsGetMoreSegmentsThanTheOldFixedRing) {
+  EXPECT_GT(marker_segment_count(marker_segment_lod(k_bow_range, k_tile)), 96);
+  EXPECT_GT(marker_segment_count(marker_segment_lod(k_siege_range, k_tile)), 96);
+}
+
+TEST(GroundMarkerTessellation, LevelNeverFallsAsTheRadiusGrows) {
+  std::size_t previous = 0;
+  for (float radius = 0.0F; radius < 60.0F; radius += 0.1F) {
+    const std::size_t lod = marker_segment_lod(radius, k_tile);
+    EXPECT_GE(lod, previous) << "radius " << radius;
+    previous = lod;
+  }
+  EXPECT_EQ(previous, k_marker_segment_lods.size() - 1U);
+}
+
+TEST(GroundMarkerTessellation, CoarserTerrainNeedsFewerSegments) {
+  const std::size_t fine = marker_segment_lod(k_bow_range, 0.5F);
+  const std::size_t coarse = marker_segment_lod(k_bow_range, 4.0F);
+  EXPECT_LT(coarse, fine)
+      << "a ring only has to follow the ground as finely as the ground is defined";
+}
+
+TEST(GroundMarkerTessellation, DegenerateInputsStayInRange) {
+  for (const float world_per_cell : {0.0F, -1.0F, 1.0F, 1e6F}) {
+    for (const float radius : {-1.0F, 0.0F, 1e6F}) {
+      const std::size_t lod = marker_segment_lod(radius, world_per_cell);
+      EXPECT_LT(lod, k_marker_segment_lods.size());
+      EXPECT_GT(marker_segment_count(lod), 0);
+      EXPECT_GT(marker_angular_step(lod), 0.0F);
+    }
+  }
+  EXPECT_EQ(marker_segment_count(k_marker_segment_lods.size() + 7U),
+            k_marker_segment_lods.back());
+}
+
+TEST(GroundMarkerTessellation, AngularStepMatchesTheSegmentCount) {
+  for (std::size_t lod = 0; lod < k_marker_segment_lods.size(); ++lod) {
+    const float full_turn =
+        marker_angular_step(lod) * static_cast<float>(marker_segment_count(lod));
+    EXPECT_NEAR(full_turn, 2.0F * 3.14159265F, 1e-4F);
+  }
+}

--- a/tests/support/movement_test_access.h
+++ b/tests/support/movement_test_access.h
@@ -28,7 +28,6 @@ struct MovementTestAccess {
     m.route_opening_waypoint_index = opening_waypoint;
     m.route_reform_waypoint_index = reform_waypoint;
   }
-  static void set_stuck_time(MovementComponent& m, float v) { m.stuck_timer = v; }
 };
 
 } // namespace Engine::Core

--- a/tests/systems/ai_system_test.cpp
+++ b/tests/systems/ai_system_test.cpp
@@ -1909,6 +1909,32 @@ TEST_F(AISystemTest, BaseManagerSeparatesProductionAndDefensiveResponsibilities)
   EXPECT_NE(production->role, Game::Systems::AI::BaseRole::Defensive);
 }
 
+TEST_F(AISystemTest, ASoldierOnTheOuterSlotOfAWideStationIsStationedNotLeftAtSpawn) {
+
+  Game::Systems::AI::AISnapshot snapshot;
+  snapshot.player_id = 3;
+  snapshot.game_time = 10.0F;
+  snapshot.friendly_units = {
+      make_barracks(50, 0.0F, 10.0F),
+      make_unit(60, 0.0F, 11.0F),
+  };
+
+  Game::Systems::AI::AIContext context;
+  context.player_id = 3;
+  context.station.x = 0.0F;
+  context.station.z = 22.0F;
+  context.macro_targets.assembly_radius = 9.0F;
+  context.station.required_radius = 12.0F;
+
+  Game::Systems::AI::update_station_report(snapshot, context);
+
+  EXPECT_EQ(context.station_report.stationed, 1)
+      << "a soldier on its outer slot, inside the ground the formation needs, "
+         "was not counted at its station";
+  EXPECT_EQ(context.station_report.at_spawn, 0)
+      << "a soldier the AI stationed was reported as left by its barracks";
+}
+
 TEST_F(AISystemTest, BaseManagerKeepsBaseIdentityAcrossUpdates) {
   Game::Systems::AI::AISnapshot snapshot;
   snapshot.player_id = 3;

--- a/tests/systems/building_obstruction_lifecycle_test.cpp
+++ b/tests/systems/building_obstruction_lifecycle_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#include "../../game/core/movement_facts.h"
 #include "core/component_gameplay.h"
 #include "core/entity.h"
 #include "core/world.h"
@@ -370,8 +371,32 @@ TEST_F(BuildingObstructionLifecycleTest, UnitsRerouteThroughNewlyOpenedBreach) {
   for (auto* soldier : soldiers) {
     auto const* transform = soldier->get_component<TransformComponent>();
     ASSERT_NE(transform, nullptr);
+    auto const* movement = soldier->get_component<Engine::Core::MovementComponent>();
+    auto const* facts = soldier->get_component<Engine::Core::MovementFactsComponent>();
     EXPECT_GT(transform->position.x, 0.0F)
-        << "units should walk through the breach once the wall is destroyed";
+        << "units should walk through the breach once the wall is destroyed; at ("
+        << transform->position.x << ", " << transform->position.z << ") state "
+        << (facts != nullptr ? Engine::Core::movement_state_name(facts->progress.state)
+                             : "?")
+        << " rung "
+        << (facts != nullptr ? static_cast<int>(facts->progress.stall.rung) : -1)
+        << " holding " << (facts != nullptr && facts->progress.holding_at_obstruction)
+        << " abandoned "
+        << (facts != nullptr && facts->progress.stall.objective_abandoned)
+        << " repaths " << (facts != nullptr ? facts->progress.repath_count : 0U)
+        << " target " << (movement != nullptr && movement->get_has_target())
+        << " goal (" << (movement != nullptr ? movement->get_goal_x() : 0.0F) << ", "
+        << (movement != nullptr ? movement->get_goal_y() : 0.0F) << ") desired "
+        << (facts != nullptr && facts->desired.valid) << " steer "
+        << (facts != nullptr ? static_cast<int>(facts->steering.result) : -1)
+        << " neighbours " << (facts != nullptr ? facts->steering.neighbor_count : 0U)
+        << " motor_blocked " << (facts != nullptr && facts->motor.blocked)
+        << " blocked_steps " << (facts != nullptr ? facts->progress.blocked_steps : 0U)
+        << " clearance "
+        << (movement != nullptr ? movement->get_navigation_clearance() : -1.0F)
+        << " path " << (movement != nullptr ? movement->get_path_index() : 0U) << "/"
+        << (movement != nullptr ? movement->get_path().size() : 0U) << " relief "
+        << (facts != nullptr ? facts->progress.stall.clearance_relief : -1.0F);
   }
 }
 

--- a/tests/systems/command_service_test.cpp
+++ b/tests/systems/command_service_test.cpp
@@ -362,6 +362,38 @@ TEST_F(CommandServiceTest, SharpWaypointTurnLimitsSidewaysTranslation) {
   EXPECT_GT(std::hypot(movement->get_vx(), movement->get_vz()), 0.0F);
 }
 
+TEST_F(CommandServiceTest, AnOrderedUnitMarchesAtItsOwnPace) {
+
+  Engine::Core::World world;
+  auto* entity = create_unit(world, -12.0F, 0.0F, Game::Units::SpawnType::Spearman);
+  ASSERT_NE(entity, nullptr);
+  auto* transform = entity->get_component<Engine::Core::TransformComponent>();
+  transform->rotation.y = 90.0F;
+  Game::Systems::CommandService::move_unit(
+      world, entity->get_id(), QVector3D(14.0F, 0.0F, 0.0F));
+
+  Game::Systems::MovementPipeline movement_system;
+  constexpr float k_step = 1.0F / 60.0F;
+  float peak_speed = 0.0F;
+  float desired_speed = 0.0F;
+  for (int frame = 0; frame < 120; ++frame) {
+    movement_system.update(&world, k_step);
+    const auto* facts = entity->get_component<Engine::Core::MovementFactsComponent>();
+    ASSERT_NE(facts, nullptr);
+    if (facts->desired.valid) {
+      desired_speed =
+          std::max(desired_speed,
+                   std::hypot(facts->desired.velocity_x, facts->desired.velocity_z));
+    }
+    peak_speed = std::max(
+        peak_speed, std::hypot(facts->motor.accepted_vx, facts->motor.accepted_vz));
+  }
+  ASSERT_GT(desired_speed, 0.5F);
+  EXPECT_GE(peak_speed, desired_speed * 0.95F)
+      << "two seconds into a march across open ground the unit made " << peak_speed
+      << " m/s of the " << desired_speed << " m/s its route asked for";
+}
+
 TEST_F(CommandServiceTest, FormationFacesItsRouteAroundAnObstacleInsteadOfTheGoal) {
   Engine::Core::World world;
   auto* entity = create_unit(world, 0.0F, 0.0F, Game::Units::SpawnType::Spearman);

--- a/tests/systems/movement_route_test.cpp
+++ b/tests/systems/movement_route_test.cpp
@@ -95,6 +95,51 @@ TEST(MovementRouteTest, SteeringNeverAimsPastTheCorner) {
   EXPECT_NEAR(tangent.second, 0.0F, 1.0e-3F);
 }
 
+TEST(MovementRouteTest, TheAimLooksPastCloseCornersOnlyWhereTheWayIsClear) {
+
+  MovementRoute route;
+  std::vector<std::pair<float, float>> zigzag;
+  for (int step = 1; step <= 12; ++step) {
+    zigzag.emplace_back(static_cast<float>(step), (step % 2 == 1) ? 0.4F : 0.0F);
+  }
+  ASSERT_TRUE(route.build(1U, 0U, 0.0F, 0.0F, zigzag, 0U, 12.0F, 0.0F));
+  route.advance_to(route.project(0.8F, 0.3F, 2.0F).s);
+
+  auto const always_clear = [](float, float, float, float) {
+    return true;
+  };
+  auto const heading_from = [&](float x, float z, const auto& clear) {
+    float const aim_s = route.steering_aim_s(x, z, 1.6F, 1.2F, clear);
+    auto const aim = route.point_at(aim_s);
+    return std::atan2(aim.first - x, aim.second - z) * 180.0F / 3.14159265F;
+  };
+  float const left = heading_from(0.8F, 0.38F, always_clear);
+  float const right = heading_from(0.8F, 0.22F, always_clear);
+  EXPECT_LT(std::fabs(left - right), 15.0F)
+      << "a 16 cm sideways nudge swung the aim by " << std::fabs(left - right)
+      << " degrees";
+  float const aim_s = route.steering_aim_s(0.8F, 0.3F, 1.6F, 1.2F, always_clear);
+  EXPECT_GT(aim_s, route.next_vertex_s(route.travelled()))
+      << "with the way clear the aim still stopped at the nearest corner";
+
+  auto const never_clear = [](float, float, float, float) {
+    return false;
+  };
+  float const blocked_s = route.steering_aim_s(0.8F, 0.3F, 1.6F, 1.2F, never_clear);
+  EXPECT_LE(blocked_s, route.next_vertex_s(route.travelled()) + 1.0e-4F)
+      << "the aim went past a corner the body cannot see round";
+}
+
+TEST(MovementRouteTest, ANonFiniteLookaheadStillAimsDownTheRoute) {
+
+  const auto route = corner_route();
+  float const nan = std::numeric_limits<float>::quiet_NaN();
+  float const aim_s = route.steering_aim_s(
+      0.0F, 0.0F, nan, nan, [](float, float, float, float) { return true; });
+  EXPECT_GT(aim_s, route.travelled() + 0.1F)
+      << "a non-finite look-ahead put the aim point on the body";
+}
+
 TEST(MovementRouteTest, ADirectTargetIsAOneSegmentRoute) {
   MovementRoute route;
   ASSERT_TRUE(route.build(1U, 0U, 0.0F, 0.0F, {}, 0U, 3.0F, 4.0F));

--- a/tests/systems/movement_stage_ownership_test.cpp
+++ b/tests/systems/movement_stage_ownership_test.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
@@ -14,6 +15,7 @@
 #include "game/core/system_schedule.h"
 #include "game/core/world.h"
 #include "game/session/session_context.h"
+#include "game/systems/body_contact_system.h"
 #include "game/systems/local_avoidance_system.h"
 #include "game/systems/movement_pipeline.h"
 #include "game/systems/movement_system.h"
@@ -21,6 +23,7 @@
 #include "game/systems/route_follow_system.h"
 #include "game/systems/runtime_system_registry.h"
 #include "game/systems/unit_traversal_layout_system.h"
+#include "game/util/planar_math.h"
 
 namespace {
 
@@ -110,6 +113,57 @@ TEST(MovementStageOwnershipTest, SteeringDoesNotTouchTheIntegratedVelocity) {
   EXPECT_EQ(source.find("->vz ="), std::string::npos);
 }
 
+TEST(MovementStageOwnershipTest, TheYawHelpersAreExactForUnwrappedAngles) {
+
+  for (float const from : {-1260.0F, -900.0F, -30.0F, 0.0F, 355.0F, 1085.0F}) {
+    for (float const to : {-1000.0F, -181.0F, 0.0F, 179.0F, 720.0F, 2000.0F}) {
+      float const delta = Game::Systems::signed_yaw_delta(from, to);
+      EXPECT_LE(std::fabs(delta), 180.0F + 1.0e-3F) << from << " -> " << to;
+      EXPECT_NEAR(std::remainder(from + delta - to, 360.0F), 0.0F, 1.0e-2F)
+          << from << " -> " << to;
+    }
+  }
+  EXPECT_NEAR(Game::Systems::turn_yaw_toward(-900.0F, 10.0F, 5.0F), -905.0F, 1.0e-3F);
+}
+
+TEST(MovementStageOwnershipTest, EverySimulationYawTurnsThroughOneHelper) {
+
+  const auto root = find_repo_root();
+  std::vector<std::string> offenders;
+  for (const auto& entry :
+       std::filesystem::recursive_directory_iterator(root / "game")) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    const auto extension = entry.path().extension().string();
+    if (extension != ".cpp" && extension != ".h") {
+      continue;
+    }
+    const auto relative =
+        std::filesystem::relative(entry.path(), root).generic_string();
+    if (relative == "game/util/planar_math.h") {
+      continue;
+    }
+    std::ifstream stream(entry.path());
+    std::string line;
+    int number = 0;
+    while (std::getline(stream, line)) {
+      ++number;
+      if (line.find("540.0F") != std::string::npos ||
+          (line.find("std::remainder(") != std::string::npos &&
+           line.find("360") != std::string::npos)) {
+        offenders.push_back(relative + ":" + std::to_string(number));
+      }
+    }
+  }
+  std::string listing;
+  for (const auto& offender : offenders) {
+    listing += "\n  " + offender;
+  }
+  EXPECT_TRUE(offenders.empty())
+      << "private yaw-wrap arithmetic outside planar_math.h:" << listing;
+}
+
 TEST(MovementStageOwnershipTest, TheRegistryOrdersFollowThenSteerThenMotor) {
   SessionContext session;
   const ScopedSession scope(session);
@@ -120,17 +174,23 @@ TEST(MovementStageOwnershipTest, TheRegistryOrdersFollowThenSteerThenMotor) {
   const auto steer =
       index_of_system<Game::Systems::LocalAvoidanceSystem>(session.world());
   const auto motor = index_of_system<Game::Systems::MovementSystem>(session.world());
+  const auto contact =
+      index_of_system<Game::Systems::BodyContactSystem>(session.world());
   const auto traversal =
       index_of_system<Game::Systems::UnitTraversalLayoutSystem>(session.world());
 
   ASSERT_NE(follow, std::string::npos);
   ASSERT_NE(steer, std::string::npos);
   ASSERT_NE(motor, std::string::npos);
+  ASSERT_NE(contact, std::string::npos)
+      << "the shipped game runs no body-contact pass: bodies walk through each "
+         "other and the BodyOverlap gate measures nothing";
   ASSERT_NE(traversal, std::string::npos);
   EXPECT_LT(follow, steer) << "steering ran before there was an intent to steer";
   EXPECT_LT(steer, motor) << "the motor ran before steering could correct it";
-  EXPECT_LT(motor, traversal)
-      << "traversal layout ran before the motor published its accepted pose";
+  EXPECT_LT(motor, contact) << "contact separated bodies the motor had not moved yet";
+  EXPECT_LT(contact, traversal)
+      << "traversal layout ran before the motor and contact published the root";
 
   const auto phases = session.world().system_phases();
   EXPECT_EQ(phases[follow], SystemPhase::Movement);

--- a/tests/systems/production_system_test.cpp
+++ b/tests/systems/production_system_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <memory>
+#include <vector>
 
 #include "core/component_economy.h"
 #include "core/component_presentation.h"
@@ -514,6 +515,37 @@ TEST_F(ProductionSystemTest, RepairingAStructureThatIsGoneReportsALostTarget) {
 
   EXPECT_TRUE(production->has_active_fault());
   EXPECT_EQ(production->fault, Engine::Core::BuilderTaskFault::TargetLost);
+}
+
+TEST_F(ProductionSystemTest, TwoCrewsHeldApartOnOneSiteBothStartWork) {
+
+  auto const site = Game::Systems::NavGrid::grid_to_world({4, 4});
+  Engine::Core::World world;
+  std::vector<Engine::Core::BuilderProductionComponent*> crews;
+  for (float const side : {-0.25F, 0.25F}) {
+    auto* builder = world.create_entity();
+    builder->add_component<Engine::Core::TransformComponent>(
+        site.x() + side, 0.0F, site.z());
+    builder->add_component<Engine::Core::MovementComponent>();
+    builder->add_component<Engine::Core::UnitComponent>()->owner_id = 1;
+    auto* production =
+        builder->add_component<Engine::Core::BuilderProductionComponent>();
+    production->product_type = "defense_tower";
+    production->build_time = 10.0F;
+    production->time_remaining = 10.0F;
+    production->has_construction_site = true;
+    production->construction_site_x = site.x();
+    production->construction_site_z = site.z();
+    crews.push_back(production);
+  }
+
+  Game::Systems::ProductionSystem system;
+  system.update(&world, 0.1F);
+
+  for (auto const* crew : crews) {
+    EXPECT_TRUE(crew->at_construction_site)
+        << "a crew held 0.25 m from its site by another crew never started work";
+  }
 }
 
 TEST_F(ProductionSystemTest, WalkingOffASiteIsRecordedAsAnInterruption) {

--- a/tests/systems/unit_activity_test.cpp
+++ b/tests/systems/unit_activity_test.cpp
@@ -196,17 +196,39 @@ TEST(UnitActivityTest, AWedgedUnitReportsBlockedRatherThanMoving) {
   MovementTestAccess::set_has_target(*movement, true);
   MovementTestAccess::set_target_x(*movement, 10.0F);
   MovementTestAccess::set_target_y(*movement, 10.0F);
+  auto* facts = entity->add_component<Engine::Core::MovementFactsComponent>();
 
   auto activity = classify_unit_activity(*entity);
   EXPECT_EQ(activity.kind, ActivityKind::Move);
   EXPECT_FALSE(Game::Systems::activity_is_noteworthy(activity))
       << "an ordinary march must not put a marker over every soldier";
 
-  MovementTestAccess::set_stuck_time(*movement, 5.0F);
+  facts->progress.no_progress_seconds = 5.0F;
+  facts->progress.state = Engine::Core::MovementOrderState::Yielding;
+  facts->progress.stall.rung = Engine::Core::MovementRecoveryRung::Replan;
+  activity = classify_unit_activity(*entity);
+  EXPECT_EQ(activity.kind, ActivityKind::Move)
+      << "a unit that is merely slow, or that replanned once, is still moving";
+
+  facts->progress.stall.rung = Engine::Core::MovementRecoveryRung::Sidestep;
   activity = classify_unit_activity(*entity);
   EXPECT_EQ(activity.kind, ActivityKind::Blocked);
   EXPECT_EQ(activity.state, ActivityState::Unavailable);
   EXPECT_TRUE(Game::Systems::activity_is_noteworthy(activity));
+}
+
+TEST(UnitActivityTest, ArrivingShortOfAnUnreachablePointIsNotBlocked) {
+  Engine::Core::World world;
+  auto* entity = make_unit(world);
+  entity->add_component<Engine::Core::MovementComponent>();
+  auto* facts = entity->add_component<Engine::Core::MovementFactsComponent>();
+  facts->progress.state = Engine::Core::MovementOrderState::Arrived;
+  facts->progress.arrived_short = true;
+
+  const auto activity = classify_unit_activity(*entity);
+  EXPECT_NE(activity.kind, ActivityKind::Blocked)
+      << "walking to the nearest reachable point and stopping is a finished order";
+  EXPECT_FALSE(Game::Systems::activity_is_noteworthy(activity));
 }
 
 TEST(UnitActivityTest, IdsRoundTripSoQmlAndCppNameTheSameThing) {

--- a/tests/ui/qml/tst_hud_focus_guard.qml
+++ b/tests/ui/qml/tst_hud_focus_guard.qml
@@ -1,0 +1,92 @@
+import QtQuick 2.15
+import QtTest 1.15
+import StandardOfIron.Design 1.0
+
+TestCase {
+    id: testCase
+
+    name: "HudFocusGuard"
+    when: windowShown
+    width: 800
+    height: 600
+    visible: true
+
+    function test_a_click_survives_the_guard_stealing_focus() {
+        var host = guardedHost.createObject(testCase, {
+                "width": 800,
+                "height": 600
+            });
+        waitForRendering(host);
+        var button = host.button;
+        mousePress(button, button.width / 2, button.height / 2);
+        wait(80);
+        mouseRelease(button, button.width / 2, button.height / 2);
+        wait(80);
+        compare(host.clicks, 1, "the focus guard cancelled the press and the click was lost");
+        compare(host.steals, 0, "a click must not hand the keyboard to a HUD button");
+        host.destroy();
+    }
+
+    function test_repeated_clicks_all_land() {
+        var host = guardedHost.createObject(testCase, {
+                "width": 800,
+                "height": 600
+            });
+        waitForRendering(host);
+        var button = host.button;
+        for (var i = 0; i < 3; ++i) {
+            mousePress(button, button.width / 2, button.height / 2);
+            wait(40);
+            mouseRelease(button, button.width / 2, button.height / 2);
+            wait(40);
+        }
+        compare(host.clicks, 3, "clicks stopped landing once the guard had run");
+        host.destroy();
+    }
+
+    function test_the_keyboard_can_still_reach_the_button() {
+        var host = guardedHost.createObject(testCase, {
+                "width": 800,
+                "height": 600
+            });
+        waitForRendering(host);
+        verify((host.button.focusPolicy & Qt.TabFocus) === Qt.TabFocus, "tab navigation lost its way to the button");
+        host.destroy();
+    }
+
+    Component {
+        id: guardedHost
+
+        Item {
+            id: host
+
+            property alias button: btn
+            property int clicks: 0
+            property int steals: 0
+
+            Item {
+                id: battlefield
+
+                anchors.fill: parent
+                focus: true
+            }
+
+            IronButton {
+                id: btn
+
+                anchors.centerIn: parent
+                text: "Battle Report"
+                tone: "primary"
+                onClicked: host.clicks += 1
+                onActiveFocusChanged: {
+                    if (!btn.activeFocus)
+                        return;
+                    host.steals += 1;
+                    Qt.callLater(function () {
+                            battlefield.forceActiveFocus();
+                        });
+                }
+            }
+        }
+    }
+}

--- a/tools/arena/CMakeLists.txt
+++ b/tools/arena/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
     arena_formation_scenarios.cpp
     arena_navigation_scenarios.cpp
     arena_stuck_recovery_scenarios.cpp
+    arena_maneuver_scenarios.cpp
     arena_traversal_scenarios.cpp
     arena_showcase_scenarios.cpp
     arena_facade_scenarios.cpp

--- a/tools/arena/arena_maneuver_scenarios.cpp
+++ b/tools/arena/arena_maneuver_scenarios.cpp
@@ -1,0 +1,684 @@
+#include "arena_maneuver_scenarios.h"
+
+#include <QString>
+#include <QStringList>
+#include <QVector3D>
+
+#include <utility>
+#include <vector>
+
+#include "arena_scenarios.h"
+#include "game/formation/army_formation_types.h"
+#include "game/systems/nation_registry.h"
+#include "game/units/spawn_type.h"
+#include "game/units/troop_type.h"
+
+namespace Arena::Scenarios {
+namespace {
+
+using Command = ScenarioCommandKind;
+using Expect = ArenaExpectationKind;
+using Intent = Game::Formation::ArmyFormationIntent;
+using Nation = Game::Systems::NationID;
+using Spawn = Game::Units::SpawnType;
+using Trigger = ScenarioTriggerKind;
+using Troop = Game::Units::TroopType;
+
+constexpr float k_response_seconds = 1.0F;
+
+constexpr float k_stall_budget_seconds = 8.0F;
+
+constexpr float k_walkable_ground_budget = 24.0F;
+
+auto definition(QString id,
+                QString label,
+                QString description,
+                float duration,
+                ArenaCameraView camera) -> ArenaScenarioDefinition {
+  ArenaScenarioDefinition result;
+  result.id = std::move(id);
+  result.label = std::move(label);
+  result.description = std::move(description);
+  result.duration_seconds = duration;
+  result.camera = camera;
+  result.suppress_spawn_anchor = true;
+  result.suppress_ui_overlays = true;
+  result.suppress_boundary_mountains = true;
+  result.suppress_terrain_scatter = false;
+  result.camera_focus = QVector3D(0.0F, 0.0F, 0.0F);
+  return result;
+}
+
+auto group(QString name,
+           Troop troop,
+           int owner,
+           int count,
+           QVector3D origin,
+           int individuals,
+           QVector3D spacing = QVector3D(0.0F, 0.0F, 3.6F)) -> ArenaScenarioGroup {
+  ArenaScenarioGroup result;
+  result.name = std::move(name);
+  result.troop_type = troop;
+  result.nation_id = owner == 1 ? Nation::RomanRepublic : Nation::Carthage;
+  result.owner_id = owner;
+  result.count = count;
+  result.individuals_per_unit = individuals;
+  result.origin = origin;
+  result.spacing = spacing;
+  result.facing_degrees = owner == 1 ? 90.0F : 270.0F;
+  return result;
+}
+
+auto building(QString name,
+              Spawn type,
+              int owner,
+              int count,
+              QVector3D origin,
+              QVector3D spacing) -> ArenaScenarioGroup {
+  ArenaScenarioGroup result;
+  result.name = std::move(name);
+  result.spawn_type = type;
+  result.nation_id = owner == 1 ? Nation::RomanRepublic : Nation::Carthage;
+  result.owner_id = owner;
+  result.count = count;
+  result.origin = origin;
+  result.spacing = spacing;
+  result.facing_degrees = 0.0F;
+  return result;
+}
+
+auto expectation(Expect kind,
+                 QString source = {},
+                 float threshold = 0.0F,
+                 float distance = 0.0F) -> ArenaExpectation {
+  ArenaExpectation result;
+  result.kind = kind;
+  result.group = std::move(source);
+  result.threshold = threshold;
+  result.distance = distance;
+  return result;
+}
+
+auto patch_of(const char* prop_type,
+              int count,
+              QVector3D origin,
+              QVector3D spacing,
+              float scale) -> ArenaScenarioResourcePatch {
+  ArenaScenarioResourcePatch patch;
+  patch.prop_type = QString::fromLatin1(prop_type);
+  patch.count = count;
+  patch.origin = origin;
+  patch.spacing = spacing;
+  patch.scale = scale;
+  patch.exact = true;
+  return patch;
+}
+
+auto move_to(float time,
+             const QString& group_name,
+             QVector3D destination,
+             const QString& order_name) -> ArenaScenarioStep {
+  ArenaScenarioStep step;
+  step.name = QStringLiteral("%1_%2").arg(order_name, group_name);
+  step.trigger = {Trigger::AtTime, time, {}, {}, 0.0F};
+  step.command = Command::FormationMove;
+  step.group = group_name;
+  step.destination = destination;
+  return step;
+}
+
+auto deploy_army(float time,
+                 const QStringList& groups,
+                 QVector3D anchor,
+                 float facing_degrees,
+                 Intent intent,
+                 const QString& order_name) -> ArenaScenarioStep {
+  ArenaScenarioStep step;
+  step.name = order_name;
+  step.trigger = {Trigger::AtTime, time, {}, {}, 0.0F};
+  step.command = Command::FormArmy;
+  step.group = groups.first();
+  step.formation.groups = groups;
+  step.formation.anchor = anchor;
+  step.formation.facing_degrees = facing_degrees;
+  step.formation.intent = intent;
+  return step;
+}
+
+void order_army(ArenaScenarioDefinition& scenario,
+                float time,
+                const QStringList& groups,
+                QVector3D destination,
+                const QString& order_name,
+                float lateral_spread = 6.0F) {
+
+  int const count = groups.size();
+  for (int index = 0; index < count; ++index) {
+    float const offset =
+        (static_cast<float>(index) - (count - 1) * 0.5F) * lateral_spread;
+    scenario.steps.push_back(move_to(time,
+                                     groups.at(index),
+                                     destination + QVector3D(0.0F, 0.0F, offset),
+                                     order_name));
+  }
+}
+
+void expect_a_responsive_group(ArenaScenarioDefinition& scenario,
+                               const QString& group_name) {
+  scenario.expectations.push_back(
+      expectation(Expect::AllGroupsRespondWithin, group_name, k_response_seconds));
+  scenario.expectations.push_back(expectation(Expect::NoRootTeleport, group_name));
+  scenario.expectations.push_back(expectation(Expect::GroupIsRendered, group_name));
+  scenario.expectations.push_back(
+      expectation(Expect::MovementAnimationObserved, group_name));
+  scenario.expectations.push_back(
+      expectation(Expect::NoPermanentStall, group_name, k_stall_budget_seconds));
+  scenario.expectations.push_back(
+      expectation(Expect::UnitsClearOfBuildings, group_name));
+  scenario.expectations.push_back(expectation(
+      Expect::SoldiersStayOnWalkableGround, group_name, k_walkable_ground_budget));
+}
+
+void expect_arrival(ArenaScenarioDefinition& scenario,
+                    const QString& group_name,
+                    QVector3D destination,
+                    float tolerance) {
+  auto arrived = expectation(Expect::GroupReachedDestination, group_name);
+  arrived.distance = tolerance;
+  arrived.position = destination;
+  scenario.expectations.push_back(std::move(arrived));
+}
+
+void build_staggered_town(ArenaScenarioDefinition& scenario) {
+  constexpr float k_house_step = 10.0F;
+  scenario.groups.push_back(building(QStringLiteral("row_a"),
+                                     Spawn::Home,
+                                     1,
+                                     5,
+                                     QVector3D(-25.0F, 0.0F, 12.0F),
+                                     QVector3D(k_house_step, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("row_b_west"),
+                                     Spawn::Home,
+                                     1,
+                                     2,
+                                     QVector3D(-20.0F, 0.0F, 4.0F),
+                                     QVector3D(k_house_step, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("row_b_east"),
+                                     Spawn::Home,
+                                     1,
+                                     1,
+                                     QVector3D(10.0F, 0.0F, 4.0F),
+                                     QVector3D(k_house_step, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("row_c_west"),
+                                     Spawn::Home,
+                                     1,
+                                     2,
+                                     QVector3D(-25.0F, 0.0F, -4.0F),
+                                     QVector3D(k_house_step, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("row_c_east"),
+                                     Spawn::Home,
+                                     1,
+                                     1,
+                                     QVector3D(5.0F, 0.0F, -4.0F),
+                                     QVector3D(k_house_step, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("row_d"),
+                                     Spawn::Home,
+                                     1,
+                                     5,
+                                     QVector3D(-20.0F, 0.0F, -12.0F),
+                                     QVector3D(k_house_step, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("market"),
+                                     Spawn::Marketplace,
+                                     1,
+                                     1,
+                                     QVector3D(26.0F, 0.0F, 6.0F),
+                                     QVector3D(0.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("north_barracks"),
+                                     Spawn::Barracks,
+                                     1,
+                                     1,
+                                     QVector3D(-6.0F, 0.0F, 26.0F),
+                                     QVector3D(0.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("south_barracks"),
+                                     Spawn::Barracks,
+                                     1,
+                                     1,
+                                     QVector3D(14.0F, 0.0F, -26.0F),
+                                     QVector3D(0.0F, 0.0F, 0.0F)));
+  scenario.resource_patches = {
+      patch_of("supply_cart",
+               2,
+               QVector3D(-30.0F, 0.0F, 8.0F),
+               QVector3D(0.0F, 0.0F, -16.0F),
+               1.0F),
+      patch_of("weapon_rack",
+               3,
+               QVector3D(3.0F, 0.0F, -8.0F),
+               QVector3D(3.0F, 0.0F, 0.0F),
+               1.0F),
+      patch_of("supply_cart",
+               2,
+               QVector3D(20.0F, 0.0F, 0.0F),
+               QVector3D(0.0F, 0.0F, 8.0F),
+               1.0F),
+      patch_of("boulder",
+               4,
+               QVector3D(-34.0F, 0.0F, -20.0F),
+               QVector3D(6.0F, 0.0F, 2.0F),
+               1.1F),
+      patch_of("boulder",
+               3,
+               QVector3D(30.0F, 0.0F, 20.0F),
+               QVector3D(5.0F, 0.0F, -3.0F),
+               1.2F),
+      patch_of("ruins",
+               2,
+               QVector3D(-38.0F, 0.0F, 22.0F),
+               QVector3D(7.0F, 0.0F, 0.0F),
+               1.0F),
+      patch_of("pine_tree",
+               4,
+               QVector3D(36.0F, 0.0F, -12.0F),
+               QVector3D(3.0F, 0.0F, -3.0F),
+               1.0F),
+  };
+}
+
+auto add_roman_army(ArenaScenarioDefinition& scenario, QVector3D west) -> QStringList {
+
+  const QString swords = QStringLiteral("swords");
+  const QString spears = QStringLiteral("spears");
+  const QString archers = QStringLiteral("archers");
+  const QString horse = QStringLiteral("horse");
+  QVector3D const across(0.0F, 0.0F, 4.2F);
+  scenario.groups.push_back(group(
+      swords, Troop::Swordsman, 1, 5, west + QVector3D(4.0F, 0.0F, 0.0F), 12, across));
+  scenario.groups.push_back(group(
+      spears, Troop::Spearman, 1, 4, west + QVector3D(-2.0F, 0.0F, 0.0F), 12, across));
+  scenario.groups.push_back(group(
+      archers, Troop::Archer, 1, 3, west + QVector3D(-8.0F, 0.0F, 0.0F), 10, across));
+  scenario.groups.push_back(group(horse,
+                                  Troop::MountedKnight,
+                                  1,
+                                  2,
+                                  west + QVector3D(-14.0F, 0.0F, 0.0F),
+                                  6,
+                                  across));
+  return {swords, spears, archers, horse};
+}
+
+auto town_relay_scenario() -> ArenaScenarioDefinition {
+  auto scenario = definition(
+      QStringLiteral("maneuver_town_relay"),
+      QStringLiteral("Manoeuvre: An Army Relayed Through A Town"),
+      QStringLiteral(
+          "Fourteen units of four troop types are driven back and forth through a "
+          "town whose staggered houses leave no straight street. Seven orders in "
+          "under two minutes, three of them reversing a march in progress and one "
+          "a full deploy; every one has to be acknowledged at once, nobody may pop, "
+          "stand in a wall or wedge, and the army must end where it was last sent."),
+      112.0F,
+      {70.0F, 52.0F, 20.0F});
+  scenario.terrain_grid_extent = 190;
+  scenario.arena_floor_half_extent = 60.0F;
+  scenario.owner_teams = {{.owner_id = 1, .team_id = 1}};
+  build_staggered_town(scenario);
+
+  scenario.groups.push_back(building(QStringLiteral("north_palisade"),
+                                     Spawn::WallSegment,
+                                     1,
+                                     44,
+                                     QVector3D(-43.0F, 0.0F, 18.0F),
+                                     QVector3D(2.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("south_palisade"),
+                                     Spawn::WallSegment,
+                                     1,
+                                     44,
+                                     QVector3D(-43.0F, 0.0F, -18.0F),
+                                     QVector3D(2.0F, 0.0F, 0.0F)));
+
+  QVector3D const west(-44.0F, 0.0F, 0.0F);
+  QVector3D const east(44.0F, 0.0F, 0.0F);
+  QVector3D const north_east(40.0F, 0.0F, 12.0F);
+  QVector3D const south(-40.0F, 0.0F, -12.0F);
+  QVector3D const plaza(-1.0F, 0.0F, 0.0F);
+  auto const army = add_roman_army(scenario, west);
+
+  order_army(scenario, 1.0F, army, east, QStringLiteral("east"));
+  order_army(scenario, 13.0F, army, west, QStringLiteral("about_face"));
+  order_army(scenario, 25.0F, army, north_east, QStringLiteral("north_east"));
+  order_army(scenario, 40.0F, army, south, QStringLiteral("south"), 8.0F);
+  scenario.steps.push_back(deploy_army(56.0F,
+                                       army,
+                                       QVector3D(-54.0F, 0.0F, 0.0F),
+                                       90.0F,
+                                       Intent::Line,
+                                       QStringLiteral("deploy_west_line")));
+  order_army(scenario,
+             72.0F,
+             army,
+             east + QVector3D(-4.0F, 0.0F, -4.0F),
+             QStringLiteral("east_again"));
+  order_army(scenario, 90.0F, army, plaza, QStringLiteral("plaza"), 2.5F);
+
+  for (auto const& name : army) {
+    expect_a_responsive_group(scenario, name);
+  }
+
+  for (int index = 0; index < army.size(); ++index) {
+    float const offset = (static_cast<float>(index) - (army.size() - 1) * 0.5F) * 2.5F;
+    expect_arrival(
+        scenario, army.at(index), plaza + QVector3D(0.0F, 0.0F, offset), 9.0F);
+  }
+  scenario.expectations.push_back(expectation(Expect::FrameBudget, {}, 33.34F));
+  return scenario;
+}
+
+auto obstacle_slalom_scenario() -> ArenaScenarioDefinition {
+  auto scenario = definition(
+      QStringLiteral("maneuver_obstacle_slalom"),
+      QStringLiteral("Manoeuvre: An Army Slaloms Through Clutter"),
+      QStringLiteral(
+          "The same army over open ground strewn with boulder fields, ruins, tree "
+          "clusters and a few farmsteads, ordered from corner to corner along a "
+          "zigzag with two mid-march reversals. No leg is straight; every group has "
+          "to keep re-steering around the next obstacle without stalling, popping "
+          "or losing a soldier in the scenery."),
+      96.0F,
+      {72.0F, 54.0F, 25.0F});
+  scenario.terrain_grid_extent = 190;
+  scenario.arena_floor_half_extent = 60.0F;
+  scenario.owner_teams = {{.owner_id = 1, .team_id = 1}};
+
+  scenario.groups.push_back(building(QStringLiteral("farm_a"),
+                                     Spawn::Farm,
+                                     1,
+                                     1,
+                                     QVector3D(-12.0F, 0.0F, 14.0F),
+                                     QVector3D(0.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("homestead"),
+                                     Spawn::Home,
+                                     1,
+                                     3,
+                                     QVector3D(8.0F, 0.0F, -6.0F),
+                                     QVector3D(9.0F, 0.0F, 5.0F)));
+  scenario.groups.push_back(building(QStringLiteral("farm_b"),
+                                     Spawn::Farm,
+                                     1,
+                                     1,
+                                     QVector3D(24.0F, 0.0F, 22.0F),
+                                     QVector3D(0.0F, 0.0F, 0.0F)));
+  scenario.resource_patches = {
+      patch_of("boulder",
+               5,
+               QVector3D(-30.0F, 0.0F, -12.0F),
+               QVector3D(4.0F, 0.0F, 3.0F),
+               1.3F),
+      patch_of("boulder",
+               4,
+               QVector3D(-8.0F, 0.0F, -24.0F),
+               QVector3D(5.0F, 0.0F, -2.0F),
+               1.2F),
+      patch_of("boulder",
+               5,
+               QVector3D(14.0F, 0.0F, 10.0F),
+               QVector3D(3.5F, 0.0F, 3.5F),
+               1.1F),
+      patch_of("boulder",
+               4,
+               QVector3D(30.0F, 0.0F, -20.0F),
+               QVector3D(4.0F, 0.0F, 4.0F),
+               1.3F),
+      patch_of("ruins",
+               3,
+               QVector3D(-26.0F, 0.0F, 24.0F),
+               QVector3D(8.0F, 0.0F, -3.0F),
+               1.0F),
+      patch_of(
+          "ruins", 2, QVector3D(36.0F, 0.0F, 4.0F), QVector3D(0.0F, 0.0F, 9.0F), 1.0F),
+      patch_of("pine_tree",
+               6,
+               QVector3D(-4.0F, 0.0F, 30.0F),
+               QVector3D(4.0F, 0.0F, -2.0F),
+               1.0F),
+      patch_of("pine_tree",
+               5,
+               QVector3D(-38.0F, 0.0F, 4.0F),
+               QVector3D(2.0F, 0.0F, 5.0F),
+               1.0F),
+      patch_of("pine_tree",
+               5,
+               QVector3D(18.0F, 0.0F, -30.0F),
+               QVector3D(4.0F, 0.0F, 2.0F),
+               1.0F),
+      patch_of("supply_cart",
+               3,
+               QVector3D(0.0F, 0.0F, 4.0F),
+               QVector3D(4.0F, 0.0F, -4.0F),
+               1.0F),
+  };
+
+  QVector3D const start(-44.0F, 0.0F, -30.0F);
+  auto const army = add_roman_army(scenario, start);
+
+  order_army(scenario,
+             1.0F,
+             army,
+             QVector3D(40.0F, 0.0F, 30.0F),
+             QStringLiteral("north_east"));
+  order_army(scenario,
+             14.0F,
+             army,
+             QVector3D(-40.0F, 0.0F, 30.0F),
+             QStringLiteral("north_west"));
+  order_army(scenario,
+             27.0F,
+             army,
+             QVector3D(40.0F, 0.0F, -30.0F),
+             QStringLiteral("south_east"));
+  order_army(
+      scenario, 42.0F, army, QVector3D(-10.0F, 0.0F, 34.0F), QStringLiteral("north"));
+  order_army(
+      scenario, 56.0F, army, QVector3D(38.0F, 0.0F, 6.0F), QStringLiteral("east"));
+  order_army(
+      scenario, 68.0F, army, QVector3D(-42.0F, 0.0F, 0.0F), QStringLiteral("west"));
+  order_army(scenario,
+             80.0F,
+             army,
+             QVector3D(-4.0F, 0.0F, -4.0F),
+             QStringLiteral("centre"),
+             5.0F);
+
+  for (auto const& name : army) {
+    expect_a_responsive_group(scenario, name);
+  }
+  for (int index = 0; index < army.size(); ++index) {
+    float const offset = (static_cast<float>(index) - (army.size() - 1) * 0.5F) * 5.0F;
+    expect_arrival(
+        scenario, army.at(index), QVector3D(-4.0F, 0.0F, -4.0F + offset), 9.0F);
+  }
+  scenario.expectations.push_back(expectation(Expect::FrameBudget, {}, 33.34F));
+  return scenario;
+}
+
+auto countermarch_streets_scenario() -> ArenaScenarioDefinition {
+  auto scenario = definition(
+      QStringLiteral("maneuver_countermarch_streets"),
+      QStringLiteral("Manoeuvre: Two Armies Counter-March Through Streets"),
+      QStringLiteral(
+          "Two friendly armies of six units each are sent through the same street "
+          "grid from opposite ends, reversed before they meet, sent on again into "
+          "each other, then crossed at right angles through the one junction, with "
+          "an enemy block standing in the middle of it. Head-on traffic has to pass; "
+          "neither army may deadlock, pile up or leave a unit behind."),
+      104.0F,
+      {70.0F, 54.0F, 20.0F});
+  scenario.terrain_grid_extent = 190;
+  scenario.arena_floor_half_extent = 60.0F;
+  scenario.owner_teams = {{.owner_id = 1, .team_id = 1}, {.owner_id = 2, .team_id = 2}};
+
+  scenario.groups.push_back(building(QStringLiteral("north_row_west"),
+                                     Spawn::Home,
+                                     1,
+                                     3,
+                                     QVector3D(-30.0F, 0.0F, 7.0F),
+                                     QVector3D(10.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("north_row_east"),
+                                     Spawn::Home,
+                                     1,
+                                     3,
+                                     QVector3D(10.0F, 0.0F, 7.0F),
+                                     QVector3D(10.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("south_row_west"),
+                                     Spawn::Home,
+                                     1,
+                                     3,
+                                     QVector3D(-30.0F, 0.0F, -7.0F),
+                                     QVector3D(10.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("south_row_east"),
+                                     Spawn::Home,
+                                     1,
+                                     3,
+                                     QVector3D(10.0F, 0.0F, -7.0F),
+                                     QVector3D(10.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("outer_north"),
+                                     Spawn::Home,
+                                     1,
+                                     5,
+                                     QVector3D(-25.0F, 0.0F, 17.0F),
+                                     QVector3D(11.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("outer_south"),
+                                     Spawn::Home,
+                                     1,
+                                     5,
+                                     QVector3D(-19.0F, 0.0F, -17.0F),
+                                     QVector3D(11.0F, 0.0F, 0.0F)));
+  scenario.groups.push_back(building(QStringLiteral("market"),
+                                     Spawn::Marketplace,
+                                     1,
+                                     1,
+                                     QVector3D(0.0F, 0.0F, 26.0F),
+                                     QVector3D(0.0F, 0.0F, 0.0F)));
+  scenario.resource_patches = {
+      patch_of("weapon_rack",
+               2,
+               QVector3D(-14.0F, 0.0F, 2.5F),
+               QVector3D(3.0F, 0.0F, 0.0F),
+               1.0F),
+      patch_of("supply_cart",
+               1,
+               QVector3D(16.0F, 0.0F, -2.5F),
+               QVector3D(0.0F, 0.0F, 0.0F),
+               1.0F),
+      patch_of("boulder",
+               3,
+               QVector3D(-40.0F, 0.0F, 24.0F),
+               QVector3D(5.0F, 0.0F, 3.0F),
+               1.2F),
+      patch_of("boulder",
+               3,
+               QVector3D(36.0F, 0.0F, -26.0F),
+               QVector3D(5.0F, 0.0F, 3.0F),
+               1.2F),
+  };
+
+  const QString west_swords = QStringLiteral("west_swords");
+  const QString west_spears = QStringLiteral("west_spears");
+  const QString east_swords = QStringLiteral("east_swords");
+  const QString east_archers = QStringLiteral("east_archers");
+  const QString holders = QStringLiteral("holders");
+  QVector3D const west_home(-44.0F, 0.0F, 0.0F);
+  QVector3D const east_home(44.0F, 0.0F, 0.0F);
+  scenario.groups.push_back(group(west_swords,
+                                  Troop::Swordsman,
+                                  1,
+                                  3,
+                                  west_home + QVector3D(0.0F, 0.0F, -5.0F),
+                                  12));
+  scenario.groups.push_back(group(
+      west_spears, Troop::Spearman, 1, 3, west_home + QVector3D(0.0F, 0.0F, 6.0F), 12));
+  auto east_a = group(east_swords,
+                      Troop::Swordsman,
+                      1,
+                      3,
+                      east_home + QVector3D(0.0F, 0.0F, -5.0F),
+                      12);
+  east_a.facing_degrees = 270.0F;
+  scenario.groups.push_back(std::move(east_a));
+  auto east_b = group(
+      east_archers, Troop::Archer, 1, 3, east_home + QVector3D(0.0F, 0.0F, 6.0F), 10);
+  east_b.facing_degrees = 270.0F;
+  scenario.groups.push_back(std::move(east_b));
+  auto blockers =
+      group(holders, Troop::Swordsman, 2, 1, QVector3D(0.0F, 0.0F, 1.0F), 10);
+  blockers.attacks_disabled = true;
+  scenario.groups.push_back(std::move(blockers));
+
+  QStringList const west_army{west_swords, west_spears};
+  QStringList const east_army{east_swords, east_archers};
+
+  order_army(
+      scenario, 1.0F, west_army, east_home, QStringLiteral("west_to_east"), 5.0F);
+  order_army(
+      scenario, 1.0F, east_army, west_home, QStringLiteral("east_to_west"), 5.0F);
+  order_army(scenario, 15.0F, west_army, west_home, QStringLiteral("west_back"), 5.0F);
+  order_army(scenario, 15.0F, east_army, east_home, QStringLiteral("east_back"), 5.0F);
+  order_army(scenario,
+             28.0F,
+             west_army,
+             east_home,
+             QStringLiteral("west_to_east_again"),
+             5.0F);
+  order_army(scenario,
+             28.0F,
+             east_army,
+             west_home,
+             QStringLiteral("east_to_west_again"),
+             5.0F);
+  order_army(scenario,
+             50.0F,
+             west_army,
+             QVector3D(0.0F, 0.0F, 34.0F),
+             QStringLiteral("west_to_north"),
+             5.0F);
+  order_army(scenario,
+             50.0F,
+             east_army,
+             QVector3D(0.0F, 0.0F, -34.0F),
+             QStringLiteral("east_to_south"),
+             5.0F);
+  order_army(scenario,
+             70.0F,
+             west_army,
+             QVector3D(0.0F, 0.0F, -30.0F),
+             QStringLiteral("west_to_south"),
+             5.0F);
+  order_army(scenario,
+             70.0F,
+             east_army,
+             QVector3D(0.0F, 0.0F, 30.0F),
+             QStringLiteral("east_to_north"),
+             5.0F);
+
+  for (auto const& name : {west_swords, west_spears, east_swords, east_archers}) {
+    expect_a_responsive_group(scenario, name);
+  }
+  expect_arrival(scenario, west_swords, QVector3D(0.0F, 0.0F, -32.5F), 9.0F);
+  expect_arrival(scenario, west_spears, QVector3D(0.0F, 0.0F, -27.5F), 9.0F);
+  expect_arrival(scenario, east_swords, QVector3D(0.0F, 0.0F, 27.5F), 9.0F);
+  expect_arrival(scenario, east_archers, QVector3D(0.0F, 0.0F, 32.5F), 9.0F);
+  scenario.expectations.push_back(expectation(Expect::FrameBudget, {}, 33.34F));
+  return scenario;
+}
+
+} // namespace
+
+auto build_maneuver_definitions() -> std::vector<ArenaScenarioDefinition> {
+  return {
+      town_relay_scenario(),
+      obstacle_slalom_scenario(),
+      countermarch_streets_scenario(),
+  };
+}
+
+} // namespace Arena::Scenarios

--- a/tools/arena/arena_maneuver_scenarios.h
+++ b/tools/arena/arena_maneuver_scenarios.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <vector>
+
+#include "arena_scenario.h"
+
+namespace Arena::Scenarios {
+
+[[nodiscard]] auto build_maneuver_definitions() -> std::vector<ArenaScenarioDefinition>;
+
+} // namespace Arena::Scenarios

--- a/tools/arena/arena_scenario_catalog.cpp
+++ b/tools/arena/arena_scenario_catalog.cpp
@@ -14,6 +14,7 @@
 #include "arena_engagement_scenarios.h"
 #include "arena_facade_scenarios.h"
 #include "arena_formation_scenarios.h"
+#include "arena_maneuver_scenarios.h"
 #include "arena_navigation_scenarios.h"
 #include "arena_scenarios.h"
 #include "arena_showcase_scenarios.h"
@@ -11775,6 +11776,10 @@ auto definitions() -> const std::vector<ArenaScenarioDefinition>& {
     values.insert(values.end(),
                   std::make_move_iterator(stuck_recovery.begin()),
                   std::make_move_iterator(stuck_recovery.end()));
+    auto maneuver = build_maneuver_definitions();
+    values.insert(values.end(),
+                  std::make_move_iterator(maneuver.begin()),
+                  std::make_move_iterator(maneuver.end()));
     auto traversal = build_traversal_definitions();
     values.insert(values.end(),
                   std::make_move_iterator(traversal.begin()),

--- a/ui/qml/HUD.qml
+++ b/ui/qml/HUD.qml
@@ -22,6 +22,8 @@ Item {
 
     property bool overlay_active: false
 
+    readonly property Item keyboard_owner: hudVictory.visible ? hudVictory : null
+
     function right_stack_margin(card_height) {
         var preferred = hud.right_stack_bottom - topPanel.height;
         var latest = hud.height - topPanel.height - hud.bottom_panel_height - Design.Metrics.space8 - card_height;

--- a/ui/qml/Main.qml
+++ b/ui/qml/Main.qml
@@ -86,6 +86,8 @@ ApplicationWindow {
             if (overlays[i].visible)
                 return overlays[i];
         }
+        if (hud.visible && hud.keyboard_owner)
+            return hud.keyboard_owner;
         if (mainWindow.game_started)
             return gameViewItem;
         return null;

--- a/ui/qml/design/controls/IronButton.qml
+++ b/ui/qml/design/controls/IronButton.qml
@@ -20,6 +20,8 @@ Button {
     implicitHeight: Design.Metrics.controlHeight
     implicitWidth: Math.max(112, contentItem.implicitWidth + Design.Metrics.space24 * 2)
     hoverEnabled: true
+
+    focusPolicy: Qt.TabFocus
     Accessible.name: accessibleName
     Accessible.description: interactive ? ToolTip.text : disabledReason
     ToolTip.text: interactive ? "" : disabledReason


### PR DESCRIPTION
Make movement orders behave predictably through towns, gates, and other crowded terrain while keeping the player-facing presentation coherent.

- Treat the nearest reachable point as a terminal arrival outcome, unify objective stall recovery, and make blocked activity follow the recovery ladder.

- Register body contact in the shipped runtime, share the navigation-passage predicate with steering, and keep bodies from overlapping, backtracking, or deadlocking in one-lane passages.

- Add shared planar yaw helpers and route look-ahead guards, bound formation turning, preserve motion while folding through pinches, and prevent traversal recovery from producing soldier pops.

- Stabilize formation slot orientation during an about-face, reduce soldier turn speed, synchronize movement trace timing with the world step, and make terrain and prop identifiers deterministic across map loads.

- Tessellate ground markers according to terrain scale, restore occluded range rings behind terrain, preserve wildlife and production visibility behavior, and keep end-of-battle HUD buttons keyboard accessible without losing clicks.

- Add a movement review, maneuver arena scenarios, movement and rendering regression coverage, and the required arena, QML, and test build wiring.